### PR TITLE
remove scratch and cert configurations for datavolumes

### DIFF
--- a/pkg/api/datavolume/schema.go
+++ b/pkg/api/datavolume/schema.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rancher/steve/pkg/stores/proxy"
 
 	"github.com/rancher/harvester/pkg/config"
-	"github.com/rancher/harvester/pkg/util"
 )
 
 const (
@@ -25,5 +24,5 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	}
 
 	server.SchemaFactory.AddTemplate(t)
-	return util.InitCertConfigMap(scaled)
+	return nil
 }

--- a/pkg/api/datavolume/store.go
+++ b/pkg/api/datavolume/store.go
@@ -11,22 +11,11 @@ import (
 
 	cdiv1beta1 "github.com/rancher/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
 	"github.com/rancher/harvester/pkg/ref"
-	"github.com/rancher/harvester/pkg/util"
 )
 
 type dvStore struct {
 	types.Store
 	dvCache cdiv1beta1.DataVolumeCache
-}
-
-func (s *dvStore) Create(request *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
-	util.SetHTTPSourceDataVolume(data.Data())
-	return s.Store.Create(request, request.Schema, data)
-}
-
-func (s *dvStore) Update(request *types.APIRequest, schema *types.APISchema, data types.APIObject, id string) (types.APIObject, error) {
-	util.SetHTTPSourceDataVolume(data.Data())
-	return s.Store.Update(request, request.Schema, data, id)
 }
 
 func (s *dvStore) Delete(request *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {

--- a/pkg/api/vm/store.go
+++ b/pkg/api/vm/store.go
@@ -27,16 +27,6 @@ type vmStore struct {
 	dataVolumesCache ctlcdiv1beta1.DataVolumeCache
 }
 
-func (s *vmStore) Create(request *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
-	setHTTPSourceDVTemplates(data)
-	return s.Store.Create(request, request.Schema, data)
-}
-
-func (s *vmStore) Update(request *types.APIRequest, schema *types.APISchema, data types.APIObject, id string) (types.APIObject, error) {
-	setHTTPSourceDVTemplates(data)
-	return s.Store.Update(request, request.Schema, data, id)
-}
-
 func (s *vmStore) Delete(request *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	removedDisks := request.Query["removedDisks"]
 	vm, err := s.vmCache.Get(request.Namespace, request.Name)
@@ -125,12 +115,4 @@ func (s *vmStore) deleteDataVolumes(namespace string, names []string) error {
 		}
 	}
 	return nil
-}
-
-func setHTTPSourceDVTemplates(data types.APIObject) {
-	dvTemplates := data.Data().Slice("spec", "dataVolumeTemplates")
-	for _, t := range dvTemplates {
-		util.SetHTTPSourceDataVolume(t)
-	}
-	data.Data().SetNested(dvTemplates, "spec", "dataVolumeTemplates")
 }

--- a/pkg/util/data_volume.go
+++ b/pkg/util/data_volume.go
@@ -1,41 +1,5 @@
 package util
 
-import (
-	"github.com/rancher/wrangler/pkg/data"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/rancher/harvester/pkg/config"
-)
-
 const (
-	defaultNamespace                = "default"
-	certNoneConfigMapName           = "importer-ca-none"
 	RemovedDataVolumesAnnotationKey = "harvester.cattle.io/removedDataVolumes"
 )
-
-// SetHTTPSourceDataVolume sets the requiresScratch annotation, and certConfigMap with an existing empty configmap
-// It changes the CDI's decision to convert image after the whole file is downloaded.
-func SetHTTPSourceDataVolume(data data.Object) {
-	if data.Map("spec", "source", "http") != nil {
-		data.SetNested("true", "metadata", "annotations", "cdi.kubevirt.io/storage.import.requiresScratch")
-		data.SetNested(certNoneConfigMapName, "spec", "source", "http", "certConfigMap")
-	}
-}
-
-func InitCertConfigMap(scaled *config.Scaled) error {
-	configmaps := scaled.Management.CoreFactory.Core().V1().ConfigMap()
-	certNoneConfigmap := &corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
-			Name: certNoneConfigMapName,
-			//DVs are created in the default namespace
-			Namespace: defaultNamespace,
-		},
-	}
-	_, err := configmaps.Create(certNoneConfigmap)
-	if apierrors.IsAlreadyExists(err) {
-		return nil
-	}
-	return err
-}


### PR DESCRIPTION
Remove scratch and ca configurations in datavolumes.
This does not work anymore in lattest CDI and we are using backing image support

**Related Issue:**
https://github.com/rancher/harvester/issues/227
