### PR TITLE
Fix find command in script/test

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -8,7 +8,7 @@ mkdir -p "${ROOT_DIR}/dist"
 
 echo  "Running unit tests"
 
-unit_test_targets=($(find "${ROOT_DIR}/pkg" -type d -maxdepth 1 -mindepth 1 ! -path '*generated*' ! -path '*apis*' -exec echo {}/... \;))
+unit_test_targets=($(find "${ROOT_DIR}/pkg" -maxdepth 1 -mindepth 1 -type d ! -path '*generated*' ! -path '*apis*' -exec echo {}/... \;))
 
 CGO_ENABLED=1 go test \
 	-tags=test \


### PR DESCRIPTION
'type' option should be placed after 'mindepth/maxdepth'.

**Problem:**
While I was compiling Harvester I had warning messages from the `find` command in `script/test`:
```
Successfully tagged harvester:master
Running unit tests
find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.

find: warning: you have specified the -mindepth option after a non-option argument -type, but options are not positional (-mindepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments
```

**Solution:**
Move the `type` option after the `mindepth/maxdepth` ones.

**Related Issue:**
#936

**Test plan:**
Simply execute `make`: there shouldn't be warning message from `find` anymore.
Manually tested on my dev environment without error.