### PR TITLE
Restore manually attached disk as datavolumes datasource instead of pvc

### DIFF
--- a/tests/integration/api/vm_apis_utils_test.go
+++ b/tests/integration/api/vm_apis_utils_test.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 
 	"github.com/harvester/harvester/pkg/builder"
 )
@@ -144,4 +148,29 @@ func CreateTmpFile(dir, pattern, content string, mode os.FileMode) (string, erro
 func NewDefaultTestVMBuilder(labels map[string]string) *builder.VMBuilder {
 	return builder.NewVMBuilder(testCreator).Namespace(testVMNamespace).Labels(labels).
 		CPU(testVMCPUCores).Memory(testVMMemory).Run(false)
+}
+
+func NewDataVolume(labels map[string]string, namespace, volumeName string) *cdiv1beta1.DataVolume {
+	volumeMode := corev1.PersistentVolumeBlock
+	return &cdiv1beta1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      volumeName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: cdiv1beta1.DataVolumeSpec{
+			Source: cdiv1beta1.DataVolumeSource{
+				Blank: &cdiv1beta1.DataVolumeBlankImage{},
+			},
+			PVC: &corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("2Gi"),
+					},
+				},
+				VolumeMode: &volumeMode,
+			},
+		},
+	}
 }

--- a/tests/integration/api/vm_backup_restore_test.go
+++ b/tests/integration/api/vm_backup_restore_test.go
@@ -54,7 +54,7 @@ var _ = Describe("verify vm backup & restore APIs", func() {
 			podController = scaled.CoreFactory.Core().V1().Pod()
 			svcController = scaled.CoreFactory.Core().V1().Service()
 			backupNamespace = testVMNamespace
-			sourceImage = "https://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
+			sourceImage = "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/alpine-virt-3.14.0-x86_64.iso"
 			vmBackupTarget = fmt.Sprintf("nfs://harvester-nfs-svc.%s:/opt/backupstore", backupNamespace)
 		})
 


### PR DESCRIPTION
### Problem

When restoring a VM with manually attached volumes, those volumes will be restored as PVC data source but not data volume, which makes them not discoverable in Web UI.

### Solution

When restoring, the restore handler manually checks whether a volume was manually attached (not in `vm.spec.dataVolumeTemplates`). If yes, it'll restore an additional data volume for that volume, and then add the data volume into `vm.spec.templates.volumes`.

### Related Issue

#987 

### Test plan

1. Run preprogrammed e2e tests by
    1. Prepare a clean harvester cluster
    1. Run following commands
        ```shell
        USE_EXISTING_CLUSTER=true \
        SKIP_HARVESTER_INSTALLATION=true \
        DONT_USE_EMULATION=true \
        ENABLE_E2E_TESTS=true \
        bash ./scripts/test-integration
        ```
    1. The test "verify vm backup api" should pass
1. Do e2e test by hands
    1. Prepare a clean harvester cluster
    1. Manually create a volume from the Web UI "Volume" page
    1. Create a VM with a root disk and add the volume created in previous step as second disk
    1. Take a backup on the VM (both S3 and NFS are ok as long as they succeed)
    1. Restore a new VM from the backup
    1. Navigate to the VM page > Volume section. There should exist both root-disk and manually created volume.
    1. Navigate to "Volume" page. Both root disk and manually attached disk show up there.
