### PR TITLE
Fix invalid VM backup state and add annotations

### DIFF
--- a/pkg/api/vmtemplate/template_version_store.go
+++ b/pkg/api/vmtemplate/template_version_store.go
@@ -33,6 +33,10 @@ func (s *templateVersionStore) Create(request *types.APIRequest, schema *types.A
 		return types.APIObject{}, apierror.NewAPIError(validation.InvalidBodyContent, "Template version and template should belong to same namespace")
 	}
 
+	if _, err := s.templateCache.Get(templateNs, templateName); err != nil {
+		return types.APIObject{}, apierror.NewAPIError(validation.InvalidBodyContent, err.Error())
+	}
+
 	keyPairIDs := newData.StringSlice("spec", "keyPairIds")
 	if len(keyPairIDs) != 0 {
 		for _, v := range keyPairIDs {

--- a/pkg/apis/harvesterhci.io/v1beta1/backup.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/backup.go
@@ -17,7 +17,7 @@ const (
 	BackupConditionReady condition.Cond = "Ready"
 
 	// ConditionProgressing is the "progressing" condition type
-	BackupConditionProgressing condition.Cond = "Progressing"
+	BackupConditionProgressing condition.Cond = "InProgress"
 )
 
 // DeletionPolicy defines that to do with resources when VirtualMachineRestore is deleted

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -644,6 +644,7 @@ func (h *RestoreHandler) createNewVM(restore *harvesterv1.VirtualMachineRestore,
 			Running: pointer.BoolPtr(true),
 			Template: &kv1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: vmCpy.VirtualMachineSpec.Template.ObjectMeta.Annotations,
 					Labels: map[string]string{
 						vmCreatorLabel: "harvester",
 						vmNameLabel:    vmName,


### PR DESCRIPTION
**Problem:**
1. invalid VM backup state 
1. missing the backup VM annotations when restoring to a new VM
1. User can still create VM template version if VM template is not exist

**Solution:**
1. fix invalid VM backup state and clone backup VM annotations
2. Add VM template exists check on VM template version creating

**Related Issue:**
https://github.com/rancher/harvester/issues/711
https://github.com/rancher/harvester/issues/710

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
