### PR TITLE
fix: unable to access profiling service

### DIFF
--- a/deploy/charts/harvester/templates/service.yaml
+++ b/deploy/charts/harvester/templates/service.yaml
@@ -30,6 +30,3 @@ spec:
       port: {{ .Values.service.harvester.httpPort }}
       targetPort: http
 {{- end }}
-    - name: profile
-      port: {{ .Values.service.harvester.profile }}
-      targetPort: profile

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:        "profile-listen-address",
-			Value:       "127.0.0.1:6060",
+			Value:       "0.0.0.0:6060",
 			Usage:       "Address to listen on for profiling",
 			Destination: &profileAddress,
 		},


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
fix unable to access harvester profiling server.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. update profiling address from `127.0.0.1` to `0.0.0.0`
2. remove the default profiling service in the harvester since this is not commonly used by the user, and for debugging purposes the developer or administrator should be able to add it manually.


**Related Issue:**
https://github.com/rancher/harvester/issues/436

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
After the harvester pod is running, users can either run `kubectl port-forwad $harvester_pod 9060:6060` and access via localhost:9060 to check it or manually expose port 6060 via a service.
