### PR TITLE
Fix builder machine type panic

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -99,7 +99,9 @@ func (v *VMBuilder) Namespace(namespace string) *VMBuilder {
 }
 
 func (v *VMBuilder) MachineType(machineType string) *VMBuilder {
-	v.VirtualMachine.Spec.Template.Spec.Domain.Machine.Type = machineType
+	v.VirtualMachine.Spec.Template.Spec.Domain.Machine = &kubevirtv1.Machine{
+		Type: machineType,
+	}
 	return v
 }
 


### PR DESCRIPTION
if VirtualMachine.Spec.Template.Spec.Domain.Machine == nil will panic


**Related issued**
harvester/harvester#1108