### PR TITLE
fix: remove default spec of kubevirt chart

### DIFF
--- a/deploy/charts/harvester/charts/kubevirt-operator/values.yaml
+++ b/deploy/charts/harvester/charts/kubevirt-operator/values.yaml
@@ -50,7 +50,7 @@ containers:
 
       ## Specify the pull policy of image.
       ##
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
 
       ## Specify the repository of image.
       ##

--- a/deploy/charts/harvester/charts/kubevirt/values.yaml
+++ b/deploy/charts/harvester/charts/kubevirt/values.yaml
@@ -29,7 +29,7 @@ spec:
   ## Specify the image pull policy of KubeVirt bundle components,
   ## defaults to "IfNotPresent".
   ##
-  imagePullPolicy: "IfNotPresent"
+  # imagePullPolicy: "IfNotPresent"
 
   ## Specify the namespace Prometheus is deployed in OpenShift,
   ## defaults to "openshift-monitor".
@@ -45,56 +45,56 @@ spec:
   ## defaults to "RemoveWorkloads".
   ## -- If specifies to BlockUninstallIfWorkloadsExist, we cannot drop KubeVirt CRD directly, we need to change this field to blank or RemoveWorkloads.
   ##
-  uninstallStrategy: "RemoveWorkloads"
+  # uninstallStrategy: "RemoveWorkloads"
 
   ## Specify the strategy of KubeVrit bundle components certificate rotation.
   ##
-  certificateRotateStrategy:
+  # certificateRotateStrategy:
 
     ## Specify the configuration of self signed certificate.
     ##
-    selfSigned:
+    # selfSigned:
 
       ## Specify the interval of CA rotation,
       ## defaults to "168h", 7d.
       ##
-      caRotateInterval: "168h"
+      # caRotateInterval: "168h"
 
       ## Specify the interval of Certificate rotation,
       ## defaults to "24h", 1d.
       ##
-      certRotateInterval: "24h"
+      # certRotateInterval: "24h"
 
       ## Specify the interval of CA overlap,
       ## defaults to "24h", 1d.
-      caOverlapInterval: "24h"
+      # caOverlapInterval: "24h"
 
   ## Specify the default configuration of KubeVirt virtual machine.
   ##
-  configuration:
+  # configuration:
 
     ## Specify the directory that contains the EFI roms,
     ## this argument will be passed to "virt-launcher" as "--ovmf-path",
     ## defaults to "/usr/share/OVMF".
     ##
-    ovmfPath: "/usr/share/OVMF"
+    # ovmfPath: "/usr/share/OVMF"
 
     ## Specify the SELinux type, this argument will fill into `spec.securityContext.selinuxOptions.type` of the generated Pod for "virt-launcher",
     ## and also fill into `spec.containers[?(.name!=compute)].securityContext.selinuxOptions.type` and `spec.containers[?(.name!=compute)].securityContext.selinuxOptions.level=s0`.
     ##
-    selinuxLauncherType: ""
+    # selinuxLauncherType: ""
 
     ## Specify the version regex of guest agent, which is used for processing the Condition(AgentVersionNotSupported) of VirtualMachineInstance,
     ## defaults to "[3.*, 4.*]".
     #
-    supportedGuestAgentVersions:
-      - "3.*"
-      - "4.*"
+    # supportedGuestAgentVersions:
+      # - "3.*"
+      # - "4.*"
 
     ## Specify the default CPU model of VirtualMachineInstance, selects from https://github.com/libvirt/libvirt/tree/master/src/cpu_map,
     ## defaults to "host-model".
     ##
-    cpuModel: "host-model"
+    # cpuModel: "host-model"
 
     ## Specify the default CPU request of VirtualMachineInstance(`spec.domain.requests.cpu`),
     ## defaults to "100m"
@@ -104,39 +104,39 @@ spec:
     ## Specify the machine type regex for validating the emulation of VirtualMachineInstance,
     ## defaults to discover automatically, "pseries*" if arch is ppc64le, otherwise "q35*,pc-q35*".
     ##
-    emulatedMachines: []
+    # emulatedMachines: []
 
     ## Specify the machine type for filling VirtualMachineInstance(`spec.domain.machine.type`),
     ## defaults to discover automatically, "pseries" if arch is ppc64le, otherwise "q35".
     ##
-    machineType: ""
+    # machineType: ""
 
     ## Specify the virtual machine image pull policy of `virt-launcher` Pod,
     ## defaults to "IfNotPresent".
     ##
-    imagePullPolicy: "IfNotPresent"
+    # imagePullPolicy: "IfNotPresent"
 
     ## Specify the developer configuration of KubeVirt.
     ##
-    developerConfiguration:
+    # developerConfiguration:
 
       ## Specify whether an optional feature is enabled or not at the global level,
       ## select many from [CPUManager, ExperimentalIgnitionSupport, LiveMigration, CPUNodeDiscovery, HypervStrictCheck, Sidecar, GPU, Snapshot, HostDisk], ref to:
       ## https://github.com/kubevirt/kubevirt/blob/f5ffba5f84365155c81d0e2cda4aa709da062230/pkg/virt-config/feature-gates.go#L26-L36.
       ##
-      featureGates: []
+      # featureGates: []
 
       ## Specify the toleration in percent when PVs' available space is smaller than requested,
       ## this argument will be passed to "virt-launcher" as "--less-pvc-space-toleration",
       ## defaults to "10" percent.
       ##
-      pvcTolerateLessSpaceUpToPercont: "10"
+      # pvcTolerateLessSpaceUpToPercont: "10"
 
       ## Specify the memory overcommit in percent,
       ## which will effect VirtualMachineInstance(`spec.domain.resources.memory`),
       ## defaults to "100" percent, which means 100% to overcommit the memory.
       ##
-      memoryOvercommit: "100"
+      # memoryOvercommit: "100"
 
       ## Specify the selector of VirtualMachineInstance(`spec.nodeSelector`), it can override the same key defined in origin.
       ## -- When enabling "CPUNodeDiscovery" feature, `feature.node.kubernetes.io/cpu-model-<model-specified-in-crd>=true` will attach to here if `spec.domain.cpu.model` is not blank, except "host-model" and "host-passthourgh".
@@ -144,103 +144,103 @@ spec:
       ## -- When enabling "HypervStrictCheck" feature, `feature.node.kubernetes.io/kvm-info-cap-hyperv-<feature-label-name-specified-in-crd>=true` will attach to here if `spec.domain.cpu.hyperv` is not empty.
       ## -- `kubevirt.io/schedulable=true` must attach to here.
       ##
-      nodeSelector: {}
+      # nodeSelector: {}
 
       ## Specify if uses eumlation,
       ## this argument will be passed to "virt-launcher" as "--use-eumlation",
       ## defaults to "false".
       ## -- `devices.kubevirt.io/kvm=1` will attach to `resources.limits` if here is "false".
       ##
-      useEmulation: "false"
+      # useEmulation: "false"
 
     ## Specify the migration configuration of KubeVirt.
     ##
-    migrations:
+    # migrations:
 
       ## Specify if allows to converge automatically,
       ## defaults to "false"
       ##
-      allowAutoConverge: "false"
+      # allowAutoConverge: "false"
 
       ## Specify the bandwidth per migration,
       ## defaults to "64Mi"
       ##
-      bandwidthPerMigration: "64Mi"
+      # bandwidthPerMigration: "64Mi"
 
       ## Specify the timeout for completing each GB migration,
       ## defaults to "800".
       ##
-      completionTimeoutPerGiB: "800"
+      # completionTimeoutPerGiB: "800"
 
       ## Specify the label of node,
       ## defaults to "kubevirt.io/drain".
       ##
-      nodeDrainTaintKey: "kubevirt.io/drain"
+      # nodeDrainTaintKey: "kubevirt.io/drain"
 
       ## Specify the amount of outbound migrations of parallels per node,
       ## defaults to "2".
       ##
-      parallelOutboundMigrationsPerNode: "2"
+      # parallelOutboundMigrationsPerNode: "2"
 
       ## Specify the amount of migrations of parallels per cluster,
       ## defaults to "5".
       ##
-      parallelMigrationsPerCluster: "5"
+      # parallelMigrationsPerCluster: "5"
 
       ## Specify the timeout of progress,
       ## defaults to "150".
       ##
-      progressTimeout: "150"
+      # progressTimeout: "150"
 
       ## Specify if overrides unsafe migration,
       ## defaults to "false".
       ##
-      unsafeMigrationOverride: "false"
+      # unsafeMigrationOverride: "false"
 
     ## Specify the network configuration of VirtualMachineInstance.
     ##
-    network:
+    # network:
 
       ## Specify the default network interface of VirtualMachineInstance(`spec.domain.devices.interfaces[?(.name="default")]`),
       ## defaults to "bridge".
       ##
-      defaultNetworkInterface: "bridge"
+      # defaultNetworkInterface: "bridge"
 
       ## Specify to permit slirp interface,
       ## defaults to "false".
       ## -- If the `defaultNetworkInterface` is "slirp", here must specify to "true".
       ##
-      permitSlirpInterface: "false"
+      # permitSlirpInterface: "false"
 
       ## Specify to permit bridge interface,
       ## defaults to "true".
       ## -- If the `defaultNetworkInterface` is "bridge", here must specify to "true".
       ##
-      permitBridgeInterfaceOnPodNetwork: "true"
+      # permitBridgeInterfaceOnPodNetwork: "true"
 
     ## Specify the SMBIOS which should pass to "libvirt".
     ##
-    smbios:
+    # smbios:
 
       ## Specify the manufacturer,
       ## defaults to "KubeVirt".
       ##
-      manufacturer: "KubVirt"
+      # manufacturer: "KubVirt"
 
       ## Specify the product,
       ## defaults to "None".
       ##
-      product: "None"
+      # product: "None"
 
       ## Specify the version.
       ##
-      version: ""
+      # version: ""
 
       ## Specify the SKU.
       ##
-      sku: ""
+      # sku: ""
 
       ## Specify the family,
       ## defaults to "KubeVirt".
       ##
-      family: "KubeVirt"
+      # family: "KubeVirt"

--- a/deploy/charts/harvester/questions.yaml
+++ b/deploy/charts/harvester/questions.yaml
@@ -5,9 +5,9 @@ namespace: harvester-system
 questions:
 
 ###
-#################### Harvester Advance Options ####################
+#################### Harvester Advanced Options ####################
 ###
-  #################### Harvester Image Settings ####################
+#################### Harvester Image Settings ####################
   - variable: containers.apiserver.image.repository
     default: "rancher/harvester"
     label: "Image"
@@ -49,7 +49,7 @@ questions:
   - variable: service.harvester.asClusterService
     default: "true"
     label: "Access From Rancher Proxy"
-    description: "specify as cluster service, and then can be accessed from rancher proxy"
+    description: "specify as cluster service, and then can be accessed from the rancher proxy"
     type: "boolean"
     group: "Harvester Settings"
   - variable: service.harvester.type
@@ -64,8 +64,8 @@ questions:
     group: "Harvester Settings"
   - variable: service.harvester.httpsPort
     default: "8443"
-    label: "Service HTTPs Port"
-    description: "specify the port of HTTPs endpoint"
+    label: "Service HTTPS Port"
+    description: "specify the port of HTTPS endpoint"
     type: "int"
     min: 1
     group: "Harvester Settings"
@@ -80,7 +80,7 @@ questions:
 ###
 #################### Harvester Cleanup Job Options ####################
 ###
-  #################### Harvester Cleanup Job Settings ####################
+#################### Harvester Cleanup Job Settings ####################
   - variable: jobs.preDelete.containers.kubectl.image.repository
     default: "bitnami/kubectl"
     label: "Image"
@@ -95,52 +95,23 @@ questions:
     type: "string"
     group: "Harvester Cleanup Job Settings"
     show_if: "tags.kubevirt=true || tags.cdi=true"
-  #################### Harvester Cleanup Job Resource Settings ####################
-  - variable: jobs.preDelete.containers.kubectl.resources.requests.cpu
-    default: "250m"
-    label: "CPU Request"
-    description: "specify the request of CPU resource"
-    type: "string"
-    group: "Harvester Cleanup Job Settings"
-    show_if: "tags.kubevirt=true || tags.cdi=true"
-  - variable: jobs.preDelete.containers.kubectl.resources.requests.memory
-    default: "128Mi"
-    label: "Memory Request"
-    description: "specify the request of memory resource"
-    type: "string"
-    group: "Harvester Cleanup Job Settings"
-    show_if: "tags.kubevirt=true || tags.cdi=true"
-  - variable: jobs.preDelete.containers.kubectl.resources.limits.cpu
-    default: "250m"
-    label: "CPU Limit"
-    description: "specify the limit of CPU resource"
-    type: "string"
-    group: "Harvester Cleanup Job Settings"
-    show_if: "tags.kubevirt=true || tags.cdi=true"
-  - variable: jobs.preDelete.containers.kubectl.resources.limits.memory
-    default: "128Mi"
-    label: "Memory Limit"
-    description: "specify the limit of memory resource"
-    type: "string"
-    group: "Harvester Cleanup Job Settings"
-    show_if: "tags.kubevirt=true || tags.cdi=true"
-
 ###
-#################### KubeVirt Advance Options ####################
+#################### KubeVirt Advanced Options ####################
 ###
+#################### KubeVirt Advanced Control Settings ####################
+  - variable: tags.kubevirt
+    default: "true"
+    label: "Install KubeVirt operator and CRD resources"
+    type: "boolean"
+    group: "KubeVirt Settings"
   - variable: show_kubevirt_advance_options
     default: "false"
-    label: "Show Advance Options"
+    label: "Show Advanced Options"
     type: "boolean"
+    show_if: "tags.kubevirt=true"
     show_subquestion_if: true
     group: "KubeVirt Settings"
     subquestions:
-      #################### KubeVirt Advance Control Settings ####################
-      - variable: tags.kubevirt
-        default: "true"
-        label: "Install KubeVirt operator and CRD resource"
-        type: "boolean"
-        group: "KubeVirt Settings"
       #################### KubeVirt Operator Image Settings ####################
       - variable: kubevirt-operator.containers.operator.image.repository
         default: "kubevirt/virt-operator"
@@ -150,7 +121,7 @@ questions:
         group: "KubeVirt Settings"
         show_if: "tags.kubevirt=true"
       - variable: kubevirt-operator.containers.operator.image.tag
-        default: "latest"
+        default: "v0.32.0"
         label: "Operator Image Tag"
         description: "specify the tag of operator image"
         type: "string"
@@ -185,73 +156,23 @@ questions:
         type: "string"
         group: "KubeVirt Settings"
         show_if: "tags.kubevirt=true"
-      #################### KubeVirt CRD Settings ####################
-      - variable: kubevirt.spec.configuration.cpuModel
-        default: "host-model"
-        label: "Default Virtual Machine CPU Model"
-        description: "specify the default CPU model of vm"
-        type: "string"
-        group: "KubeVirt Settings"
-        show_if: "tags.kubevirt=true"
-      - variable: kubevirt.spec.configuration.cpuRequest
-        default: "100m"
-        label: "Default Virtual Machine CPU Request"
-        description: "specify the default CPU request of vm"
-        type: "string"
-        group: "KubeVirt Settings"
-        show_if: "tags.kubevirt=true"
-      - variable: kubevirt.spec.configuration.developerConfiguration.memoryOvercommit
-        default: "100"
-        label: "Default Virtual Machine Memory Overcommit Percent"
-        description: "specify the memory overcommit in percent, default is means 100% to overcommit the memory"
-        type: "string"
-        group: "KubeVirt Settings"
-        show_if: "tags.kubevirt=true"
-      - variable: kubevirt.spec.configuration.network.defaultNetworkInterface
-        default: "bridge"
-        label: "Default Virtual Machine Network Interface"
-        description: "specify the default network interface of vm"
-        type: "enum"
-        options:
-          - bridge
-          - slirp
-          - masquerade
-        group: "KubeVirt Settings"
-        show_if: "tags.kubevirt=true"
-      - variable: kubevirt.spec.configuration.developerConfiguration.useEmulation
-        default: "false"
-        label: "Use Emulated Virtual Machine"
-        description: "specify if uses emulation"
-        type: "boolean"
-        group: "KubeVirt Settings"
-        show_if: "tags.kubevirt=true"
-      - variable: kubevirt.spec.uninstallStrategy
-        default: "RemoveWorkloads"
-        label: "Uninstall Strategy"
-        description: "specify the uninstall strategy of KubeVirt"
-        type: "enum"
-        options:
-          - "RemoveWorkloads"
-          - "BlockUninstallIfWorkloadsExist"
-        group: "KubeVirt Settings"
-        show_if: "tags.kubevirt=true"
-
 ###
-#################### CDI Advance Options ####################
+#################### CDI Advanced Options ####################
 ###
+#################### CDI Advanced Control Settings ####################
+  - variable: tags.cdi
+    default: "true"
+    label: "Install CDI operator and CRD resources"
+    type: "boolean"
+    group: "CDI Settings"
   - variable: show_cdi_advance_options
     default: "false"
-    label: "Show Advance Options"
+    label: "Show Advanced Options"
     type: "boolean"
     show_subquestion_if: true
+    show_if: "tags.cdi=true"
     group: "CDI Settings"
     subquestions:
-      #################### CDI Advance Control Settings ####################
-      - variable: tags.cdi
-        default: "true"
-        label: "Install CDI operator and CRD resource"
-        type: "boolean"
-        group: "CDI Settings"
       #################### CDI Operator Image Settings ####################
       - variable: cdi-operator.containers.operator.image.repository
         default: "kubevirt/cdi-operator"
@@ -309,7 +230,7 @@ questions:
         show_if: "tags.cdi=true"
       - variable: show_cdi_components_advance_options
         default: "false"
-        label: "Show CDI Components Advance Options"
+        label: "Show CDI Components Advanced Options"
         type: "boolean"
         show_if: "tags.cdi=true"
         group: "CDI Settings"
@@ -405,21 +326,21 @@ questions:
         show_if: "tags.cdi=true && show_cdi_components_advance_options=true"
 
 ###
-#################### Minio Advance Options ####################
+#################### Minio Advanced Options ####################
 ###
+  - variable: minio.enabled
+    default: "true"
+    label: "Install Minio"
+    type: "boolean"
+    group: "Minio Settings"
   - variable: show_minio_advance_options
     default: "false"
-    label: "Show Advance Options"
+    label: "Show Advanced Options"
     type: "boolean"
     show_subquestion_if: true
+    show_if: "minio.enabled=true"
     group: "Minio Settings"
     subquestions:
-      #################### Minio Advance Control Settings ####################
-      - variable: minio.enabled
-        default: "true"
-        label: "Install Minio"
-        type: "boolean"
-        group: "Minio Settings"
       #################### Minio Image Settings ####################
       - variable: minio.image.repository
         default: "minio/minio"


### PR DESCRIPTION
 https://github.com/rancher/harvester/pulls
1. set the default kubevirt spec to empty as this is more preferred (in this way, bump kubevirt will not introduce unexpected bugs and the user can always set those values via custom config)
1. update the chart Q&A with changing the first option to enable or disable each component