### PR TITLE
Prompt which network is used

### DIFF
--- a/pkg/api/network/store.go
+++ b/pkg/api/network/store.go
@@ -87,7 +87,8 @@ func (s *networkStore) checkUniqueVlanID(ns string, config *NetConf) error {
 }
 
 func (s *networkStore) Delete(request *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
-	vms, err := s.vmCache.GetByIndex(indexeres.VMByNetworkIndex, request.Name)
+	networkName := request.Name
+	vms, err := s.vmCache.GetByIndex(indexeres.VMByNetworkIndex, networkName)
 	if err != nil {
 		return types.APIObject{}, apierror.NewAPIError(validation.ServerError, err.Error())
 	}
@@ -97,7 +98,7 @@ func (s *networkStore) Delete(request *types.APIRequest, schema *types.APISchema
 		for _, vm := range vms {
 			vmNameList = append(vmNameList, vm.Name)
 		}
-		errorMessage := fmt.Sprintf("network is still used by vm：%s", strings.Join(vmNameList, ","))
+		errorMessage := fmt.Sprintf("network %s is still used by vm：%s", networkName, strings.Join(vmNameList, ","))
 		errorCode := validation.ErrorCode{
 			Code:   "ResourceIsUsed",
 			Status: http.StatusBadRequest,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When batch delete network, the prompt message does not indicate which network cannot be deleted.
![image](https://user-images.githubusercontent.com/15064560/103621769-abab6500-4f70-11eb-8f14-a69b645701cc.png)

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
prompt the used network name

**Related Issue:**
#381

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
