### PR TITLE
validate goimports in CI

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -28,5 +28,10 @@
 		"build-tags": [
 			"test"
 		]
-	}
+	},
+        "linters-settings": {
+                "goimports": {
+                        "local-prefixes": "github.com/harvester/harvester"
+                }
+        }
 }

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,9 +3,9 @@ set -e
 
 cd $(dirname $0)
 
-./build
-./test
 ./validate
 ./validate-ci
+./build
+./test
 ./test-integration
 ./package


### PR DESCRIPTION
Checks go import format in CI so that we don't need to care about it in PR reviews.

Example output: 
```
$ golangci-lint run
pkg/settings/settings.go:10: File is not `goimports`-ed with -local github.com/harvester/harvester (goimports)
	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
```