### PR TITLE
Use yq to promote node

### DIFF
--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -53,8 +53,8 @@ if [ ! -f /var/lib/rancher/k3os/config.yaml ]; then \
 	echo done clone config; \
 fi && \
 echo update config && \
-sudo sed -i ':a;N;s/k3sArgs:\n  - agent/k3sArgs:\n  - server/g;ta' /var/lib/rancher/k3os/config.yaml && \
-sudo sed -i 's/command_args=\"agent/command_args=\"server/g' /etc/init.d/k3s-service && \
+sudo yq -i eval '.k3os.k3sArgs[0] = \"server\"' /var/lib/rancher/k3os/config.yaml && \
+sudo yq -i eval '.k3os.k3sArgs |= . + [\"--disable\",\"local-storage\"]' /var/lib/rancher/k3os/config.yaml && \
 echo restart and promote k3s node && \
 cat /var/run/k3s-restarter-trap.pid | xargs -r kill -HUP && \
 echo finish promote


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
missing `--disable local-storage` in k3sArgs on promoted nodes

**Solution:**
1. after promote node to master, use `yq` to add `--disable local-storage` into k3sArgs
2. (harvester-installer) use `rc-service ccapply restart ` to generate /etc/init.d/k3s-service and restart k3s

**Related Issue:**
#455
#259

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
