### PR TITLE
Fix incorrect NAD crd name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace (
 	github.com/knative/pkg => github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e
 	github.com/rancher/apiserver => github.com/cnrancher/apiserver v0.0.0-20200731031228-a0459feeb0de
 	github.com/rancher/steve => github.com/cnrancher/steve v0.0.0-20200922090254-a3cedc4d23cd
+	github.com/rancher/wrangler => github.com/cnrancher/wrangler v0.6.2-0.20201110032717-f01dc974d85b
 	k8s.io/client-go => k8s.io/client-go v0.18.0
 	k8s.io/code-generator => k8s.io/code-generator v0.18.3
 	kubevirt.io/client-go => github.com/cnrancher/kubevirt-client-go v0.31.1-0.20200715061104-844cb60487e4

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/cnrancher/kubevirt-containerized-data-importer v1.22.0-apis-only h1:b
 github.com/cnrancher/kubevirt-containerized-data-importer v1.22.0-apis-only/go.mod h1:0chciJ0tNJeCyURBdqIclYj9gXgBxWgbuQcbcin1o6A=
 github.com/cnrancher/steve v0.0.0-20200922090254-a3cedc4d23cd h1:KuIi0ICnEgCSvhpV/zeCbmslxncWZkTUGoVrmLCHdq4=
 github.com/cnrancher/steve v0.0.0-20200922090254-a3cedc4d23cd/go.mod h1:dsdFk9qs1Jb/LR8Z4pHFn9tnLIFc6gs7YvHs7BwT+zc=
+github.com/cnrancher/wrangler v0.6.2-0.20201110032717-f01dc974d85b h1:MOXcvh4ydOCl6gjvtU/7BKxbLBPIpSGxS5SOSRZn1cc=
+github.com/cnrancher/wrangler v0.6.2-0.20201110032717-f01dc974d85b/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/pkg/controller/crds/setup.go
+++ b/pkg/controller/crds/setup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rancher/harvester/pkg/apis/harvester.cattle.io/v1alpha1"
 	"github.com/rancher/harvester/pkg/util/crd"
+	wcrd "github.com/rancher/wrangler/pkg/crd"
 )
 
 func Setup(ctx context.Context, server *server.Server) error {
@@ -29,7 +30,14 @@ func createCRDs(ctx context.Context, server *server.Server) error {
 			crd.FromGV(v1alpha1.SchemeGroupVersion, "KeyPair"),
 			crd.FromGV(v1alpha1.SchemeGroupVersion, "VirtualMachineTemplate"),
 			crd.FromGV(v1alpha1.SchemeGroupVersion, "VirtualMachineTemplateVersion"),
-			crd.FromGV(cniv1.SchemeGroupVersion, "Network-Attachment-Definition"),
+			createNetworkAttachmentDefinitionCRD(),
 		).
 		Wait()
+}
+
+func createNetworkAttachmentDefinitionCRD() wcrd.CRD {
+	nad := crd.FromGV(cniv1.SchemeGroupVersion, "NetworkAttachmentDefinition")
+	nad.PluralName = "network-attachment-definitions"
+	nad.SingularName = "network-attachment-definition"
+	return nad
 }

--- a/vendor/github.com/rancher/wrangler/pkg/crd/init.go
+++ b/vendor/github.com/rancher/wrangler/pkg/crd/init.go
@@ -33,6 +33,7 @@ type Factory struct {
 type CRD struct {
 	GVK          schema.GroupVersionKind
 	PluralName   string
+	SingularName string
 	NonNamespace bool
 	Schema       *v1beta1.JSONSchemaProps
 	SchemaObject interface{}
@@ -188,6 +189,11 @@ func (c CRD) ToCustomResourceDefinition() (apiext.CustomResourceDefinition, erro
 		plural = strings.ToLower(name.GuessPluralName(c.GVK.Kind))
 	}
 
+	singular := c.SingularName
+	if singular == "" {
+		singular = strings.ToLower(c.GVK.Kind)
+	}
+
 	name := strings.ToLower(plural + "." + c.GVK.Group)
 
 	crd := apiext.CustomResourceDefinition{
@@ -207,6 +213,7 @@ func (c CRD) ToCustomResourceDefinition() (apiext.CustomResourceDefinition, erro
 			},
 			Names: apiext.CustomResourceDefinitionNames{
 				Plural:     plural,
+				Singular:   singular,
 				Kind:       c.GVK.Kind,
 				Categories: c.Categories,
 				ShortNames: c.ShortNames,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,7 +184,7 @@ github.com/rancher/steve/pkg/stores/proxy
 github.com/rancher/steve/pkg/stores/selector
 github.com/rancher/steve/pkg/stores/switchschema
 github.com/rancher/steve/pkg/stores/switchstore
-# github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407
+# github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407 => github.com/cnrancher/wrangler v0.6.2-0.20201110032717-f01dc974d85b
 github.com/rancher/wrangler/pkg/apply
 github.com/rancher/wrangler/pkg/apply/injectors
 github.com/rancher/wrangler/pkg/broadcast


### PR DESCRIPTION
create NAD follows upstream name definition: https://github.com/intel/multus-cni/blob/36d3874c4c987affb101bbac8b2d69b4429266df/e2e/multus-daemonset.yml#L9-L12
address https://github.com/rancher/harvester/issues/228

Verification Steps:
if the CRD `network-attachment-definitions.k8s.cni.cncf.io` does not exist, it should create a new with the following name spec according to the upstream multus-cni:
```
spec:
  group: k8s.cni.cncf.io
  names:
    kind: NetworkAttachmentDefinition
    listKind: NetworkAttachmentDefinitionList
    plural: network-attachment-definitions
    singular: network-attachment-definition

```