### PR TITLE
Fix invalid owner reference of backup & restore

### DIFF
--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -30,7 +30,6 @@ const (
 	backupControllerName = "harvester-vm-backup-controller"
 
 	vmBackupKindName = "VirtualMachineBackup"
-	vmKindName       = "VirtualMachine"
 
 	backupTargetAnnotation       = "backup.harvester.cattle.io/backupTarget"
 	backupBucketNameAnnotation   = "backup.harvester.cattle.io/BucketName"
@@ -120,7 +119,7 @@ func (h *Handler) OnBackupChange(key string, vmBackup *harvesterapiv1.VirtualMac
 
 func (h *Handler) getBackupSource(vmBackup *harvesterapiv1.VirtualMachineBackup) (*kv1.VirtualMachine, error) {
 	switch vmBackup.Spec.Source.Kind {
-	case vmKindName:
+	case kv1.VirtualMachineGroupVersionKind.Kind:
 		vm, err := h.vmCache.Get(vmBackup.Namespace, vmBackup.Spec.Source.Name)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/master/backup/backupcontent.go
+++ b/pkg/controller/master/backup/backupcontent.go
@@ -247,7 +247,7 @@ func (h *ContentHandler) createVolumeSnapshot(content *harvesterapiv1.VirtualMac
 			Namespace: content.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         snapshotv1.SchemeGroupVersion.String(),
+					APIVersion:         harvesterapiv1.SchemeGroupVersion.String(),
 					Kind:               vmBackupContentKindName,
 					Name:               content.Name,
 					UID:                content.UID,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
OwnerReferece API of the `volumeSnapshot` and `vmRestore` is incorrect

**Solution:**
Fix invalid owner reference API version

**Related Issue:**
https://github.com/rancher/harvester/issues/385

**Test plan:**
1. delete backup will remove its `volumeSnapshot` and data in the backup target
2. delete resorted new VM will removes its relational `vmRestore`
