### PR TITLE
Bump support-bundle-kit to v0.0.3

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -26,7 +26,7 @@ var (
 	UpgradeCheckerEnabled        = NewSetting("upgrade-checker-enabled", "true")
 	UpgradeCheckerURL            = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
 	LogLevel                     = NewSetting("log-level", "info") // options are info, debug and trace
-	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:master-head")
+	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.3")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
 	DefaultStorageClass          = NewSetting("default-storage-class", "longhorn")
 )


### PR DESCRIPTION

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Support-bundle-kit will change, we need to stick to a tested version.

**Solution:**
Stick to the latest version.

**Related Issue:**
https://github.com/harvester/harvester/issues/1114

**Test plan:**
- Click Support on the bottom-left corner of Harvester GUI.
- Click Generate Support Bundle