### PR TITLE
don't delete attached volume

### DIFF
--- a/pkg/ref/annotation.go
+++ b/pkg/ref/annotation.go
@@ -90,6 +90,16 @@ func (o *AnnotationSchemaOwners) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
+// List returns the owner's name list by given group kind.
+func (o AnnotationSchemaOwners) List(ownerGK schema.GroupKind) []string {
+	var schemaID = GroupKindToSchemaID(ownerGK)
+	var schemaRef, existed = o[schemaID]
+	if !existed || schemaRef.SchemaID != schemaID {
+		return []string{}
+	}
+	return schemaRef.References.UnsortedList()
+}
+
 // Has checks if the given owner is owned.
 func (o AnnotationSchemaOwners) Has(ownerGK schema.GroupKind, owner metav1.Object) bool {
 	var schemaID = GroupKindToSchemaID(ownerGK)


### PR DESCRIPTION
#198 

## Problem
function `canDelete` only check `ownerReferences` before delete volumes, but existing volumes don't have this information.

## Solution
since harvester's VM controller adds an annotation `harvester.cattle.io/owned-by` to mark attached volume,
let's check annotation `harvester.cattle.io/owned-by` before deleting volumes.

![image](https://user-images.githubusercontent.com/15064560/101452007-06e53a00-3968-11eb-9063-2e9c13961cff.png)
