### PR TITLE
Remove volume's owner if it has been unattached

### DIFF
--- a/pkg/controller/master/virtualmachine/vm_controller.go
+++ b/pkg/controller/master/virtualmachine/vm_controller.go
@@ -5,23 +5,59 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	kubevirtapis "kubevirt.io/client-go/api/v1alpha3"
+	kubevirtv1alpha3 "kubevirt.io/client-go/api/v1alpha3"
 
-	cdictrl "github.com/rancher/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
+	ctlcdiv1beta1 "github.com/rancher/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
+	"github.com/rancher/harvester/pkg/indexeres"
+	"github.com/rancher/harvester/pkg/ref"
 )
 
 type VMController struct {
-	dataVolumeClient cdictrl.DataVolumeClient
-	dataVolumeCache  cdictrl.DataVolumeCache
+	dataVolumeClient ctlcdiv1beta1.DataVolumeClient
+	dataVolumeCache  ctlcdiv1beta1.DataVolumeCache
 }
 
 // SetOwnerOfDataVolumes records the target VirtualMachine as the owner of the DataVolumes in annotation.
-func (h *VMController) SetOwnerOfDataVolumes(_ string, vm *kubevirtapis.VirtualMachine) (*kubevirtapis.VirtualMachine, error) {
+func (h *VMController) SetOwnerOfDataVolumes(_ string, vm *kubevirtv1alpha3.VirtualMachine) (*kubevirtv1alpha3.VirtualMachine, error) {
 	if vm == nil || vm.DeletionTimestamp != nil || vm.Spec.Template == nil {
 		return vm, nil
 	}
 
-	var dataVolumeNames = getDataVolumeNames(&vm.Spec.Template.Spec)
+	dataVolumeNames := getDataVolumeNames(&vm.Spec.Template.Spec)
+
+	vmReferenceKey := ref.Construct(vm.Namespace, vm.Name)
+	// get all the volumes attached to this virtual machine
+	attachedDataVolumes, err := h.dataVolumeCache.GetByIndex(indexeres.DataVolumeByVMIndex, vmReferenceKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get attached datavolumes by vm index: %w", err)
+	}
+
+	vmGK := kubevirtv1alpha3.VirtualMachineGroupVersionKind.GroupKind()
+	for _, attachedDataVolume := range attachedDataVolumes {
+		// check if it's still attached
+		if dataVolumeNames.Has(attachedDataVolume.Name) {
+			continue
+		}
+		// if this volume is no longer attached, update it's "owner-by" annotation
+		owners, err := ref.GetSchemaOwnersFromAnnotation(attachedDataVolume)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get schema owners from annotation: %w", err)
+		}
+
+		if isOwned := owners.Delete(vmGK, vm); !isOwned {
+			continue
+		}
+
+		toUpdate := attachedDataVolume.DeepCopy()
+		if err := owners.Apply(toUpdate); err != nil {
+			return nil, fmt.Errorf("failed to apply schema owners to annotation: %w", err)
+		}
+
+		if _, err = h.dataVolumeClient.Update(toUpdate); err != nil {
+			return nil, fmt.Errorf("failed to clean schema owners for DataVolume(%s/%s): %w",
+				attachedDataVolume.Namespace, attachedDataVolume.Name, err)
+		}
+	}
 
 	var dataVolumeNamespace = vm.Namespace
 	for _, dataVolumeName := range dataVolumeNames.List() {
@@ -46,7 +82,7 @@ func (h *VMController) SetOwnerOfDataVolumes(_ string, vm *kubevirtapis.VirtualM
 }
 
 // UnsetOwnerOfDataVolumes erases the target VirtualMachine from the owner of the DataVolumes in annotation.
-func (h *VMController) UnsetOwnerOfDataVolumes(_ string, vm *kubevirtapis.VirtualMachine) (*kubevirtapis.VirtualMachine, error) {
+func (h *VMController) UnsetOwnerOfDataVolumes(_ string, vm *kubevirtv1alpha3.VirtualMachine) (*kubevirtv1alpha3.VirtualMachine, error) {
 	if vm == nil || vm.DeletionTimestamp == nil || vm.Spec.Template == nil {
 		return vm, nil
 	}
@@ -76,7 +112,7 @@ func (h *VMController) UnsetOwnerOfDataVolumes(_ string, vm *kubevirtapis.Virtua
 }
 
 // getDataVolumeNames returns a name set of the DataVolumes.
-func getDataVolumeNames(vmiSpecPtr *kubevirtapis.VirtualMachineInstanceSpec) sets.String {
+func getDataVolumeNames(vmiSpecPtr *kubevirtv1alpha3.VirtualMachineInstanceSpec) sets.String {
 	var dataVolumeNames = sets.String{}
 
 	// collects all DataVolumes

--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -1,15 +1,21 @@
 package indexeres
 
 import (
-	"github.com/rancher/harvester/pkg/apis/harvester.cattle.io/v1alpha1"
-	"github.com/rancher/harvester/pkg/config"
+	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	kubevirtv1alpha3 "kubevirt.io/client-go/api/v1alpha3"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+
+	"github.com/rancher/harvester/pkg/apis/harvester.cattle.io/v1alpha1"
+	"github.com/rancher/harvester/pkg/config"
+	"github.com/rancher/harvester/pkg/ref"
 )
 
 const (
 	UserNameIndex           = "auth.harvester.cattle.io/user-username-index"
 	RbByRoleAndSubjectIndex = "auth.harvester.cattle.io/crb-by-role-and-subject"
+	DataVolumeByVMIndex     = "cdi.harvester.cattle.io/datavolume-by-vm"
 )
 
 func RegisterScaledIndexers(scaled *config.Scaled) {
@@ -18,8 +24,10 @@ func RegisterScaledIndexers(scaled *config.Scaled) {
 }
 
 func RegisterManagementIndexers(management *config.Management) {
-	informer := management.RbacFactory.Rbac().V1().ClusterRoleBinding().Cache()
-	informer.AddIndexer(RbByRoleAndSubjectIndex, rbByRoleAndSubject)
+	crbInformer := management.RbacFactory.Rbac().V1().ClusterRoleBinding().Cache()
+	crbInformer.AddIndexer(RbByRoleAndSubjectIndex, rbByRoleAndSubject)
+	dataVolumeInformer := management.CDIFactory.Cdi().V1beta1().DataVolume().Cache()
+	dataVolumeInformer.AddIndexer(DataVolumeByVMIndex, dataVolumeByVM)
 }
 
 func indexUserByUsername(obj *v1alpha1.User) ([]string, error) {
@@ -36,5 +44,12 @@ func rbByRoleAndSubject(obj *rbacv1.ClusterRoleBinding) ([]string, error) {
 
 func RbRoleSubjectKey(roleName string, subject rbacv1.Subject) string {
 	return roleName + "." + subject.Kind + "." + subject.Name
+}
 
+func dataVolumeByVM(obj *cdiv1beta1.DataVolume) ([]string, error) {
+	annotationSchemaOwners, err := ref.GetSchemaOwnersFromAnnotation(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schema owners from datavolume %s's annotation: %w", obj.Name, err)
+	}
+	return annotationSchemaOwners.List(kubevirtv1alpha3.VirtualMachineGroupVersionKind.GroupKind()), nil
 }


### PR DESCRIPTION
#279

## Problem
At present, only when the virtual machine is deleted, the `attached` mark (`harvester.cattle.io/owned-by` annotation) will be removed.

## Solution
If VM changed:
* get all the volumes attached to this virtual machine
* for each attached volume, if this volume is no longer attached, update it's "owner-by" annotation