### PR TITLE
Bump Kubevirt containers release version

### DIFF
--- a/deploy/charts/harvester/questions.yaml
+++ b/deploy/charts/harvester/questions.yaml
@@ -143,7 +143,7 @@ questions:
         group: "KubeVirt Settings"
         show_if: "tags.kubevirt=true"
       - variable: kubevirt-operator.containers.operator.image.tag
-        default: "0.40.0-1"
+        default: "0.40.0-2"
         label: "Operator Image Tag"
         description: "specify the tag of operator image"
         type: "string"

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -32,7 +32,7 @@ kubevirt-operator:
     operator:
       image:
         repository: registry.suse.com/harvester-beta/virt-operator
-        tag: &kubevirtVersion 0.40.0-1
+        tag: &kubevirtVersion 0.40.0-2
     ## The following four images are placeholder for images in use.
     ## They are not used by the kubevirt-operator chart.
     controller:


### PR DESCRIPTION
The update fixes virt-handler crash caused by missing SELinux policies for virt-launcher.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Crashing virt-handler due to the missing /virt_launcher.cil

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The missing file is now included into the container image.

**Related Issue:** https://github.com/harvester/harvester/issues/805

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
