### PR TITLE
Disable network controller in the integartion test

### DIFF
--- a/tests/integration/runtime/construct.go
+++ b/tests/integration/runtime/construct.go
@@ -37,10 +37,11 @@ func Construct(ctx context.Context, kubeConfig *restclient.Config) error {
 func installHarvesterChart(ctx context.Context, kubeConfig *restclient.Config) error {
 	// chart values patches
 	patches := map[string]interface{}{
-		"replicas":               0,
-		"minio.service.type":     "NodePort",
-		"minio.mode":             "standalone",
-		"minio.persistence.size": "5Gi",
+		"replicas":                             0,
+		"minio.service.type":                   "NodePort",
+		"minio.mode":                           "standalone",
+		"minio.persistence.size":               "5Gi",
+		"harvester-network-controller.enabled": false,
 	}
 	if env.IsE2ETestsEnabled() {
 		patches["longhorn.enabled"] = "true"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Drone CI failed to pass the integration test of the harvester-network-controller

**Solution:**
Disable the network controller on CI's integration tests for now since it has environment dependency

**Related Issue:**
tracked on https://github.com/rancher/harvester/issues/532

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
