### PR TITLE
Update vm backup & template actions

### DIFF
--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -32,6 +32,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	server.BaseSchemas.MustImportAndCustomize(BackupInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(RestoreInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(MigrateInput{}, nil)
+	server.BaseSchemas.MustImportAndCustomize(CreateTemplateInput{}, nil)
 
 	vms := scaled.VirtFactory.Kubevirt().V1().VirtualMachine()
 	vmis := scaled.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
@@ -121,7 +122,9 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				restoreVM: {
 					Input: "restoreInput",
 				},
-				createTemplate: {},
+				createTemplate: {
+					Input: "createTemplateInput",
+				},
 			}
 		},
 		Formatter: vmformatter.formatter,

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -23,3 +23,8 @@ type RestoreInput struct {
 type MigrateInput struct {
 	NodeName string `json:"nodeName"`
 }
+
+type CreateTemplateInput struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}


### PR DESCRIPTION
**Problem:**
1. Should allow the user to perform VM `backup` and `create template` action when the VM is stopped.
2. When creating a new template of the existing VM, the template name should be required.

**Solution:**
1. allow users to create VM backup or template when the VM is stopped and VMI should be in running state if the VMI exists.
2. add template name and description inputs of the VM `createTemplate` action.

**Related Issue:**
https://github.com/rancher/harvester/issues/703
https://github.com/rancher/harvester/issues/702

**Test plan:**
1. allow users to create VM backup or template when the VM is stopped and VMI should be in running state if the VMI exists.
2. add template name and description inputs of the VM `createTemplate` action.
3. can't create VM template using the same template name
