### PR TITLE
Adapt support-bundle-kit changes

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -43,6 +43,7 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string) error {
 	logrus.Debugf("creating deployment %s with image %s", deployName, image)
 
 	pullPolicy := m.getImagePullPolicy()
+	namespaces := []string{sb.Namespace, "longhorn-system"}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -77,23 +78,23 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string) error {
 						{
 							Name:            "manager",
 							Image:           image,
-							Args:            []string{"/usr/bin/support-bundle-utils", "manager"},
+							Args:            []string{"/usr/bin/support-bundle-kit", "manager"},
 							ImagePullPolicy: pullPolicy,
 							Env: []corev1.EnvVar{
 								{
-									Name:  "HARVESTER_NAMESPACE",
-									Value: sb.Namespace,
+									Name:  "SUPPORT_BUNDLE_TARGET_NAMESPACES",
+									Value: strings.Join(namespaces, ","),
 								},
 								{
-									Name:  "HARVESTER_SUPPORT_BUNDLE_NAME",
+									Name:  "SUPPORT_BUNDLE_NAME",
 									Value: sb.Name,
 								},
 								{
-									Name:  "HARVESTER_SUPPORT_BUNDLE_DEBUG",
+									Name:  "SUPPORT_BUNDLE_DEBUG",
 									Value: "true",
 								},
 								{
-									Name: "HARVESTER_SUPPORT_BUNDLE_MANAGER_POD_IP",
+									Name: "SUPPORT_BUNDLE_MANAGER_POD_IP",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "status.podIP",
@@ -101,16 +102,16 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string) error {
 									},
 								},
 								{
-									Name:  "HARVESTER_SUPPORT_BUNDLE_IMAGE",
+									Name:  "SUPPORT_BUNDLE_IMAGE",
 									Value: image,
 								},
 								{
-									Name:  "HARVESTER_SUPPORT_BUNDLE_IMAGE_PULL_POLICY",
+									Name:  "SUPPORT_BUNDLE_IMAGE_PULL_POLICY",
 									Value: string(pullPolicy),
 								},
 								{
-									Name:  "HARVESTER_SUPPORT_BUNDLE_WAIT_TIMEOUT",
-									Value: types.NodeBundleWaitTimeout,
+									Name:  "SUPPORT_BUNDLE_NODE_SELECTOR",
+									Value: "harvesterhci.io/managed=true",
 								},
 							},
 							Ports: []corev1.ContainerPort{

--- a/pkg/controller/master/supportbundle/types/types.go
+++ b/pkg/controller/master/supportbundle/types/types.go
@@ -10,10 +10,8 @@ const (
 	StateReady      = "ready"
 
 	// labels
-	HarvesterNodeLabelKey   = "harvesterhci.io/managed"
-	HarvesterNodeLabelValue = "true"
-	SupportBundleLabelKey   = "harvesterhci.io/supportbundle"
-	DrainKey                = "kubevirt.io/drain"
+	SupportBundleLabelKey = "rancher/supportbundle"
+	DrainKey              = "kubevirt.io/drain"
 
 	AppManager = "support-bundle-manager"
 	AppAgent   = "support-bundle-agent"

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -32,7 +32,7 @@ var (
 	UpgradeCheckerEnabled        = NewSetting("upgrade-checker-enabled", "true")
 	UpgradeCheckerURL            = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
 	LogLevel                     = NewSetting("log-level", "info") // options are info, debug and trace
-	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/harvester-support-bundle-utils:master-head")
+	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:master-head")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
 	DefaultStorageClass          = NewSetting("default-storage-class", "longhorn")
 )


### PR DESCRIPTION

**Problem:**
Support-bundle-utils is renamed to support-bundle-kit

**Solution:**
Adapt the change.

Here is a generated bundle for reference: 
[supportbundle_c9eafbd9-6984-463f-b34c-af3ca8bdb085_2021-09-06T03-02-06Z.zip](https://github.com/harvester/harvester/files/7113060/supportbundle_c9eafbd9-6984-463f-b34c-af3ca8bdb085_2021-09-06T03-02-06Z.zip)


**Related Issue:**
https://github.com/harvester/harvester/issues/1114

**Test plan:**
- Click `Support` on the bottom-left corner of Harvester GUI.
- Click `Generate Support Bundle`