### PR TITLE
Serve bundled UI in Harvester server

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -66,10 +66,6 @@ spec:
             - name: RANCHER_EMBEDDED
               value: "true"
 {{- end }}
-{{- if not .Values.auth.enabled }}
-            - name: SKIP_AUTHENTICATION
-              value: "true"
-{{- end }}
 {{- if .Values.rancherURL }}
             - name: RANCHER_SERVER_URL
               value: {{  .Values.rancherURL }}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -390,8 +390,6 @@ longhorn:
     concurrentAutomaticEngineUpgradePerNodeLimit: 3
 
 rancherEmbedded: false
-auth:
-  enabled: false
 
 webhook:
   replicas: 3

--- a/main.go
+++ b/main.go
@@ -53,12 +53,6 @@ func main() {
 			Required:    true,
 		},
 		cli.BoolFlag{
-			Name:        "skip-authentication",
-			EnvVar:      "SKIP_AUTHENTICATION",
-			Usage:       "Define whether to skip auth login or not, default to false",
-			Destination: &options.SkipAuthentication,
-		},
-		cli.BoolFlag{
 			Name:        "hci-mode",
 			EnvVar:      "HCI_MODE",
 			Usage:       "Enable HCI mode. Additional controllers are registered in HCI mode",
@@ -75,11 +69,6 @@ func main() {
 			EnvVar:      "RANCHER_SERVER_URL",
 			Usage:       "Specify the URL to connect to the Rancher server",
 			Destination: &options.RancherURL,
-		},
-		cli.BoolFlag{
-			Name:        "add-local-ui",
-			Usage:       "Add local dashboard UI (true, false)",
-			Destination: &options.AddLocalUI,
 			Hidden:      true,
 		},
 	}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -40,11 +40,9 @@ type Options struct {
 	HTTPListenPort  int
 	HTTPSListenPort int
 
-	SkipAuthentication bool
-	RancherEmbedded    bool
-	RancherURL         string
-	HCIMode            bool
-	AddLocalUI         bool
+	RancherEmbedded bool
+	RancherURL      string
+	HCIMode         bool
 }
 
 type Scaled struct {

--- a/pkg/controller/master/rancher/embedded_rancher.go
+++ b/pkg/controller/master/rancher/embedded_rancher.go
@@ -5,14 +5,10 @@ import (
 
 	rancherv3api "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
-
-	"github.com/harvester/harvester/pkg/settings"
 )
 
 var UpdateRancherUISettings = map[string]string{
-	"ui-dashboard-index":   settings.DefaultDashboardUIURL,
-	"ui-offline-preferred": "false",
-	"ui-pl":                "Harvester",
+	"ui-pl": "Harvester",
 }
 
 func (h *Handler) RancherSettingOnChange(key string, setting *rancherv3api.Setting) (*rancherv3api.Setting, error) {

--- a/pkg/data/apiservice.go
+++ b/pkg/data/apiservice.go
@@ -22,7 +22,7 @@ func addAPIService(apply apply.Apply, namespace string) error {
 			Spec: v3.APIServiceSpec{
 				SecretName:      AggregationSecretName,
 				SecretNamespace: namespace,
-				PathPrefixes:    []string{"/v1/harvester/"},
+				PathPrefixes:    []string{"/v1/harvester/", "/dashboard/"},
 				Paths:           []string{"/v1/harvester"},
 			},
 		})

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -73,27 +73,24 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	m.Path("/v1/harvester/{type}/{namespace}/{name}").Handler(h.K8sResource)
 	m.Path("/v1/harvester/{type}/{namespace}/{name}/{link}").Handler(h.K8sResource)
 
-	// enable local dashboard ui for dev
-	if r.options.AddLocalUI {
-		vueUI := ui.Vue
-		m.Handle("/dashboard/", vueUI.IndexFile())
-		m.PathPrefix("/dashboard/").Handler(vueUI.IndexFileOnNotFound())
-		m.PathPrefix("/api-ui").Handler(vueUI.ServeAsset())
+	vueUI := ui.Vue
+	m.Handle("/dashboard/", vueUI.IndexFile())
+	m.PathPrefix("/dashboard/").Handler(vueUI.IndexFileOnNotFound())
+	m.PathPrefix("/api-ui").Handler(vueUI.ServeAsset())
 
-		if r.options.RancherURL != "" {
-			host, scheme, err := parseRancherServerURL(r.options.RancherURL)
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			rancherHandler := &proxy.Handler{
-				Host:   host,
-				Scheme: scheme,
-			}
-			m.PathPrefix("/v3-public/").Handler(rancherHandler)
-			m.PathPrefix("/v3/").Handler(rancherHandler)
-			m.PathPrefix("/v1/userpreferences").Handler(rancherHandler)
-			m.PathPrefix("/v1/management.cattle.io.setting").Handler(rancherHandler)
+	if r.options.RancherURL != "" {
+		host, scheme, err := parseRancherServerURL(r.options.RancherURL)
+		if err != nil {
+			logrus.Fatal(err)
 		}
+		rancherHandler := &proxy.Handler{
+			Host:   host,
+			Scheme: scheme,
+		}
+		m.PathPrefix("/v3-public/").Handler(rancherHandler)
+		m.PathPrefix("/v3/").Handler(rancherHandler)
+		m.PathPrefix("/v1/userpreferences").Handler(rancherHandler)
+		m.PathPrefix("/v1/management.cattle.io.setting").Handler(rancherHandler)
 	}
 
 	m.NotFoundHandler = router.Routes(h)

--- a/pkg/server/ui/api.go
+++ b/pkg/server/ui/api.go
@@ -27,7 +27,7 @@ func ConfigureAPIUI(server *apiserver.Server) {
 }
 
 func JSURL() string {
-	switch settings.APIUISource.Get() {
+	switch settings.UISource.Get() {
 	case "auto":
 		if !settings.IsRelease() {
 			return ""
@@ -39,7 +39,7 @@ func JSURL() string {
 }
 
 func CSSURL() string {
-	switch settings.APIUISource.Get() {
+	switch settings.UISource.Get() {
 	case "auto":
 		if !settings.IsRelease() {
 			return ""

--- a/pkg/server/ui/ui.go
+++ b/pkg/server/ui/ui.go
@@ -26,9 +26,9 @@ var (
 		},
 	}
 
-	Vue = newHandler(settings.LocalUIIndex.Get,
+	Vue = newHandler(settings.UIIndex.Get,
 		settings.UIPath.Get,
-		settings.APIUISource.Get)
+		settings.UISource.Get)
 	VueIndex = Vue.IndexFile()
 )
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -17,9 +17,9 @@ var (
 
 	APIUIVersion                 = NewSetting("api-ui-version", "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
 	ServerVersion                = NewSetting("server-version", "dev")
-	LocalUIIndex                 = NewSetting("local-ui-index", DefaultDashboardUIURL)
+	UIIndex                      = NewSetting("ui-index", DefaultDashboardUIURL)
 	UIPath                       = NewSetting("ui-path", "/usr/share/harvester/harvester")
-	APIUISource                  = NewSetting("api-ui-source", "auto") // Options are 'auto', 'external' or 'bundled'
+	UISource                     = NewSetting("ui-source", "auto") // Options are 'auto', 'external' or 'bundled'
 	VolumeSnapshotClass          = NewSetting("volume-snapshot-class", "longhorn")
 	BackupTargetSet              = NewSetting(BackupTargetSettingName, InitBackupTargetToString())
 	UpgradableVersions           = NewSetting("upgradable-versions", "")


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/1219

**Problem:**
Fail to load UI in offline environments.

**Solution:**
Get dashboard UI from Harvester api-server.

**Test plan:**
For tag release, check that UI is loaded as expected in air-gapped env.

For master build, it still defaults to fetch the latest remote UI. 
Run
```
kubectl patch setting ui-source --type=merge -p 'value: bundled'
```
Then verify it works in air-gapped env.