### PR TITLE
Update UI package to latest

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk add -u --no-cache git curl unzip tar tini bash nfs-utils &
 
 WORKDIR /var/lib/rancher/harvester
 
-ENV HARVESTER_UI_VERSION v0.1.3
+ENV HARVESTER_UI_VERSION latest
 ENV HARVESTER_UI_PATH /usr/share/rancher/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9


### PR DESCRIPTION
**Problem:**
The `master-head` image still packages the v0.1.0 UI as the offline assets, need to bump to use the latest UI.

**Solution:**
Update offline packaged UI to use the latest build.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
