### PR TITLE
Add node maintenance mode

### DIFF
--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -1,0 +1,103 @@
+package node
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/rancher/apiserver/pkg/apierror"
+	"github.com/rancher/apiserver/pkg/types"
+	ctlcorev1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/pkg/schemas/validation"
+	corev1 "k8s.io/api/core/v1"
+
+	ctlnode "github.com/rancher/harvester/pkg/controller/master/node"
+)
+
+const (
+	drainKey                     = "kubevirt.io/drain"
+	enableMaintenanceModeAction  = "enableMaintenanceMode"
+	disableMaintenanceModeAction = "disableMaintenanceMode"
+)
+
+func Formatter(request *types.APIRequest, resource *types.RawResource) {
+	resource.Actions = make(map[string]string)
+	if resource.APIObject.Data().String("metadata", "annotations", ctlnode.MaintainStatusAnnotationKey) != "" {
+		resource.AddAction(request, disableMaintenanceModeAction)
+	} else {
+		resource.AddAction(request, enableMaintenanceModeAction)
+	}
+}
+
+type ActionHandler struct {
+	nodeCache  ctlcorev1.NodeCache
+	nodeClient ctlcorev1.NodeClient
+}
+
+func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if err := h.do(rw, req); err != nil {
+		status := http.StatusInternalServerError
+		if e, ok := err.(*apierror.APIError); ok {
+			status = e.Code.Status
+		}
+		rw.WriteHeader(status)
+		_, _ = rw.Write([]byte(err.Error()))
+		return
+	}
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+func (h ActionHandler) do(rw http.ResponseWriter, req *http.Request) error {
+	vars := mux.Vars(req)
+	action := vars["action"]
+	name := vars["name"]
+	node, err := h.nodeCache.Get(name)
+	if err != nil {
+		return err
+	}
+	toUpdate := node.DeepCopy()
+	switch action {
+	case enableMaintenanceModeAction:
+		return h.enableMaintenanceMode(toUpdate)
+	case disableMaintenanceModeAction:
+		return h.disableMaintenanceMode(toUpdate)
+	default:
+		return apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
+	}
+}
+
+func (h ActionHandler) enableMaintenanceMode(node *corev1.Node) error {
+	node.Spec.Unschedulable = true
+	noDrainTaint := true
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == drainKey {
+			noDrainTaint = false
+			break
+		}
+	}
+	if noDrainTaint {
+		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+			Key:    drainKey,
+			Value:  "scheduling",
+			Effect: corev1.TaintEffectNoSchedule,
+		})
+	}
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+	node.Annotations[ctlnode.MaintainStatusAnnotationKey] = ctlnode.MaintainStatusRunning
+	_, err := h.nodeClient.Update(node)
+	return err
+}
+
+func (h ActionHandler) disableMaintenanceMode(node *corev1.Node) error {
+	node.Spec.Unschedulable = false
+	for i, taint := range node.Spec.Taints {
+		if taint.Key == drainKey {
+			node.Spec.Taints = append(node.Spec.Taints[:i], node.Spec.Taints[i+1:]...)
+			break
+		}
+	}
+	delete(node.Annotations, ctlnode.MaintainStatusAnnotationKey)
+	_, err := h.nodeClient.Update(node)
+	return err
+}

--- a/pkg/api/node/schema.go
+++ b/pkg/api/node/schema.go
@@ -1,0 +1,35 @@
+package node
+
+import (
+	"net/http"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/schema"
+	"github.com/rancher/steve/pkg/server"
+	"github.com/rancher/wrangler/pkg/schemas"
+
+	"github.com/rancher/harvester/pkg/config"
+)
+
+func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+	nodeHandler := ActionHandler{
+		nodeClient: scaled.Management.CoreFactory.Core().V1().Node(),
+		nodeCache:  scaled.Management.CoreFactory.Core().V1().Node().Cache(),
+	}
+	t := schema.Template{
+		ID: "node",
+		Customize: func(s *types.APISchema) {
+			s.Formatter = Formatter
+			s.ResourceActions = map[string]schemas.Action{
+				enableMaintenanceModeAction:  {},
+				disableMaintenanceModeAction: {},
+			}
+			s.ActionHandlers = map[string]http.Handler{
+				enableMaintenanceModeAction:  nodeHandler,
+				disableMaintenanceModeAction: nodeHandler,
+			}
+		},
+	}
+	server.SchemaFactory.AddTemplate(t)
+	return nil
+}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/harvester/pkg/api/image"
 	"github.com/rancher/harvester/pkg/api/keypair"
 	"github.com/rancher/harvester/pkg/api/network"
+	"github.com/rancher/harvester/pkg/api/node"
 	"github.com/rancher/harvester/pkg/api/setting"
 	"github.com/rancher/harvester/pkg/api/user"
 	"github.com/rancher/harvester/pkg/api/vm"
@@ -37,5 +38,6 @@ func Setup(ctx context.Context, server *server.Server, controllers *server.Contr
 		setting.RegisterSchema,
 		user.RegisterSchema,
 		network.RegisterSchema,
+		node.RegisterSchema,
 		datavolume.RegisterSchema)
 }

--- a/pkg/controller/master/node/maintain_controller.go
+++ b/pkg/controller/master/node/maintain_controller.go
@@ -1,0 +1,67 @@
+package node
+
+import (
+	"context"
+
+	ctlcorev1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/rancher/harvester/pkg/config"
+	v1 "github.com/rancher/harvester/pkg/generated/controllers/kubevirt.io/v1"
+)
+
+const (
+	maintainNodeControllerName = "maintain-node-controller"
+	labelNodeNameKey           = "kubevirt.io/nodeName"
+
+	MaintainStatusAnnotationKey = "harvester.cattle.io/maintain-status"
+	MaintainStatusComplete      = "completed"
+	MaintainStatusRunning       = "running"
+)
+
+// maintainNodeHandler updates maintenance status of a node in its annotations, so that we can tell whether the node is
+// entering maintenance mode(migrating VMs on it) or in maintenance mode(VMs migrated).
+type maintainNodeHandler struct {
+	nodes                       ctlcorev1.NodeClient
+	nodeCache                   ctlcorev1.NodeCache
+	virtualMachineInstanceCache v1.VirtualMachineInstanceCache
+}
+
+// MaintainRegister registers the node controller
+func MaintainRegister(ctx context.Context, management *config.Management, options config.Options) error {
+	nodes := management.CoreFactory.Core().V1().Node()
+	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
+	maintainNodeHandler := &maintainNodeHandler{
+		nodes:                       nodes,
+		nodeCache:                   nodes.Cache(),
+		virtualMachineInstanceCache: vmis.Cache(),
+	}
+
+	nodes.OnChange(ctx, maintainNodeControllerName, maintainNodeHandler.OnNodeChanged)
+
+	return nil
+}
+
+// OnNodeChanged updates node maintenance status when all VMs are migrated
+func (h *maintainNodeHandler) OnNodeChanged(key string, node *corev1.Node) (*corev1.Node, error) {
+	if node == nil || node.DeletionTimestamp != nil {
+		return node, nil
+	}
+	if maintenanceStatus, ok := node.Annotations[MaintainStatusAnnotationKey]; !ok || maintenanceStatus != MaintainStatusRunning {
+		return node, nil
+	}
+	sets := labels.Set{
+		labelNodeNameKey: node.Name,
+	}
+	vmis, err := h.virtualMachineInstanceCache.List(corev1.NamespaceAll, sets.AsSelector())
+	if err != nil {
+		return node, err
+	}
+	if len(vmis) != 0 {
+		return node, nil
+	}
+	toUpdate := node.DeepCopy()
+	toUpdate.Annotations[MaintainStatusAnnotationKey] = MaintainStatusComplete
+	return h.nodes.Update(toUpdate)
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -25,6 +25,7 @@ var registerFuncs = []registerFunc{
 	keypair.Register,
 	node.BalanceRegister,
 	node.PromoteRegister,
+	node.MaintainRegister,
 	template.Register,
 	virtualmachine.Register,
 	user.Register,

--- a/tests/integration/api/host_apis_test.go
+++ b/tests/integration/api/host_apis_test.go
@@ -1,10 +1,15 @@
 package api_test
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
+	ctlnode "github.com/rancher/harvester/pkg/controller/master/node"
 	"github.com/rancher/harvester/tests/framework/cluster"
 	. "github.com/rancher/harvester/tests/framework/dsl"
 	"github.com/rancher/harvester/tests/framework/helper"
@@ -30,6 +35,43 @@ var _ = Describe("verify host APIs", func() {
 				MustRespCodeIs(http.StatusOK, "get host", err, respCode, respBody)
 				MustEqual(len(nodes.Data), cluster.DefaultWorkers+cluster.DefaultControlPlanes)
 
+			})
+
+		})
+
+		Specify("verify host maintenance mode", func() {
+
+			nodes, respCode, respBody, err := helper.GetCollection(nodesAPI)
+			MustRespCodeIs(http.StatusOK, "get host", err, respCode, respBody)
+			nodeName := nodes.Data[0].ID
+			nodeObjectAPI := fmt.Sprintf("%s/%s", nodesAPI, nodeName)
+
+			By("enable maintenance mode of the host", func() {
+				respCode, respBody, err = helper.PostAction(nodeObjectAPI, "enableMaintenanceMode")
+				MustRespCodeIs(http.StatusNoContent, "post enableMaintenanceMode action", err, respCode, respBody)
+			})
+
+			By("then the node is unschedulable and maintain-status is set")
+			MustFinallyBeTrue(func() bool {
+				var retNode corev1.Node
+				respCode, respBody, err = helper.GetObject(nodeObjectAPI, &retNode)
+				MustRespCodeIs(http.StatusOK, "get host", err, respCode, respBody)
+				Expect(retNode.Spec.Unschedulable).To(BeEquivalentTo(true))
+				maintainStatus := retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]
+				return maintainStatus == ctlnode.MaintainStatusComplete
+			}, 10*time.Second, 1*time.Second)
+
+			By("disable maintenance mode of the host", func() {
+				respCode, respBody, err = helper.PostAction(nodeObjectAPI, "disableMaintenanceMode")
+				MustRespCodeIs(http.StatusNoContent, "post disableMaintenanceMode action", err, respCode, respBody)
+			})
+
+			By("then the node is schedulable and maintain-status is removed", func() {
+				var retNode corev1.Node
+				respCode, respBody, err = helper.GetObject(nodeObjectAPI, &retNode)
+				MustRespCodeIs(http.StatusOK, "get host", err, respCode, respBody)
+				Expect(retNode.Spec.Unschedulable).To(BeEquivalentTo(false))
+				Expect(retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]).To(BeEmpty())
 			})
 
 		})


### PR DESCRIPTION
Add enable/disableMaintenanceMode actions to nodes.
By enabling maintenance mode, a node is unschedulable, and VMs(expected to have liveMigrate evictionStategy) running on it start live-migrations.

**Related Issue:**
https://github.com/rancher/harvester/issues/384
