### PR TITLE
Fix dangling `owned-by` annotation which preventing deletion

### DIFF
--- a/pkg/api/vm/store.go
+++ b/pkg/api/vm/store.go
@@ -105,12 +105,3 @@ func (s *vmStore) removeVMDataVolumeOwnerRef(vmNamespace, vmName string, savedDa
 
 	return nil
 }
-
-func (s *vmStore) deleteDataVolumes(namespace string, names []string) error {
-	for _, v := range names {
-		if err := s.dataVolumes.Delete(namespace, v, &metav1.DeleteOptions{}); err != nil && !k8sapierrors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}

--- a/pkg/controller/master/virtualmachine/datavolume_util.go
+++ b/pkg/controller/master/virtualmachine/datavolume_util.go
@@ -34,6 +34,17 @@ func setOwnerlessDataVolumeReference(dataVolumeClient cdictrl.DataVolumeClient, 
 	return err
 }
 
+// numberOfBoundedDataVolumeReference tries to get the number of bounded references on a DataVolume
+func numberOfBoundedDataVolumeReference(dataVolumeClient cdictrl.DataVolumeClient, dv *cdiapis.DataVolume, vm *kubevirtapis.VirtualMachine) (int, error) {
+	annotationSchemaOwners, err := ref.GetSchemaOwnersFromAnnotation(dv)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get schema owners from object: %w", err)
+	}
+	ownerGroupKind := kubevirtapis.VirtualMachineGroupVersionKind.GroupKind()
+	length := len(annotationSchemaOwners.List(ownerGroupKind))
+	return length, nil
+}
+
 // unsetBoundedDataVolumeReference tries to unset the DataVolume's annotation schema owner of the target VirtualMachine.
 func unsetBoundedDataVolumeReference(dataVolumeClient cdictrl.DataVolumeClient, dv *cdiapis.DataVolume, vm *kubevirtapis.VirtualMachine) error {
 	if vm == nil || dv == nil || dv.DeletionTimestamp != nil {

--- a/tests/framework/dsl/datavolume_action.go
+++ b/tests/framework/dsl/datavolume_action.go
@@ -5,8 +5,10 @@ import (
 	"github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 
 	ctldatavolumev1 "github.com/harvester/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
+	"github.com/harvester/harvester/pkg/ref"
 )
 
 func MustDataVolumeDeleted(controller ctldatavolumev1.DataVolumeController, namespace, name string) {
@@ -17,5 +19,31 @@ func MustDataVolumeDeleted(controller ctldatavolumev1.DataVolumeController, name
 		}
 		ginkgo.GinkgoT().Logf("datavolume %s is still exist: %v", name, err)
 		return false
+	}, dvTimeoutInterval, dvPollingInterval).Should(gomega.BeTrue())
+}
+
+func MustDataVolumeSucceeded(controller ctldatavolumev1.DataVolumeController, namespace, name string) {
+	AfterDataVolumeExist(controller, namespace, name, func(dv *cdiv1beta1.DataVolume) bool {
+		return dv.Status.Phase == cdiv1beta1.Succeeded
+	})
+}
+
+func MustDataVolumeUnowned(controller ctldatavolumev1.DataVolumeController, namespace, name string) {
+	AfterDataVolumeExist(controller, namespace, name, func(dv *cdiv1beta1.DataVolume) bool {
+		var annotations = dv.GetAnnotations()
+		var _, ok = annotations[ref.AnnotationSchemaOwnerKeyName]
+		return !ok
+	})
+}
+
+func AfterDataVolumeExist(controller ctldatavolumev1.DataVolumeController, namespace, name string,
+	callback func(dv *cdiv1beta1.DataVolume) bool) {
+	gomega.Eventually(func() bool {
+		var dv, err = controller.Get(namespace, name, metav1.GetOptions{})
+		if err != nil {
+			ginkgo.GinkgoT().Logf("failed to get data volume: %v", err)
+			return false
+		}
+		return callback(dv)
 	}, dvTimeoutInterval, dvPollingInterval).Should(gomega.BeTrue())
 }


### PR DESCRIPTION
**Problem:**

When a VM has existing volumes attached to it, since those data volumes do not have ownerReferences, it can not simply trigger garbage collection to perform the deletion. Hence, from a VM side, it needs to

1. unset the `harvesterchi.io/owned-by` annotation in
2. delete the data volume if requested and the VM is sole owner

**Related Issue:**

#985 

**Test plan:**

- Create a VM from Web UI. 
   - Use an image for the first disk,
   - and an existing volume for the second one,
   - and then the other existing volume for the last one.
- Wait until the VM is running and delete the VM. A dialog will pop up to ask if the user also want to delete volumes. Choose  the first and second disk. Leave the last uncheck and then confirm.
- VM will be in terminating state. After a while the VM should be disappear from the Virtual Machines page.
- Go to Volumes page. The first and second volumes should be deleted and the last one remains.
- The remaining volume should be able to be deleted.

