### PR TITLE
sets cacerts default on cacerts syncs

### DIFF
--- a/pkg/controller/master/rancher/register.go
+++ b/pkg/controller/master/rancher/register.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	controllerRancherName     = "harvester-rancher-controller"
+	caCertsSetting            = "cacerts"
 	cattleSystemNamespaceName = "cattle-system"
 	defaultAdminLabelKey      = "authz.management.cattle.io/bootstrapping"
 	defaultAdminLabelValue    = "admin-user"


### PR DESCRIPTION
**Problem:**
Currently, we set the cacerts value once. When a rancher pod(with --no-cacerts) is created/restarted, the cacerts will be reset to empty.

**Solution:**
Sets cacerts value on cacerts syncs.

**Related Issue:**
https://github.com/harvester/harvester/issues/1298
