### PR TITLE
Support external Rancher

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -75,22 +75,26 @@ spec:
 {{ toYaml .Values.containers.apiserver.args | indent 12 }}
 {{- end }}
           env:
-            - name: HARVESTER_AUTHENTICATION_MODE
-              value: {{ .Values.containers.apiserver.authMode | quote }}
-{{- if .Values.containers.apiserver.hciMode }}
-            - name: HCI_MODE
-              value: "true"
-{{- end }}
             - name: HARVESTER_SERVER_HTTPS_PORT
               value: {{ .Values.service.harvester.httpsPort | quote }}
             - name: HARVESTER_DEBUG
               value: {{ .Values.containers.apiserver.debug | quote }}
             - name: HARVESTER_SERVER_HTTP_PORT
               value: {{ .Values.service.harvester.httpPort | quote }}
-            {{- if .Values.rancherEmbedded }}
+            - name: HARVESTER_AUTHENTICATION_MODE
+              value: {{ .Values.containers.apiserver.authMode | quote }}
+{{- if .Values.containers.apiserver.hciMode }}
+            - name: HCI_MODE
+              value: "true"
+{{- end }}
+{{- if .Values.rancherEmbedded }}
             - name: RANCHER_EMBEDDED
               value: "true"
-            {{- end }}
+{{- end }}
+{{- if .Values.rancherURL }}
+            - name: RANCHER_SERVER_URL
+              value: {{  .Values.rancherURL }}
+{{- end }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pkg/api/auth/auth_handler.go
+++ b/pkg/api/auth/auth_handler.go
@@ -23,19 +23,19 @@ const (
 	jwtServiceAccountClaimSubject = "sub" // https://github.com/kubernetes/kubernetes/blob/3783e03dc9df61604c470aa21f198a888e3ec692/pkg/serviceaccount/claims.go#L64
 )
 
-func NewMiddleware(ctx context.Context, scaled *config.Scaled, restConfig *rest.Config, rancherEmbedded bool) (*Middleware, error) {
+func NewMiddleware(ctx context.Context, scaled *config.Scaled, rancherRestConfig *rest.Config, AddRancherAuthenticator bool) (*Middleware, error) {
 	middleware := &Middleware{
 		tokenManager: scaled.TokenManager,
 	}
 
-	if !rancherEmbedded {
+	if !AddRancherAuthenticator {
 		return middleware, nil
 	}
 
 	emptyClusterID := func(*http.Request) string {
 		return ""
 	}
-	sc, err := rancherconfig.NewScaledContext(*restConfig, nil)
+	sc, err := rancherconfig.NewScaledContext(*rancherRestConfig, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -65,7 +65,7 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 		downloadRoute.Handler(sbDownloadHandler)
 	}
 
-	if r.options.RancherEmbedded {
+	if r.options.RancherEmbedded || r.options.RancherURL != "" {
 		host, err := parseRancherServerURL(r.options.RancherURL)
 		if err != nil {
 			logrus.Fatal(err)


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. If the user creates a secret `rancher-kubeconfig` on namespace `harvester-system`, then the harvester will use this kubeconfig to connect to the rancher
2. if the user specifies rancherURL, the harvester will proxy /v3 API to it.

Steps to create secret rancher-kubeconfig
```bash
# the kubeconfig filename  must be `kubernetes.kubeconfig`
vi kubernetes.kubeconfig
kubectl -n harvester-system create secret generic rancher-kubeconfig --from-file=kubernetes.kubeconfig
kubectl -n harvester-system get secret rancher-kubeconfig -o yaml
``` 
**Related Issue:**
#883 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
