### PR TITLE
Bump installer to v0.1.8

### DIFF
--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=v0.1.7
+HARVESTER_INSTALLER_VERSION=v0.1.8
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
Bump installer to v0.1.8 of fixing invalid cert-manager chart URL.

Related PR:
https://github.com/harvester/harvester-installer/pull/85