### PR TITLE
Update kubevirt to v0.32.0

### DIFF
--- a/deploy/charts/harvester/charts/kubevirt-operator/values.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/values.yaml
@@ -58,7 +58,7 @@ containers:
 
       ## Specify the tag of image.
       ##
-      tag: latest
+      tag: v0.32.0
 
     ## Specify the command.
     ##


### PR DESCRIPTION
Tracked a VM pod crashing issue which is caused by recent kubevirt master changes. We should use a specific release version to avoid unexpected crashes.