### PR TITLE
[charts kubevirt] #417 machine type default i440fx 

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -85,6 +85,11 @@ kubevirt:
         ##
         permitBridgeInterfaceOnPodNetwork: true
 
+      ## Specify the machine type regex for validating the emulation of VirtualMachineInstance,
+      ## defaults to discover automatically, "pseries*" if arch is ppc64le, otherwise "q35, pc-g35*, pc, pc-i440fx*".
+      ##
+      emulatedMachines: ["q35","pc-q35*","pc","pc-i440fx*"]
+
 ## Specify the parameters to override the sub-chart.
 ##
 cdi-operator:


### PR DESCRIPTION
Signed-off-by: kevin <kk@sudo-i.net>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Support i440fx by default

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
adding i440fx in filter

**Related Issue:**
#417 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
tested with citrix adc vpx 