### PR TITLE
fix cannot add indexers to running index

### DIFF
--- a/pkg/controller/master/controller.go
+++ b/pkg/controller/master/controller.go
@@ -26,6 +26,8 @@ var registerFuncs = []registerFunc{
 }
 
 func register(ctx context.Context, server *server.Server, management *config.Management) error {
+	indexeres.RegisterManagementIndexers(management)
+
 	for _, f := range registerFuncs {
 		if err := f(ctx, management); err != nil {
 			return err
@@ -36,6 +38,5 @@ func register(ctx context.Context, server *server.Server, management *config.Man
 		return err
 	}
 
-	indexeres.RegisterManagementIndexers(management)
 	return nil
 }


### PR DESCRIPTION
#205 
* Problem
  - Now user.Register is befor indexeres.RegisterManagementIndexers
  - This will cause a panic when userRBACController.OnChanged is triggered and indexeres.RegisterManagementIndexers start running at the same time
* Solution
   - Adjust code order
   - Make sure indexeres.RegisterManagementIndexers is finished befor user.Register