### PR TITLE
Add harvester-network-controller sub chart

### DIFF
--- a/deploy/charts/harvester/Chart.yaml
+++ b/deploy/charts/harvester/Chart.yaml
@@ -46,3 +46,7 @@ dependencies:
     version: 5.0.32
     repository: file://charts/minio
     condition: minio.enabled
+  - name: harvester-network-controller
+    version: 0.1.0
+    repository: file://charts/harvester-network-controller
+    condition: harvester-network-controller.enabled

--- a/deploy/charts/harvester/charts/harvester-network-controller/.helmignore
+++ b/deploy/charts/harvester/charts/harvester-network-controller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/harvester/charts/harvester-network-controller/Chart.yaml
+++ b/deploy/charts/harvester/charts/harvester-network-controller/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: harvester-network-controller
+description: A Helm chart for Harvester Network Controller
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/deploy/charts/harvester/charts/harvester-network-controller/README.md
+++ b/deploy/charts/harvester/charts/harvester-network-controller/README.md
@@ -1,0 +1,15 @@
+# Harvester-Network-Controller Helm Chart
+
+[Harvester Network Contrller](https://github.com/rancher/harvester-network-controller) is a network controller that helps to manage the host network configuration of the Harvester cluster.
+
+Introduction
+------------
+
+This chart installs the network-controller daemonset on the [harvester](https://github.com/rancher/harvester) cluster using the [Helm](https://helm.sh) package manager.
+
+Prerequisites
+-------------
+- [multus-cni](https://github.com/intel/multus-cni) v3.6+
+- Vlan filtering support on bridge
+- Switch to support `trunk` mode
+

--- a/deploy/charts/harvester/charts/harvester-network-controller/templates/NOTES.txt
+++ b/deploy/charts/harvester/charts/harvester-network-controller/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The harvester-network-controller has been installed into "{{ .Release.Namespace }}" namespace.

--- a/deploy/charts/harvester/charts/harvester-network-controller/templates/_helpers.tpl
+++ b/deploy/charts/harvester/charts/harvester-network-controller/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "harvester-network-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "harvester-network-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "harvester-network-controller.labels" -}}
+helm.sh/chart: {{ include "harvester-network-controller.chart" . }}
+{{ include "harvester-network-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: network
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "harvester-network-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "harvester-network-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/charts/harvester/charts/harvester-network-controller/templates/daemonset.yaml
+++ b/deploy/charts/harvester/charts/harvester-network-controller/templates/daemonset.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harvester-network-controller.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "harvester-network-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+    {{- include "harvester-network-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "harvester-network-controller.name" . }}
+      hostNetwork: true
+      containers:
+        - name: network
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/harvester/charts/harvester-network-controller/templates/rbac.yaml
+++ b/deploy/charts/harvester/charts/harvester-network-controller/templates/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "harvester-network-controller.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+rules:
+  - apiGroups: ["harvester.cattle.io"]
+    resources: ["settings"]
+    verbs: ["get", "watch", "list", "update", "create"]
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources: ["network-attachment-definitions"]
+    verbs: ["get", "watch", "list", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "harvester-network-controller.name" . }}
+  labels:
+  {{- include "harvester-network-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "harvester-network-controller.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "harvester-network-controller.name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/harvester/charts/harvester-network-controller/values.yaml
+++ b/deploy/charts/harvester/charts/harvester-network-controller/values.yaml
@@ -1,0 +1,28 @@
+# Default values for harvester-network-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: rancher/harvester-network-controller
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "master-head"
+
+nameOverride: ""
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+nodeSelector: {}
+
+tolerations:
+  # this toleration is to have the daemonset runnable on master nodes
+  # remove it if your masters can't run pods
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+
+affinity: {}

--- a/deploy/charts/harvester/questions.yaml
+++ b/deploy/charts/harvester/questions.yaml
@@ -20,6 +20,18 @@ questions:
     description: "specify the tag of harvester image"
     type: "string"
     group: "Harvester Settings"
+  - variable: harvester-network-controller.image.repository
+    default: "rancher/harvester-network-controller"
+    label: "Image"
+    description: "specify the repository of harvester-network-controller image"
+    type: "string"
+    group: "Harvester Settings"
+  - variable: harvester-network-controller.image.tag
+    default: "master-head"
+    label: "Image Tag"
+    description: "specify the tag of harvester-network-controller image"
+    type: "string"
+    group: "Harvester Settings"
   #################### Harvester Resource Settings ####################
   - variable: containers.apiserver.resources.requests.cpu
     default: "250m"

--- a/deploy/charts/harvester/questions.yaml
+++ b/deploy/charts/harvester/questions.yaml
@@ -423,6 +423,16 @@ questions:
         group: "Minio Settings"
         show_if: "minio.enabled=true"
       #################### Minio Storage Settings ####################
+      - variable: minio.mode
+        default: "distributed"
+        label: "Specify the Minio mode"
+        description: "specify the deployment mode to use of Minio"
+        type: "enum"
+        options:
+          - "standalone"
+          - "distributed"
+        group: "Minio Settings"
+        show_if: "minio.enabled=true"
       - variable: minio.persistence.enabled
         default: "true"
         label: "Use Storage"
@@ -439,7 +449,7 @@ questions:
         show_if: "minio.enabled=true && minio.persistence.enabled=true"
         required: true
       - variable: minio.persistence.size
-        default: "500Gi"
+        default: "100Gi"
         label: "Storage Size"
         description: "specify the size of persistence volume claim"
         type: "string"

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -363,3 +363,14 @@ jobs:
           requests:
             cpu: 250m
             memory: 128Mi
+
+harvester-network-controller:
+  ## Specify to install harvester network controller,
+  ## defaults to "true".
+  enabled: true
+
+  image:
+    repository: rancher/harvester-network-controller
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "master-head"


### PR DESCRIPTION
**Description:**
add harvester-network-controller sub chart to support VLAN network management of the harvester.

Related Issue:
https://github.com/rancher/harvester/issues/201