### PR TITLE
Fix deleted VMs stays in terminating state

### DIFF
--- a/pkg/webhook/resources/datavolume/validator.go
+++ b/pkg/webhook/resources/datavolume/validator.go
@@ -40,6 +40,10 @@ func (v *dataVolumeValidator) Resource() types.Resource {
 }
 
 func (v *dataVolumeValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+	if request.IsGarbageCollection() {
+		return nil
+	}
+
 	dataVolume := oldObj.(*v1beta1.DataVolume)
 
 	dv, err := v.dataVolumes.Get(dataVolume.Namespace, dataVolume.Name)

--- a/tests/framework/dsl/action.go
+++ b/tests/framework/dsl/action.go
@@ -15,6 +15,8 @@ const (
 
 	vmTimeoutInterval = 300
 	vmPollingInterval = 2
+	dvTimeoutInterval = 300
+	dvPollingInterval = 2
 )
 
 // Cleanup executes the target cleanup execution if "KEEP_TESTING_RESOURCE" isn't "true".

--- a/tests/framework/dsl/datavolume_action.go
+++ b/tests/framework/dsl/datavolume_action.go
@@ -1,0 +1,21 @@
+package dsl
+
+import (
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctldatavolumev1 "github.com/harvester/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
+)
+
+func MustDataVolumeDeleted(controller ctldatavolumev1.DataVolumeController, namespace, name string) {
+	gomega.Eventually(func() bool {
+		_, err := controller.Get(namespace, name, metav1.GetOptions{})
+		if err != nil && apierrors.IsNotFound(err) {
+			return true
+		}
+		ginkgo.GinkgoT().Logf("datavolume %s is still exist: %v", name, err)
+		return false
+	}, dvTimeoutInterval, dvPollingInterval).Should(gomega.BeTrue())
+}

--- a/tests/integration/api/vm_apis_utils_test.go
+++ b/tests/integration/api/vm_apis_utils_test.go
@@ -31,6 +31,7 @@ const (
 	testVMCDRomDiskName                = "cdromdisk"
 	testVMContainerDiskName            = "containerdisk"
 	testVMContainerDiskImageName       = "kubevirt/fedora-cloud-container-disk-demo:v0.35.0"
+	testVMRemoveDiskName               = "sparedisk"
 	testVMContainerDiskImagePullPolicy = builder.DefaultImagePullPolicy
 	testVMCloudInitDiskName            = builder.CloudInitDiskName
 


### PR DESCRIPTION
**Problem:**
A VM state stays terminating after deleting.
 
**Solution:**
The root cause is the validation webhook reject garbage collection on datavolumes.

The following are changes in the PR:
- Do not manually remove datavolumes in delete virtual machine API calls.
  Let garbage collector do that.
- Validation webhook: allow garbage collection on datavolumes.
- Add a new test case. The test case asks backend to delete a provisioned VM
  and its volume together.


**Related Issue:**
https://github.com/harvester/harvester/issues/970


**Test plan:**
- Create a VM from GUI (Virtual Machines page). Use an image for the first disk and a new volume for the second one.
- Wait until the VM is running and delete the VM. A dialog will pop up to ask if the user want to also delete volumes. Choose one of them and confirm.
- VM will be in terminating state. After a while the VM should be disappear from the Virtual Machines page.
- Go to Volumes page. There should be one remaining volume there.
- The remaining volume should be able to be deleted.
