### PR TITLE
Remove Harvester pod limit

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -293,9 +293,6 @@ containers:
     ## Specify the resources.
     ##
     resources:
-      limits:
-        cpu: 500m
-        memory: 500Mi
       requests:
         cpu: 250m
         memory: 256Mi


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Harvester pod crash due to OOM

**Solution:**
Remove Harvester pod limit

**Related Issue:**
https://github.com/rancher/harvester/issues/629

**Test plan:**
While uploading multiple images, the Harvester pod will not crash due to the original 500Mi memory limit.
