### PR TITLE
Fix failed to revoke datavolumes's owner

### DIFF
--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -58,6 +58,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 
 	vmStore := &vmStore{
 		Store:            proxy.NewProxyStore(server.ClientFactory, nil, server.AccessSetLookup),
+		vms:              scaled.VirtFactory.Kubevirt().V1().VirtualMachine(),
 		vmCache:          scaled.VirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 		dataVolumes:      scaled.CDIFactory.Cdi().V1beta1().DataVolume(),
 		dataVolumesCache: scaled.CDIFactory.Cdi().V1beta1().DataVolume().Cache(),

--- a/pkg/util/data_volume.go
+++ b/pkg/util/data_volume.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	defaultNamespace      = "default"
-	certNoneConfigMapName = "importer-ca-none"
+	defaultNamespace                = "default"
+	certNoneConfigMapName           = "importer-ca-none"
+	RemovedDataVolumesAnnotationKey = "harvester.cattle.io/removedDataVolumes"
 )
 
 // SetHTTPSourceDataVolume sets the requiresScratch annotation, and certConfigMap with an existing empty configmap


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
After a vm be deleted through ui, UnsetOwnerOfDataVolumes(vm's OnRemove) will revoke vm's all datavolumes's owner
if some datavolumes has been deleted, the revoke owner operation will fail.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. Before deleting the vm, add removedDataVolumes to  vm's annotation
2. Add a judgment to UnsetOwnerOfDataVolumes(vm's OnRemove). If it is a volume that needs to be deleted, it will skip the revoke owner operation

**Related Issue:**
#501 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
