### PR TITLE
Integrate KubeVirt hotplug volume API

### DIFF
--- a/deploy/charts/harvester/dependency_charts/kubevirt/values.yaml
+++ b/deploy/charts/harvester/dependency_charts/kubevirt/values.yaml
@@ -127,11 +127,18 @@ spec:
     ##
     developerConfiguration:
 
-      ## Specify whether an optional feature is enabled or not at the global level,
-      ## select many from [CPUManager, ExperimentalIgnitionSupport, LiveMigration, CPUNodeDiscovery, HypervStrictCheck, Sidecar, GPU, Snapshot, HostDisk], ref to:
-      ## https://github.com/kubevirt/kubevirt/blob/f5ffba5f84365155c81d0e2cda4aa709da062230/pkg/virt-config/feature-gates.go#L26-L36.
+      ## Specify whether an optional feature is enabled at the global level.
+      ## Select many from [
+      ##    CPUManager, ExperimentalIgnitionSupport, LiveMigration,
+      ##    SRIOVLiveMigration, CPUNodeDiscovery, HypervStrictCheck,
+      ##    Sidecar, GPU, HostDevices, Snapshot, HotplugVolumes,
+      ##    HostDisk, ExperimentalVirtiofsSupport, Macvtap, DownwardMetrics
+      ## ].
+      ## Ref to: https://github.com/kubevirt/kubevirt/blob/7c7a2f4ace9ce3a88b164d4d282db55f08b6dc5e/pkg/virt-config/feature-gates.go#L26-L44.
       ##
-      featureGates: ["LiveMigration"]
+      featureGates: 
+      - "LiveMigration"
+      - "HotplugVolumes"
 
       ## Specify the toleration in percent when PVs' available space is smaller than requested,
       ## this argument will be passed to "virt-launcher" as "--less-pvc-space-toleration",

--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -22,6 +22,8 @@ const (
 	backupVM       = "backup"
 	restoreVM      = "restore"
 	createTemplate = "createTemplate"
+	addVolume      = "addVolume"
+	removeVolume   = "removeVolume"
 )
 
 type vmformatter struct {
@@ -38,6 +40,9 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 	if err != nil {
 		return
 	}
+
+	resource.AddAction(request, addVolume)
+	resource.AddAction(request, removeVolume)
 
 	if canEjectCdRom(vm) {
 		resource.AddAction(request, ejectCdRom)

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -33,6 +33,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	server.BaseSchemas.MustImportAndCustomize(RestoreInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(MigrateInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(CreateTemplateInput{}, nil)
+	server.BaseSchemas.MustImportAndCustomize(AddVolumeInput{}, nil)
+	server.BaseSchemas.MustImportAndCustomize(RemoveVolumeInput{}, nil)
 
 	vms := scaled.VirtFactory.Kubevirt().V1().VirtualMachine()
 	vmis := scaled.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
@@ -41,6 +43,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	restores := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore()
 	settings := scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	nodes := scaled.CoreFactory.Core().V1().Node()
+	pvcs := scaled.CoreFactory.Core().V1().PersistentVolumeClaim()
 	vmt := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate()
 	vmtv := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion()
 
@@ -71,6 +74,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		restores:                  restores,
 		settingCache:              settings.Cache(),
 		nodeCache:                 nodes.Cache(),
+		pvcCache:                  pvcs.Cache(),
 		virtSubresourceRestClient: virtSubresourceClient,
 		virtRestClient:            virtv1Client.RESTClient(),
 	}
@@ -102,6 +106,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				backupVM:       &actionHandler,
 				restoreVM:      &actionHandler,
 				createTemplate: &actionHandler,
+				addVolume:      &actionHandler,
+				removeVolume:   &actionHandler,
 			}
 			apiSchema.ResourceActions = map[string]schemas.Action{
 				startVM:   {},
@@ -124,6 +130,12 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				},
 				createTemplate: {
 					Input: "createTemplateInput",
+				},
+				addVolume: {
+					Input: "addVolumeInput",
+				},
+				removeVolume: {
+					Input: "removeVolumeInput",
 				},
 			}
 		},

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -28,3 +28,12 @@ type CreateTemplateInput struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 }
+
+type AddVolumeInput struct {
+	DiskName         string `json:"diskName"`
+	VolumeSourceName string `json:"volumeSourceName"`
+}
+
+type RemoveVolumeInput struct {
+	DiskName string `json:"diskName"`
+}


### PR DESCRIPTION
### Problem

Integrate KubeVirt hotplug volume API.

### Solution

Two new VM actions

- `addvolume`:  hot-plug a volume into a VM -> https://kubevirt.io/api-reference/v0.44.0/operations.html#_v1vm-addvolume
- `removevolume`: hot-unplug a volume from a VM -> https://kubevirt.io/api-reference/v0.44.0/operations.html#_v1vm-removevolume

### Related Issue

- #283 
- https://github.com/rancher/rke2/issues/1188 (new OS with RKE2 need to support runc with v1.0.0 or above)

### Test plan

> ⚠️⚠️⚠️ ~~There is a devmappper bug introduced in libvirt 6.5.0-2 and it seems that 6.6.0 does not fix it. Unfortunately for harvester master we are using kubevirt 0.40.0 which is based on [libvirt 6.6.0]. This bug would not affect the logic of API itself, but hotplug volumes would be useless after plugged-in. You can follow the [upgrade instruction here] for an upgrade to latest KubeVirt. I've tested it against KubeVirt v0.42.1 and it works.~~

[upgrade instruction here]: https://kubevirt.io/labs/kubernetes/lab3.html
[libvirt 6.6.0]: https://github.com/kubevirt/kubevirt/blob/v0.40.0/hack/rpm-deps.sh#L8

First, run unit tests `go test -v github.com/harvester/harvester/pkg/api/vm`, then e2e tests.

1. Run a harvester cluster

1. Enable `HotplugVolumes` feature gate. Put simply, append `HotplugVolumes` into `kubevirt.spec.configuration.developerConfiguration.featureGates`
    ```shell
    k patch -n harvester-system kubevirt kubevirt \
    --type='json' \
    -p='[{"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-", "value": "HotplugVolumes"}]'
    ```

1. Run the harvester backend

1. Create a VM and a volume independently

1. Test with cURL
    ```shell
    # Remove
    curl -XPOST -k --cookie $your_jwe_token \
    "https://<harvester-backend>/v1/kubevirt.io.virtualmachine/<ns>/<vm>?action=removevolume" \
    --data '{"diskName": "<disk-name>"}'
    
    # Add 
    curl -XPOST -k --cookie $your_jwe_token \
    "https://<harvester-backend>/v1/kubevirt.io.virtualmachine/<ns>/<vm>?action=addvolume" \
    --data '{"volumeSourceName":"<volume-source-name>","diskName": "<disk-name>"}'
    ```




