### PR TITLE
Fix invalid certificate errors

### DIFF
--- a/deploy/charts/harvester/templates/service.yaml
+++ b/deploy/charts/harvester/templates/service.yaml
@@ -13,6 +13,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
 {{- end }}
 spec:
+  sessionAffinity: {{ .Values.service.harvester.sessionAffinity }}
   type: {{ .Values.service.harvester.type }}
   selector:
 {{ include "harvester.labels" . | indent 4 }}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -359,6 +359,10 @@ service:
     ##
     httpPort: 0
 
+    ## Specify the session affinity,
+    ## defaults to "ClientIP".
+    sessionAffinity: ClientIP
+
 ## Specify the lifecycle jobs.
 ##
 jobs:

--- a/pkg/controller/global/setup.go
+++ b/pkg/controller/global/setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/rancher/steve/pkg/server"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rancher/harvester/pkg/config"
 	"github.com/rancher/harvester/pkg/controller/global/auth"
@@ -23,10 +24,20 @@ var registerFuncs = []registerFunc{
 func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
 	indexeres.RegisterScaledIndexers(scaled)
+	registerControllers(ctx, scaled)
 	for _, f := range registerFuncs {
 		if err := f(ctx, scaled, server, options); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func registerControllers(ctx context.Context, scaled *config.Scaled) {
+	// to start secret controller so that it syncs in
+	// https://github.com/rancher/dynamiclistener/blob/9b1b7d3132e8b0dad6493f257386aa3bfb7b69f8/storage/kubernetes/controller.go#L78
+	scaled.CoreFactory.Core().V1().Secret().OnChange(ctx, "harvester-tls-storage",
+		func(key string, secret *corev1.Secret) (*corev1.Secret, error) {
+			return secret, nil
+		})
 }

--- a/pkg/controller/master/setting/controller.go
+++ b/pkg/controller/master/setting/controller.go
@@ -1,0 +1,60 @@
+package setting
+
+import (
+	"net/url"
+	"strings"
+
+	v1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/rancher/harvester/pkg/apis/harvester.cattle.io/v1alpha1"
+)
+
+const (
+	certNamespace = "kube-system"
+	certName      = "serving-cert"
+	cnPrefix      = "listener.cattle.io/cn-"
+)
+
+// Handler updates harvester certificate SANs on server-url setting changes
+type Handler struct {
+	v1.SecretClient
+	v1.SecretCache
+}
+
+func (h *Handler) OnChanged(key string, setting *v1alpha1.Setting) (*v1alpha1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != "server-url" || setting.Value == "" {
+		return setting, nil
+	}
+	u, err := url.Parse(setting.Value)
+	if err != nil {
+		return setting, err
+	}
+
+	secret, err := h.SecretCache.Get(certNamespace, certName)
+	if errors.IsNotFound(err) {
+		return setting, nil
+	} else if err != nil {
+		return setting, err
+	}
+	cn := u.Hostname()
+	if secret.Annotations[cnPrefix+cn] == cn {
+		return setting, nil
+	}
+	toUpdate := secret.DeepCopy()
+	if toUpdate.Annotations == nil {
+		toUpdate.Annotations = make(map[string]string)
+	}
+
+	//clean up other cns
+	newAnnotations := map[string]string{}
+	for k, v := range toUpdate.Annotations {
+		if !strings.Contains(k, cnPrefix) {
+			newAnnotations[k] = v
+		}
+	}
+	toUpdate.Annotations = newAnnotations
+	toUpdate.Annotations[cnPrefix+cn] = cn
+	_, err = h.SecretClient.Update(toUpdate)
+	return setting, err
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -1,0 +1,23 @@
+package setting
+
+import (
+	"context"
+
+	"github.com/rancher/harvester/pkg/config"
+)
+
+const (
+	controllerName = "server-url-setting-controller"
+)
+
+func Register(ctx context.Context, management *config.Management, options config.Options) error {
+	secrets := management.CoreFactory.Core().V1().Secret()
+	settings := management.HarvesterFactory.Harvester().V1alpha1().Setting()
+	controller := &Handler{
+		SecretCache:  secrets.Cache(),
+		SecretClient: secrets,
+	}
+
+	settings.OnChange(ctx, controllerName, controller.OnChanged)
+	return nil
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/harvester/pkg/controller/master/image"
 	"github.com/rancher/harvester/pkg/controller/master/keypair"
 	"github.com/rancher/harvester/pkg/controller/master/node"
+	"github.com/rancher/harvester/pkg/controller/master/setting"
 	"github.com/rancher/harvester/pkg/controller/master/template"
 	"github.com/rancher/harvester/pkg/controller/master/user"
 	"github.com/rancher/harvester/pkg/controller/master/virtualmachine"
@@ -27,6 +28,7 @@ var registerFuncs = []registerFunc{
 	node.BalanceRegister,
 	node.PromoteRegister,
 	node.MaintainRegister,
+	setting.Register,
 	template.Register,
 	virtualmachine.Register,
 	user.Register,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -23,6 +23,7 @@ var (
 	AuthSecretName         = NewSetting("auth-secret-name", "harvester-key-holder")
 	AuthTokenMaxTTLMinutes = NewSetting("auth-token-max-ttl-minutes", "720")
 	NoDefaultAdmin         = NewSetting("no-default-admin", "")
+	ServerURL              = NewSetting("server-url", "")
 	ServerVersion          = NewSetting("server-version", "dev")
 	UIIndex                = NewSetting("ui-index", "https://releases.rancher.com/harvester-ui/latest/index.html")
 	UIPath                 = NewSetting("ui-path", "/usr/share/rancher/harvester")


### PR DESCRIPTION

**Problem:**
1. TLS certs in harvester replicas might be inconsistent. When the cert is updated by dynamiclistener, it may be different from the trusted cert in the browser, and results in request errors.
2. The default harvester managment url is not included in the certificate SAN, therefore the certificate is invalid even if we trust the custom CA in the system.

**Solution:**
1. Add session affinity to Harvester service.
2. Add server-url setting and update certificate SANs on server-url changes

**Related Issue:**
https://github.com/rancher/harvester/issues/268

