### PR TITLE
Proxy management.cattle.io.setting APIs

### DIFF
--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -90,6 +90,7 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 		m.PathPrefix("/v3-public/").Handler(rancherHandler)
 		m.PathPrefix("/v3/").Handler(rancherHandler)
 		m.PathPrefix("/v1/userpreferences").Handler(rancherHandler)
+		m.PathPrefix("/v1/management.cattle.io.setting").Handler(rancherHandler)
 	}
 
 	m.NotFoundHandler = router.Routes(h)

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -237,7 +237,7 @@ func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 		md, err := auth.NewMiddleware(s.Context, scaled,
 			s.RancherRESTConfig, options.RancherEmbedded || options.RancherURL != "",
 			[]string{"/v1", "/apis"},
-			[]string{"/v1-public"})
+			[]string{"/v1-public", "/v1/management.cattle.io.setting"})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/1043

**Problem:**
Previously we detect the first-login via `/v3/settings/first-login`. This API is not available when mcm is disabled. We need to check `/v1/management.cattle.io.setting/first-login` as the dashboard does.
The /v1/management.cattle.io.setting is unauthed in Rancher API but it is authed in Harvester API. 

**Solution:**
Proxy `/v1/management.cattle.io.setting` to Rancher server. We will refactor/drop this part when UI/API is merged, so we use this straightforward solution for now.