### PR TITLE
Mark node schedulable only if it supports virtualization

### DIFF
--- a/tests/integration/runtime/construct.go
+++ b/tests/integration/runtime/construct.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"os"
 
 	restclient "k8s.io/client-go/rest"
 
@@ -67,6 +68,14 @@ func installHarvesterChart(ctx context.Context, kubeConfig *restclient.Config) e
 
 	if env.IsUsingEmulation() {
 		patches["kubevirt.spec.configuration.developerConfiguration.useEmulation"] = "true"
+
+		// Create fake /dev/kvm device if software emulation is enabled
+		// to get kubevirt.io/schedulable=true label for node
+		f, err := os.Create("/host/dev/kvm")
+		if err != nil {
+			fmt.Println(err)
+		}
+		defer f.Close()
 	}
 
 	// install chart


### PR DESCRIPTION
**Problem:**
I did piloting by running Harvester on VM without enabling nested virtualization and noticed that node still had `kubevirt.io/schedulable=true` label.

**Solution:**
Added extra check that node will be marked schedulable only if `/dev/kvm` exist like it is done on debug script too:
https://github.com/harvester/harvester/blob/40dfbba994d4dce19e2909a73135369098f603a2/hack/host-check.sh#L30-L37

**Related Issue:**
Closes #1290

**Test plan:**
Disable virtualization support from VM/bare metal, install Harvester to it and verify that it have `kubevirt.io/schedulable=false` label. Then enable virtualization support and make sure that node gets `kubevirt.io/schedulable=true` label.
