### PR TITLE
Scale harvester replicas to 3

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -208,7 +208,7 @@ fullnameOverride: ""
 
 ## Specify the replicas of workload.
 ##
-replicas: 1
+replicas: 3
 
 ## Specify the security context of workload.
 ##


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently, harvester replicas is 1, if the node which harvester running on is down, can't access harvester  service.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
in order to support HA, scale harvester deployment replicas to 3.

**Related Issue:**
#459

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
