### PR TITLE
Fix RollingUpdate

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
                     operator: In
                     values:
                       - apiserver
+                  - key: app.kubernetes.io/version
+                    operator: In
+                    values:
+                      - {{ .Chart.AppVersion }}
               topologyKey: kubernetes.io/hostname
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -227,6 +227,9 @@ tolerations: []
 ## Specify the update strategy of workload.
 ##
 strategy:
+  rollingUpdate:
+    maxSurge: 2
+    maxUnavailable: 2
   type: RollingUpdate
 
 ## Specify the parameter of containers.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Can't RollingUpdate harevster deployment if node numbers <3

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. Change maxSurge from 25% (3*25%≈2) to 2
2. Change maxUnavailable from 25% (3*25%≈1) to 2
3. Add key `app.kubernetes.io/version` to podAntiAffinity's labelSelector

**Related Issue:**
#518

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
