### PR TITLE
Add Rancher CA integration

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
               value: {{ .Values.containers.apiserver.debug | quote }}
             - name: HARVESTER_SERVER_HTTP_PORT
               value: {{ .Values.service.harvester.httpPort | quote }}
+            {{- if .Values.rancherEmbedded }}
+            - name: RANCHER_EMBEDDED
+              value: "true"
+            {{- end }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -493,3 +493,5 @@ longhorn:
   defaultSettings:
     ## Specify the concurrent automatic engine upgrade per node limit
     concurrentAutomaticEngineUpgradePerNodeLimit: 3
+
+rancherEmbedded: false

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/rancher/dynamiclistener v0.2.1-0.20200910203214-85f32491cb09
 	github.com/rancher/lasso v0.0.0-20210219160604-9baf1c12751b
 	github.com/rancher/rancher v0.0.0-20210312225102-c824d91cd247
+	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/steve v0.0.0-20210302143000-362617a677a9
 	github.com/rancher/wrangler v0.7.3-0.20210219161540-ef7fe9ce2443
 	github.com/rancher/wrangler-api v0.6.1-0.20200515193802-dcf70881b087

--- a/go.sum
+++ b/go.sum
@@ -1142,6 +1142,7 @@ github.com/rancher/lasso v0.0.0-20200905045615-7fcb07d6a20b/go.mod h1:OhBBBO1pBw
 github.com/rancher/lasso v0.0.0-20210218221607-54c79222a9ad/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
 github.com/rancher/lasso v0.0.0-20210219160604-9baf1c12751b h1:CqS7xql6zJ7AKc1IFeKSy+3JZqVuEoEvKRE3bSj78JU=
 github.com/rancher/lasso v0.0.0-20210219160604-9baf1c12751b/go.mod h1:OhBBBO1pBwYp0hacWdnvSGOj+XE9yMLOLnaypIlic18=
+github.com/rancher/machine v0.15.0-rancher25 h1:i78iohBm9QLmxHOMM1ZssYwSNIObPdDUQjZ9h1mo8Jc=
 github.com/rancher/machine v0.15.0-rancher25/go.mod h1:Q7gKLOkNb8z8A/fYUhHFJ/ChJfpF8JVFxHPKZgEgpPA=
 github.com/rancher/norman v0.0.0-20200517050325-f53cae161640/go.mod h1:92rz/7QN7DOeLQZlJY/8aFBOmF085igIVguR0wpxLas=
 github.com/rancher/norman v0.0.0-20200714195611-b3163ad4ebc4 h1:9lH3XiG7lSoQVaqeZTmydzxasRSiYoc3PdOoAvpQAyc=
@@ -1206,6 +1207,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samalba/dockerclient v0.0.0-20151231000007-f661dd4754aa h1:kIglQ8vg9EkWKEYTBuUl6ESDc65LFrhdoq7a9EvROGI=
 github.com/samalba/dockerclient v0.0.0-20151231000007-f661dd4754aa/go.mod h1:yeYR4SlaRZJct6lwNRKR+qd0CocnxxWDE7Vh5dxsn/w=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v0.0.0-20151028231719-d41af8bb6a77/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -1883,6 +1885,7 @@ k8s.io/component-base v0.20.4 h1:gdvPs4G11e99meQnW4zN+oYOjH8qkLz1sURrAzvKWqc=
 k8s.io/component-base v0.20.4/go.mod h1:t4p9EdiagbVCJKrQ1RsA5/V4rFQNDfRlevJajlGwgjI=
 k8s.io/component-helpers v0.20.4/go.mod h1:S7jGg8zQp3kwvSzfuGtNaQAMVmvzomXDioTm5vABn9g=
 k8s.io/controller-manager v0.20.4/go.mod h1:WEvFUeeywQl0dIUvorC8Zx/vSqgB8sGKrzNncUEcjlE=
+k8s.io/cri-api v0.20.4 h1:AwwzhJMfaxiw8NnEJAUQI+FWlX1mAp9tHODTVxnkEQg=
 k8s.io/cri-api v0.20.4/go.mod h1:2JRbKt+BFLTjtrILYVqQK5jqhI+XNdF6UiGMgczeBCI=
 k8s.io/csi-translation-lib v0.20.4/go.mod h1:WisLItCdoDKB4lr6nkhzQsfgBNBJDI/TD9m4Crw92JM=
 k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/main.go
+++ b/main.go
@@ -113,13 +113,25 @@ func main() {
 		cli.StringFlag{
 			Name:   "authentication-mode",
 			EnvVar: "HARVESTER_AUTHENTICATION_MODE",
-			Usage:  "Define authentication mode, kubernetesCredentials and localUser are supported, could config more than one mode, separated by comma",
+			Usage:  "Define authentication mode, kubernetesCredentials, localUser and rancher are supported, could config more than one mode, separated by comma",
 		},
 		cli.StringFlag{
 			Name:        "profile-listen-address",
 			Value:       "0.0.0.0:6060",
 			Usage:       "Address to listen on for profiling",
 			Destination: &profileAddress,
+		},
+		cli.BoolFlag{
+			Name:        "rancher-embedded",
+			EnvVar:      "RANCHER_EMBEDDED",
+			Usage:       "Specify whether the Harvester is running with embedded Rancher mode, default to false",
+			Destination: &options.RancherEmbedded,
+		},
+		cli.StringFlag{
+			Name:        "rancher-server-url",
+			EnvVar:      "RANCHER_SERVER_URL",
+			Usage:       "Specify the URL to connect to the Rancher server",
+			Destination: &options.RancherURL,
 		},
 	}
 	app.Action = func(c *cli.Context) error {

--- a/pkg/api/auth/auth_handler.go
+++ b/pkg/api/auth/auth_handler.go
@@ -22,9 +22,13 @@ const (
 	jwtServiceAccountClaimSubject = "sub" // https://github.com/kubernetes/kubernetes/blob/3783e03dc9df61604c470aa21f198a888e3ec692/pkg/serviceaccount/claims.go#L64
 )
 
-func NewMiddleware(ctx context.Context, scaled *config.Scaled, restConfig *rest.Config) (*Middleware, error) {
+func NewMiddleware(ctx context.Context, scaled *config.Scaled, restConfig *rest.Config, rancherEmbedded bool) (*Middleware, error) {
 	middleware := &Middleware{
 		tokenManager: scaled.TokenManager,
+	}
+
+	if !rancherEmbedded {
+		return middleware, nil
 	}
 
 	emptyClusterID := func(*http.Request) string {

--- a/pkg/api/proxy/handler.go
+++ b/pkg/api/proxy/handler.go
@@ -8,6 +8,7 @@ import (
 
 // Handler proxies requests to the rancher service
 type Handler struct {
+	Host string
 }
 
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -15,6 +16,9 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		r.URL.Scheme = "https"
 		r.URL.Host = "rancher.cattle-system"
 		r.URL.Path = req.URL.Path
+		if h.Host != "" {
+			r.URL.Host = h.Host
+		}
 	}
 	httpProxy := &httputil.ReverseProxy{
 		Director: director,

--- a/pkg/controller/crds/setup.go
+++ b/pkg/controller/crds/setup.go
@@ -5,20 +5,20 @@ import (
 
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	longhornv1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
-	"github.com/rancher/steve/pkg/server"
+	rancherv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	wcrd "github.com/rancher/wrangler/pkg/crd"
+	"k8s.io/client-go/rest"
 
 	"github.com/rancher/harvester/pkg/apis/harvester.cattle.io/v1alpha1"
-	"github.com/rancher/harvester/pkg/config"
 	"github.com/rancher/harvester/pkg/util/crd"
 )
 
-func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
-	return createCRDs(ctx, server)
+func Setup(ctx context.Context, restConfig *rest.Config) error {
+	return createCRDs(ctx, restConfig)
 }
 
-func createCRDs(ctx context.Context, server *server.Server) error {
-	factory, err := crd.NewFactoryFromClient(ctx, server.RESTConfig)
+func createCRDs(ctx context.Context, restConfig *rest.Config) error {
+	factory, err := crd.NewFactoryFromClient(ctx, restConfig)
 	if err != nil {
 		return err
 	}
@@ -26,6 +26,10 @@ func createCRDs(ctx context.Context, server *server.Server) error {
 		BatchCreateCRDsIfNotExisted(
 			crd.NonNamespacedFromGV(v1alpha1.SchemeGroupVersion, "Setting"),
 			crd.NonNamespacedFromGV(v1alpha1.SchemeGroupVersion, "User"),
+			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "Setting"),
+			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "User"),
+			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "UserAttribute"),
+			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "Token"),
 		).
 		BatchCreateCRDsIfNotExisted(
 			crd.FromGV(v1alpha1.SchemeGroupVersion, "VirtualMachineImage"),

--- a/pkg/controller/master/rancher/ca_controller.go
+++ b/pkg/controller/master/rancher/ca_controller.go
@@ -1,0 +1,176 @@
+package rancher
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"time"
+
+	rancherv3api "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	rancherv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	corev1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1alpha1 "github.com/rancher/harvester/pkg/apis/harvester.cattle.io/v1alpha1"
+	sett "github.com/rancher/harvester/pkg/controller/master/setting"
+	harvesterv1 "github.com/rancher/harvester/pkg/generated/controllers/harvester.cattle.io/v1alpha1"
+)
+
+const (
+	CAName               = "serving-ca"
+	ServerURLSettingName = "server-url"
+
+	RancherNamespace        = "cattle-system"
+	RancherInternalCAName   = "tls-rancher-internal-ca"
+	RancherInternalCertName = "tls-rancher-internal"
+	RancherPrivateCAName    = "tls-ca"
+
+	tlsCertName = "tls.crt"
+	tlsKeyName  = "tls.key"
+	tlsCAName   = "cacerts.pem"
+)
+
+var (
+	syncProgressInterval = 5 * time.Second
+)
+
+type Handler struct {
+	Secrets         corev1.SecretClient
+	SecretCache     corev1.SecretCache
+	RancherSettings rancherv3.SettingClient
+	Settings        harvesterv1.SettingClient
+}
+
+func (h *Handler) SettingOnChange(key string, setting *rancherv3api.Setting) (*rancherv3api.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != ServerURLSettingName || setting.Value == "" {
+		return nil, nil
+	}
+
+	u, err := url.Parse(setting.Value)
+	if err != nil {
+		return setting, err
+	}
+
+	secret, err := h.SecretCache.Get(RancherNamespace, RancherInternalCertName)
+	if err != nil {
+		return setting, nil
+	}
+
+	cn := u.Hostname()
+	if secret.Annotations[sett.CNPrefix+cn] == cn {
+		return setting, nil
+	}
+
+	toUpdate := secret.DeepCopy()
+	if toUpdate.Annotations == nil {
+		toUpdate.Annotations = make(map[string]string)
+	}
+
+	//clean up other cns
+	newAnnotations := map[string]string{}
+	for k, v := range toUpdate.Annotations {
+		if !strings.Contains(k, sett.CNPrefix) {
+			newAnnotations[k] = v
+		}
+	}
+	toUpdate.Annotations = newAnnotations
+	toUpdate.Annotations[sett.CNPrefix+cn] = cn
+	if _, err = h.Secrets.Update(toUpdate); err != nil {
+		return setting, err
+	}
+
+	return setting, nil
+}
+
+func (h *Handler) ServerURLOnChange(key string, setting *harvesterv1alpha1.Setting) (*harvesterv1alpha1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != ServerURLSettingName || setting.Value == "" {
+		return nil, nil
+	}
+
+	serverURL, err := h.RancherSettings.Get(ServerURLSettingName, metav1.GetOptions{})
+	if err != nil {
+		return setting, err
+	}
+
+	if serverURL.Value != "" {
+		return setting, nil
+	}
+
+	toUpdate := serverURL.DeepCopy()
+	toUpdate.Value = strings.Replace(setting.Value, "30443", "30444", 1)
+	if _, err = h.RancherSettings.Update(toUpdate); err != nil {
+		return setting, err
+	}
+
+	return setting, nil
+}
+
+func (h *Handler) registerPrivateCA(ctx context.Context) {
+	for {
+		err := h.createDefaultRancherPrivateCA()
+		if err != nil {
+			logrus.Errorf("Failed to create rancher default CA, error:%s", err.Error())
+		} else {
+			logrus.Infof("Done register rancher private CA")
+			return
+		}
+
+		select {
+		case <-time.After(syncProgressInterval):
+			continue
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (h *Handler) createDefaultRancherPrivateCA() error {
+	secret, err := h.Secrets.Get(sett.CertNamespace, CAName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, err = h.SecretCache.Get(RancherNamespace, RancherInternalCAName)
+	if apierrors.IsNotFound(err) {
+		logrus.Infof("creating default rancher internal CA %s", RancherInternalCAName)
+		secretInternalCA := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RancherInternalCAName,
+				Namespace: RancherNamespace,
+			},
+			StringData: map[string]string{
+				tlsCertName: string(secret.Data[tlsCertName]),
+				tlsKeyName:  string(secret.Data[tlsKeyName]),
+			},
+		}
+		if _, err := h.Secrets.Create(secretInternalCA); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	_, err = h.SecretCache.Get(RancherNamespace, RancherPrivateCAName)
+	if apierrors.IsNotFound(err) {
+		logrus.Infof("creating default rancher private CA %s", RancherPrivateCAName)
+		secretCA := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RancherPrivateCAName,
+				Namespace: RancherNamespace,
+			},
+			StringData: map[string]string{
+				tlsCAName: string(secret.Data[tlsCertName]),
+			},
+		}
+		if _, err := h.Secrets.Create(secretCA); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/master/rancher/register.go
+++ b/pkg/controller/master/rancher/register.go
@@ -1,0 +1,32 @@
+package rancher
+
+import (
+	"context"
+
+	"github.com/rancher/harvester/pkg/config"
+)
+
+const (
+	controllerRancherName = "harvester-rancher-controller"
+)
+
+func Register(ctx context.Context, management *config.Management, options config.Options) error {
+	if options.RancherEmbedded {
+		secrets := management.CoreFactory.Core().V1().Secret()
+		rancherSettings := management.RancherManagementFactory.Management().V3().Setting()
+		settings := management.HarvesterFactory.Harvester().V1alpha1().Setting()
+		h := Handler{
+			Secrets:         secrets,
+			SecretCache:     secrets.Cache(),
+			RancherSettings: rancherSettings,
+			Settings:        settings,
+		}
+
+		// add Rancher private CA
+		go h.registerPrivateCA(ctx)
+
+		rancherSettings.OnChange(ctx, controllerRancherName, h.SettingOnChange)
+		settings.OnChange(ctx, controllerRancherName, h.ServerURLOnChange)
+	}
+	return nil
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/harvester/pkg/controller/master/image"
 	"github.com/rancher/harvester/pkg/controller/master/keypair"
 	"github.com/rancher/harvester/pkg/controller/master/node"
+	"github.com/rancher/harvester/pkg/controller/master/rancher"
 	"github.com/rancher/harvester/pkg/controller/master/setting"
 	"github.com/rancher/harvester/pkg/controller/master/template"
 	"github.com/rancher/harvester/pkg/controller/master/user"
@@ -35,6 +36,7 @@ var registerFuncs = []registerFunc{
 	backup.RegisterContent,
 	backup.RegisterRestore,
 	backup.RegisterBackupTarget,
+	rancher.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -147,14 +147,18 @@ func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 
 	s.ASL = accesscontrol.NewAccessStore(s.Context, true, s.controllers.RBAC)
 
-	router, err := NewRouter(scaled, s.RESTConfig)
+	router, err := NewRouter(scaled, s.RESTConfig, options)
 	if err != nil {
+		return err
+	}
+
+	if err := crds.Setup(s.Context, s.RESTConfig); err != nil {
 		return err
 	}
 
 	var authMiddleware steveauth.Middleware
 	if !options.SkipAuthentication {
-		md, err := auth.NewMiddleware(s.Context, scaled, s.RESTConfig)
+		md, err := auth.NewMiddleware(s.Context, scaled, s.RESTConfig, options.RancherEmbedded)
 		if err != nil {
 			return err
 		}
@@ -172,7 +176,6 @@ func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 	}
 
 	s.startHooks = []StartHook{
-		crds.Setup,
 		master.Setup,
 		global.Setup,
 		api.Setup,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -30,6 +30,7 @@ var (
 	APIUISource            = NewSetting("api-ui-source", "auto") // Options are 'auto', 'external' or 'bundled'
 	VolumeSnapshotClass    = NewSetting("volume-snapshot-class", "longhorn")
 	BackupTargetSet        = NewSetting(BackupTargetSettingName, InitBackupTargetToString())
+	RancherEnabled         = NewSetting("rancher-enabled", "false") // Specify whether the UI should display the Rancher UI navigation
 )
 
 const BackupTargetSettingName = "backup-target"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
On the HCI mode, the rancher is exposed via the nodePort but the certificate generated by the dynamic listener is neither authorized nor trusted CA, will need to address by using private CA.

**Solution:**
Use the Harvester `serving-ca` as a custom private CA and the CA of `tls-rancher-internal-ca`, therefore the Rancher server accessed by NodePort on the HCI mode will be validated for x509 authorization.

**Related Issue:**
Related PR: https://github.com/rancher/harvester-installer/pull/64

**Test plan:**
validate if the user can either import a cluster or create a node using a custom node driver successfully.