### PR TITLE
feat: add installation chart framework

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 ./.dapper
 ./.cache
 ./dist
+.idea
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /dist
 *.swp
 .idea
-harvester
+/harvester
+.DS_Store

--- a/deploy/charts/cdi
+++ b/deploy/charts/cdi
@@ -1,0 +1,1 @@
+harvester/charts/cdi

--- a/deploy/charts/cdi-operator
+++ b/deploy/charts/cdi-operator
@@ -1,0 +1,1 @@
+harvester/charts/cdi-operator

--- a/deploy/charts/harvester/.helmignore
+++ b/deploy/charts/harvester/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/charts/harvester/Chart.yaml
+++ b/deploy/charts/harvester/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: harvester
+version: 0.1.0
+appVersion: 0.1.x
+description: Harvester is a virtual machine management add-on based on KubeVirt for Kubernetes.
+type: application
+keywords:
+  - virtualization
+  - kubevirt
+home: https://github.com/rancher/harvester
+sources:
+  - https://github.com/rancher/harvester
+maintainers:
+  - name: thxCode
+    email: frank@rancher.com
+dependencies:
+  - name: kubevirt-operator
+    version: 0.1.0
+    repository: file://charts/kubevirt-operator
+    condition: kubevirt-operator.enabled
+  - name: kubevirt
+    version: 0.1.0
+    repository: file://charts/kubevirt
+    condition: kubevirt.enabled
+  - name: cdi-operator
+    version: 0.1.0
+    repository: file://charts/cdi-operator
+    condition: cdi-operator.enabled
+  - name: cdi
+    version: 0.1.0
+    repository: file://charts/cdi
+    condition: cdi.enabled
+  - name: minio
+    version: 5.0.32
+    repository: file://charts/minio
+    condition: minio.enabled

--- a/deploy/charts/harvester/LICENSE
+++ b/deploy/charts/harvester/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/deploy/charts/harvester/README.md
+++ b/deploy/charts/harvester/README.md
@@ -1,0 +1,173 @@
+# Harvester Helm Chart
+
+Harvester provides a friendly virtual machine management experience in Kubernetes based on [KubeVirt](https://kubervirt.io) and [KubeVirt Containerized Data Importer](https://github.com/kubevirt/containerized-data-importer).
+
+## Chart Details
+
+This chart will do the following:
+
+- Deploy a KubeVirt Operator if needed, defaults to deploy.
+- Deploy a KubeVirt CRD resource to enable KubeVirt if needed, defaults to deploy.
+- Deploy a KubeVirt Containerized Data Importer Operator if needed, defaults to deploy.
+- Deploy a CDI CRD resource to enable KubeVirt Containerized Data Importer if needed, default to deploy.
+- Deploy a Minio as virtual machine image storage if needed, defaults to deploy.
+- Deploy the Harvester resources.
+
+### Prerequisites
+
+- Kubernetes 1.16+.
+- Helm 3.2+.
+- **Default** [StorageClass](https://v1-16.docs.kubernetes.io/docs/concepts/storage/storage-classes/).
+
+#### Notes
+
+- Use the existing KubeVirt/CDI/Image-Storage Service.
+
+    If you have already prepared the KubeVirt, CDI or image storage compatible with S3 like Minio, you can disable these installations in this chart.
+    
+    ```bash
+    $ helm install harvester harvester --name harvester-system \
+        --set kubevirt.enabled=false --set kubevirt-operator.enabled=false \
+        --set cdi.enabled=false --set cdi-operator.enabled=false \
+        --set minio.enabled=false
+    ```
+
+- Change the default StorageClass.
+    
+    By default, the default StorageClass is required for both the Minio and [`DataVolume`](https://github.com/kubevirt/containerized-data-importer#datavolumes). You can follow the [official document](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/) to change the default StorageClass of Kubernetes cluster.
+
+### Installing the Chart
+
+To install the chart with the release name `harvester`.
+
+```bash
+$ # create target namespace
+$ kubectl create ns harvester-system
+
+$ # install chart to target namespace
+$ helm install harvester harvester --namespace harvester-system
+```
+
+### Uninstalling the Chart
+
+To uninstall/delete the `harvester` release.
+
+```bash
+$ # uninstall chart from target namespace
+$ helm uninstall harvester --namespace harvester-system
+```
+
+### Configuration
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or `helm upgrade`.
+
+For details on using parameters, please refer to [values.yaml](values.yaml).
+
+#### Configure KubeVirt Operator
+
+To configure the KubeVirt Operator, you need to know its [parameters](charts/kubevirt-operator/values.yaml) and put all items under `kubevirt-operator` domain. 
+
+For example, if you want to change the Secret name of admission webhooks, you can do as below.
+
+```bash
+$ helm install harvester harvester --namespace harvester-system \
+    --set-string kubevirt-operator.containers.operator.certificates.admissionWebhook.secretName=mysecret
+```
+
+If you don't want to install KubeVirt Operator, you can do the following.
+
+```bash
+$ helm install harvester harvester --namespace harvester-system \
+    --set kubevirt-operator.enabled=false
+```
+
+#### Configure KubeVirt (CRD resource)
+
+To configure the KubeVirt CRD resource, you need to know its [parameters](charts/kubevirt/values.yaml) and put all items under `kubevirt` domain. 
+
+> **It is worth noting that almost all KubeVirt parameters are string type, including bool field and numeric field.**
+
+For example, if you want to enable the emulation mode on the non-KVM supported hosts, you can do as below.
+
+```bash
+$ helm install harvester harvester --namesapce harvester-system \
+    --set-string kubevirt.spec.configuration.developerConfiguration.useEmulation=true
+```
+
+If you don't want to install KubeVirt CRD resource, you can do the following.
+
+```bash
+$ helm install harvester harvester --namespace harvester-system \
+    --set kubevirt.enabled=false
+```
+
+#### Configure KubeVirt Containerized Data Importer Operator
+
+To configure the KubeVirt Containerized Data Importer Operator, you need to know its [parameters](charts/cdi-operator/values.yaml) and put all items under `cdi-operator` domain. 
+
+For example, if you want to change the image name of CDI cloner, you can do as below.
+
+```bash
+$ helm install harvester harvester --namespace harvester-system \
+    --set-string cdi-operator.containers.cloner.image.repository=myrepo/my-cloner-image
+```
+
+If you don't want to install KubeVirt Containerized Data Importer Operator, you can do the following.
+
+```bash
+$ helm install harvester harvester --namespace harvester-system \
+    --set cdi-operator.enabled=false
+```
+
+#### Configure KubeVirt Containerized Data Importer (CRD resource)
+
+To configure the KubeVirt Containerized Data Importer CRD resource, you need to know its [parameters](charts/cdi/values.yaml) and put all items under `cdi` domain. 
+
+For example, if you want to override the pull policy of CDI operator, you can do as below.
+
+```bash
+$ helm install harvester harvester --namesapce harvester-system \
+    --set-string cdi.spec.imagePullPolicy=Always
+```
+
+If you don't want to install KubeVirt Containerized Data Importer CRD resource, you can do the following.
+
+```bash
+$ helm install harvester harvester --namespace harvester-system \
+    --set cdi.enabled=false
+```
+
+#### Configure Minio
+
+> **Noted:** Minio chart mirrors from the [Minio official](https://github.com/minio/charts).
+
+To configure the Minio, you need to know its [parameters](https://github.com/minio/charts#configuration) and put all items under `minio` domain.
+
+For example, if you want to use "distributed" mode Minio, you can do as below.
+
+```bash
+$ helm install harvester harvester --namesapce harvester-system \
+    --set minio.mode=distributed
+```
+
+If you don't want to install Minio, you can do the following.
+
+```bash
+$ helm install harvester harvester --namespace harvester-system \
+    --set minio.enabled=false
+```
+
+## License
+Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/deploy/charts/harvester/charts/cdi-operator/.helmignore
+++ b/deploy/charts/harvester/charts/cdi-operator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/charts/harvester/charts/cdi-operator/Chart.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: cdi-operator
+version: 0.1.0
+appVersion: 1.12.x
+description: KubeVirt Containerized Data Importer Operator provides deployment and management of KubeVirt Containerized Data Importer bundle components.
+icon: https://kubevirt.io/assets/images/KubeVirt_logo_color.svg
+type: application
+keywords:
+  - containerized-data-importer
+  - operator
+home: https://github.com/kubevirt/containerized-data-importer
+sources:
+  - https://github.com/kubevirt/containerized-data-importer
+maintainers:
+  - name: thxCode
+    email: frank@rancher.com

--- a/deploy/charts/harvester/charts/cdi-operator/LICENSE
+++ b/deploy/charts/harvester/charts/cdi-operator/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/deploy/charts/harvester/charts/cdi-operator/README.md
+++ b/deploy/charts/harvester/charts/cdi-operator/README.md
@@ -1,0 +1,58 @@
+# KubeVirt Containerized Data Importer Operator Helm Chart
+
+KubeVirt Containerized Data Importer Operator provides an easy way to deploy and manage the [KubeVirt Containerized Data Importer](https://github.com/kubevirt/containerized-data-importer) bundle components in Kubernetes.
+
+[KubeVirt Containerized Data Importer repo](https://github.com/kubevirt/containerized-data-importer) has already provided an all-in-one YAML for deploying [the KubeVirt Containerized Data Importer Operator](https://github.com/kubevirt/containerized-data-importer/blob/master/manifests/templates/release/cdi-operator.yaml.in), but it is not flexible for configuring. This chart is going to supplement the all-in-one YAML and provide a way to deploy the KubeVirt Containerized Data Importer Operator in air-gap environment.
+
+## Chart Details
+
+This chart will do the following:
+
+- Deploy the KubeVirt Containerized Data Importer Operator.
+
+### Prerequisites
+
+- Kubernetes 1.16+.
+- Helm 3.2+.
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`.
+
+```bash
+$ # create target namespace
+$ kubectl create ns harvester-system
+
+$ # install chart to target namespace
+$ helm install my-release cdi-operator --namespace harvester-system
+```
+
+### Uninstalling the Chart
+
+To uninstall/delete the `my-release` release.
+
+```bash
+$ # uninstall chart from target namespace
+$ helm uninstall my-release --namespace harvester-system
+```
+
+### Configuration
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or `helm upgrade`.
+
+For details on using parameters, please refer to [values.yaml](values.yaml).
+
+## License
+Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/deploy/charts/harvester/charts/cdi-operator/crds/crd-cdi.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/crds/crd-cdi.yaml
@@ -1,0 +1,44 @@
+# we use "x-kubernetes-preserve-unknown-fields: true" to skip the validation of apiserver, you can find the schema of CDI from here:
+# https://github.com/kubevirt/containerized-data-importer/blob/dbab72c93e05957fe8eb5d8d861843d79f7998bf/pkg/operator/resources/operator/operator.go#L280-L558.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cdis.cdi.kubevirt.io
+spec:
+  group: cdi.kubevirt.io
+  names:
+    kind: CDI
+    listKind: CDIList
+    plural: cdis
+    shortNames:
+      - cdi
+      - cdis
+    singular: cdi
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1alpha1
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+  scope: Cluster

--- a/deploy/charts/harvester/charts/cdi-operator/templates/NOTES.txt
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/NOTES.txt
@@ -1,0 +1,8 @@
+The KubeVirt Containerized Data Importer Operator has been installed into "{{ .Release.Namespace }}" namespace with "{{ .Release.Name }}" as release name.
+
+Please make sure there is a default StorageClass in the Kubernetes cluster.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/deploy/charts/harvester/charts/cdi-operator/templates/_helpers.tpl
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "cdi-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "cdi-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cdi-operator.chartref" -}}
+{{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end }}
+
+{{/*
+Generate immutable labels.
+We use the immutable labels to select low-level components(like the Deployment selects the Pods).
+*/}}
+{{- define "cdi-operator.immutableLabels" -}}
+helm.sh/release: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ template "cdi-operator.name" . }}
+{{- end }}
+
+{{/*
+Generate basic labels.
+*/}}
+{{- define "cdi-operator.labels" -}}
+app.kubernetes.io/managed-by: {{ default "helm" $.Release.Service | quote }}
+helm.sh/chart: {{ template "cdi-operator.chartref" . }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{ include "cdi-operator.immutableLabels" . }}
+{{- end }}

--- a/deploy/charts/harvester/charts/cdi-operator/templates/clusterrole.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/clusterrole.yaml
@@ -1,0 +1,197 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: cdi-operator-cluster
+  labels:
+{{ include "cdi-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: cdi-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - '*'
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - cdi.kubevirt.io
+      - upload.cdi.kubevirt.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - '*'
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+    verbs:
+      - list
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - cdis
+    verbs:
+      - get
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - cdis/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+      - volumesnapshots
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims/finalizers
+      - pods/finalizers
+      - volumesnapshots/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get

--- a/deploy/charts/harvester/charts/cdi-operator/templates/clusterrolebinding.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: cdi-operator
+  labels:
+{{ include "cdi-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: cdi-operator
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: cdi-operator-cluster
+subjects:
+  - kind: ServiceAccount
+    # NB(thxCode): name should not be customized as below:
+    # name: {{ template "cdi-operator.fullname" . }}
+    # because we need to keep it as same as all-in-one YAML from upstream.
+    name: cdi-operator
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/harvester/charts/cdi-operator/templates/deployment.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: cdi-operator
+  labels:
+{{ include "cdi-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: cdi-operator
+    app.kubernetes.io/component: operator
+spec:
+  selector:
+    matchLabels:
+{{ include "cdi-operator.immutableLabels" . | indent 6 }}
+      app.kubernetes.io/name: cdi-operator
+      app.kubernetes.io/component: operator
+      cdi.kubevirt.io: cdi-operator
+{{- if .Values.replicas }}
+  replicas: {{ .Values.replicas }}
+{{- end }}
+{{- if .Values.strategy }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+{{- end }}
+  template:
+    metadata:
+      labels:
+{{ include "cdi-operator.labels" . | indent 8 }}
+        app.kubernetes.io/name: cdi-operator
+        app.kubernetes.io/component: operator
+        cdi.kubevirt.io: cdi-operator
+    spec:
+      serviceAccountName: cdi-operator
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: cdi.kubevirt.io
+                      operator: In
+                      values:
+                        - cdi-operator
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - name: cdi-operator
+          image: {{ .Values.containers.operator.image.repository }}:{{ .Values.containers.operator.image.tag }}
+          imagePullPolicy: {{ .Values.containers.operator.image.imagePullPolicy }}
+{{- if .Values.containers.operator.command }}
+          command:
+{{ toYaml .Values.containers.operator.command | indent 12 }}
+{{- end }}
+{{- if .Values.containers.operator.args }}
+          args:
+{{ toYaml .Values.containers.operator.args | indent 12 }}
+{{- end }}
+          env:
+            # the following variables can be overridden by input.
+            - name: VERBOSITY
+              value: "1"
+            - name: PULL_POLICY
+              value: {{ .Values.containers.operator.image.imagePullPolicy }}
+{{- if .Values.containers.operator.env }}
+{{ toYaml .Values.containers.operator.env | indent 12 }}
+{{- end }}
+            # the following variables can NOT be overridden by input.
+            - name: DEPLOY_CLUSTER_RESOURCES
+              value: "true"
+            - name: OPERATOR_VERSION
+              value: {{ .Values.containers.operator.image.tag }}
+            - name: CONTROLLER_IMAGE
+              value: {{ .Values.containers.controller.image.repository }}:{{ default .Values.containers.operator.image.tag .Values.containers.controller.image.tag }}
+            - name: IMPORTER_IMAGE
+              value: {{ .Values.containers.importer.image.repository }}:{{ default .Values.containers.operator.image.tag .Values.containers.importer.image.tag }}
+            - name: CLONER_IMAGE
+              value: {{ .Values.containers.cloner.image.repository }}:{{ default .Values.containers.operator.image.tag .Values.containers.cloner.image.tag }}
+            - name: APISERVER_IMAGE
+              value: {{ .Values.containers.apiserver.image.repository }}:{{ default .Values.containers.operator.image.tag .Values.containers.apiserver.image.tag }}
+            - name: UPLOAD_SERVER_IMAGE
+              value: {{ .Values.containers.uploadserver.image.repository }}:{{ default .Values.containers.operator.image.tag .Values.containers.uploadserver.image.tag }}
+            - name: UPLOAD_PROXY_IMAGE
+              value: {{ .Values.containers.uploadproxy.image.repository }}:{{ default .Values.containers.operator.image.tag .Values.containers.uploadproxy.image.tag }}
+          # NB(thxCode): there is not metrics exporter from cdi-operator implementation.
+          # ports:
+            # - containerPort: 60000
+            #  name: metrics
+            #  protocol: TCP
+{{- if .Values.containers.operator.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.containers.operator.livenessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.containers.operator.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.containers.operator.readinessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.containers.operator.resources }}
+          resources:
+{{ toYaml .Values.containers.operator.resources | indent 12 }}
+{{- end }}
+{{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}

--- a/deploy/charts/harvester/charts/cdi-operator/templates/role.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/role.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: cdi-operator
+  labels:
+{{ include "cdi-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: cdi-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - configmaps
+      - events
+      - secrets
+      - services
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+      - routes/custom-host
+    verbs:
+      - '*'

--- a/deploy/charts/harvester/charts/cdi-operator/templates/rolebinding.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/rolebinding.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: cdi-operator
+  labels:
+{{ include "cdi-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: cdi-operator
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: cdi-operator
+subjects:
+  - kind: ServiceAccount
+    # NB(thxCode): name should not be customized as below:
+    # name: {{ template "cdi-operator.fullname" . }}
+    # because we need to keep it as same as all-in-one YAML from upstream.
+    name: cdi-operator
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/harvester/charts/cdi-operator/templates/serviceaccount.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # NB(thxCode): name cannot be customized as below:
+  # name: {{ template "cdi-operator.fullname" . }}
+  # because the installation strategy dump action needs this ServiceAccount.
+  name: cdi-operator
+  labels:
+{{ include "cdi-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: cdi-operator
+    app.kubernetes.io/component: operator

--- a/deploy/charts/harvester/charts/cdi-operator/values.yaml
+++ b/deploy/charts/harvester/charts/cdi-operator/values.yaml
@@ -1,0 +1,195 @@
+###########################################################################
+###########################################################################
+##                    Default values for CDI Operator                    ##
+###########################################################################
+###########################################################################
+
+## Provide a name in place of labels.
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources.
+##
+fullnameOverride: ""
+
+## Specify the replicas of workload.
+##
+replicas: 1
+
+## Specify the security context of workload.
+##
+securityContext:
+  runAsNonRoot: true
+
+## Specify the node selector of workload.
+##
+nodeSelector: {}
+
+## Specify the tolerations of workload.
+##
+tolerations: []
+#  - key: CriticalAddonsOnly
+#    operator: Exists
+
+## Specify the update strategy of workload.
+##
+strategy:
+  type: RollingUpdate
+
+## Specify the parameter of containers.
+##
+containers:
+
+  ## Specify the parameter of cdi-operator container.
+  ##
+  operator:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the pull policy of image.
+      ##
+      imagePullPolicy: Always
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/cdi-operator
+
+      ## Specify the tag of image.
+      ##
+      tag: latest
+
+    ## Specify the command.
+    ##
+    command: []
+
+    ## Specify the args.
+    ##
+    args: []
+
+    ## Specify the env.
+    ##
+    env: []
+    #  - name: OPERATOR_VERSION
+    #    value: xxx
+
+    ## Specify the liveness probe.
+    ##
+    livenessProbe: {}
+
+    ## Specify the readiness probe.
+    ##
+    readinessProbe:
+
+    ## Specify the resources.
+    ##
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+
+  ## Specify the parameter of cdi-controller container.
+  ##
+  controller:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/cdi-controller
+
+      ## Specify the tag of image,
+      ## defaults to the tag of operator image.
+      ##
+      tag: ""
+
+  ## Specify the parameter of cdi-importer container.
+  ##
+  importer:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/cdi-importer
+
+      ## Specify the tag of image,
+      ## defaults to the tag of operator image.
+      ##
+      tag: ""
+
+  ## Specify the parameter of cdi-cloner container.
+  ##
+  cloner:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/cdi-cloner
+
+      ## Specify the tag of image,
+      ## defaults to the tag of operator image.
+      ##
+      tag: ""
+
+  ## Specify the parameter of cdi-apiserver container.
+  ##
+  apiserver:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/cdi-apiserver
+
+      ## Specify the tag of image,
+      ## defaults to the tag of operator image.
+      ##
+      tag: ""
+
+  ## Specify the parameter of cdi-uploadserver container.
+  ##
+  uploadserver:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/cdi-uploadserver
+
+      ## Specify the tag of image,
+      ## defaults to the tag of operator image.
+      ##
+      tag: ""
+
+  ## Specify the parameter of cdi-uploadproxy container.
+  ##
+  uploadproxy:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/cdi-uploadproxy
+
+      ## Specify the tag of image,
+      ## defaults to the tag of operator image.
+      ##
+      tag: ""

--- a/deploy/charts/harvester/charts/cdi/.helmignore
+++ b/deploy/charts/harvester/charts/cdi/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/charts/harvester/charts/cdi/Chart.yaml
+++ b/deploy/charts/harvester/charts/cdi/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: cdi
+version: 0.1.0
+appVersion: v1beta1
+description: KubeVirt Containerized Data Importer creates a CDI instance into target Namespace.
+icon: https://kubevirt.io/assets/images/KubeVirt_logo_color.svg
+type: application
+keywords:
+  - cdi
+  - crd
+home: https://github.com/kubevirt/containerized-data-importer
+sources:
+  - https://github.com/kubevirt/containerized-data-importer
+maintainers:
+  - name: thxCode
+    email: frank@rancher.com

--- a/deploy/charts/harvester/charts/cdi/LICENSE
+++ b/deploy/charts/harvester/charts/cdi/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/deploy/charts/harvester/charts/cdi/README.md
+++ b/deploy/charts/harvester/charts/cdi/README.md
@@ -1,0 +1,59 @@
+# KubeVirt Containerized Data Importer Helm Chart
+
+[`CDI`](https://github.com/kubevirt/containerized-data-importer/blob/dbab72c93e05957fe8eb5d8d861843d79f7998bf/pkg/apis/core/v1beta1/types.go#L230-L245) declaratively defines a desired [KubeVirt Containerized Data Importer](https://github.com/kubevirt/containerized-data-importer) setup to run in a Kubernetes cluster. It provides options to configure KubeVirt Containerized Data Importer bundle components to deploy.
+
+The current configuration management of KubeVirt Containerized Data Importer Operator for `CDI` resource has some limitations as below:
+
+- `CDI` resource is a cluster scope resource.
+- Only the first deployed one in multiple `CDI` resources is valid.
+
+## Chart Details
+
+This chart will do the following:
+
+- Deploy a `CDI` CRD resource named `cdi`.
+
+### Prerequisites
+
+- Kubernetes 1.16+.
+- Helm 3.2+.
+- KubeVirt Containerized Data Importer Operator v1.21.0+.
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`.
+
+```bash
+$ # install chart to target namespace installed cdi-operator, i.e: harvester-system
+$ helm install my-release cdi --namespace harvester-system
+```
+
+### Uninstalling the Chart
+
+To uninstall/delete the `my-release` release.
+
+```bash
+$ # uninstall chart from target namespace
+$ helm uninstall my-release --namespace harvester-system
+```
+
+### Configuration
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or `helm upgrade`.
+
+For details on using parameters, please refer to [values.yaml](values.yaml).
+
+## License
+Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/deploy/charts/harvester/charts/cdi/templates/NOTES.txt
+++ b/deploy/charts/harvester/charts/cdi/templates/NOTES.txt
@@ -1,0 +1,8 @@
+The KubeVirt Containerized Data Importer(CDI) has been installed into "{{ .Release.Namespace }}" namespace with "{{ .Release.Name }}" as release name.
+
+Please make sure there is a default StorageClass in the Kubernetes cluster.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/deploy/charts/harvester/charts/cdi/templates/_helpers.tpl
+++ b/deploy/charts/harvester/charts/cdi/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "cdi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "cdi.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cdi.chartref" -}}
+{{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end }}
+
+{{/*
+Generate immutable labels.
+We use the immutable labels to select low-level components(like the Deployment selects the Pods).
+*/}}
+{{- define "cdi.immutableLabels" -}}
+helm.sh/release: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ template "cdi.name" . }}
+{{- end }}
+
+{{/*
+Generate basic labels.
+*/}}
+{{- define "cdi.labels" -}}
+app.kubernetes.io/managed-by: {{ default "helm" $.Release.Service | quote }}
+helm.sh/chart: {{ template "cdi.chartref" . }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{ include "cdi.immutableLabels" . }}
+{{- end }}

--- a/deploy/charts/harvester/charts/cdi/templates/cdi.yaml
+++ b/deploy/charts/harvester/charts/cdi/templates/cdi.yaml
@@ -1,0 +1,17 @@
+# NB(thxCode): the api version controls by the app version specification of Chart.yaml.
+apiVersion: {{ printf "cdi.kubevirt.io/%s" .Chart.AppVersion }}
+kind: CDI
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "cdi.fullname" . }}
+  # because multiple CDI resources are useless,
+  # only the first instance will be deployed.
+  name: cdi
+  labels:
+{{ include "cdi.labels" . | indent 4 }}
+    app.kubernetes.io/name: cdi
+    app.kubernetes.io/component: metadata
+spec:
+{{- if .Values.spec }}
+{{ toYaml .Values.spec | indent 2 }}
+{{- end }}

--- a/deploy/charts/harvester/charts/cdi/values.yaml
+++ b/deploy/charts/harvester/charts/cdi/values.yaml
@@ -1,0 +1,30 @@
+###########################################################################
+###########################################################################
+##                        Default values for CDI CR                      ##
+###########################################################################
+###########################################################################
+
+## Provide a name in place of labels.
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources.
+##
+fullnameOverride: ""
+
+## Specify the specification of CDI resource.
+##
+spec:
+
+  ## Specify the pull policy of image,
+  ## which is used for overriding the PULL_POLICY env of cdi-operator，
+  ## defaults to "IfNotPresent".
+  ##
+  imagePullPolicy: "IfNotPresent"
+
+  ## Specify the uninstall strategy of CDI resource,
+  ## select from [RemoveWorkloads, BlockUninstallIfWorkloadsExist],
+  ## defaults to "RemoveWorkloads".
+  ## -- If specifies to BlockUninstallIfWorkloadsExist, we cannot drop CDI CRD directly, we need to change this field to blank or RemoveWorkloads.
+  ##
+  uninstallStrategy: "RemoveWorkloads"

--- a/deploy/charts/harvester/charts/kubevirt-operator/.helmignore
+++ b/deploy/charts/harvester/charts/kubevirt-operator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/charts/harvester/charts/kubevirt-operator/Chart.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: kubevirt-operator
+version: 0.1.0
+appVersion: 0.30.x
+description: KubeVirt Operator provides deployment and management of KubeVirt bundle components.
+icon: https://kubevirt.io/assets/images/KubeVirt_logo_color.svg
+type: application
+keywords:
+  - kubevirt
+  - operator
+home: https://github.com/kubevirt/kubevirt
+sources:
+  - https://github.com/kubevirt/kubevirt
+maintainers:
+  - name: thxCode
+    email: frank@rancher.com

--- a/deploy/charts/harvester/charts/kubevirt-operator/LICENSE
+++ b/deploy/charts/harvester/charts/kubevirt-operator/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/deploy/charts/harvester/charts/kubevirt-operator/README.md
+++ b/deploy/charts/harvester/charts/kubevirt-operator/README.md
@@ -1,0 +1,58 @@
+# KubeVirt Operator Helm Chart
+
+KubeVirt Operator provides an easy way to deploy and manage the [KubeVirt](https://github.com/kubevirt/kubevirt) bundle components in Kubernetes.
+
+[KubeVirt repo](https://github.com/kubevirt/kubevirt) has already provided an all-in-one YAML for deploying [the KubeVirt Operator](https://github.com/kubevirt/kubevirt/blob/master/manifests/release/kubevirt-operator.yaml.in), but it is not flexible for configuring. This chart is going to supplement the all-in-one YAML and provide a way to deploy the KubeVirt Operator in air-gap environment.
+
+## Chart Details
+
+This chart will do the following:
+
+- Deploy the KubeVirt Operator.
+
+### Prerequisites
+
+- Kubernetes 1.16+.
+- Helm 3.2+.
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`.
+
+```bash
+$ # create target namespace
+$ kubectl create ns harvester-system
+
+$ # install chart to target namespace
+$ helm install my-release kubevirt-operator --namespace harvester-system
+```
+
+### Uninstalling the Chart
+
+To uninstall/delete the `my-release` release.
+
+```bash
+$ # uninstall chart from target namespace
+$ helm uninstall my-release --namespace harvester-system
+```
+
+### Configuration
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or `helm upgrade`.
+
+For details on using parameters, please refer to [values.yaml](values.yaml).
+
+## License
+Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/deploy/charts/harvester/charts/kubevirt-operator/crds/crd-kubevirt.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/crds/crd-kubevirt.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirts.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    categories:
+      - all
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+      - kv
+      - kvs
+    singular: kubevirt
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+      name: v1alpha3
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+  scope: Namespaced

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/NOTES.txt
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/NOTES.txt
@@ -1,0 +1,6 @@
+The KubeVirt Operator has been installed into "{{ .Release.Namespace }}" namespace with "{{ .Release.Name }}" as release name.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/_helpers.tpl
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "kubevirt-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "kubevirt-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubevirt-operator.chartref" -}}
+{{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end }}
+
+{{/*
+Generate immutable labels.
+We use the immutable labels to select low-level components(like the Deployment selects the Pods).
+*/}}
+{{- define "kubevirt-operator.immutableLabels" -}}
+helm.sh/release: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ template "kubevirt-operator.name" . }}
+{{- end }}
+
+{{/*
+Generate basic labels.
+*/}}
+{{- define "kubevirt-operator.labels" -}}
+app.kubernetes.io/managed-by: {{ default "helm" $.Release.Service | quote }}
+helm.sh/chart: {{ template "kubevirt-operator.chartref" . }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{ include "kubevirt-operator.immutableLabels" . }}
+{{- end }}

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/clusterrole.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/clusterrole.yaml
@@ -1,0 +1,542 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # NB(thxCode): we need to keep it as same as all-in-one YAML from upstream.
+  name: kubevirt.io:operator
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - kubevirts
+    verbs:
+      - get
+      - delete
+      - create
+      - update
+      - patch
+      - list
+      - watch
+      - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: kubevirt-operator
+  labels:
+{{ include "kubevirt-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: virt-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - kubevirts
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - services
+      - endpoints
+      - pods/exec
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - patch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - kubevirt-handler
+      - kubevirt-controller
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - delete
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+    verbs:
+      - put
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - delete
+      - patch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstancemigrations
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstancepresets
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - limitranges
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - update
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - update
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - k8s.cni.cncf.io
+    resources:
+      - network-attachment-definitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances
+    verbs:
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - version
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachineinstances/console
+      - virtualmachineinstances/vnc
+      - virtualmachineinstances/pause
+      - virtualmachineinstances/unpause
+    verbs:
+      - get
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+    verbs:
+      - update
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+      - virtualmachineinstancepresets
+      - virtualmachineinstancereplicasets
+      - virtualmachineinstancemigrations
+    verbs:
+      - get
+      - delete
+      - create
+      - update
+      - patch
+      - list
+      - watch
+      - deletecollection
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachineinstances/console
+      - virtualmachineinstances/vnc
+      - virtualmachineinstances/pause
+      - virtualmachineinstances/unpause
+    verbs:
+      - get
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+    verbs:
+      - update
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+      - virtualmachineinstancepresets
+      - virtualmachineinstancereplicasets
+      - virtualmachineinstancemigrations
+    verbs:
+      - get
+      - delete
+      - create
+      - update
+      - patch
+      - list
+      - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+      - virtualmachineinstancepresets
+      - virtualmachineinstancereplicasets
+      - virtualmachineinstancemigrations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - "snapshot.kubevirt.io"
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - "snapshot.storage.k8s.io"
+    resources:
+      - volumesnapshotclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "snapshot.storage.k8s.io"
+    resources:
+      - volumesnapshots
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/clusterrolebinding.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: kubevirt-operator
+  labels:
+{{ include "kubevirt-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: virt-operator
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: kubevirt-operator
+subjects:
+  - kind: ServiceAccount
+    # NB(thxCode): name should not be customized as below:
+    # name: {{ template "kubevirt-operator.fullname" . }}
+    # because we need to keep it as same as all-in-one YAML from upstream.
+    name: kubevirt-operator
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/deployment.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: virt-operator
+  labels:
+{{ include "kubevirt-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: virt-operator
+    app.kubernetes.io/component: operator
+spec:
+  selector:
+    matchLabels:
+{{ include "kubevirt-operator.immutableLabels" . | indent 6 }}
+      app.kubernetes.io/name: virt-operator
+      app.kubernetes.io/component: operator
+      kubevirt.io: virt-operator
+{{- if .Values.replicas }}
+  replicas: {{ .Values.replicas }}
+{{- end }}
+{{- if .Values.strategy }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+{{- end }}
+  template:
+    metadata:
+      labels:
+{{ include "kubevirt-operator.labels" . | indent 8 }}
+        app.kubernetes.io/name: virt-operator
+        app.kubernetes.io/component: operator
+        kubevirt.io: virt-operator
+        prometheus.kubevirt.io: ""
+    spec:
+      priorityClassName: kubevirt-cluster-critical
+      serviceAccountName: kubevirt-operator
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: kubevirt.io
+                      operator: In
+                      values:
+                        - virt-operator
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - name: virt-operator
+          image: {{ .Values.containers.operator.image.repository }}:{{ .Values.containers.operator.image.tag }}
+          imagePullPolicy: {{ .Values.containers.operator.image.imagePullPolicy }}
+{{- if .Values.containers.operator.command }}
+          command:
+{{ toYaml .Values.containers.operator.command | indent 12 }}
+{{- end }}
+{{- if .Values.containers.operator.args }}
+          args:
+{{ toYaml .Values.containers.operator.args | indent 12 }}
+{{- end }}
+          env:
+{{- if .Values.containers.operator.env }}
+{{ toYaml .Values.containers.operator.env | indent 12 }}
+{{- end }}
+            - name: OPERATOR_IMAGE
+              value: {{ .Values.containers.operator.image.repository }}:{{ .Values.containers.operator.image.tag }}
+          ports:
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            - containerPort: 8444
+              name: webhooks
+              protocol: TCP
+{{- if .Values.containers.operator.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.containers.operator.livenessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.containers.operator.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.containers.operator.readinessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.containers.operator.resources }}
+          resources:
+{{ toYaml .Values.containers.operator.resources | indent 12 }}
+{{- end }}
+          volumeMounts:
+            - mountPath: /etc/virt-operator/certificates
+              name: kubevirt-operator-certs
+              readOnly: true
+{{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+      volumes:
+        - name: kubevirt-operator-certs
+          secret:
+            optional: true
+            secretName: {{ .Values.containers.operator.certificates.admissionWebhook.secretName }}

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/priorityclass.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/priorityclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because the installation strategy dump action needs this PriorityClass.
+  name: kubevirt-cluster-critical
+  labels:
+{{ include "kubevirt-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: virt-operator
+    app.kubernetes.io/component: operator
+value: 1000000000
+globalDefault: false
+description: "This priority class should be used for core kubevirt components only."

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/role.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/role.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: kubevirt-operator
+  labels:
+{{ include "kubevirt-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: virt-operator
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - delete

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/rolebinding.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/rolebinding.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: kubevirt-operator
+  labels:
+{{ include "kubevirt-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: virt-operator
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because we need to keep it as same as all-in-one YAML from upstream.
+  name: kubevirt-operator
+subjects:
+  - kind: ServiceAccount
+    # NB(thxCode): name should not be customized as below:
+    # name: {{ template "kubevirt-operator.fullname" . }}
+    # because we need to keep it as same as all-in-one YAML from upstream.
+    name: kubevirt-operator
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/harvester/charts/kubevirt-operator/templates/serviceaccount.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # NB(thxCode): name cannot be customized as below:
+  # name: {{ template "kubevirt-operator.fullname" . }}
+  # because the installation strategy dump action needs this ServiceAccount.
+  name: kubevirt-operator
+  labels:
+{{ include "kubevirt-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: virt-operator
+    app.kubernetes.io/component: operator

--- a/deploy/charts/harvester/charts/kubevirt-operator/values.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/values.yaml
@@ -1,0 +1,126 @@
+###########################################################################
+###########################################################################
+##                   Default values for KubeVirt Operator                ##
+###########################################################################
+###########################################################################
+
+## Provide a name in place of labels.
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources.
+##
+fullnameOverride: ""
+
+## Specify the replicas of workload.
+##
+replicas: 1
+
+## Specify the security context of workload.
+##
+securityContext:
+  runAsNonRoot: true
+
+## Specify the node selector of workload.
+##
+nodeSelector: {}
+
+## Specify the tolerations of workload.
+##
+tolerations: []
+#  - key: CriticalAddonsOnly
+#    operator: Exists
+
+## Specify the update strategy of workload.
+##
+strategy:
+  type: RollingUpdate
+
+## Specify the parameter of containers.
+##
+containers:
+
+  ## Specify the parameter of kubevirt-operator container.
+  ##
+  operator:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the pull policy of image.
+      ##
+      imagePullPolicy: Always
+
+      ## Specify the repository of image.
+      ##
+      repository: kubevirt/virt-operator
+
+      ## Specify the tag of image.
+      ##
+      tag: latest
+
+    ## Specify the command.
+    ##
+    command:
+      - virt-operator
+      - --port
+      - "8443"
+      - -v
+      - "2"
+
+    ## Specify the args.
+    ##
+    args: []
+
+    ## Specify the env.
+    ##
+    env: []
+    #  - name: OPERATOR_IMAGE
+    #    value: xxx
+
+    ## Specify the liveness probe.
+    ##
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: 8443
+        scheme: HTTPS
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 10
+
+    ## Specify the readiness probe.
+    ##
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: 8443
+        scheme: HTTPS
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 10
+
+    ## Specify the resources.
+    ##
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+
+    ## Specify the certificate.
+    ##
+    certificates:
+
+      ## For admission webhook.
+      ##
+      admissionWebhook:
+
+        ## Specify the name of the same namespace existing Secret instance,
+        ## which stored the admission webhook certificate of KubeVirt Operator.
+        ##
+        secretName: "kubevirt-operator-certs"
+        ## TODO should we support to inject certificate from values?

--- a/deploy/charts/harvester/charts/kubevirt/.helmignore
+++ b/deploy/charts/harvester/charts/kubevirt/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/charts/harvester/charts/kubevirt/Chart.yaml
+++ b/deploy/charts/harvester/charts/kubevirt/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: kubevirt
+version: 0.1.0
+appVersion: v1alpha3
+description: KubeVirt creates a KubeVirt CRD instance into target Namespace.
+icon: https://kubevirt.io/assets/images/KubeVirt_logo_color.svg
+type: application
+keywords:
+  - kubevirt
+  - crd
+home: https://github.com/kubevirt/kubevirt
+sources:
+  - https://github.com/kubevirt/kubevirt
+maintainers:
+  - name: thxCode
+    email: frank@rancher.com

--- a/deploy/charts/harvester/charts/kubevirt/LICENSE
+++ b/deploy/charts/harvester/charts/kubevirt/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/deploy/charts/harvester/charts/kubevirt/README.md
+++ b/deploy/charts/harvester/charts/kubevirt/README.md
@@ -1,0 +1,61 @@
+# KubeVirt Helm Chart
+
+[`KubeVirt`](https://github.com/kubevirt/kubevirt/blob/6f3f5b489a72c12bef026d6c2c3c90fcc63edbe8/staging/src/kubevirt.io/client-go/api/v1/types.go#L1058-L1067) CRD declaratively defines a desired [KubeVirt](https://github.com/kubevirt/kubevirt) setup to run in a Kubernetes cluster. It provides options to configure KubeVirt bundle components to deploy.
+
+For each `KubeVirt` CRD resource, the [KubeVirt Operator](../kubevirt-operator) deploys the corresponding bundle components in the same Namespace, like [virt-api](https://github.com/kubevirt/kubevirt/tree/master/cmd/virt-api) Deployment, [virt-controller](https://github.com/kubevirt/kubevirt/tree/master/cmd/virt-controller) Deployment and [virt-handler](https://github.com/kubevirt/kubevirt/tree/master/cmd/virt-handler) Deamonset, at the same time, some required CRDs will be created, like [`VirtualMachine`](https://github.com/kubevirt/kubevirt/blob/6f3f5b489a72c12bef026d6c2c3c90fcc63edbe8/staging/src/kubevirt.io/client-go/api/v1/types.go#L817-L833), [`VirtualMachineInstance`](https://github.com/kubevirt/kubevirt/blob/6f3f5b489a72c12bef026d6c2c3c90fcc63edbe8/staging/src/kubevirt.io/client-go/api/v1/types.go#L46-L57) and so on.
+
+The current configuration management of KubeVirt Operator for `KubeVirt` resource has some limitations as below:
+
+- `KubeVirt` resource should deploy into the **same Namespace** as KubeVirt Operator.
+- Only the first deployed one in multiple `KubeVirt` resources is valid.
+
+## Chart Details
+
+This chart will do the following:
+
+- Deploy a `KubeVirt` CRD resource named `kubevirt`.
+
+### Prerequisites
+
+- Kubernetes 1.16+.
+- Helm 3.2+.
+- KubeVirt Operator v0.30.5+.
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`.
+
+```bash
+$ # install chart to target namespace installed kubevirt-operator, i.e: harvester-system
+$ helm install my-release kubevirt --namespace harvester-system
+```
+
+### Uninstalling the Chart
+
+To uninstall/delete the `my-release` release.
+
+```bash
+$ # uninstall chart from target namespace
+$ helm uninstall my-release --namespace harvester-system
+```
+
+### Configuration
+
+It is worth noting that almost all parameters are string type, including bool field and numeric field, please use `--set-string key=value[,key=value]` to indicate. However, for array parameter, please keep using `--set`. 
+
+For details on using parameters, please refer to [values.yaml](values.yaml).
+
+## License
+Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/deploy/charts/harvester/charts/kubevirt/templates/NOTES.txt
+++ b/deploy/charts/harvester/charts/kubevirt/templates/NOTES.txt
@@ -1,0 +1,6 @@
+The KubeVirt has been installed into "{{ .Release.Namespace }}" namespace with "{{ .Release.Name }}" as release name.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/deploy/charts/harvester/charts/kubevirt/templates/_helpers.tpl
+++ b/deploy/charts/harvester/charts/kubevirt/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "kubevirt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "kubevirt.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubevirt.chartref" -}}
+{{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end }}
+
+{{/*
+Generate immutable labels.
+We use the immutable labels to select low-level components(like the Deployment selects the Pods).
+*/}}
+{{- define "kubevirt.immutableLabels" -}}
+helm.sh/release: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ template "kubevirt.name" . }}
+{{- end }}
+
+{{/*
+Generate basic labels.
+*/}}
+{{- define "kubevirt.labels" -}}
+app.kubernetes.io/managed-by: {{ default "helm" $.Release.Service | quote }}
+helm.sh/chart: {{ template "kubevirt.chartref" . }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{ include "kubevirt.immutableLabels" . }}
+{{- end }}

--- a/deploy/charts/harvester/charts/kubevirt/templates/kubevirt.yaml
+++ b/deploy/charts/harvester/charts/kubevirt/templates/kubevirt.yaml
@@ -1,0 +1,17 @@
+# NB(thxCode): the api version controls by the app version specification of Chart.yaml.
+apiVersion: {{ printf "kubevirt.io/%s" .Chart.AppVersion }}
+kind: KubeVirt
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "kubevirt.fullname" . }}
+  # because multiple KubeVirt resources are useless,
+  # only the first instance will be deployed.
+  name: kubevirt
+  labels:
+{{ include "kubevirt.labels" . | indent 4 }}
+    app.kubernetes.io/name: kubevirt
+    app.kubernetes.io/component: metadata
+spec:
+{{- if .Values.spec }}
+{{ toYaml .Values.spec | indent 2 }}
+{{- end }}

--- a/deploy/charts/harvester/charts/kubevirt/values.yaml
+++ b/deploy/charts/harvester/charts/kubevirt/values.yaml
@@ -1,0 +1,246 @@
+###########################################################################
+###########################################################################
+##                     Default values for KubeVirt CR                    ##
+###########################################################################
+###########################################################################
+
+## Provide a name in place of labels.
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources.
+##
+fullnameOverride: ""
+
+## Specify the specification of KubeVirt resource.
+##
+spec:
+
+  ## Specify the image tag of KubeVirt bundle components,
+  ## defaults to the same tag as the operator image.
+  ##
+  # imageTag: ""
+
+  ## Specify the image registry of KubeVirt bundle components,
+  ## defaults to the same registry as the operator image.
+  ##
+  # imageRegistry: ""
+
+  ## Specify the image pull policy of KubeVirt bundle components,
+  ## defaults to "IfNotPresent".
+  ##
+  imagePullPolicy: "IfNotPresent"
+
+  ## Specify the namespace Prometheus is deployed in OpenShift,
+  ## defaults to "openshift-monitor".
+  ##
+  # monitorNamespace: "openshift-monitor"
+
+  ## Specify the name of the Prometheus service account that needs read-access to KubeVirt endpoints in OpenShift,
+  ## defaults to "prometheus-k8s".
+  # monitorAccount: "prometheus-k8s"
+
+  ## Specify the uninstall strategy of KubeVirt resource,
+  ## select from [RemoveWorkloads, BlockUninstallIfWorkloadsExist],
+  ## defaults to "RemoveWorkloads".
+  ## -- If specifies to BlockUninstallIfWorkloadsExist, we cannot drop KubeVirt CRD directly, we need to change this field to blank or RemoveWorkloads.
+  ##
+  uninstallStrategy: "RemoveWorkloads"
+
+  ## Specify the strategy of KubeVrit bundle components certificate rotation.
+  ##
+  certificateRotateStrategy:
+
+    ## Specify the configuration of self signed certificate.
+    ##
+    selfSigned:
+
+      ## Specify the interval of CA rotation,
+      ## defaults to "168h", 7d.
+      ##
+      caRotateInterval: "168h"
+
+      ## Specify the interval of Certificate rotation,
+      ## defaults to "24h", 1d.
+      ##
+      certRotateInterval: "24h"
+
+      ## Specify the interval of CA overlap,
+      ## defaults to "24h", 1d.
+      caOverlapInterval: "24h"
+
+  ## Specify the default configuration of KubeVirt virtual machine.
+  ##
+  configuration:
+
+    ## Specify the directory that contains the EFI roms,
+    ## this argument will be passed to "virt-launcher" as "--ovmf-path",
+    ## defaults to "/usr/share/OVMF".
+    ##
+    ovmfPath: "/usr/share/OVMF"
+
+    ## Specify the SELinux type, this argument will fill into `spec.securityContext.selinuxOptions.type` of the generated Pod for "virt-launcher",
+    ## and also fill into `spec.containers[?(.name!=compute)].securityContext.selinuxOptions.type` and `spec.containers[?(.name!=compute)].securityContext.selinuxOptions.level=s0`.
+    ##
+    selinuxLauncherType: ""
+
+    ## Specify the version regex of guest agent, which is used for processing the Condition(AgentVersionNotSupported) of VirtualMachineInstance,
+    ## defaults to "[3.*, 4.*]".
+    #
+    supportedGuestAgentVersions:
+      - "3.*"
+      - "4.*"
+
+    ## Specify the default CPU model of VirtualMachineInstance, selects from https://github.com/libvirt/libvirt/tree/master/src/cpu_map,
+    ## defaults to "host-model".
+    ##
+    cpuModel: "host-model"
+
+    ## Specify the default CPU request of VirtualMachineInstance(`spec.domain.requests.cpu`),
+    ## defaults to "100m"
+    ##
+    # cpuRequest: "100m"
+
+    ## Specify the machine type regex for validating the emulation of VirtualMachineInstance,
+    ## defaults to discover automatically, "pseries*" if arch is ppc64le, otherwise "q35*,pc-q35*".
+    ##
+    emulatedMachines: []
+
+    ## Specify the machine type for filling VirtualMachineInstance(`spec.domain.machine.type`),
+    ## defaults to discover automatically, "pseries" if arch is ppc64le, otherwise "q35".
+    ##
+    machineType: ""
+
+    ## Specify the virtual machine image pull policy of `virt-launcher` Pod,
+    ## defaults to "IfNotPresent".
+    ##
+    imagePullPolicy: "IfNotPresent"
+
+    ## Specify the developer configuration of KubeVirt.
+    ##
+    developerConfiguration:
+
+      ## Specify whether an optional feature is enabled or not at the global level,
+      ## select many from [CPUManager, ExperimentalIgnitionSupport, LiveMigration, CPUNodeDiscovery, HypervStrictCheck, Sidecar, GPU, Snapshot, HostDisk], ref to:
+      ## https://github.com/kubevirt/kubevirt/blob/f5ffba5f84365155c81d0e2cda4aa709da062230/pkg/virt-config/feature-gates.go#L26-L36.
+      ##
+      featureGates: []
+
+      ## Specify the toleration in percent when PVs' available space is smaller than requested,
+      ## this argument will be passed to "virt-launcher" as "--less-pvc-space-toleration",
+      ## defaults to "10" percent.
+      ##
+      pvcTolerateLessSpaceUpToPercont: "10"
+
+      ## Specify the memory overcommit in percent,
+      ## which will effect VirtualMachineInstance(`spec.domain.resources.memory`),
+      ## defaults to "100" percent, which means 100% to overcommit the memory.
+      ##
+      memoryOvercommit: "100"
+
+      ## Specify the selector of VirtualMachineInstance(`spec.nodeSelector`), it can override the same key defined in origin.
+      ## -- When enabling "CPUNodeDiscovery" feature, `feature.node.kubernetes.io/cpu-model-<model-specified-in-crd>=true` will attach to here if `spec.domain.cpu.model` is not blank, except "host-model" and "host-passthourgh".
+      ##    And then, `feature.node.kubernetes.io/cpu-feature-<feature-name-specified-in-crd>=true` if `spec.domain.cpu.features` is not empty and the policy of feature is "require".
+      ## -- When enabling "HypervStrictCheck" feature, `feature.node.kubernetes.io/kvm-info-cap-hyperv-<feature-label-name-specified-in-crd>=true` will attach to here if `spec.domain.cpu.hyperv` is not empty.
+      ## -- `kubevirt.io/schedulable=true` must attach to here.
+      ##
+      nodeSelector: {}
+
+      ## Specify if uses eumlation,
+      ## this argument will be passed to "virt-launcher" as "--use-eumlation",
+      ## defaults to "false".
+      ## -- `devices.kubevirt.io/kvm=1` will attach to `resources.limits` if here is "false".
+      ##
+      useEmulation: "false"
+
+    ## Specify the migration configuration of KubeVirt.
+    ##
+    migrations:
+
+      ## Specify if allows to converge automatically,
+      ## defaults to "false"
+      ##
+      allowAutoConverge: "false"
+
+      ## Specify the bandwidth per migration,
+      ## defaults to "64Mi"
+      ##
+      bandwidthPerMigration: "64Mi"
+
+      ## Specify the timeout for completing each GB migration,
+      ## defaults to "800".
+      ##
+      completionTimeoutPerGiB: "800"
+
+      ## Specify the label of node,
+      ## defaults to "kubevirt.io/drain".
+      ##
+      nodeDrainTaintKey: "kubevirt.io/drain"
+
+      ## Specify the amount of outbound migrations of parallels per node,
+      ## defaults to "2".
+      ##
+      parallelOutboundMigrationsPerNode: "2"
+
+      ## Specify the amount of migrations of parallels per cluster,
+      ## defaults to "5".
+      ##
+      parallelMigrationsPerCluster: "5"
+
+      ## Specify the timeout of progress,
+      ## defaults to "150".
+      ##
+      progressTimeout: "150"
+
+      ## Specify if overrides unsafe migration,
+      ## defaults to "false".
+      ##
+      unsafeMigrationOverride: "false"
+
+    ## Specify the network configuration of VirtualMachineInstance.
+    ##
+    network:
+
+      ## Specify the default network interface of VirtualMachineInstance(`spec.domain.devices.interfaces[?(.name="default")]`),
+      ## defaults to "bridge".
+      ##
+      defaultNetworkInterface: "bridge"
+
+      ## Specify to permit slirp interface,
+      ## defaults to "false".
+      ## -- If the `defaultNetworkInterface` is "slirp", here must specify to "true".
+      ##
+      permitSlirpInterface: "false"
+
+      ## Specify to permit bridge interface,
+      ## defaults to "true".
+      ## -- If the `defaultNetworkInterface` is "bridge", here must specify to "true".
+      ##
+      permitBridgeInterfaceOnPodNetwork: "true"
+
+    ## Specify the SMBIOS which should pass to "libvirt".
+    ##
+    smbios:
+
+      ## Specify the manufacturer,
+      ## defaults to "KubeVirt".
+      ##
+      manufacturer: "KubVirt"
+
+      ## Specify the product,
+      ## defaults to "None".
+      ##
+      product: "None"
+
+      ## Specify the version.
+      ##
+      version: ""
+
+      ## Specify the SKU.
+      ##
+      sku: ""
+
+      ## Specify the family,
+      ## defaults to "KubeVirt".
+      ##
+      family: "KubeVirt"

--- a/deploy/charts/harvester/charts/minio/.helmignore
+++ b/deploy/charts/harvester/charts/minio/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/deploy/charts/harvester/charts/minio/Chart.yaml
+++ b/deploy/charts/harvester/charts/minio/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+appVersion: master
+description: High Performance, Kubernetes Native Object Storage
+home: https://min.io
+icon: https://min.io/resources/img/logo/MINIO_wordmark.png
+keywords:
+- storage
+- object-storage
+- S3
+maintainers:
+- email: dev@minio.io
+  name: Minio
+name: minio
+sources:
+- https://github.com/minio/minio
+version: 6.0.4

--- a/deploy/charts/harvester/charts/minio/README.md
+++ b/deploy/charts/harvester/charts/minio/README.md
@@ -1,0 +1,373 @@
+MinIO
+=====
+
+[MinIO](https://min.io) is a High Performance Object Storage released under Apache License v2.0. It is API compatible with Amazon S3 cloud storage service. Use MinIO to build high performance infrastructure for machine learning, analytics and application data workloads.
+
+MinIO supports [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide). In distributed mode, you can pool multiple drives (even on different machines) into a single object storage server.
+
+For more detailed documentation please visit [here](https://docs.minio.io/)
+
+Introduction
+------------
+
+This chart bootstraps MinIO deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Prerequisites
+-------------
+
+- Kubernetes 1.4+ with Beta APIs enabled for default standalone mode.
+- Kubernetes 1.5+ with Beta APIs enabled to run MinIO in [distributed mode](#distributed-minio).
+- PV provisioner support in the underlying infrastructure.
+
+Configure MinIO Helm repo
+--------------------
+```bash
+$ helm repo add minio https://helm.min.io/
+```
+
+Installing the Chart
+--------------------
+
+Install this chart using:
+
+```bash
+$ helm install --namespace minio --generate-name minio/minio
+```
+
+The command deploys MinIO on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Release name
+
+An instance of a chart running in a Kubernetes cluster is called a release. Each release is identified by a unique name within the cluster. Helm automatically assigns a unique release name after installing the chart. You can also set your preferred name by:
+
+```bash
+$ helm install my-release minio/minio
+```
+
+### Access and Secret keys
+
+By default a pre-generated access and secret key will be used. To override the default keys, pass the access and secret keys as arguments to helm install.
+
+```bash
+$ helm install --set accessKey=myaccesskey,secretKey=mysecretkey --generate-name minio/minio
+```
+
+### Updating MinIO configuration via Helm
+
+[ConfigMap](https://kubernetes.io/docs/user-guide/configmap/) allows injecting containers with configuration data even while a Helm release is deployed.
+
+To update your MinIO server configuration while it is deployed in a release, you need to
+
+1. Check all the configurable values in the MinIO chart using `helm inspect values minio/minio`.
+2. Override the `minio_server_config` settings in a YAML formatted file, and then pass that file like this `helm upgrade -f config.yaml minio/minio`.
+3. Restart the MinIO server(s) for the changes to take effect.
+
+You can also check the history of upgrades to a release using `helm history my-release`. Replace `my-release` with the actual release name.
+
+Uninstalling the Chart
+----------------------
+
+Assuming your release is named as `my-release`, delete it using the command:
+
+```bash
+$ helm delete my-release
+```
+
+or
+
+```bash
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+Upgrading the Chart
+-------------------
+
+You can use Helm to update MinIO version in a live release. Assuming your release is named as `my-release`, get the values using the command:
+
+```bash
+$ helm get values my-release > old_values.yaml
+```
+
+Then change the field `image.tag` in `old_values.yaml` file with MinIO image tag you want to use. Now update the chart using
+
+```bash
+$ helm upgrade -f old_values.yaml my-release minio/minio
+```
+
+Default upgrade strategies are specified in the `values.yaml` file. Update these fields if you'd like to use a different strategy.
+
+Configuration
+-------------
+
+The following table lists the configurable parameters of the MinIO chart and their default values.
+
+| Parameter                                 | Description                                                                                                                             | Default                          |
+|:------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------|
+| `nameOverride`                            | Provide a name in place of `minio`                                                                                                      | `""`                             |
+| `fullnameOverride`                        | Provide a name to substitute for the full names of resources                                                                            | `""`                             |
+| `image.repository`                        | Image repository                                                                                                                        | `minio/minio`                    |
+| `image.tag`                               | MinIO image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).                                             | `RELEASE.2020-08-08T04-50-06Z`   |
+| `image.pullPolicy`                        | Image pull policy                                                                                                                       | `IfNotPresent`                   |
+| `imagePullSecrets`                        | List of container registry secrets                                                                                                      | `[]`                             |
+| `mcImage.repository`                      | Client image repository                                                                                                                 | `minio/mc`                       |
+| `mcImage.tag`                             | mc image tag. Possible values listed [here](https://hub.docker.com/r/minio/mc/tags/).                                                   | `RELEASE.2020-08-08T02-33-58Z`   |
+| `mcImage.pullPolicy`                      | mc Image pull policy                                                                                                                    | `IfNotPresent`                   |
+| `ingress.enabled`                         | Enables Ingress                                                                                                                         | `false`                          |
+| `ingress.labels     `                     | Ingress labels                                                                                                                          | `{}`                             |
+| `ingress.annotations`                     | Ingress annotations                                                                                                                     | `{}`                             |
+| `ingress.hosts`                           | Ingress accepted hostnames                                                                                                              | `[]`                             |
+| `ingress.tls`                             | Ingress TLS configuration                                                                                                               | `[]`                             |
+| `mode`                                    | MinIO server mode (`standalone` or `distributed`)                                                                                       | `standalone`                     |
+| `extraArgs`                               | Additional command line arguments to pass to the MinIO server                                                                           | `[]`                             |
+| `replicas`                                | Number of nodes (applicable only for MinIO distributed mode).                                                                           | `4`                              |
+| `zones`                                   | Number of zones (applicable only for MinIO distributed mode).                                                                           | `1`                              |
+| `drivesPerNode`                           | Number of drives per node (applicable only for MinIO distributed mode).                                                                 | `1`                              |
+| `existingSecret`                          | Name of existing secret with access and secret key.                                                                                     | `""`                             |
+| `accessKey`                               | Default access key (5 to 20 characters)                                                                                                 | `YOURACCESSKEY`                  |
+| `secretKey`                               | Default secret key (8 to 40 characters)                                                                                                 | `YOURSECRETKEY`                  |
+| `certsPath`                               | Default certs path location                                                                                                             | `/etc/minio/certs`               |
+| `configPathmc`                            | Default config file location for MinIO client - mc                                                                                      | `/etc/minio/mc`                  |
+| `mountPath`                               | Default mount location for persistent drive                                                                                             | `/export`                        |
+| `bucketRoot`                              | Directory from where minio should serve buckets.                                                                                        | Value of `.mountPath`            |
+| `clusterDomain`                           | domain name of kubernetes cluster where pod is running.                                                                                 | `cluster.local`                  |
+| `service.type`                            | Kubernetes service type                                                                                                                 | `ClusterIP`                      |
+| `service.port`                            | Kubernetes port where service is exposed                                                                                                | `9000`                           |
+| `service.externalIPs`                     | service external IP addresses                                                                                                           | `nil`                            |
+| `service.annotations`                     | Service annotations                                                                                                                     | `{}`                             |
+| `serviceAccount.create`                   | Toggle creation of new service account                                                                                                  | `true`                           |
+| `serviceAccount.name`                     | Name of service account to create and/or use                                                                                            | `""`                             |
+| `persistence.enabled`                     | Use persistent volume to store data                                                                                                     | `true`                           |
+| `persistence.size`                        | Size of persistent volume claim                                                                                                         | `500Gi`                          |
+| `persistence.existingClaim`               | Use an existing PVC to persist data                                                                                                     | `nil`                            |
+| `persistence.storageClass`                | Storage class name of PVC                                                                                                               | `nil`                            |
+| `persistence.accessMode`                  | ReadWriteOnce or ReadOnly                                                                                                               | `ReadWriteOnce`                  |
+| `persistence.subPath`                     | Mount a sub directory of the persistent volume if set                                                                                   | `""`                             |
+| `resources`                               | Memory resource requests                                                                                                                | Memory: `4Gi`                    |
+| `priorityClassName`                       | Pod priority settings                                                                                                                   | `""`                             |
+| `securityContext.enabled`                 | Enable to run containers as non-root. NOTE: if `persistence.enabled=false` then securityContext will be automatically disabled          | `true`                           |
+| `securityContext.runAsUser`               | User id of the user for the container                                                                                                   | `1000`                           |
+| `securityContext.runAsGroup`              | Group id of the user for the container                                                                                                  | `1000`                           |
+| `securityContext.fsGroup`                 | Group id of the persistent volume mount for the container                                                                               | `1000`                           |
+| `nodeSelector`                            | Node labels for pod assignment                                                                                                          | `{}`                             |
+| `affinity`                                | Affinity settings for pod assignment                                                                                                    | `{}`                             |
+| `tolerations`                             | Toleration labels for pod assignment                                                                                                    | `[]`                             |
+| `podAnnotations`                          | Pod annotations                                                                                                                         | `{}`                             |
+| `podLabels`                               | Pod Labels                                                                                                                              | `{}`                             |
+| `tls.enabled`                             | Enable TLS for MinIO server                                                                                                             | `false`                          |
+| `tls.certSecret`                          | Kubernetes Secret with `public.crt` and `private.key` files.                                                                            | `""`                             |
+| `livenessProbe.initialDelaySeconds`       | Delay before liveness probe is initiated                                                                                                | `5`                              |
+| `livenessProbe.periodSeconds`             | How often to perform the probe                                                                                                          | `5`                              |
+| `livenessProbe.timeoutSeconds`            | When the probe times out                                                                                                                | `1`                              |
+| `livenessProbe.successThreshold`          | Minimum consecutive successes for the probe to be considered successful after having failed.                                            | `1`                              |
+| `livenessProbe.failureThreshold`          | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                              | `1`                              |
+| `defaultBucket.enabled`                   | If set to true, a bucket will be created after MinIO install                                                                            | `false`                          |
+| `defaultBucket.name`                      | Bucket name                                                                                                                             | `bucket`                         |
+| `defaultBucket.policy`                    | Bucket policy                                                                                                                           | `none`                           |
+| `defaultBucket.purge`                     | Purge the bucket if already exists                                                                                                      | `false`                          |
+| `buckets`                                 | List of buckets to create after MinIO install                                                                                           | `[]`                             |
+| `makeBucketJob.annotations`               | Additional annotations for the Kubernetes Batch (make-bucket-job)                                                                       | `""`                             |
+| `s3gateway.enabled`                       | Use MinIO as a [s3 gateway](https://github.com/minio/minio/blob/master/docs/gateway/s3.md)                                              | `false`                          |
+| `s3gateway.replicas`                      | Number of s3 gateway instances to run in parallel                                                                                       | `4`                              |
+| `s3gateway.serviceEndpoint`               | Endpoint to the S3 compatible service                                                                                                   | `""`                             |
+| `s3gateway.accessKey`                     | Access key of S3 compatible service                                                                                                     | `""`                             |
+| `s3gateway.secretKey`                     | Secret key of S3 compatible service                                                                                                     | `""`                             |
+| `azuregateway.enabled`                    | Use MinIO as an [azure gateway](https://docs.minio.io/docs/minio-gateway-for-azure)                                                     | `false`                          |
+| `azuregateway.replicas`                   | Number of azure gateway instances to run in parallel                                                                                    | `4`                              |
+| `gcsgateway.enabled`                      | Use MinIO as a [Google Cloud Storage gateway](https://docs.minio.io/docs/minio-gateway-for-gcs)                                         | `false`                          |
+| `gcsgateway.gcsKeyJson`                   | credential json file of service account key                                                                                             | `""`                             |
+| `gcsgateway.projectId`                    | Google cloud project id                                                                                                                 | `""`                             |
+| `ossgateway.enabled`                      | Use MinIO as an [Alibaba Cloud Object Storage Service gateway](https://github.com/minio/minio/blob/master/docs/gateway/oss.md)          | `false`                          |
+| `ossgateway.replicas`                     | Number of oss gateway instances to run in parallel                                                                                      | `4`                              |
+| `ossgateway.endpointURL`                  | OSS server endpoint.                                                                                                                    | `""`                             |
+| `nasgateway.enabled`                      | Use MinIO as a [NAS gateway](https://docs.MinIO.io/docs/minio-gateway-for-nas)                                                          | `false`                          |
+| `nasgateway.replicas`                     | Number of NAS gateway instances to be run in parallel on a PV                                                                           | `4`                              |
+| `b2gateway.enabled`                       | Use MinIO as a [Backblaze B2 gateway](https://github.com/minio/minio/blob/master/docs/gateway/b2.md)                                    | `false`                          |
+| `b2gateway.replicas`                      | Number of b2 gateway instances to run in parallel                                                                                       | `4`                              |
+| `environment`                             | Set MinIO server relevant environment variables in `values.yaml` file. MinIO containers will be passed these variables when they start. | `MINIO_API_READY_DEADLINE: "5s"` |
+| `metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                                                                     | `false`                          |
+| `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                                   | `{}`                             |
+| `metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonitor                                                                                    | `nil`                            |
+| `metrics.serviceMonitor.interval`         | Scrape interval. If not set, the Prometheus default scrape interval is used                                                             | `nil`                            |
+| `metrics.serviceMonitor.scrapeTimeout`    | Scrape timeout. If not set, the Prometheus default scrape timeout is used                                                               | `nil`                            |
+| `etcd.endpoints`                          | Enpoints of etcd                                                                                                                        | `[]`                             |
+| `etcd.pathPrefix`                         | Prefix for all etcd keys                                                                                                                | `""`                             |
+| `etcd.corednsPathPrefix`                  | Prefix for all CoreDNS etcd keys                                                                                                        | `""`                             |
+| `etcd.clientCert`                         | Certificate used for SSL/TLS connections to etcd [(etcd Security)](https://etcd.io/docs/latest/op-guide/security/)                      | `""`                             |
+| `etcd.clientCertKey`                      | Key for the certificate [(etcd Security)](https://etcd.io/docs/latest/op-guide/security/)                                               | `""`                             |
+
+Some of the parameters above map to the env variables defined in the [MinIO DockerHub image](https://hub.docker.com/r/minio/minio/).
+
+You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release --set persistence.size=1Ti minio/minio
+```
+
+The above command deploys MinIO server with a 100Gi backing persistent volume.
+
+Alternately, you can provide a YAML file that specifies parameter values while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml minio/minio
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+Distributed MinIO
+-----------
+
+This chart provisions a MinIO server in standalone mode, by default. To provision MinIO server in [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide), set the `mode` field to `distributed`,
+
+```bash
+$ helm install --set mode=distributed minio/minio
+```
+
+This provisions MinIO server in distributed mode with 4 nodes. To change the number of nodes in your distributed MinIO server, set the `replicas` field,
+
+```bash
+$ helm install --set mode=distributed,replicas=8 minio/minio
+```
+
+This provisions MinIO server in distributed mode with 8 nodes. Note that the `replicas` value should be a minimum value of 4, there is no limit on number of servers you can run.
+
+You can also expand an existing deployment by adding new zones, following command will create a total of 16 nodes with each zone running 8 nodes.
+
+```bash
+$ helm install --set mode=distributed,replicas=8,zones=2 minio/minio
+```
+
+### StatefulSet [limitations](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations) applicable to distributed MinIO
+
+1. StatefulSets need persistent storage, so the `persistence.enabled` flag is ignored when `mode` is set to `distributed`.
+2. When uninstalling a distributed MinIO release, you'll need to manually delete volumes associated with the StatefulSet.
+
+NAS Gateway
+-----------
+
+### Prerequisites
+
+MinIO in [NAS gateway mode](https://docs.minio.io/docs/minio-gateway-for-nas) can be used to create multiple MinIO instances backed by single PV in `ReadWriteMany` mode. Currently few [Kubernetes volume plugins](https://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes) support `ReadWriteMany` mode. To deploy MinIO NAS gateway with Helm chart you'll need to have a Persistent Volume running with one of the supported volume plugins. [This document](https://kubernetes.io/docs/user-guide/volumes/#nfs)
+outlines steps to create a NFS PV in Kubernetes cluster.
+
+### Provision NAS Gateway MinIO instances
+
+To provision MinIO servers in [NAS gateway mode](https://docs.minio.io/docs/minio-gateway-for-nas), set the `nasgateway.enabled` field to `true`,
+
+```bash
+$ helm install --set nasgateway.enabled=true minio/minio
+```
+
+This provisions 4 MinIO NAS gateway instances backed by single storage. To change the number of instances in your MinIO deployment, set the `replicas` field,
+
+```bash
+$ helm install --set nasgateway.enabled=true,nasgateway.replicas=8 minio/minio
+```
+
+This provisions MinIO NAS gateway with 8 instances.
+
+Persistence
+-----------
+
+This chart provisions a PersistentVolumeClaim and mounts corresponding persistent volume to default location `/export`. You'll need physical storage available in the Kubernetes cluster for this to work. If you'd rather use `emptyDir`, disable PersistentVolumeClaim by:
+
+```bash
+$ helm install --set persistence.enabled=false minio/minio
+```
+
+> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+Existing PersistentVolumeClaim
+------------------------------
+
+If a Persistent Volume Claim already exists, specify it during installation.
+
+1. Create the PersistentVolume
+2. Create the PersistentVolumeClaim
+3. Install the chart
+
+```bash
+$ helm install --set persistence.existingClaim=PVC_NAME minio/minio
+```
+
+NetworkPolicy
+-------------
+
+To enable network policy for MinIO,
+install [a networking plugin that implements the Kubernetes
+NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin),
+and set `networkPolicy.enabled` to `true`.
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
+the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
+
+    kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+
+With NetworkPolicy enabled, traffic will be limited to just port 9000.
+
+For more precise policy, set `networkPolicy.allowExternal=true`. This will
+only allow pods with the generated client label to connect to MinIO.
+This label will be displayed in the output of a successful install.
+
+Existing secret
+---------------
+
+Instead of having this chart create the secret for you, you can supply a preexisting secret, much
+like an existing PersistentVolumeClaim.
+
+First, create the secret:
+```bash
+$ kubectl create secret generic my-minio-secret --from-literal=accesskey=foobarbaz --from-literal=secretkey=foobarbazqux
+```
+
+Then install the chart, specifying that you want to use an existing secret:
+```bash
+$ helm install --set existingSecret=my-minio-secret minio/minio
+```
+
+The following fields are expected in the secret
+1. `accesskey` - the access key ID
+2. `secretkey` - the secret key
+3. `gcs_key.json` - The GCS key if you are using the GCS gateway feature. This is optional.
+
+Configure TLS
+-------------
+
+To enable TLS for MinIO containers, acquire TLS certificates from a CA or create self-signed certificates. While creating / acquiring certificates ensure the corresponding domain names are set as per the standard [DNS naming conventions](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity) in a Kubernetes StatefulSet (for a distributed MinIO setup). Then create a secret using
+
+```bash
+$ kubectl create secret generic tls-ssl-minio --from-file=path/to/private.key --from-file=path/to/public.crt
+```
+
+Then install the chart, specifying that you want to use the TLS secret:
+
+```bash
+$ helm install --set tls.enabled=true,tls.certSecret=tls-ssl-minio minio/minio
+```
+
+Pass environment variables to MinIO containers
+----------------------------------------------
+
+To pass environment variables to MinIO containers when deploying via Helm chart, use the below command line format
+
+```bash
+$ helm install --set environment.MINIO_BROWSER=on,environment.MINIO_DOMAIN=domain-name minio/minio
+```
+
+You can add as many environment variables as required, using the above format. Just add `environment.<VARIABLE_NAME>=<value>` under `set` flag.
+
+Create buckets after install
+---------------------------
+
+Install the chart, specifying the buckets you want to create after install:
+
+```bash
+$ helm install --set buckets[0].name=bucket1,buckets[0].policy=none,buckets[0].purge=false minio/minio
+```
+
+Description of the configuration parameters used above -
+
+- `buckets[].name` - name of the bucket to create, must be a string with length > 0
+- `buckets[].policy` - can be one of none|download|upload|public
+- `buckets[].purge` - purge if bucket exists already

--- a/deploy/charts/harvester/charts/minio/ci/distributed-values.yaml
+++ b/deploy/charts/harvester/charts/minio/ci/distributed-values.yaml
@@ -1,0 +1,1 @@
+mode: distributed

--- a/deploy/charts/harvester/charts/minio/templates/NOTES.txt
+++ b/deploy/charts/harvester/charts/minio/templates/NOTES.txt
@@ -1,0 +1,44 @@
+{{- if eq .Values.service.type "ClusterIP" "NodePort" }}
+Minio can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
+{{ template "minio.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access Minio from localhost, run the below commands:
+
+  1. export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+
+  2. kubectl port-forward $POD_NAME 9000 --namespace {{ .Release.Namespace }}
+
+Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/
+
+You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. mc config host add {{ template "minio.fullname" . }}-local http://localhost:9000 {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+
+  3. mc ls {{ template "minio.fullname" . }}-local
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}
+{{- if eq .Values.service.type "LoadBalancer" }}
+Minio can be accessed via port {{ .Values.service.port }} on an external IP address. Get the service external IP address by:
+kubectl get svc --namespace {{ .Release.Namespace }} -l app={{ template "minio.fullname" . }}
+
+Note that the public IP may take a couple of minutes to be available.
+
+You can now access Minio server on http://<External-IP>:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. mc config host add {{ template "minio.fullname" . }}-local http://<External-IP>:{{ .Values.service.port }} {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+
+  3. mc ls {{ template "minio.fullname" . }}-local
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}
+
+{{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+Note: Since NetworkPolicy is enabled, only pods with label
+{{ template "minio.fullname" . }}-client=true"
+will be able to connect to this minio cluster.
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/_helper_create_bucket.txt
+++ b/deploy/charts/harvester/charts/minio/templates/_helper_create_bucket.txt
@@ -1,0 +1,96 @@
+#!/bin/sh
+set -e ; # Have script exit in the event of a failed command.
+
+{{- if .Values.configPathmc }}
+MC_CONFIG_DIR="{{ .Values.configPathmc }}"
+MC="/usr/bin/mc --config-dir ${MC_CONFIG_DIR}"
+{{- else }}
+MC="/usr/bin/mc"
+{{- end }}
+
+# connectToMinio
+# Use a check-sleep-check loop to wait for Minio service to be available
+connectToMinio() {
+  SCHEME=$1
+  ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+  set -e ; # fail if we can't read the keys.
+  ACCESS=$(cat /config/accesskey) ; SECRET=$(cat /config/secretkey) ;
+  set +e ; # The connections to minio are allowed to fail.
+  echo "Connecting to Minio server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+  MC_COMMAND="${MC} config host add myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+  $MC_COMMAND ;
+  STATUS=$? ;
+  until [ $STATUS = 0 ]
+  do
+    ATTEMPTS=`expr $ATTEMPTS + 1` ;
+    echo \"Failed attempts: $ATTEMPTS\" ;
+    if [ $ATTEMPTS -gt $LIMIT ]; then
+      exit 1 ;
+    fi ;
+    sleep 2 ; # 1 second intervals between attempts
+    $MC_COMMAND ;
+    STATUS=$? ;
+  done ;
+  set -e ; # reset `e` as active
+  return 0
+}
+
+# checkBucketExists ($bucket)
+# Check if the bucket exists, by using the exit code of `mc ls`
+checkBucketExists() {
+  BUCKET=$1
+  CMD=$(${MC} ls myminio/$BUCKET > /dev/null 2>&1)
+  return $?
+}
+
+# createBucket ($bucket, $policy, $purge)
+# Ensure bucket exists, purging if asked to
+createBucket() {
+  BUCKET=$1
+  POLICY=$2
+  PURGE=$3
+
+  # Purge the bucket, if set & exists
+  # Since PURGE is user input, check explicitly for `true`
+  if [ $PURGE = true ]; then
+    if checkBucketExists $BUCKET ; then
+      echo "Purging bucket '$BUCKET'."
+      set +e ; # don't exit if this fails
+      ${MC} rm -r --force myminio/$BUCKET
+      set -e ; # reset `e` as active
+    else
+      echo "Bucket '$BUCKET' does not exist, skipping purge."
+    fi
+  fi
+
+  # Create the bucket if it does not exist
+  if ! checkBucketExists $BUCKET ; then
+    echo "Creating bucket '$BUCKET'"
+    ${MC} mb myminio/$BUCKET
+  else
+    echo "Bucket '$BUCKET' already exists."
+  fi
+
+  # At this point, the bucket should exist, skip checking for existence
+  # Set policy on the bucket
+  echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
+  ${MC} policy set $POLICY myminio/$BUCKET
+}
+
+# Try connecting to Minio instance
+{{- if .Values.tls.enabled }}
+scheme=https
+{{- else }}
+scheme=http
+{{- end }}
+connectToMinio $scheme
+
+{{- if or .Values.defaultBucket.enabled }}
+# Create the bucket
+createBucket {{ .Values.defaultBucket.name }} {{ .Values.defaultBucket.policy }} {{ .Values.defaultBucket.purge }}
+{{ else if .Values.buckets }}
+# Create the buckets
+{{- range .Values.buckets }}
+createBucket {{ .name }} {{ .policy }} {{ .purge }} 
+{{- end }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/_helpers.tpl
+++ b/deploy/charts/harvester/charts/minio/templates/_helpers.tpl
@@ -1,0 +1,121 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "minio.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "minio.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "minio.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "minio.networkPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "minio.deployment.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "minio.statefulset.apiVersion" -}}
+{{- if semverCompare "<1.17-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "minio.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine service account name for deployment or statefulset.
+*/}}
+{{- define "minio.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "minio.fullname" .) .Values.serviceAccount.name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Properly format optional additional arguments to Minio binary
+*/}}
+{{- define "minio.extraArgs" -}}
+{{- range .Values.extraArgs -}}
+{{ " " }}{{ . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "minio.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets:
+    {{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets:
+    {{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/harvester/charts/minio/templates/configmap.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  initialize: |-
+{{ include (print $.Template.BasePath "/_helper_create_bucket.txt") . | indent 4 }}

--- a/deploy/charts/harvester/charts/minio/templates/deployment.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/deployment.yaml
@@ -1,0 +1,264 @@
+{{- if eq .Values.mode "standalone" }}
+{{ $bucketRoot := or ($.Values.bucketRoot) ($.Values.mountPath) }}
+apiVersion: {{ template "minio.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  strategy:
+    type: {{ .Values.DeploymentUpdate.type }}
+    {{- if eq .Values.DeploymentUpdate.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.DeploymentUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.DeploymentUpdate.maxUnavailable }}
+    {{- end}}
+  {{- if .Values.nasgateway.enabled }}
+  replicas: {{ .Values.nasgateway.replicas }}
+  {{- end }}
+  {{- if .Values.s3gateway.enabled }}
+  replicas: {{ .Values.s3gateway.replicas }}
+  {{- end }}
+  {{- if .Values.azuregateway.enabled }}
+  replicas: {{ .Values.azuregateway.replicas }}
+  {{- end }}
+  {{- if .Values.gcsgateway.enabled }}
+  replicas: {{ .Values.gcsgateway.replicas }}
+  {{- end }}
+  {{- if .Values.ossgateway.enabled }}
+  replicas: {{ .Values.ossgateway.replicas }}
+  {{- end }}
+  {{- if .Values.b2gateway.enabled }}
+  replicas: {{ .Values.b2gateway.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "minio.fullname" . }}
+      labels:
+        app: {{ template "minio.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trimSuffix "\n" | indent 8 }}
+{{- end }}
+    spec:
+  {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+  {{- end }}
+      serviceAccountName: {{ include "minio.serviceAccountName" . | quote }}
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.s3gateway.enabled }}
+          command: [ "/bin/sh",
+          "-ce",
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }} {{- template `minio.extraArgs` . }}" ]
+          {{- else }}
+          {{- if .Values.azuregateway.enabled }}
+          command: [ "/bin/sh",
+          "-ce",
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure {{- template `minio.extraArgs` . }}" ]
+          {{- else }}
+          {{- if .Values.gcsgateway.enabled }}
+          command: [ "/bin/sh",
+          "-ce",
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId }} {{- template `minio.extraArgs` . }}" ]
+          {{- else }}
+          {{- if .Values.ossgateway.enabled }}
+          command: [ "/bin/sh",
+          "-ce",
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway oss {{ .Values.ossgateway.endpointURL }} {{- template `minio.extraArgs` . }}" ]
+          {{- else }}
+          {{- if .Values.nasgateway.enabled }}
+          command: [ "/bin/sh",
+          "-ce",
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }} {{- template `minio.extraArgs` . }}" ]
+          {{- else }}
+          {{- if .Values.b2gateway.enabled }}
+          command: [ "/bin/sh",
+          "-ce",
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway b2 {{- template `minio.extraArgs` . }}" ]
+          {{- else }}
+          command: [ "/bin/sh",
+          "-ce",
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }} {{- template `minio.extraArgs` . }}" ]
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          volumeMounts:
+            {{- if and .Values.persistence.enabled (not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) (not .Values.b2gateway.enabled) }}
+            - name: export
+              mountPath: {{ .Values.mountPath }}
+              {{- if .Values.persistence.subPath }}
+              subPath: "{{ .Values.persistence.subPath }}"
+              {{- end }}
+            {{- end }}
+            {{- if or .Values.gcsgateway.enabled .Values.etcd.clientCert .Values.etcd.clientCertKey }}
+            - name: minio-user
+              mountPath: "/etc/credentials"
+              readOnly: true
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: cert-secret-volume
+              mountPath: {{ .Values.certsPath }}
+            {{ end }}
+          ports:
+            {{- if .Values.tls.enabled }}
+            - name: https
+            {{ else }}
+            - name: http
+            {{- end }}
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: secretkey
+            {{- if .Values.gcsgateway.enabled }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/credentials/gcs_key.json"
+            {{- end }}
+            {{- if .Values.etcd.endpoints }}
+            - name: MINIO_ETCD_ENDPOINTS
+              value: {{ join "," .Values.etcd.endpoints | quote }}
+            {{- end }}
+            {{- if .Values.etcd.clientCert }}
+            - name: MINIO_ETCD_CLIENT_CERT
+              value: "/etc/credentials/etcd_client_cert.pem"
+            {{- end }}
+            {{- if .Values.etcd.clientCertKey }}
+            - name: MINIO_ETCD_CLIENT_CERT_KEY
+              value: "/etc/credentials/etcd_client_cert_key.pem"
+            {{- end }}
+            {{- if .Values.etcd.pathPrefix }}
+            - name: MINIO_ETCD_PATH_PREFIX
+              value: {{ .Values.etcd.pathPrefix }}
+            {{- end }}
+            {{- if .Values.etcd.corednsPathPrefix }}
+            - name: MINIO_ETCD_COREDNS_PATH
+              value: {{ .Values.etcd.corednsPathPrefix }}
+            {{- end }}
+            {{- if .Values.s3gateway.enabled -}}
+            {{- if .Values.s3gateway.accessKey }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: awsAccessKeyId
+            {{- end }}
+            {{- if .Values.s3gateway.secretKey }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: awsSecretAccessKey
+            {{- end }}
+            {{- end }}
+            {{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end}}
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              {{- if .Values.tls.enabled }}
+              port: https
+              {{ else }}
+              port: http
+              {{- end }}
+              {{- if .Values.tls.enabled }}
+              scheme: HTTPS
+              {{ else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              {{- if .Values.tls.enabled }}
+              scheme: HTTPS
+              {{- end }}
+              path: /minio/health/ready
+              {{- if .Values.tls.enabled }}
+              port: https
+              {{ else }}
+              port: http
+              {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        {{- if and (not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) (not .Values.b2gateway.enabled) }}
+        - name: export
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "minio.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        {{- end }}
+        - name: minio-user
+          secret:
+            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+        {{- if .Values.tls.enabled }}
+        - name: cert-secret-volume
+          secret:
+            secretName: {{ .Values.tls.certSecret }}
+            items:
+            - key: {{ .Values.tls.publicCrt }}
+              path: public.crt
+            - key: {{ .Values.tls.privateKey }}
+              path: private.key
+            - key: {{ .Values.tls.publicCrt }}
+              path: CAs/public.crt
+        {{ end }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/ingress.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "minio.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: {{ template "minio.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+      {{- if . }}
+      host: {{ . | quote }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/networkpolicy.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ template "minio.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+      release: {{ .Release.Name }}
+  ingress:
+    - ports:
+        - port: {{ .Values.service.port }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "minio.name" . }}-client: "true"
+      {{- end }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: minio
+  labels:
+    app: {{ template "minio.name" . }}
+spec:
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/post-install-create-bucket-job.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/post-install-create-bucket-job.yaml
@@ -1,0 +1,77 @@
+{{- if or .Values.defaultBucket.enabled .Values.buckets }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "minio.fullname" . }}-make-bucket-job
+  labels:
+    app: {{ template "minio.name" . }}-make-bucket-job
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- with .Values.makeBucketJob.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "minio.name" . }}-job
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+      restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: {{ template "minio.fullname" . }}
+            - secret:
+                name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+        {{- if .Values.tls.enabled }}
+        - name: cert-secret-volume-mc
+          secret:
+            secretName: {{ .Values.tls.certSecret }}
+            items:
+            - key: {{ .Values.tls.publicCrt }}
+              path: CAs/public.crt
+        {{ end }}
+      serviceAccountName: {{ include "minio.serviceAccountName" . | quote }}
+      containers:
+      - name: minio-mc
+        image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+        imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        command: ["/bin/sh", "/config/initialize"]
+        env:
+          - name: MINIO_ENDPOINT
+            value: {{ template "minio.fullname" . }}
+          - name: MINIO_PORT
+            value: {{ .Values.service.port | quote }}
+        volumeMounts:
+          - name: minio-configuration
+            mountPath: /config
+          {{- if .Values.tls.enabled }}
+          - name: cert-secret-volume-mc
+            mountPath: {{ .Values.configPathmc }}certs
+          {{ end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  {{ toYaml .Values.updatePrometheusJob.annotations | indent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "minio.name" . }}-update-prometheus-secret
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ $fullName }}-update-prometheus-secret
+{{- end }}
+      restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        - name: workdir
+          emptyDir: {}
+      initContainers:
+        - name: minio-mc
+          image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+          imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            - mc admin prometheus generate target --json --no-color -q > /workdir/mc.json
+          env:
+            # mc admin prometheus generate don't really connect to remote server, TLS cert isn't required
+            - name: MC_HOST_target
+              value: http{{ if .Values.tls.enabled }}s{{ end }}://{{ .Values.accessKey }}:{{ .Values.secretKey }}@{{ $fullName }}:{{ .Values.service.port }}
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        # extract bearerToken from mc admin output
+        - name: jq
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            - jq -e -c -j -r .bearerToken < /workdir/mc.json > /workdir/token
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - name: kubectl-create
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            # The following script does:
+            # - get the servicemonitor that need this secret and copy some metadata and create the ownerreference for the secret file
+            # - create the secret
+            # - merge both json
+            - >
+              kubectl -n {{ .Release.Namespace }} get servicemonitor {{ $fullName }} -o json |
+                jq -c '{metadata: {name: "{{ $fullName }}-prometheus", namespace: .metadata.namespace, labels: {app: .metadata.labels.app, release: .metadata.labels.release}, ownerReferences: [{apiVersion: .apiVersion, kind: .kind, blockOwnerDeletion: true, controller: true, uid: .metadata.uid, name: .metadata.name}]}}' > /workdir/metadata.json &&
+              kubectl create secret generic {{ $fullName }}-prometheus --from-file=token=/workdir/token --dry-run -o json > /workdir/secret.json &&
+              cat /workdir/secret.json /workdir/metadata.json | jq -s add > /workdir/object.json
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      containers:
+        - name: kubectl-apply
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - kubectl
+            - apply
+            - "-f"
+            - /workdir/object.json
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-role.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-role.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+    resourceNames:
+      - {{ $fullName }}-prometheus
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+    resourceNames:
+      - {{ $fullName }}
+{{- end -}}

--- a/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-update-prometheus-secret
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-update-prometheus-secret
+    namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/deploy/charts/harvester/charts/minio/templates/pvc.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/pvc.yaml
@@ -1,0 +1,35 @@
+{{- if eq .Values.mode "standalone" }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+{{- if and .Values.nasgateway.enabled .Values.nasgateway.pv }}
+  selector:
+    matchLabels:
+      pv: {{ .Values.nasgateway.pv | quote }}
+{{- end }}
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+      
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- if .Values.persistence.VolumeName }}
+  volumeName: "{{ .Values.persistence.VolumeName }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/secrets.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/secrets.yaml
@@ -1,0 +1,32 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  accesskey: {{ if .Values.accessKey }}{{ .Values.accessKey | b64enc | quote }}{{ else }}{{ randAlphaNum 20 | b64enc | quote }}{{ end }}
+  secretkey: {{ if .Values.secretKey }}{{ .Values.secretKey | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
+{{- if .Values.gcsgateway.enabled }}
+  gcs_key.json: {{ .Values.gcsgateway.gcsKeyJson | b64enc }}
+{{- end }}
+{{- if .Values.s3gateway.enabled -}}
+{{- if .Values.s3gateway.accessKey }}
+  awsAccessKeyId: {{ .Values.s3gateway.accessKey | b64enc | quote }}
+{{- end }}
+{{- if .Values.s3gateway.secretKey }}
+  awsSecretAccessKey: {{ .Values.s3gateway.secretKey | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.etcd.clientCert }}
+  etcd_client_cert.pem: {{ .Values.etcd.clientCert | b64enc | quote }}
+{{- end }}
+{{- if .Values.etcd.clientCertKey }}
+  etcd_client_cert_key.pem: {{ .Values.etcd.clientCertKey | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/service.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/service.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP" "") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if not (empty .Values.service.clusterIP) }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+  ports:
+    {{- if .Values.tls.enabled }}
+    - name: https
+    {{ else }}
+    - name: http
+    {{- end }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+{{- if (and (eq .Values.service.type "NodePort") ( .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- else }}
+      targetPort: 9000
+{{- end}}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{- range $i , $ip := .Values.service.externalIPs }}
+  - {{ $ip }}
+{{- end }}
+{{- end }}
+  selector:
+    app: {{ template "minio.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/charts/harvester/charts/minio/templates/serviceaccount.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "minio.serviceAccountName" . | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: "{{ .Release.Name }}"
+{{- end -}}

--- a/deploy/charts/harvester/charts/minio/templates/servicemonitor.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "minio.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    {{- if .Values.tls.enabled }}
+    - port: https
+    {{ else }}
+    - port: http
+    {{- end }}
+      path: /minio/prometheus/metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      bearerTokenSecret:
+        name: {{ template "minio.fullname" . }}-prometheus
+        key: token
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      app: {{ include "minio.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/templates/statefulset.yaml
+++ b/deploy/charts/harvester/charts/minio/templates/statefulset.yaml
@@ -1,0 +1,232 @@
+{{- if eq .Values.mode "distributed" }}
+{{ $zoneCount := .Values.zones | int }}
+{{ $nodeCount := .Values.replicas | int }}
+{{ $drivesPerNode := .Values.drivesPerNode | int }}
+{{ $scheme := "http" }}
+{{- if .Values.tls.enabled }}
+{{ $scheme = "https" }}
+{{ end }}
+{{ $mountPath := .Values.mountPath }}
+{{ $bucketRoot := or ($.Values.bucketRoot) ($.Values.mountPath) }}
+{{ $subPath := .Values.persistence.subPath }}
+{{ $penabled := .Values.persistence.enabled }}
+{{ $accessMode := .Values.persistence.accessMode }}
+{{ $storageClass := .Values.persistence.storageClass }}
+{{ $psize := .Values.persistence.size }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "minio.fullname" . }}-svc
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  publishNotReadyAddresses: true
+  clusterIP: None
+  ports:
+    {{- if .Values.tls.enabled }}
+    - name: https
+    {{ else }}
+    - name: http
+    {{- end }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "minio.name" . }}
+    release: {{ .Release.Name }}
+---
+apiVersion: {{ template "minio.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ template "minio.fullname" . }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  updateStrategy:
+    type: {{ .Values.StatefulSetUpdate.updateStrategy }}
+  podManagementPolicy: "Parallel"
+  serviceName: {{ template "minio.fullname" . }}-svc
+  replicas: {{ mul $zoneCount $nodeCount }}
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ template "minio.fullname" . }}
+      labels:
+        app: {{ template "minio.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trimSuffix "\n" | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      serviceAccountName: {{ include "minio.serviceAccountName" . | quote }}
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          command: [ "/bin/sh",
+            "-ce",
+            "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{- range $i := until $zoneCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.fullname` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{else}}{{ $bucketRoot }}{{end}}{{- end}}{{- template `minio.extraArgs` . }}" ]
+          volumeMounts:
+            {{- if $penabled }}
+            {{- if (gt $drivesPerNode 1) }}
+            {{- range $i := until $drivesPerNode }}
+            - name: export-{{ $i }}
+              mountPath: {{ $mountPath }}-{{ $i }}
+              {{- if and $penabled $subPath }}
+              subPath: {{ $subPath }}
+              {{- end }}
+            {{- end }}
+            {{- else }}
+            - name: export
+              mountPath: {{ $mountPath }}
+              {{- if and $penabled $subPath }}
+              subPath: {{ $subPath }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: cert-secret-volume
+              mountPath: {{ .Values.certsPath }}
+            {{ end }}
+          ports:
+            {{- if .Values.tls.enabled }}
+            - name: https
+            {{ else }}
+            - name: http
+            {{- end }}
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: secretkey
+            {{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end}}
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              {{- if .Values.tls.enabled }}
+              port: https
+              {{ else }}
+              port: http
+              {{- end }}
+              {{- if .Values.tls.enabled }}
+              scheme: HTTPS
+              {{ else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              {{- if .Values.tls.enabled }}
+              port: https
+              {{ else }}
+              port: http
+              {{- end }}
+              {{- if .Values.tls.enabled }}
+              scheme: HTTPS
+              {{ else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: minio-user
+          secret:
+            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+        {{- if .Values.tls.enabled }}
+        - name: cert-secret-volume
+          secret:
+            secretName: {{ .Values.tls.certSecret }}
+            items:
+            - key: {{ .Values.tls.publicCrt }}
+              path: public.crt
+            - key: {{ .Values.tls.privateKey }}
+              path: private.key
+            - key: {{ .Values.tls.publicCrt }}
+              path: CAs/public.crt
+        {{ end }}
+{{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  {{- if gt $drivesPerNode 1 }}
+    {{- range $diskId := until $drivesPerNode}}
+    - metadata:
+        name: export-{{ $diskId }}
+      spec:
+        accessModes: [ {{ $accessMode | quote }} ]
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $psize }}
+    {{- end }}
+  {{- else }}
+    - metadata:
+        name: export
+      spec:
+        accessModes: [ {{ $accessMode | quote }} ]
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $psize }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/harvester/charts/minio/values.yaml
+++ b/deploy/charts/harvester/charts/minio/values.yaml
@@ -1,0 +1,144 @@
+DeploymentUpdate:
+  maxSurge: 100%
+  maxUnavailable: 0
+  type: RollingUpdate
+StatefulSetUpdate:
+  updateStrategy: RollingUpdate
+accessKey: YOURACCESSKEY
+affinity: {}
+azuregateway:
+  enabled: false
+  replicas: 4
+b2gateway:
+  enabled: false
+  replicas: 4
+bucketRoot: ""
+buckets: []
+certsPath: /etc/minio/certs/
+clusterDomain: cluster.local
+configPathmc: /etc/minio/mc/
+defaultBucket:
+  enabled: false
+  name: bucket
+  policy: none
+  purge: false
+drivesPerNode: 1
+environment:
+  MINIO_API_READY_DEADLINE: 5s
+etcd:
+  clientCert: ""
+  clientCertKey: ""
+  corednsPathPrefix: ""
+  endpoints: []
+  pathPrefix: ""
+existingSecret: ""
+extraArgs: []
+fullnameOverride: ""
+gcsgateway:
+  enabled: false
+  gcsKeyJson: ""
+  projectId: ""
+  replicas: 4
+helmKubectlJqImage:
+  pullPolicy: IfNotPresent
+  repository: bskim45/helm-kubectl-jq
+  tag: 3.1.0
+image:
+  pullPolicy: IfNotPresent
+  repository: minio/minio
+  tag: RELEASE.2020-08-08T04-50-06Z
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  enabled: false
+  hosts:
+  - chart-example.local
+  labels: {}
+  path: /
+  tls: []
+livenessProbe:
+  failureThreshold: 1
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  successThreshold: 1
+  timeoutSeconds: 1
+makeBucketJob:
+  annotations: null
+mcImage:
+  pullPolicy: IfNotPresent
+  repository: minio/mc
+  tag: RELEASE.2020-08-08T02-33-58Z
+metrics:
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+mode: standalone
+mountPath: /export
+nameOverride: ""
+nasgateway:
+  enabled: false
+  pv: null
+  replicas: 4
+networkPolicy:
+  allowExternal: true
+  enabled: false
+nodeSelector: {}
+ossgateway:
+  enabled: false
+  endpointURL: ""
+  replicas: 4
+persistence:
+  VolumeName: ""
+  accessMode: ReadWriteOnce
+  enabled: true
+  existingClaim: ""
+  size: 500Gi
+  storageClass: ""
+  subPath: ""
+podAnnotations: {}
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1
+podLabels: {}
+priorityClassName: ""
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  successThreshold: 1
+  timeoutSeconds: 6
+replicas: 4
+resources:
+  requests:
+    memory: 4Gi
+s3gateway:
+  accessKey: ""
+  enabled: false
+  replicas: 4
+  secretKey: ""
+  serviceEndpoint: ""
+secretKey: YOURSECRETKEY
+securityContext:
+  enabled: true
+  fsGroup: 1000
+  runAsGroup: 1000
+  runAsUser: 1000
+service:
+  annotations: {}
+  clusterIP: null
+  externalIPs: []
+  nodePort: 32000
+  port: 9000
+  type: ClusterIP
+serviceAccount:
+  create: true
+  name: null
+tls:
+  certSecret: ""
+  enabled: false
+  privateKey: private.key
+  publicCrt: public.crt
+tolerations: []
+updatePrometheusJob:
+  annotations: null
+zones: 1

--- a/deploy/charts/harvester/templates/NOTES.txt
+++ b/deploy/charts/harvester/templates/NOTES.txt
@@ -1,0 +1,14 @@
+The Harvester has been installed into "{{ .Release.Namespace }}" namespace with "{{ .Release.Name }}" as release name.
+
+- {{ if index .Values "kubevirt-operator" "enabled" }}[x]{{ else }}[ ]{{ end }} KubeVirt Operator
+- {{ if .Values.kubevirt.enabled }}[x]{{ else }}[ ]{{ end }} KubeVirt Resource named "kubevirt"
+- {{ if index .Values "cdi-operator" "enabled" }}[x]{{ else }}[ ]{{ end }} KubeVirt Containerized Data Importer Operator
+- {{ if .Values.cdi.enabled }}[x]{{ else }}[ ]{{ end }} KubeVirt Containerized Data Importer(CDI) Resource named "cdi"
+- {{ if .Values.minio.enabled }}[x]{{ else }}[ ]{{ end }} Minio
+
+Please make sure there is a default StorageClass in the Kubernetes cluster.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/deploy/charts/harvester/templates/_helpers.tpl
+++ b/deploy/charts/harvester/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "harvester.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, which is no longer than 63 chars.
+We truncate at 63 chars as some Kubernetes naming policies are limited to this.
+*/}}
+{{- define "harvester.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "harvester.chartref" -}}
+{{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end }}
+
+{{/*
+Generate immutable labels.
+We use the immutable labels to select low-level components(like the Deployment selects the Pods).
+*/}}
+{{- define "harvester.immutableLabels" -}}
+helm.sh/release: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ template "harvester.name" . }}
+{{- end }}
+
+{{/*
+Generate basic labels.
+*/}}
+{{- define "harvester.labels" -}}
+app.kubernetes.io/managed-by: {{ default "helm" $.Release.Service | quote }}
+helm.sh/chart: {{ template "harvester.chartref" . }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{ include "harvester.immutableLabels" . }}
+{{- end }}
+
+{{/*
+NB(thxCode): Get the default fully qualified name of Minio,
+the below logic is from "charts/minio/templates/_helpers.tpl",
+and then we indicate the values from "minio" domain.
+*/}}
+{{- define "charts.minio.fullname" }}
+{{- if .Values.minio.fullnameOverride -}}
+{{- .Values.minio.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "minio" .Values.minio.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/deploy/charts/harvester/templates/clusterrolebinding.yaml
+++ b/deploy/charts/harvester/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "harvester.fullname" . }}
+  # because we can easily confirm this resource directly.
+  name: harvester
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  # NB(thxCode): we give the whole permission of cluster admin to harvester.
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: harvester
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -1,0 +1,140 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "harvester.fullname" . }}
+  # because we can easily confirm this resource from the corresponding namespace.
+  name: harvester
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver
+spec:
+  selector:
+    matchLabels:
+{{ include "harvester.immutableLabels" . | indent 6 }}
+      app.kubernetes.io/name: harvester
+      app.kubernetes.io/component: apiserver
+  replicas: {{ .Values.replicas }}
+{{- if .Values.strategy }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+{{- end }}
+  template:
+    metadata:
+      labels:
+{{ include "harvester.labels" . | indent 8 }}
+        app.kubernetes.io/name: harvester
+        app.kubernetes.io/component: apiserver
+    spec:
+      serviceAccountName: harvester
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - harvester
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                        - apiserver
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - name: vm
+          image: {{ .Values.containers.apiserver.image.repository }}:{{ .Values.containers.apiserver.image.tag }}
+          imagePullPolicy: {{ .Values.containers.apiserver.image.imagePullPolicy }}
+{{- if .Values.containers.apiserver.command }}
+          command:
+{{ toYaml .Values.containers.apiserver.command | indent 12 }}
+{{- end }}
+{{- if .Values.containers.apiserver.args }}
+          args:
+{{ toYaml .Values.containers.apiserver.args | indent 12 }}
+{{- end }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: accesskey
+{{- if .Values.minio.enabled }}
+                  name: {{ if .Values.minio.existingSecret }}{{ .Values.minio.existingSecret }}{{ else }}{{ template "charts.minio.fullname" . }}{{ end }}
+{{- else }}
+                  {{- with .Values.containers.apiserver.vmImageStorageGateway }}
+                  name: {{ if .secretName }}{{ .secretName }}{{ else }}harvester-vm-image-storage-gateway{{ end }}
+                  {{- end }}
+{{- end }}
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secretkey
+{{- if .Values.minio.enabled }}
+                  name: {{ if .Values.minio.existingSecret }}{{ .Values.minio.existingSecret }}{{ else }}{{ template "charts.minio.fullname" . }}{{ end }}
+{{- else }}
+                  {{- with .Values.containers.apiserver.vmImageStorageGateway }}
+                  name: {{ if .secretName }}{{ .secretName }}{{ else }}harvester-vm-image-storage-gateway{{ end }}
+                  {{- end }}
+{{- end }}
+            - name: MINIO_URL
+{{- if .Values.minio.enabled }}
+              value: {{printf "http://%s.%s:%s" (include "charts.minio.fullname" .) .Release.Namespace (.Values.minio.service.port | toString) }}
+{{- else }}
+              {{- with .Values.containers.apiserver.vmImageStorageGateway }}
+              value: {{ if .endpoint }}{{ .endpoint }}{{ else }}{{ fail "Please indicate the endpoint of S3 service if disabled default Minio deployment" }}{{ end }}
+              {{- end }}
+{{- end }}
+{{- if .Values.containers.apiserver.env }}
+{{ toYaml .Values.containers.apiserver.env | indent 12 }}
+{{- end }}
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+{{- if .Values.containers.apiserver.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.containers.apiserver.livenessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.containers.apiserver.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.containers.apiserver.readinessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.containers.apiserver.resources }}
+          resources:
+{{ toYaml .Values.containers.apiserver.resources | indent 12 }}
+{{- end }}
+{{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}

--- a/deploy/charts/harvester/templates/job.yaml
+++ b/deploy/charts/harvester/templates/job.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.jobs.preDelete.enabled }}
+{{- if or (index .Values "kubevirt-operator" "enabled") (index .Values "cdi-operator" "enabled") }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "harvester.fullname" . }}-pre-delete
+  # because we can easily confirm this resource from the corresponding namespace.
+  name: harvester-pre-delete
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver
+spec:
+{{- if .Values.jobs.preDelete.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.jobs.preDelete.activeDeadlineSeconds }}
+{{- end }}
+{{- if .Values.jobs.preDelete.backoffLimit }}
+  backoffLimit: {{ .Values.jobs.preDelete.backoffLimit }}
+{{- end }}
+{{- if .Values.jobs.preDelete.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.jobs.preDelete.ttlSecondsAfterFinished }}
+{{- end }}
+  template:
+    metadata:
+      name: harvester-pre-delete
+      labels:
+{{ include "harvester.immutableLabels" . | indent 8 }}
+        app.kubernetes.io/name: pre-delete
+        app.kubernetes.io/component: job
+    spec:
+      # NB(thxCode): reuse the "harvester" ServiceAccount under the same namespace.
+      serviceAccountName: harvester
+{{- if .Values.jobs.preDelete.restartPolicy }}
+      restartPolicy: {{ .Values.jobs.preDelete.restartPolicy }}
+{{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+      containers:
+        - name: pre-delete
+          image: {{ .Values.jobs.preDelete.containers.kubectl.image.repository }}:{{ .Values.jobs.preDelete.containers.kubectl.image.tag }}
+          imagePullPolicy: {{ .Values.jobs.preDelete.containers.kubectl.image.imagePullPolicy }}
+          command:
+            - "/bin/bash"
+          args:
+            - "-c"
+            - "{{if index .Values "kubevirt-operator" "enabled" }}echo '[INFO] deleting kubevirt ...'; kubectl delete kubevirt --wait --all; {{ end }}{{if index .Values "cdi-operator" "enabled" }}echo '[INFO] deleting cdi ...'; kubectl delete cdi --wait --all; {{ end }}exit"
+{{- if .Values.jobs.preDelete.containers.kubectl.resources }}
+          resources:
+{{ toYaml .Values.jobs.preDelete.containers.kubectl.resources | indent 12 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/harvester/templates/secret.yaml
+++ b/deploy/charts/harvester/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if and (not .Values.minio.enabled) (not .Values.containers.apiserver.vmImageStorageGateway.secretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "harvester.fullname" . }}
+  # because we can easily confirm this resource directly.
+  name: harvester-vm-image-storage-gateway
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver
+type: Opaque
+data:
+  {{- with .Values.containers.apiserver.vmImageStorageGateway -}}
+  accesskey: {{ if .accessKey }}{{ .accessKey | b64enc | quote }}{{ else }}{{ fail "Please indicate the access key of S3 service if disabled default Minio deployment" }}{{ end }}
+  secretkey: {{ if .secretKey }}{{ .secretKey | b64enc | quote }}{{ else }}{{ fail "Please indicate the secret key of S3 service if disabled default Minio deployment" }}{{ end }}
+  {{- end -}}
+{{- end -}}

--- a/deploy/charts/harvester/templates/service.yaml
+++ b/deploy/charts/harvester/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # NB(thxCode): name should not be customized as below:
+  # name: {{ template "harvester.fullname" . }}
+  # because we can easily confirm this resource from the corresponding namespace.
+  name: harvester
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver
+spec:
+  type: LoadBalancer
+  selector:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/charts/harvester/templates/serviceaccount.yaml
+++ b/deploy/charts/harvester/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # NB(thxCode): name cannot be customized as below:
+  # name: {{ template "harvester.fullname" . }}
+  # because we can easily confirm this resource from the corresponding namespace.
+  name: harvester
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -1,0 +1,262 @@
+###########################################################################
+###########################################################################
+##          Override the sub-charts default configuration below.         ##
+###########################################################################
+###########################################################################
+
+## Specify the parameters to override the sub-chart.
+##
+kubevirt-operator:
+
+  ## Specify to install KubeVirt Operator,
+  ## defaults to "true".
+  ##
+  enabled: true
+
+## Specify the parameters to override the sub-chart.
+##
+kubevirt:
+
+  ## Specify to install KubeVirt CRD instance,
+  ## defaults to "true".
+  ##
+  enabled: true
+
+## Specify the parameters to override the sub-chart.
+##
+cdi-operator:
+
+  ## Specify to install CDI Operator,
+  ## defaults to "true".
+  ##
+  enabled: true
+
+## Specify the parameters to override the sub-chart.
+##
+cdi:
+
+  ## Specify to install CDI CRD instance,
+  ## defaults to "true".
+  ##
+  enabled: true
+
+## Specify the parameters to override the sub-chart.
+##
+minio:
+
+  ## Specify to install Minio,
+  ## defaults to "true".
+  ##
+  enabled: true
+
+  ## Specify the full name of Minio.
+  ##
+  fullnameOverride: "minio"
+
+  ## Specify the resources of Minio container.
+  ##
+  resources:
+    requests:
+      memory: 256m
+
+  ## Specify the persistence of Minio.
+  ##
+  persistence:
+
+    ## Specify the StorageClass of Minio,
+    ## otherwise, Minio will use the default StorageClass.
+    ##
+    storageClass: ""
+
+###########################################################################
+###########################################################################
+##                    Default values for Harvester                       ##
+###########################################################################
+###########################################################################
+
+## Provide a name in place of labels.
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources.
+##
+fullnameOverride: ""
+
+## Specify the replicas of workload.
+##
+replicas: 1
+
+## Specify the security context of workload.
+##
+securityContext: {}
+
+## Specify the node selector of workload.
+##
+nodeSelector: {}
+
+## Specify the tolerations of workload.
+##
+tolerations: []
+#  - key: CriticalAddonsOnly
+#    operator: Exists
+
+## Specify the update strategy of workload.
+##
+strategy:
+  type: RollingUpdate
+
+## Specify the parameter of containers.
+##
+containers:
+
+  ## Specify the parameter of harvester-apiserver container.
+  ##
+  apiserver:
+
+    ## Specify the image.
+    ##
+    image:
+
+      ## Specify the pull policy of image.
+      ##
+      imagePullPolicy: Always
+
+      ## Specify the repository of image.
+      ##
+      repository: rancher/vm
+
+      ## Specify the tag of image.
+      ##
+      tag: master-head
+
+    ## Specify the command.
+    ##
+    command: []
+
+    ## Specify the args.
+    ##
+    args: []
+
+    ## Specify the env.
+    ##
+    env: []
+    #  - name: OPERATOR_IMAGE
+    #    value: xxx
+
+    ## Specify the liveness probe.
+    ##
+    livenessProbe: {}
+
+    ## Specify the readiness probe.
+    ##
+    readinessProbe: {}
+
+    ## Specify the resources.
+    ##
+    resources:
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+
+    ## Specify the gateway to access Minio-like VM image storage service which is compatible with S3,
+    ## only valid if Minio sub-charts is disabled in the same chart release.
+    ##
+    vmImageStorageGateway:
+
+      ## Specify the endpoint.
+      ##
+      endpoint: ""
+
+      ## Specify the name of the same namespace existing Secret instance,
+      ## which stored the access key(in "accessKey" field) and secret key(in "secretKey" field).
+      secretName: ""
+
+      ## Specify the access key,
+      ## the value will be stored in "accessKey" field of a specified Secret(named as the default fully qualified app name).
+      ##
+      accessKey: ""
+
+      ## Specify the secret key,
+      ## the value will store in "secretKey" field of a specified Secret(named as the default fully qualified app name).
+      ##
+      secretKey: ""
+
+## Specify the lifecycle jobs.
+##
+jobs:
+
+  ## Specify the pre-delete job.
+  ##
+  preDelete:
+
+    ## Specify to execute pre-delete job,
+    ## defaults to "true".
+    ##
+    enabled: true
+
+    ## Specify the node selector of workload.
+    ##
+    nodeSelector: {}
+
+    ## Specify the tolerations of workload.
+    ##
+    tolerations: []
+    #  - key: CriticalAddonsOnly
+    #    operator: Exists
+
+    ## Specify the backoff limit of workload,
+    ## defaults to "1".
+    ##
+    backoffLimit: 1
+
+    ## Specify the amount of seconds for calculate the active deadline,
+    ## defaults to "900".
+    ##
+    activeDeadlineSeconds: 900
+
+    ## Specify the amount of TTL seconds after finished(Complete/Failed),
+    ## defaults to "10".
+    ##
+    ttlSecondsAfterFinished: 10
+
+    ## Specify the restart policy of workload,
+    ## defaults to "OnFailure".
+    ##
+    restartPolicy: OnFailure
+
+    ## Specify the parameter of containers.
+    ##
+    containers:
+
+      ## Specify the parameter of kubectl action container.
+      ##
+      kubectl:
+
+        ## Specify the image.
+        ##
+        image:
+
+          ## Specify the pull policy of image.
+          ##
+          imagePullPolicy: IfNotPresent
+
+          ## Specify the repository of image.
+          ##
+          repository: bitnami/kubectl
+
+          ## Specify the tag of image.
+          ##
+          tag: 1.18.6
+
+        ## Specify the resources.
+        ##
+        resources:
+          limits:
+            cpu: 250m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/deploy/charts/kubevirt
+++ b/deploy/charts/kubevirt
@@ -1,0 +1,1 @@
+harvester/charts/kubevirt

--- a/deploy/charts/kubevirt-operator
+++ b/deploy/charts/kubevirt-operator
@@ -1,0 +1,1 @@
+harvester/charts/kubevirt-operator

--- a/scripts/charts-dependency-mirror
+++ b/scripts/charts-dependency-mirror
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+function mirror_harvester_dependencies() {
+  pushd "harvester" >/dev/null 2>&1 || exit 1
+
+  if [[ -n "$(command -v "helm")" ]]; then
+    # mirror minio
+    helm repo add minio-std https://helm.min.io/
+    helm pull minio-std/minio
+    tar -xvzf minio-*.tgz -C charts
+    rm minio-*.tgz
+  else
+    echo "failed to mirror the dependencies of 'harvester' chart as the 'helm' is not found"
+  fi
+
+  popd
+}
+
+ROOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+pushd "${ROOR_DIR}/deploy/charts" >/dev/null 2>&1 || exit 1
+
+mirror_harvester_dependencies
+
+popd


### PR DESCRIPTION
**Fixes:**

#10

**Problem:**

There is no easy approach to install Harvester.

**Solution:**

Give a Helm chart installation solution.

- `harvester` chart is used to install `kubevirt`, `cdi`, `minio`, and `harvester`.
- we can disable each component individually.
- The `minio` chart is a copy from the official chart.
  ``` bash
  $ cd deploy/charts/harvester
  $ helm repo add minio https://helm.min.io/
  $ helm pull minio/minio
  $ tar -xvzf minio-*.tgz -C charts
  $ rm minio-*.tgz
  ```
- The parameter of `kubevirt` and `cdi` charts have been sorted out, and kept consistent with the parameters of CRD as much as possible and described.

When `KubeVirt`/`CDI` resource is deleted, the admission webhook of `KubeVirt Operator`/`CDI Operator` workload will be triggered, and the related resources cannot be cleaned up if the corresponding Operator workload has been deleted. In order to avoid this, we use a `pre-delete` Helm hook to clean up the `KubeVirt`/`CDI` resource before executed `helm uninstall`.

- Installation

  ```bash
  $ # create namespace
  $ kubectl create namespace cattle-vm
  
  $ # install harvester with emulation if needed
  $ helm install harvester deploy/charts/harvester --namespace cattle-vm --set-string 
  kubevirt.spec.configuration.developerConfiguration.useEmulation=true
  ```

- Uninstallation

  ```bash
  $ # uninstall harvester
  $ helm uninstall harvester--namespace cattle-vm
  ```

**Test plan:**

- `helm install ...`