### PR TITLE
fix wrong ConfigMap for  longhorn-storageclass after upgrading

### DIFF
--- a/deploy/charts/harvester/templates/longhorn-storageclass-override.yaml
+++ b/deploy/charts/harvester/templates/longhorn-storageclass-override.yaml
@@ -6,7 +6,7 @@ metadata:
   name: longhorn-storageclass
   namespace: {{ .Values.longhorn.namespaceOverride }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
   labels: {{- include "longhorn.labels" . | nindent 4 }}
 data:
   storageclass.yaml: |


### PR DESCRIPTION
The longhorn-storageclass-override.yaml will be overridden by charts/longhorn after upgrading.
Because longhorn-storageclass-override.yaml only has "post-install" hook, after upgrading, this Configmap will apply longhorn-storageclass.yaml in charts/longhorn again which is not expected.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The longhorn-storageclass-override.yaml will be overridden by charts/longhorn after upgrading.
**Solution:**
Adding post-upgrade hook.

**Related Issue:**
https://github.com/harvester/harvester/issues/857

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
