### PR TITLE
Add ignore upgrade for newOS changes

### DIFF
--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -17,7 +17,6 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/setting"
 	"github.com/harvester/harvester/pkg/controller/master/supportbundle"
 	"github.com/harvester/harvester/pkg/controller/master/template"
-	"github.com/harvester/harvester/pkg/controller/master/upgrade"
 	"github.com/harvester/harvester/pkg/controller/master/user"
 	"github.com/harvester/harvester/pkg/controller/master/virtualmachine"
 	"github.com/harvester/harvester/pkg/indexeres"
@@ -35,7 +34,6 @@ var registerFuncs = []registerFunc{
 	setting.Register,
 	template.Register,
 	virtualmachine.Register,
-	upgrade.Register,
 	user.Register,
 	backup.RegisterBackup,
 	backup.RegisterContent,
@@ -43,6 +41,7 @@ var registerFuncs = []registerFunc{
 	backup.RegisterBackupTarget,
 	rancher.Register,
 	supportbundle.Register,
+	//upgrade.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {


### PR DESCRIPTION
**Problem:**
```
E0825 05:42:14.797805       7 reflector.go:138] github.com/rancher/lasso/pkg/cache/cache.go:124: Failed to watch *v1.Plan: failed to list *v1.Plan: the server could not find the requested resource (get plans.meta.k8s.io)
```

**Solution:**
Add ignore upgrade for newOS changes since we are going to update the upgrade controller logic of newOS changes.
