### PR TITLE
Set appliedURL on image import failure

### DIFF
--- a/pkg/controller/master/image/controller.go
+++ b/pkg/controller/master/image/controller.go
@@ -83,6 +83,7 @@ func (h *Handler) OnImageChanged(key string, image *apisv1alpha1.VirtualMachineI
 				return
 			}
 			toUpdate := currentImage.DeepCopy()
+			toUpdate.Status.AppliedURL = image.Spec.URL
 			apisv1alpha1.ImageImported.False(toUpdate)
 			apisv1alpha1.ImageImported.Reason(toUpdate, err.Error())
 			if _, err := h.UpdateStatusRetryOnConflict(toUpdate); err != nil {


### PR DESCRIPTION
https://github.com/rancher/harvester/issues/213

Problem:
reimport is not triggered when users correct the url for a
fail-to-import image.

Solution:
Set appliedURL when import fails. This tells the url is updated and
triggers the reimport.