### PR TITLE
Fix migration state

### DIFF
--- a/pkg/controller/master/migration/register.go
+++ b/pkg/controller/master/migration/register.go
@@ -21,6 +21,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		return err
 	}
 	vms := management.VirtFactory.Kubevirt().V1().VirtualMachine()
+	pods := management.CoreFactory.Core().V1().Pod()
 	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	vmims := management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration()
 	handler := &Handler{
@@ -28,11 +29,12 @@ func Register(ctx context.Context, management *config.Management, options config
 		vmiCache:   vmis.Cache(),
 		vms:        vms,
 		vmCache:    vms.Cache(),
+		pods:       pods,
+		podCache:   pods.Cache(),
 		restClient: virtv1Client.RESTClient(),
 	}
 
 	vmis.OnChange(ctx, vmiControllerName, handler.OnVmiChanged)
 	vmims.OnChange(ctx, vmimControllerName, handler.OnVmimChanged)
-	vmims.OnRemove(ctx, vmimControllerName, handler.OnVmimRemove)
 	return nil
 }

--- a/pkg/controller/master/migration/vmi_controller.go
+++ b/pkg/controller/master/migration/vmi_controller.go
@@ -3,32 +3,69 @@ package migration
 import (
 	"context"
 
-	ctlv1 "github.com/rancher/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	"github.com/rancher/harvester/pkg/util"
+	ctlcorev1 "github.com/rancher/wrangler-api/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	v1 "kubevirt.io/client-go/api/v1"
+
+	ctlv1 "github.com/rancher/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/rancher/harvester/pkg/util"
 )
 
-// Handler resets the node target in vmi annotations and nodeSelector when a migration completes
+// Handler resets vmi annotations and nodeSelector when a migration completes
 type Handler struct {
 	namespace  string
 	vmiCache   ctlv1.VirtualMachineInstanceCache
 	vms        ctlv1.VirtualMachineClient
 	vmCache    ctlv1.VirtualMachineCache
+	podCache   ctlcorev1.PodCache
+	pods       ctlcorev1.PodClient
 	restClient rest.Interface
 }
 
 func (h *Handler) OnVmiChanged(_ string, vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error) {
 	if vmi == nil || vmi.DeletionTimestamp != nil ||
-		vmi.Annotations == nil || vmi.Annotations[util.AnnotationMigrationTarget] == "" ||
-		vmi.Status.MigrationState == nil || !vmi.Status.MigrationState.Completed ||
-		vmi.Status.MigrationState.TargetNode != vmi.Annotations[util.AnnotationMigrationTarget] {
+		vmi.Annotations == nil || vmi.Status.MigrationState == nil {
 		return vmi, nil
 	}
 
-	toUpdate := vmi.DeepCopy()
-	delete(toUpdate.Annotations, util.AnnotationMigrationTarget)
-	delete(toUpdate.Spec.NodeSelector, corev1.LabelHostname)
-	return vmi, util.VirtClientUpdateVmi(context.Background(), h.restClient, h.namespace, vmi.Namespace, vmi.Name, toUpdate)
+	if vmi.Annotations[util.AnnotationMigrationUID] == string(vmi.Status.MigrationState.MigrationUID) &&
+		vmi.Status.MigrationState.Completed {
+		toUpdate := vmi.DeepCopy()
+		delete(toUpdate.Annotations, util.AnnotationMigrationUID)
+		delete(toUpdate.Annotations, util.AnnotationMigrationState)
+		if vmi.Annotations[util.AnnotationMigrationTarget] != "" {
+			delete(toUpdate.Annotations, util.AnnotationMigrationTarget)
+			delete(toUpdate.Spec.NodeSelector, corev1.LabelHostname)
+		}
+
+		if err := util.VirtClientUpdateVmi(context.Background(), h.restClient, h.namespace, vmi.Namespace, vmi.Name, toUpdate); err != nil {
+			return vmi, err
+		}
+		if err := h.syncVM(vmi); err != nil {
+			return vmi, err
+		}
+	}
+
+	if vmi.Status.MigrationState.Completed && vmi.Status.MigrationState.AbortStatus == v1.MigrationAbortSucceeded {
+		// clean up leftover pod on abortion success
+		// https://github.com/kubevirt/kubevirt/issues/5373
+		sets := labels.Set{
+			v1.MigrationJobLabel: string(vmi.Status.MigrationState.MigrationUID),
+		}
+		pods, err := h.podCache.List(vmi.Namespace, sets.AsSelector())
+		if err != nil {
+			return vmi, err
+		}
+		if len(pods) > 0 {
+			if err := h.pods.Delete(vmi.Namespace, pods[0].Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				return vmi, err
+			}
+		}
+	}
+
+	return vmi, nil
 }


### PR DESCRIPTION
Problem:
1. VM may stuck in aborting state. VMIM is removed but waits for kubevirt finalizer. If we reset the annotation on VMIM removal, it may be overwritten by VMI status update.
2. on abortion success, the target pod is not removed in several minutes. This can block follow-up migrations.

Solution:
1. reset the annotation based on VMI.migrationState instead of on VMIM removal.
2. try to clean up the target pod on abortion success.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Related Issue:**
https://github.com/rancher/harvester/issues/622