### PR TITLE
Update disk requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ To get the Harvester server up and running the following minimum hardware is req
 |:---|:---|
 | CPU | 4 cores minimum, 16 cores or above preferred |
 | Memory | 8 GB minimum, 32 GB or above preferred |
-| Disk |  120 GB minimum, 500 GB or above preferred |
+| Disk Capacity |  120 GB minimum, 500 GB or above preferred |
+| Disk Performance |  Management nodes (first 3 nodes) must be [fast enough for Etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd), SSD recommended |
 | Network Card | 1 Gbps Ethernet minimum, 10Gbps Ethernet recommended |
 | Network Switch | Trunking of ports required for VLAN support |
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
After version 0.1.0, we updated the k3s version to use etcd as the metadata store for the cluster in order to support HA.
Etcd has higher performance requirements for disks： https://etcd.io/docs/v3.4/op-guide/hardware/
Failure to meet the performance requirements of etcd on disk, resulting in constant restarts of k3s, which in turn leads to high disk IO all the time

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add harvester's requirements for disk performance to Readme

**Related issue**
#657

![image](https://user-images.githubusercontent.com/15064560/114674426-cba1b000-9d39-11eb-97cb-81a4571b221d.png)
