### PR TITLE
Fix minio image version in question file

### DIFF
--- a/deploy/charts/harvester/questions.yaml
+++ b/deploy/charts/harvester/questions.yaml
@@ -372,7 +372,7 @@ questions:
         group: "Minio Settings"
         show_if: "minio.enabled=true"
       - variable: minio.image.tag
-        default: "RELEASE.2020-11-17T00-39-14Z"
+        default: "RELEASE.2020-11-19T23-48-16Z"
         label: "Minio Image Tag"
         description: "specify the tag of minio image"
         type: "string"


### PR DESCRIPTION
We are using the tag of the `minio/mc` image: https://github.com/minio/charts/blob/8.0.5/minio/values.yaml#L25
It should be the tag of the `minio/minio` image: https://github.com/minio/charts/blob/8.0.5/minio/values.yaml#L17