### PR TITLE
Add set DV anno/cert configmap DV/VM stores

### DIFF
--- a/pkg/api/datavolume/schema.go
+++ b/pkg/api/datavolume/schema.go
@@ -1,10 +1,12 @@
 package datavolume
 
 import (
-	"github.com/rancher/harvester/pkg/config"
 	"github.com/rancher/steve/pkg/schema"
 	"github.com/rancher/steve/pkg/server"
 	"github.com/rancher/steve/pkg/stores/proxy"
+
+	"github.com/rancher/harvester/pkg/config"
+	"github.com/rancher/harvester/pkg/util"
 )
 
 const (
@@ -23,5 +25,5 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server) error {
 	}
 
 	server.SchemaTemplates = append(server.SchemaTemplates, t)
-	return nil
+	return util.InitCertConfigMap(scaled)
 }

--- a/pkg/api/datavolume/store.go
+++ b/pkg/api/datavolume/store.go
@@ -9,11 +9,22 @@ import (
 	kv1alpha3 "kubevirt.io/client-go/api/v1alpha3"
 
 	cdiv1beta1 "github.com/rancher/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
+	"github.com/rancher/harvester/pkg/util"
 )
 
 type dvStore struct {
 	types.Store
 	dvCache cdiv1beta1.DataVolumeCache
+}
+
+func (s *dvStore) Create(request *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
+	util.SetHTTPSourceDataVolume(data.Data())
+	return s.Store.Create(request, request.Schema, data)
+}
+
+func (s *dvStore) Update(request *types.APIRequest, schema *types.APISchema, data types.APIObject, id string) (types.APIObject, error) {
+	util.SetHTTPSourceDataVolume(data.Data())
+	return s.Store.Update(request, request.Schema, data, id)
 }
 
 func (s *dvStore) Delete(request *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {

--- a/pkg/util/data_volume.go
+++ b/pkg/util/data_volume.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"github.com/rancher/wrangler/pkg/data"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/harvester/pkg/config"
+)
+
+const (
+	defaultNamespace      = "default"
+	certNoneConfigMapName = "importer-ca-none"
+)
+
+// SetHTTPSourceDataVolume sets the requiresScratch annotation, and certConfigMap with an existing empty configmap
+// It changes the CDI's decision to convert image after the whole file is downloaded.
+func SetHTTPSourceDataVolume(data data.Object) {
+	logrus.Infof("%v+", data.Map("spec", "source", "http"))
+	if data.Map("spec", "source", "http") != nil {
+		data.SetNested("true", "metadata", "annotations", "cdi.kubevirt.io/storage.import.requiresScratch")
+		data.SetNested(certNoneConfigMapName, "spec", "source", "http", "certConfigMap")
+	}
+}
+
+func InitCertConfigMap(scaled *config.Scaled) error {
+	configmaps := scaled.Management.CoreFactory.Core().V1().ConfigMap()
+	certNoneConfigmap := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name: certNoneConfigMapName,
+			//DVs are created in the default namespace
+			Namespace: defaultNamespace,
+		},
+	}
+	_, err := configmaps.Create(certNoneConfigmap)
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
https://github.com/rancher/harvester/issues/253
These configurations trigger CDI to convert the image after it is downloaded.

This hacks with a empty cert configmap so that the CDI importer can do image convert locally based on this [code path](https://github.com/kubevirt/containerized-data-importer/blob/master/pkg/importer/http-datasource.go#L128). 