### PR TITLE
Add dataVolume on delete validation

### DIFF
--- a/pkg/api/datavolume/schema.go
+++ b/pkg/api/datavolume/schema.go
@@ -1,0 +1,27 @@
+package datavolume
+
+import (
+	"github.com/rancher/harvester/pkg/config"
+	"github.com/rancher/steve/pkg/schema"
+	"github.com/rancher/steve/pkg/server"
+	"github.com/rancher/steve/pkg/stores/proxy"
+)
+
+const (
+	dataVolumeSchemaID = "cdi.kubevirt.io.datavolume"
+)
+
+func RegisterSchema(scaled *config.Scaled, server *server.Server) error {
+	dvStore := &dvStore{
+		Store:   proxy.NewProxyStore(server.ClientFactory, server.AccessSetLookup),
+		dvCache: scaled.CDIFactory.Cdi().V1beta1().DataVolume().Cache(),
+	}
+
+	t := schema.Template{
+		ID:    dataVolumeSchemaID,
+		Store: dvStore,
+	}
+
+	server.SchemaTemplates = append(server.SchemaTemplates, t)
+	return nil
+}

--- a/pkg/api/datavolume/store.go
+++ b/pkg/api/datavolume/store.go
@@ -1,0 +1,41 @@
+package datavolume
+
+import (
+	"fmt"
+
+	"github.com/rancher/apiserver/pkg/apierror"
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/wrangler/pkg/schemas/validation"
+	kv1alpha3 "kubevirt.io/client-go/api/v1alpha3"
+
+	cdiv1beta1 "github.com/rancher/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
+)
+
+type dvStore struct {
+	types.Store
+	dvCache cdiv1beta1.DataVolumeCache
+}
+
+func (s *dvStore) Delete(request *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+	if err := s.canDelete(request.Namespace, request.Name); err != nil {
+		return types.APIObject{}, apierror.NewAPIError(validation.ServerError, err.Error())
+	}
+	return s.Store.Delete(request, request.Schema, id)
+}
+
+func (s *dvStore) canDelete(namespace, name string) error {
+	dv, err := s.dvCache.Get(namespace, name)
+	if err != nil {
+		return fmt.Errorf("failed to get dv %s, %v", name, err)
+	}
+
+	if len(dv.OwnerReferences) != 0 {
+		for _, owner := range dv.OwnerReferences {
+			if owner.Kind == kv1alpha3.VirtualMachineGroupVersionKind.Kind {
+				return fmt.Errorf("can not delete the volume %s which is currently owned by the VM %s", name, owner.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/api/datavolume/store_test.go
+++ b/pkg/api/datavolume/store_test.go
@@ -1,0 +1,127 @@
+package datavolume
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kv1alpha3 "kubevirt.io/client-go/api/v1alpha3"
+	cdiapis "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+
+	"github.com/rancher/harvester/pkg/generated/clientset/versioned/fake"
+	cditype "github.com/rancher/harvester/pkg/generated/clientset/versioned/typed/cdi.kubevirt.io/v1beta1"
+	cdiv1beta1 "github.com/rancher/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
+)
+
+func TestDataVolumeDelete(t *testing.T) {
+	type input struct {
+		key        string
+		dataVolume *cdiapis.DataVolume
+	}
+	type output struct {
+		err error
+	}
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "dataVolume not found",
+			given: input{
+				key: "dataVolume name",
+				dataVolume: &cdiapis.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+				},
+			},
+			expected: output{
+				err: fmt.Errorf("failed to get dv bar, datavolumes.cdi.kubevirt.io \"bar\" not found"),
+			},
+		},
+		{
+			name: "dataVolume test no delete",
+			given: input{
+				key: "dataVolume name",
+				dataVolume: &cdiapis.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-no-delete",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: kv1alpha3.VirtualMachineGroupVersionKind.Kind,
+								Name: "foo",
+							},
+						},
+					},
+				},
+			},
+			expected: output{
+				err: fmt.Errorf("can not delete the volume test-no-delete which is currently owned by the VM foo"),
+			},
+		},
+		{
+			name: "dataVolume test delete",
+			given: input{
+				key: "dataVolume name",
+				dataVolume: &cdiapis.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-no-delete",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "delete",
+								Name: "delete",
+							},
+						},
+					},
+				},
+			},
+			expected: output{
+				err: nil,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		var clientset = fake.NewSimpleClientset()
+		if tc.given.dataVolume != nil {
+			err := clientset.Tracker().Add(tc.given.dataVolume)
+			assert.Nil(t, err, "mock resource should add into fake controller tracker")
+		}
+
+		var store = &dvStore{
+			dvCache: fakeDataVolumeCache(clientset.CdiV1beta1().DataVolumes),
+		}
+
+		var actual output
+		if tc.name == "dataVolume not found" {
+			actual.err = store.canDelete("foo", "bar")
+		} else {
+			actual.err = store.canDelete(tc.given.dataVolume.Namespace, tc.given.dataVolume.Name)
+		}
+		assert.Equal(t, tc.expected, actual, "case %q", tc.name)
+	}
+}
+
+type fakeDataVolumeCache func(string) cditype.DataVolumeInterface
+
+func (c fakeDataVolumeCache) Get(namespace, name string) (*cdiapis.DataVolume, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c fakeDataVolumeCache) List(namespace string, selector labels.Selector) ([]*cdiapis.DataVolume, error) {
+	panic("implement me")
+}
+
+func (c fakeDataVolumeCache) AddIndexer(indexName string, indexer cdiv1beta1.DataVolumeIndexer) {
+	panic("implement me")
+}
+
+func (c fakeDataVolumeCache) GetByIndex(indexName, key string) ([]*cdiapis.DataVolume, error) {
+	panic("implement me")
+}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	"github.com/rancher/harvester/pkg/api/datavolume"
 	"github.com/rancher/harvester/pkg/api/image"
 	"github.com/rancher/harvester/pkg/api/keypair"
 	"github.com/rancher/harvester/pkg/api/network"
@@ -32,5 +33,6 @@ func Setup(ctx context.Context, server *server.Server) error {
 		vmtemplate.RegisterSchema,
 		vm.RegisterSchema,
 		user.RegisterSchema,
-		network.RegisterSchema)
+		network.RegisterSchema,
+		datavolume.RegisterSchema)
 }

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -57,9 +57,10 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server) error {
 	}
 
 	vmStore := &vmStore{
-		Store:       proxy.NewProxyStore(server.ClientFactory, server.AccessSetLookup),
-		dataVolumes: scaled.CDIFactory.Cdi().V1beta1().DataVolume(),
-		vmCache:     scaled.VirtFactory.Kubevirt().V1alpha3().VirtualMachine().Cache(),
+		Store:            proxy.NewProxyStore(server.ClientFactory, server.AccessSetLookup),
+		vmCache:          scaled.VirtFactory.Kubevirt().V1alpha3().VirtualMachine().Cache(),
+		dataVolumes:      scaled.CDIFactory.Cdi().V1beta1().DataVolume(),
+		dataVolumesCache: scaled.CDIFactory.Cdi().V1beta1().DataVolume().Cache(),
 	}
 
 	t := schema.Template{


### PR DESCRIPTION
**Description:**
currently, the user is able to delete the dataVolume from the UI when it is owned by a VM, and it will cause an API error on the VM deletion. 


**Solution:**
1. prevent the user to delete data volumes that are currently owned by the VM.
1. fix VM dataVolume not-found error on VM deleting.


**Related Issue:**
https://github.com/rancher/harvester/issues/221