### PR TITLE
just put impersonate info into jwe to make the cookie shorter

### DIFF
--- a/pkg/api/auth/auth_handler.go
+++ b/pkg/api/auth/auth_handler.go
@@ -1,16 +1,12 @@
 package auth
 
 import (
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"net/http"
 
-	"github.com/rancher/harvester/pkg/auth/jwt"
 	"github.com/rancher/harvester/pkg/config"
 
 	dashboardauthapi "github.com/kubernetes/dashboard/src/app/backend/auth/api"
-	"github.com/pkg/errors"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -64,40 +60,5 @@ func (h *Middleware) getUserInfoFromToken(jweToken string) (userInfo user.Info, 
 		return
 	}
 
-	userInfo, err = getUserFromAuthInfo(authInfo)
-	if err != nil {
-		return
-	}
-	return
-}
-
-func getUserFromAuthInfo(authInfo *api.AuthInfo) (user.Info, error) {
-	if authInfo.Token != "" {
-		claims, err := jwt.GetJWTTokenClaims(authInfo.Token)
-		if err != nil {
-			return nil, err
-		}
-		subject, ok1 := claims[jwtServiceAccountClaimSubject]
-		if ok1 {
-			return &user.DefaultInfo{
-				Name: subject.(string),
-			}, nil
-		}
-	}
-
-	if len(authInfo.ClientCertificateData) != 0 && len(authInfo.ClientKeyData) != 0 {
-		block, _ := pem.Decode(authInfo.ClientCertificateData)
-		clientCert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, errors.Wrapf(err, "kubeconfig's ClientCertificateData is not a valid CA")
-		}
-
-		if clientCert.Subject.CommonName == "" {
-			return nil, errors.New("Subject.CommonName from kubeconfig's ClientCertificateData is empty")
-		}
-
-		return &user.DefaultInfo{Name: clientCert.Subject.CommonName, Groups: clientCert.Subject.Organization}, nil
-	}
-
-	return nil, errors.New("Failed to get userInfo from authInfo")
+	return impersonateAuthInfoToUserInfo(authInfo), nil
 }

--- a/pkg/api/auth/public_api_handler.go
+++ b/pkg/api/auth/public_api_handler.go
@@ -127,7 +127,12 @@ func (h *PublicAPIHandler) login(input *Login) (tokenResp *TokenResponse, status
 		return nil, http.StatusUnauthorized, errors.Wrapf(err, "Failed to login")
 	}
 
-	token, err := h.tokenManager.Generate(*authInfo)
+	impersonateAuthInfo, err := getImpersonateAuthInfo(authInfo)
+	if err != nil {
+		return nil, http.StatusInternalServerError, errors.Wrapf(err, "Failed to build impersonate authInfo from authorization info")
+	}
+
+	token, err := h.tokenManager.Generate(*impersonateAuthInfo)
 	if err != nil {
 		return nil, http.StatusInternalServerError, errors.Wrapf(err, "Failed to generate token")
 	}

--- a/pkg/api/auth/token.go
+++ b/pkg/api/auth/token.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 
 	"github.com/rancher/harvester/pkg/auth/jwt"
-	"k8s.io/apiserver/pkg/authentication/user"
 
 	"github.com/pkg/errors"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"

--- a/pkg/api/auth/token_test.go
+++ b/pkg/api/auth/token_test.go
@@ -1,0 +1,166 @@
+package auth
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetImpersonateAuthInfo(t *testing.T) {
+	type input struct {
+		token      string
+		kubeconfig string
+	}
+	type output struct {
+		impersonate       string
+		impersonateGroups []string
+		errorMessage      string
+	}
+
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "valid serviceAccount token",
+			given: input{
+				token: "eyJhbGciOiJSUzI1NiIsImtpZCI6IlZ6WmFWS2N5aUs1WFZBV040V3hSYnlFT3pyOWZIN1hrU1B4NWVSeDVMbDQifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImFkbWluLXNhLXRva2VuLW56YzI5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6ImFkbWluLXNhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQudWlkIjoiMmZkMTU0ZjctMjlmYy00NTUxLTk2NmYtNDY1NTgyNzEyZDIxIiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6YWRtaW4tc2EifQ.BHdo7zKq-dFtlm0OjwFRyypgRqMWmOkx18kGxbm0qLALnWU4GZF2CGqQxTr9IsfEUR3xak9_NnEnsMIZh9yvqpwQgWZPf0LEtWBl7mw04LiQ0syXzY3sLCT7hnGDJv_sIN_zYH3apCDIENjgXQuXcvr1NUAfP9GtwaZ9JlFj1x63HB24EMSSqPpg4NF55XjyHcm6B2JKqSEfkXk1LzMpn_6XFGVv0ic_tN4c88MhXlcSvJemEsicEwgnouSAxqFXnsjM2napsgUlvctMDcXE5D97OlNhQ_EFLrFpMlr4Yo-lKQ9TRVTZ-Mv4w9zV3CoLlmXjmjq_BRgC5MH-43I5Dw",
+			},
+			expected: output{
+				errorMessage: "",
+				impersonate:  "system:serviceaccount:default:admin-sa",
+			},
+		},
+		{
+			name: "invalid serviceAccount token",
+			given: input{
+				token: "invalid",
+			},
+			expected: output{
+				errorMessage: "token contains an invalid number of segments",
+			},
+		},
+		{
+			name: "valid kubeconfig with client-certificate",
+			given: input{
+				kubeconfig: kubeconfigWithClientCert,
+			},
+			expected: output{
+				errorMessage:      "",
+				impersonate:       "kube-admin",
+				impersonateGroups: []string{"system:masters"},
+			},
+		},
+		{
+			name: "valid kubeconfig with token",
+			given: input{
+				kubeconfig: kubeconfigWithToken,
+			},
+			expected: output{
+				errorMessage: "",
+				impersonate:  "system:serviceaccount:default:admin-sa",
+			},
+		},
+		{
+			name: "invalid kubeconfig",
+			given: input{
+				kubeconfig: inValidkubeconfigWithToken,
+			},
+			expected: output{
+				errorMessage: "token contains an invalid number of segments",
+				impersonate:  "system:serviceaccount:default:admin-sa",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		authInfo, err := buildAuthInfo(tc.given.token, tc.given.kubeconfig)
+		if ok := assert.Nil(t, err, "case %q", tc.name); !ok {
+			continue
+		}
+
+		impersonateAuthInfo, err := getImpersonateAuthInfo(authInfo)
+		if tc.expected.errorMessage == "" {
+			assert.Nil(t, err, "case %q", tc.name)
+		} else {
+			assert.EqualError(t, err, tc.expected.errorMessage, "case %q", tc.name)
+			continue
+		}
+
+		userInfo := impersonateAuthInfoToUserInfo(impersonateAuthInfo)
+		expectedGroups := tc.expected.impersonateGroups
+		actualImpersionateGroups := userInfo.GetGroups()
+
+		sort.Strings(actualImpersionateGroups)
+		sort.Strings(expectedGroups)
+
+		assert.Equal(t, tc.expected.impersonate, userInfo.GetName(), "case %q", tc.name)
+		assert.Equal(t, expectedGroups, actualImpersionateGroups, "case %q", tc.name)
+	}
+
+}
+
+const (
+	kubeconfigWithClientCert = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN3akNDQWFxZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcmRXSmwKTFdOaE1CNFhEVEl3TURreE1EQXhORGd6T1ZvWERUTXdNRGt3T0RBeE5EZ3pPVm93RWpFUU1BNEdBMVVFQXhNSAphM1ZpWlMxallUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQVBHTzVjNGdlWVpSClB2SkcrRTNTdk00M1ZNams0V0tjcm9RUFlZcjNOTVRSYU8xR1EwRDJaRGlKWnkrZEF0OFFmY2VSNE5FZmRWekEKWlZaSVd6RnFOY0RlbHQ1VVVQbWdvMkRrMllvbUV3VXo1WkU3bG1WMlRoRkc3clBrUVQycWt2SXZpanM3TXJUdgovUXc3UTVUSS8wVGV4UGxRdy9oc1haM0MyWDFBK3pwTjkycU11c1FDYmFHOVRYdERiejhCdkJXZ2dURzdGdHdQCm02Rk51S0VhRTkvZFpOY0plZHFyL21LbkhQR2lPUkxOR3YyaG1QMlpkMS9zaUdrWlhJdWo3VkdqOEZMUUhSVE4KdENlNzlJN0FHQ3R4UnJLWkRmK3liZEJKUStjRXpVa1JqUlFWcmMyd3ZDRUJVRzFsbWdCdE1tNmlzRHpjQTJoSwpnbjg4SXFKZ09jVUNBd0VBQWFNak1DRXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBQzRYQzVkaCtvNWFaei9hYXRieEtwWEt3Z3ZFK1ZrZk1UWWMKUDE2bjI3a1QraDArODlRYUxRQWFkUFhDR0draUZ2MG5ROXg0Um1uKzkxbHYzVFRvK0tjenpuM0RsS2QzenZsagpITnloYmc2RVcwelozRVRZazNBaHUzUk5YSEw0aGtHR3E0TmprOTd4MEErbng3MXprRmJMeEI2UGt5ZWdyTTlxCnUzMmZDMUI4aUJibzFFT1NtUUpzbHVOZ3NjWDRZR3VOc0RYVFRKanpVTmJCYjRvZVFlOVNqVXR0dlFtOC92NUsKQS9CUnJYWWs1dml1U3Mvb1NUUGlBYVd4M2hUOVJ1TDJwbENtK256YmhweHBRN0JKVDBDL2xKMXpULzlQeGxnMApmcWx2emlHajY4SHJSMGtIRmIrOHBlSC9xa0FRdnByVUw1ZkQ3a0ViWjV5K0hHWTAwbGc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    server: https://127.0.0.1:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    namespace: test
+    user: test
+  name: test
+current-context: test
+kind: Config
+preferences: {}
+users:
+- name: test
+  user:
+    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM2VENDQWRHZ0F3SUJBZ0lJZEZkMUs3Qk91Y3N3RFFZSktvWklodmNOQVFFTEJRQXdFakVRTUE0R0ExVUUKQXhNSGEzVmlaUzFqWVRBZUZ3MHlNREE1TVRBd01UUTRNemxhRncwek1EQTVNRGd3TVRRNE5EQmFNQzR4RnpBVgpCZ05WQkFvVERuTjVjM1JsYlRwdFlYTjBaWEp6TVJNd0VRWURWUVFERXdwcmRXSmxMV0ZrYldsdU1JSUJJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW0zaTc5THQxU2VrblVLWmZRU05YTkdxOHBEVEMKbmZLTmRKTUNFMzJnbDVMVEJIcmczeXlBQlJQRnV0VHRCZE9xcTJwYWpmQnZ6WURodG9QWGRIaGtYUml1RE90MwpjMzRXai82WXhjcGNBNnNIWFE4VnFZSUpwQXpKRTBaQ2trT0xmdlVVTGVqYW42MFV1V0xrNHNFYWRiRkpZVTdDCkRzU1IyVjdwNFluT0R5YXBCRm5ya1RuUDN5b0p3dVRxcGRoeU9Db1Z6dXNCOFRJdExpVzNWd3p1czN2bUtWanoKVTZ4ZnUyWDZlRkpTZEQycDQ5dWZsUFZEOVZLczdRYkNTeGNlOHlTemx2alI4Um1iRFNEdGJiamhvWmFCU3VFQgorV25XWDk5dWZhL3JKN2x4UXB1ck42Z01xUkJqdklhV2RhMTl6US92NTNqeVdQcFFzVjZqRFJBdmpRSURBUUFCCm95Y3dKVEFPQmdOVkhROEJBZjhFQkFNQ0JhQXdFd1lEVlIwbEJBd3dDZ1lJS3dZQkJRVUhBd0l3RFFZSktvWkkKaHZjTkFRRUxCUUFEZ2dFQkFCcEtJREpxcUFkYm9Hd3MvRHVMVGRJUFg3RHZuN213ZDJVR0kxNGNhdmRFR0JFWgoxWXJUanhwNE5NUjU4QnhNRHJ6R1FkemlEMEtxV2NIL0ZNbHlLRUZHaXN5dDNhNE8zTWxUMWc3dFVQekdrL2NhCmM2aTIyZ1F6UUNFU2dSSnREVjFrT285MkFKUVEzd0hsR2ZpN0Y5WnBmaVdiRGh4cFFxZTJoSjFIQnZWUzdZUGMKbTZwOGRJVWZTQThxa1Z1M2hncHRSVmVyZUs3VVdWQ0tmb3ZZRmJSNHNOcUt0cGhKOHpBbnE5R3ZRL3JMUTUvWQpGM2p3akNXeXRHdExsSUFmcllGZ0trdzlNd0g4Q1J2UU5QaWlpNTBCbWN6SmUrTTBzeHlLQXJhZkhqclFMcGlwClhJclNTM0s0MlVoTXFKRlhOdTJ6S1RhVG1vd0lhQmFuZDE5aVdHcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBbTNpNzlMdDFTZWtuVUtaZlFTTlhOR3E4cERUQ25mS05kSk1DRTMyZ2w1TFRCSHJnCjN5eUFCUlBGdXRUdEJkT3FxMnBhamZCdnpZRGh0b1BYZEhoa1hSaXVET3QzYzM0V2ovNll4Y3BjQTZzSFhROFYKcVlJSnBBekpFMFpDa2tPTGZ2VVVMZWphbjYwVXVXTGs0c0VhZGJGSllVN0NEc1NSMlY3cDRZbk9EeWFwQkZucgprVG5QM3lvSnd1VHFwZGh5T0NvVnp1c0I4VEl0TGlXM1Z3enVzM3ZtS1ZqelU2eGZ1Mlg2ZUZKU2REMnA0OXVmCmxQVkQ5VktzN1FiQ1N4Y2U4eVN6bHZqUjhSbWJEU0R0YmJqaG9aYUJTdUVCK1duV1g5OXVmYS9ySjdseFFwdXIKTjZnTXFSQmp2SWFXZGExOXpRL3Y1M2p5V1BwUXNWNmpEUkF2alFJREFRQUJBb0lCQUg3WDBSbEplOWJTWjJZUQpadlRBL1p2aFhZam5Gc1ZBcUJJdEFtdWVlbEJQMU9QNTBNK2tBY3FpcUJiWE00NG1kRDhvSlR0YXFBelZFdElTCjNNekVrTFczdGdFS2QwbDkzTENjZWs0YzNGZU55Uk11aEhEb2pDOFEwMWhyWVZMdDByakJBVGEzbk83YmltWDUKL2wzV1NGMHZTSHdnZ29rRDdTNllsbDZSVE5Ia1prWG1CcEdSQ1JHNlJsS1JQZ2NqMHVzb1FLVGhFTWVkamE2LwozQ1hEbWJUbnNrdGxBNXFCL0NDazJMVnBLV2pqSGhReHRyMWZXcUkvR3h1THpjOVJPUmR4VjR3T243WTI2NEQ2Cnh0djcyY2t5MlZmL2tCRk5ZM0JQbG9YMDhxRDErWWIyQnhDZUN4K0laQ0MyN0N0MmIvaTIreXRKZnFSaDRaSmoKZHNPdUlVMENnWUVBeCsyYVRWVnNpb1FZNGxBMGZDS3EvYjJLQ2xjc2VtaVUwSUpteVAvSnZWMEtzcWlMRDBucQpNWnlKbVRVNHJVYUZaeFZGL21DUDlPcTkwR0hYbzFkTVVzRkF3MS9TS1Y3VGloWHhnLzluZkFUZXhEdmRhT1N4CjJxTEpSbTVaM3pKNFM2YnRneGJEYi9nazRxbTRlY1dzYWFhZ2xwdkFyc21Dd1p3MnlFQlo5VWNDZ1lFQXh4TkEKZ1FacUxLSHZSNjltblhEWWYrY2dQcE85Y3ZLU2hwWTQweHdMQ2ZYUC9WQnIvb1JkOUNNVVBOMG1JTUNFUVgwagp6ZXJ2aldGejlUakd5YTBFdVRqcjd4MzdDYW9VbkFPUjZGeXI0MG1XcXB0c0VXS1ptS2E4bzY4QitFTG8rTmpiClBsaCtVNGtFQ2VLTExKRWVyenlMbTJvUDB1dzREdXFLQTR4UTdvc0NnWUVBdUhvTnZ2M3J3WVJTVWNFZ0xNcncKYkdIUVZlcEtLRWtIeDc0TGlidzhNbmIvd0FxMUJjNTJRb0RtbG0vOWRDVjJRci9tYmVvNzZ3b1BTNUI4b1VPVQpNV2dRa2phQWZadjZKWmhKMmpwNUNuNlQ3dzR1SnZPZkNOYmNVaGpRNUpwMVZaa1ozN1BKY2kvT0dUZngrS3JsCmhEYzBSc1JBN3djUm1BVEVwOUo1TDFFQ2dZQjlJeER0Q2djN3Z4OFdSSitRWUJyM2EyWE5jRGtxUkdqdXlRYzMKVE8xemVWMGdzcWp2K0d6R3hqWTJmQjAzZ1V5aGpmUXZ3SHFNdUxHWGQvVWRXUEViTFRqQnVtclBER2FnRzI1ZwpUY0NPd3ZjK2p5eERVV09UblZ2KzJFZTRzdmFYVmxtYXV5M05mTmRaRDFyRXpRUW95enBHbTBrUElRV3IrcXArCnlIa25PUUtCZ1FDTXpsc01UMjhSRGJWWVM5MXhKSHROT2ptcWM5QmFBNTlOQzJVMXZSQjNtTzYzSGlBckVPWTEKVUlNdDdaK2lMc1JKZys3RE1NMFRDV3pjTld1U1EwN0JrQTZwaTVxNlZkalVXNkpRK3JaYjBRaGdXbDFmT3c5LwpnU2hHQmFFRzZmTjlmeEM5Rjk3elhraVE5Z2JRODcvV0RlaWkvYldROTFuZVQvWGFCREVSQlE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
+
+	kubeconfigWithToken = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN3akNDQWFxZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcmRXSmwKTFdOaE1CNFhEVEl3TURreE1EQXhORGd6T1ZvWERUTXdNRGt3T0RBeE5EZ3pPVm93RWpFUU1BNEdBMVVFQXhNSAphM1ZpWlMxallUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQVBHTzVjNGdlWVpSClB2SkcrRTNTdk00M1ZNams0V0tjcm9RUFlZcjNOTVRSYU8xR1EwRDJaRGlKWnkrZEF0OFFmY2VSNE5FZmRWekEKWlZaSVd6RnFOY0RlbHQ1VVVQbWdvMkRrMllvbUV3VXo1WkU3bG1WMlRoRkc3clBrUVQycWt2SXZpanM3TXJUdgovUXc3UTVUSS8wVGV4UGxRdy9oc1haM0MyWDFBK3pwTjkycU11c1FDYmFHOVRYdERiejhCdkJXZ2dURzdGdHdQCm02Rk51S0VhRTkvZFpOY0plZHFyL21LbkhQR2lPUkxOR3YyaG1QMlpkMS9zaUdrWlhJdWo3VkdqOEZMUUhSVE4KdENlNzlJN0FHQ3R4UnJLWkRmK3liZEJKUStjRXpVa1JqUlFWcmMyd3ZDRUJVRzFsbWdCdE1tNmlzRHpjQTJoSwpnbjg4SXFKZ09jVUNBd0VBQWFNak1DRXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBQzRYQzVkaCtvNWFaei9hYXRieEtwWEt3Z3ZFK1ZrZk1UWWMKUDE2bjI3a1QraDArODlRYUxRQWFkUFhDR0draUZ2MG5ROXg0Um1uKzkxbHYzVFRvK0tjenpuM0RsS2QzenZsagpITnloYmc2RVcwelozRVRZazNBaHUzUk5YSEw0aGtHR3E0TmprOTd4MEErbng3MXprRmJMeEI2UGt5ZWdyTTlxCnUzMmZDMUI4aUJibzFFT1NtUUpzbHVOZ3NjWDRZR3VOc0RYVFRKanpVTmJCYjRvZVFlOVNqVXR0dlFtOC92NUsKQS9CUnJYWWs1dml1U3Mvb1NUUGlBYVd4M2hUOVJ1TDJwbENtK256YmhweHBRN0JKVDBDL2xKMXpULzlQeGxnMApmcWx2emlHajY4SHJSMGtIRmIrOHBlSC9xa0FRdnByVUw1ZkQ3a0ViWjV5K0hHWTAwbGc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    server: https://127.0.0.1:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    namespace: test
+    user: test
+  name: test
+current-context: test
+kind: Config
+preferences: {}
+users:
+- name: test
+  user:
+    token: eyJhbGciOiJSUzI1NiIsImtpZCI6IlZ6WmFWS2N5aUs1WFZBV040V3hSYnlFT3pyOWZIN1hrU1B4NWVSeDVMbDQifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImFkbWluLXNhLXRva2VuLW56YzI5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6ImFkbWluLXNhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQudWlkIjoiMmZkMTU0ZjctMjlmYy00NTUxLTk2NmYtNDY1NTgyNzEyZDIxIiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6YWRtaW4tc2EifQ.BHdo7zKq-dFtlm0OjwFRyypgRqMWmOkx18kGxbm0qLALnWU4GZF2CGqQxTr9IsfEUR3xak9_NnEnsMIZh9yvqpwQgWZPf0LEtWBl7mw04LiQ0syXzY3sLCT7hnGDJv_sIN_zYH3apCDIENjgXQuXcvr1NUAfP9GtwaZ9JlFj1x63HB24EMSSqPpg4NF55XjyHcm6B2JKqSEfkXk1LzMpn_6XFGVv0ic_tN4c88MhXlcSvJemEsicEwgnouSAxqFXnsjM2napsgUlvctMDcXE5D97OlNhQ_EFLrFpMlr4Yo-lKQ9TRVTZ-Mv4w9zV3CoLlmXjmjq_BRgC5MH-43I5Dw`
+
+	inValidkubeconfigWithToken = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN3akNDQWFxZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFTTVJBd0RnWURWUVFERXdkcmRXSmwKTFdOaE1CNFhEVEl3TURreE1EQXhORGd6T1ZvWERUTXdNRGt3T0RBeE5EZ3pPVm93RWpFUU1BNEdBMVVFQXhNSAphM1ZpWlMxallUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQVBHTzVjNGdlWVpSClB2SkcrRTNTdk00M1ZNams0V0tjcm9RUFlZcjNOTVRSYU8xR1EwRDJaRGlKWnkrZEF0OFFmY2VSNE5FZmRWekEKWlZaSVd6RnFOY0RlbHQ1VVVQbWdvMkRrMllvbUV3VXo1WkU3bG1WMlRoRkc3clBrUVQycWt2SXZpanM3TXJUdgovUXc3UTVUSS8wVGV4UGxRdy9oc1haM0MyWDFBK3pwTjkycU11c1FDYmFHOVRYdERiejhCdkJXZ2dURzdGdHdQCm02Rk51S0VhRTkvZFpOY0plZHFyL21LbkhQR2lPUkxOR3YyaG1QMlpkMS9zaUdrWlhJdWo3VkdqOEZMUUhSVE4KdENlNzlJN0FHQ3R4UnJLWkRmK3liZEJKUStjRXpVa1JqUlFWcmMyd3ZDRUJVRzFsbWdCdE1tNmlzRHpjQTJoSwpnbjg4SXFKZ09jVUNBd0VBQWFNak1DRXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBQzRYQzVkaCtvNWFaei9hYXRieEtwWEt3Z3ZFK1ZrZk1UWWMKUDE2bjI3a1QraDArODlRYUxRQWFkUFhDR0draUZ2MG5ROXg0Um1uKzkxbHYzVFRvK0tjenpuM0RsS2QzenZsagpITnloYmc2RVcwelozRVRZazNBaHUzUk5YSEw0aGtHR3E0TmprOTd4MEErbng3MXprRmJMeEI2UGt5ZWdyTTlxCnUzMmZDMUI4aUJibzFFT1NtUUpzbHVOZ3NjWDRZR3VOc0RYVFRKanpVTmJCYjRvZVFlOVNqVXR0dlFtOC92NUsKQS9CUnJYWWs1dml1U3Mvb1NUUGlBYVd4M2hUOVJ1TDJwbENtK256YmhweHBRN0JKVDBDL2xKMXpULzlQeGxnMApmcWx2emlHajY4SHJSMGtIRmIrOHBlSC9xa0FRdnByVUw1ZkQ3a0ViWjV5K0hHWTAwbGc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    server: https://127.0.0.1:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    namespace: test
+    user: test
+  name: test
+current-context: test
+kind: Config
+preferences: {}
+users:
+- name: test
+  user:
+    token: invalid`
+)


### PR DESCRIPTION
Cookies are usually limited to 4096 bytes, when a user inputs the kubeconfig with certificate, the cookie may pretty long, so after user pass the kubernete access check, just put the impersonate info into the jwtToken.