### PR TITLE
Fix helm not delete all harvester resources

### DIFF
--- a/deploy/charts/harvester/templates/job.yaml
+++ b/deploy/charts/harvester/templates/job.yaml
@@ -65,11 +65,23 @@ spec:
         - name: pre-delete
           image: {{ .Values.jobs.preDelete.containers.kubectl.image.repository }}:{{ .Values.jobs.preDelete.containers.kubectl.image.tag }}
           imagePullPolicy: {{ .Values.jobs.preDelete.containers.kubectl.image.imagePullPolicy }}
-          command:
-            - "/bin/bash"
+          command: ["/bin/bash", "-c"]
           args:
-            - "-c"
-            - "{{if $isKubeVirtOperatorEnabled }}echo '[INFO] deleting kubevirt ...'; kubectl delete kubevirt --wait --all; {{ end }}{{if $isCDIOperatorEnabled }}echo '[INFO] deleting cdi ...'; kubectl delete cdi --wait --all; {{ end }}exit"
+            - >
+              {{ if $isKubeVirtOperatorEnabled }}
+              echo '[INFO] deleting kubevirt ...';
+              kubectl delete kubevirt --wait --all;
+              {{ end }}
+              {{ if $isCDIOperatorEnabled }}
+              echo '[INFO] deleting cdi ...';
+              kubectl delete cdi --wait --all;
+              {{ end }}
+              {{ if .Values.minio.enabled }}
+              echo '[INFO] deleting minio ...';
+              kubectl -n {{ .Release.Namespace }} delete statefulset/minio --ignore-not-found=true --wait;
+              kubectl -n {{ .Release.Namespace }} delete deployment/minio --ignore-not-found=true --wait;
+              {{ end }}
+              exit
 {{- if .Values.jobs.preDelete.containers.kubectl.resources }}
           resources:
 {{ toYaml .Values.jobs.preDelete.containers.kubectl.resources | indent 12 }}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The Helm uninstall order is given by the enumeration [UninstallOrder](https://github.com/helm/helm/blob/484d43913f97292648c867b56768775a55e4bba6/pkg/releaseutil/kind_sorter.go#L66). This result Kubelet not able to remove sub-charts correctly when its dependent resources are removed. In this case, the Longhorn uninstall-job pre-delete job cleans up longhorn before MinIO, and leaves behind storage dependent resources in the Terminating state.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Delete MinIO StatefulSet/Deployment in the pre-delete job that comes before Longhorn uninstall-job.

**Related Issue:**
https://github.com/rancher/harvester/issues/356

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install harvester with helm and enable longhorn, delete should clear harvester resources.
