### PR TITLE
Add log level configuration

### DIFF
--- a/pkg/controller/master/setting/controller.go
+++ b/pkg/controller/master/setting/controller.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	v1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/rancher/harvester/pkg/apis/harvester.cattle.io/v1alpha1"
@@ -23,7 +24,7 @@ type Handler struct {
 	v1.SecretCache
 }
 
-func (h *Handler) OnChanged(key string, setting *v1alpha1.Setting) (*v1alpha1.Setting, error) {
+func (h *Handler) ServerURLOnChanged(key string, setting *v1alpha1.Setting) (*v1alpha1.Setting, error) {
 	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != "server-url" || setting.Value == "" {
 		return setting, nil
 	}
@@ -58,4 +59,19 @@ func (h *Handler) OnChanged(key string, setting *v1alpha1.Setting) (*v1alpha1.Se
 	toUpdate.Annotations[CNPrefix+cn] = cn
 	_, err = h.SecretClient.Update(toUpdate)
 	return setting, err
+}
+
+func (h *Handler) LogLevelOnChanged(key string, setting *v1alpha1.Setting) (*v1alpha1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != "log-level" || setting.Value == "" {
+		return setting, nil
+	}
+
+	level, err := logrus.ParseLevel(setting.Value)
+	if err != nil {
+		return setting, err
+	}
+
+	logrus.Infof("set log level to %s", level)
+	logrus.SetLevel(level)
+	return setting, nil
 }

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	controllerName = "server-url-setting-controller"
+	controllerName = "harvester-setting-controller"
 )
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
@@ -18,6 +18,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		SecretClient: secrets,
 	}
 
-	settings.OnChange(ctx, controllerName, controller.OnChanged)
+	settings.OnChange(ctx, controllerName, controller.ServerURLOnChanged)
+	settings.OnChange(ctx, controllerName, controller.LogLevelOnChanged)
 	return nil
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -34,6 +34,7 @@ var (
 	RancherEnabled         = NewSetting("rancher-enabled", "false") // Specify whether the UI should display the Rancher UI navigation
 	UpgradableVersions     = NewSetting("upgradable-versions", "")
 	VersionMetadataURL     = NewSetting("version-metadata-url", "")
+	LogLevel               = NewSetting("log-level", "info") // options are info, debug and trace
 )
 
 const BackupTargetSettingName = "backup-target"


### PR DESCRIPTION
**Problem:**
there is no obvious way for user to configure the debug level log.

**Solution:**
Allow user to change log level via settings `log-level` configuration.

**Related Issue:**
https://github.com/rancher/harvester/issues/649

**Test plan:**
- e,g validate if debug level log is viewable on the harvester pod when the log-level is set to `debug`.
![image](https://user-images.githubusercontent.com/4569037/113847178-c5f01b80-97c9-11eb-8abe-97cfbf122b52.png)
