### PR TITLE
Doc: add missing harvester folder in app mode

### DIFF
--- a/docs/app-mode-installation.md
+++ b/docs/app-mode-installation.md
@@ -35,7 +35,7 @@ cat /proc/cpuinfo | grep vmx
 
 1. Go to the Helm chart:
     ```
-    $ cd deploy/charts
+    $ cd harvester/deploy/charts
    ```
 
 1. Install the Harvester chart with the following commands:


### PR DESCRIPTION
Fix the missing `harvester` folder.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


