### PR TITLE
Change podAntiAffinity to required

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -30,20 +30,18 @@ spec:
       serviceAccountName: harvester
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app.kubernetes.io/name
-                      operator: In
-                      values:
-                        - harvester
-                    - key: app.kubernetes.io/component
-                      operator: In
-                      values:
-                        - apiserver
-                topologyKey: kubernetes.io/hostname
-              weight: 1
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - harvester
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - apiserver
+              topologyKey: kubernetes.io/hostname
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently, Harvester's podAntiAffinity is preferredDuringSchedulingIgnoredDuringExecution, if the node which harvester running on is down, can't access harvester  service.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Change Harvester 's podAntiAffinity to requiredDuringSchedulingIgnoredDuringExecution

**Related Issue:**
#459

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
