### PR TITLE
Use scale-available annotation for harvester services auto-scaling

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -2,10 +2,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  # NB(thxCode): name should not be customized as below:
-  # name: {{ template "harvester.fullname" . }}
-  # because we can easily confirm this resource from the corresponding namespace.
   name: harvester
+{{- if .Values.replicas }}
+  # The annotation does not support 0 replicas, which is used in integration tests.
+  annotations:
+    management.cattle.io/scale-available: "{{ .Values.replicas }}"
+{{- end }}
   labels:
 {{ include "harvester.labels" . | indent 4 }}
     app.kubernetes.io/name: harvester
@@ -16,7 +18,10 @@ spec:
 {{ include "harvester.immutableLabels" . | indent 6 }}
       app.kubernetes.io/name: harvester
       app.kubernetes.io/component: apiserver
+{{- if not .Values.replicas }}
+  # Use this field instead of the scale-available annotation when it is 0 replicas.
   replicas: {{ .Values.replicas }}
+{{- end }}
 {{- if .Values.strategy }}
   strategy:
 {{ toYaml .Values.strategy | indent 4 }}
@@ -119,6 +124,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: harvester-webhook
+  annotations:
+    management.cattle.io/scale-available: "{{ .Values.webhook.replicas }}"
   labels:
 {{ include "harvester.labels" . | indent 4 }}
     app.kubernetes.io/name: harvester-webhook
@@ -129,7 +136,6 @@ spec:
 {{ include "harvester.immutableLabels" . | indent 6 }}
       app.kubernetes.io/name: harvester
       app.kubernetes.io/component: webhook-server
-  replicas: {{ .Values.webhook.replicas }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
With this solution, there won't be pending pods if the number of nodes is less than 3.