### PR TITLE
Enable RKE2 cloud controller on promoted nodes

### DIFF
--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -51,7 +51,6 @@ disable: rke2-ingress-nginx
 cluster-cidr: 10.52.0.0/16
 service-cidr: 10.53.0.0/16
 cluster-dns: 10.53.0.10
-disable-cloud-controller: true
 EOF
 systemctl disable --now rke2-agent && \
 systemctl enable --now rke2-server && \


### PR DESCRIPTION


**Problem:**
Fix the problem that nodes can't join a cluster.

**Solution:**
Enable RKE2 cloud controller on promoted nodes

**Related Issue:**
https://github.com/harvester/harvester/issues/1174

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
