### PR TITLE
Fix inconsistent versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -164,6 +164,9 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    instance:
+    - drone-publish.rancher.io
 
 - name: github_binary_release
   image: plugins/github-release
@@ -180,11 +183,10 @@ steps:
   when:
     instance:
     - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
+
+trigger:
+  event:
+  - tag
 
 volumes:
 - name: docker

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -10,6 +10,8 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
         zstd \
     && rm -rf /var/lib/apt/lists/*
 
+# install yq
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v3@3.4.1
 # set up helm
 ENV HELM_VERSION v3.4.1
 ENV HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz

--- a/deploy/charts/harvester/Chart.yaml
+++ b/deploy/charts/harvester/Chart.yaml
@@ -51,6 +51,7 @@ dependencies:
     repository: file://dependency_charts/multus
     condition: multus.enabled
   - name: minio
+    # Note: Update minio image in harvester values.yaml when this version is updated.
     version: 8.0.5
     repository: https://helm.min.io
     condition: minio.enabled

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -27,7 +27,30 @@ tags:
 
 ## Specify the parameters to override the sub-chart.
 ##
-kubevirt-operator: {}
+kubevirt-operator:
+  containers:
+    operator:
+      image:
+        repository: kubevirt/virt-operator
+        tag: &kubevirtVersion v0.35.0
+    ## The following four images are placeholder for images in use.
+    ## They are not used by the kubevirt-operator chart.
+    controller:
+      image:
+        repository: kubevirt/virt-controller
+        tag: *kubevirtVersion
+    handler:
+      image:
+        repository: kubevirt/virt-handler
+        tag: *kubevirtVersion
+    api:
+      image:
+        repository: kubevirt/virt-api
+        tag: *kubevirtVersion
+    launcher:
+      image:
+        repository: kubevirt/virt-launcher
+        tag: *kubevirtVersion
 
 ## Specify the parameters to override the sub-chart.
 ##
@@ -64,7 +87,28 @@ kubevirt:
 
 ## Specify the parameters to override the sub-chart.
 ##
-cdi-operator: {}
+cdi-operator:
+  containers:
+    operator:
+      image:
+        repository: kubevirt/cdi-operator
+        tag: &cdiVersion v1.26.1
+    controller:
+      image:
+        repository: kubevirt/cdi-controller
+        tag: *cdiVersion
+    importer:
+      image:
+        repository: kubevirt/cdi-importer
+        tag: *cdiVersion
+    apiserver:
+      image:
+        repository: kubevirt/cdi-apiserver
+        tag: *cdiVersion
+    uploadproxy:
+      image:
+        repository: kubevirt/cdi-uploadproxy
+        tag: *cdiVersion
 
 ## Specify the parameters to override the sub-chart.
 ##
@@ -78,6 +122,12 @@ minio:
   ## defaults to "true".
   ##
   enabled: true
+
+  ## Specify the image.
+  ##
+  image:
+    repository: minio/minio
+    tag: RELEASE.2020-11-19T23-48-16Z
 
   ## Specify the mode.
   ##
@@ -379,6 +429,10 @@ multus:
   ## Specify whether to install the multus-cni,
   ## defaults to "false", this will be enabled in ISO mode installation.
   enabled: false
+
+  image:
+    repository: nfvpe/multus
+    tag: v3.6
 
   ## Specify the cni hostPath, default to use the k3s cni hostPath
   hostPath:

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -11,6 +11,8 @@ ENV HARVESTER_UI_PATH /usr/share/rancher/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9
 
+ARG VERSION=dev
+ENV HARVESTER_SERVER_VERSION ${VERSION}
 RUN mkdir -p /usr/share/rancher/harvester && \
     cd /usr/share/rancher/harvester && \
     curl -sL https://releases.rancher.com/harvester-ui/${HARVESTER_UI_VERSION}.tar.gz | tar xvzf - --strip-components=2 && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk add -u --no-cache git curl unzip tar tini bash && \
 
 WORKDIR /var/lib/rancher/harvester
 
-ENV HARVESTER_UI_VERSION v0.0.1
+ENV HARVESTER_UI_VERSION v0.1.1
 ENV HARVESTER_UI_PATH /usr/share/rancher/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -15,13 +15,14 @@ var (
 	provider       Provider
 	InjectDefaults string
 
+	APIUIVersion           = NewSetting("api-ui-version", "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
+	AuthenticationMode     = NewSetting("authentication-mode", fmt.Sprintf("%s,%s", v1alpha1.KubernetesCredentials, v1alpha1.LocalUser))
+	AuthSecretName         = NewSetting("auth-secret-name", "harvester-key-holder")
+	AuthTokenMaxTTLMinutes = NewSetting("auth-token-max-ttl-minutes", "720")
+	NoDefaultAdmin         = NewSetting("no-default-admin", "")
+	ServerVersion          = NewSetting("server-version", "dev")
 	UIIndex                = NewSetting("ui-index", "https://releases.rancher.com/harvester-ui/latest/index.html")
 	UIPath                 = NewSetting("ui-path", "/usr/share/rancher/harvester")
-	APIUIVersion           = NewSetting("api-ui-version", "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
-	AuthTokenMaxTTLMinutes = NewSetting("auth-token-max-ttl-minutes", "720")
-	AuthSecretName         = NewSetting("auth-secret-name", "harvester-key-holder")
-	NoDefaultAdmin         = NewSetting("no-default-admin", "")
-	AuthenticationMode     = NewSetting("authentication-mode", fmt.Sprintf("%s,%s", v1alpha1.KubernetesCredentials, v1alpha1.LocalUser))
 )
 
 func init() {

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=master
+HARVESTER_INSTALLER_VERSION=v0.1.1
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/rancher/harvester-installer.git ../harvester-installer
 

--- a/scripts/package
+++ b/scripts/package
@@ -18,5 +18,5 @@ fi
 
 cp ../bin/harvester .
 
-docker build -f ${DOCKERFILE} -t ${IMAGE} .
+docker build --build-arg VERSION=${VERSION} -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}


### PR DESCRIPTION
https://github.com/rancher/harvester/issues/315

1. Bump packaged UI version
2. Bump installer version
3. Add `server-version` setting so that UI can show the harvester version.
4. Pin dependency image tags in harvester chart `values.yaml`. So that installer knows what images to package.