### PR TITLE
Fix reverse proxy

### DIFF
--- a/pkg/api/proxy/handler.go
+++ b/pkg/api/proxy/handler.go
@@ -2,14 +2,24 @@ package proxy
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 )
 
 // Handler proxies requests to the rancher service
 type Handler struct {
-	Host string
+	Scheme string
+	Host   string
 }
+
+const (
+	ForwardedAPIHostHeader = "X-API-Host"
+	ForwardedProtoHeader   = "X-Forwarded-Proto"
+	ForwardedHostHeader    = "X-Forwarded-Host"
+	PrefixHeader           = "X-API-URL-Prefix"
+	OriginHeader           = "Origin"
+)
 
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	director := func(r *http.Request) {
@@ -19,6 +29,17 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if h.Host != "" {
 			r.URL.Host = h.Host
 		}
+		if h.Scheme != "" {
+			r.URL.Scheme = h.Scheme
+		}
+		// set forwarded header to fix rancher api link
+		r.Header.Set(ForwardedAPIHostHeader, GetLastExistValue(req.Host, req.Header.Get(ForwardedAPIHostHeader)))
+		r.Header.Set(ForwardedHostHeader, GetLastExistValue(req.Host, req.Header.Get(ForwardedHostHeader)))
+		r.Header.Set(ForwardedProtoHeader, GetLastExistValue(req.URL.Scheme, req.Header.Get(ForwardedProtoHeader)))
+		r.Header.Set(PrefixHeader, GetLastExistValue(req.Header.Get(PrefixHeader)))
+		// set host and origin to fit scenarios: harvester->nginx->rancher
+		r.Host = r.URL.Host
+		r.Header.Set(OriginHeader, fmt.Sprintf("%s://%s", GetOriginScheme(r.URL.Scheme), r.Host))
 	}
 	httpProxy := &httputil.ReverseProxy{
 		Director: director,
@@ -27,4 +48,25 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		},
 	}
 	httpProxy.ServeHTTP(rw, req)
+}
+
+func GetOriginScheme(scheme string) string {
+	switch scheme {
+	case "ws":
+		return "http"
+	case "wss":
+		return "https"
+	default:
+		return scheme
+	}
+}
+
+func GetLastExistValue(values ...string) string {
+	var result string
+	for _, value := range values {
+		if value != "" {
+			result = value
+		}
+	}
+	return result
 }

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -66,12 +66,13 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	}
 
 	if r.options.RancherEmbedded || r.options.RancherURL != "" {
-		host, err := parseRancherServerURL(r.options.RancherURL)
+		host, scheme, err := parseRancherServerURL(r.options.RancherURL)
 		if err != nil {
 			logrus.Fatal(err)
 		}
 		rancherHandler := &proxy.Handler{
-			Host: host,
+			Host:   host,
+			Scheme: scheme,
 		}
 		m.PathPrefix("/v3-public/").Handler(rancherHandler)
 		m.PathPrefix("/v3/").Handler(rancherHandler)
@@ -83,15 +84,15 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	return m
 }
 
-func parseRancherServerURL(endpoint string) (string, error) {
+func parseRancherServerURL(endpoint string) (string, string, error) {
 	if endpoint == "" {
-		return "", nil
+		return "", "", nil
 	}
 
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return u.Host, nil
+	return u.Host, u.Scheme, nil
 }


### PR DESCRIPTION
case: ui->nginx->harvester->nginx->harvester

1. Since  we don't rewrite Host and Origin, if there has a nginx between Harvester and Rancher, nginx will return 301 and websocket 403

2. Another problem is links returned from rancher should be rewrited (set forwarded header to rancher), we also need to read forwarded header, because may be there has a nginx server in front of Harvester 


