### PR TITLE
Enable upgrade controller

### DIFF
--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/setting"
 	"github.com/harvester/harvester/pkg/controller/master/supportbundle"
 	"github.com/harvester/harvester/pkg/controller/master/template"
+	"github.com/harvester/harvester/pkg/controller/master/upgrade"
 	"github.com/harvester/harvester/pkg/controller/master/virtualmachine"
 	"github.com/harvester/harvester/pkg/indexeres"
 )
@@ -36,7 +37,7 @@ var registerFuncs = []registerFunc{
 	backup.RegisterBackupTarget,
 	supportbundle.Register,
 	rancher.Register,
-	//upgrade.Register,
+	upgrade.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -112,7 +112,7 @@ func basePlan(upgrade *harvesterv1.Upgrade, disableEviction bool) *upgradev1.Pla
 	return &upgradev1.Plan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      upgrade.Name,
-			Namespace: k3osSystemNamespace,
+			Namespace: upgradeNamespace,
 			Labels: map[string]string{
 				harvesterVersionLabel: version,
 				harvesterUpgradeLabel: upgrade.Name,
@@ -126,7 +126,7 @@ func basePlan(upgrade *harvesterv1.Upgrade, disableEviction bool) *upgradev1.Pla
 					harvesterManagedLabel: "true",
 				},
 			},
-			ServiceAccountName: k3osUpgradeServiceAccount,
+			ServiceAccountName: upgradeServiceAccount,
 			Drain: &upgradev1.DrainSpec{
 				Force:           true,
 				DisableEviction: disableEviction,
@@ -289,7 +289,8 @@ func newJobBuilder(name string) *jobBuilder {
 	return &jobBuilder{
 		job: &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
+				Name:      name,
+				Namespace: upgradeNamespace,
 			},
 		},
 	}
@@ -393,7 +394,7 @@ func newPlanBuilder(name string) *planBuilder {
 		plan: &upgradev1.Plan{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: k3osSystemNamespace,
+				Namespace: upgradeNamespace,
 			},
 		},
 	}

--- a/pkg/controller/master/upgrade/job_controller.go
+++ b/pkg/controller/master/upgrade/job_controller.go
@@ -32,7 +32,7 @@ type jobHandler struct {
 }
 
 func (h *jobHandler) OnChanged(key string, job *batchv1.Job) (*batchv1.Job, error) {
-	if job == nil || job.DeletionTimestamp != nil || job.Labels == nil {
+	if job == nil || job.DeletionTimestamp != nil || job.Labels == nil || job.Namespace != upgradeNamespace {
 		return job, nil
 	}
 
@@ -49,7 +49,7 @@ func (h *jobHandler) OnChanged(key string, job *batchv1.Job) (*batchv1.Job, erro
 }
 
 func (h *jobHandler) syncNodeJob(job *batchv1.Job, planName string, nodeName string) (*batchv1.Job, error) {
-	plan, err := h.planCache.Get(k3osSystemNamespace, planName)
+	plan, err := h.planCache.Get(upgradeNamespace, planName)
 	if err != nil {
 		return job, err
 	}

--- a/pkg/controller/master/upgrade/job_controller_test.go
+++ b/pkg/controller/master/upgrade/job_controller_test.go
@@ -133,7 +133,7 @@ func TestJobHandler_OnChanged(t *testing.T) {
 		}
 		if tc.expected.plan != nil {
 			var err error
-			actual.plan, err = handler.planCache.Get(k3osSystemNamespace, tc.given.upgrade.Name)
+			actual.plan, err = handler.planCache.Get(upgradeNamespace, tc.given.upgrade.Name)
 			assert.Nil(t, err)
 		}
 

--- a/pkg/controller/master/upgrade/plan_controller_test.go
+++ b/pkg/controller/master/upgrade/plan_controller_test.go
@@ -168,14 +168,14 @@ func TestPlanHandler_OnChanged(t *testing.T) {
 			assert.Nil(t, err)
 		}
 		if tc.expected.serverPlan != nil {
-			actual.serverPlan, err = handler.planClient.Get(k3osSystemNamespace, tc.expected.serverPlan.Name, metav1.GetOptions{})
+			actual.serverPlan, err = handler.planClient.Get(upgradeNamespace, tc.expected.serverPlan.Name, metav1.GetOptions{})
 			assert.Nil(t, err)
 			sanitizeStatus(&tc.expected.serverPlan.Status)
 			sanitizeStatus(&actual.serverPlan.Status)
 		}
 
 		if tc.expected.agentPlan != nil {
-			actual.agentPlan, err = handler.planClient.Get(k3osSystemNamespace, tc.expected.agentPlan.Name, metav1.GetOptions{})
+			actual.agentPlan, err = handler.planClient.Get(upgradeNamespace, tc.expected.agentPlan.Name, metav1.GetOptions{})
 			assert.Nil(t, err)
 			sanitizeStatus(&tc.expected.agentPlan.Status)
 			sanitizeStatus(&actual.agentPlan.Status)

--- a/pkg/controller/master/upgrade/pod_controller.go
+++ b/pkg/controller/master/upgrade/pod_controller.go
@@ -20,7 +20,7 @@ type podHandler struct {
 }
 
 func (h *podHandler) OnChanged(key string, pod *v1.Pod) (*v1.Pod, error) {
-	if pod == nil || pod.DeletionTimestamp != nil || pod.Labels == nil {
+	if pod == nil || pod.DeletionTimestamp != nil || pod.Labels == nil || pod.Namespace != upgradeNamespace {
 		return pod, nil
 	}
 
@@ -71,7 +71,7 @@ func (h *podHandler) syncNodeUpgradePod(pod *v1.Pod, planName string, nodeName s
 	if pod.Status.Phase == v1.PodSucceeded {
 		return pod, nil
 	}
-	plan, err := h.planCache.Get(k3osSystemNamespace, planName)
+	plan, err := h.planCache.Get(upgradeNamespace, planName)
 	if err != nil {
 		return pod, err
 	}

--- a/pkg/controller/master/upgrade/pod_controller_test.go
+++ b/pkg/controller/master/upgrade/pod_controller_test.go
@@ -36,7 +36,7 @@ func TestPodHandler_OnChanged(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-node-pod",
-						Namespace: k3osSystemNamespace,
+						Namespace: upgradeNamespace,
 						Labels: map[string]string{
 							upgradePlanLabel: testPlanName,
 							upgradeNodeLabel: testNodeName,
@@ -58,7 +58,7 @@ func TestPodHandler_OnChanged(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-node-pod",
-						Namespace: k3osSystemNamespace,
+						Namespace: upgradeNamespace,
 						Labels: map[string]string{
 							upgradePlanLabel: testPlanName,
 							upgradeNodeLabel: testNodeName,
@@ -113,7 +113,7 @@ func TestPodHandler_OnChanged(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-chart-pod",
-						Namespace: kubeSystemNamespace,
+						Namespace: upgradeNamespace,
 						Labels: map[string]string{
 							helmChartLabel: harvesterChartname,
 						},

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	//system upgrade controller is deployed in k3os-system namespace
-	k3osSystemNamespace            = "k3os-system"
-	k3osUpgradeServiceAccount      = "k3os-upgrade"
+	//system upgrade controller is deployed in cattle-system namespace
+	upgradeNamespace               = "cattle-system"
+	upgradeServiceAccount          = "system-upgrade-controller"
 	kubeSystemNamespace            = "kube-system"
 	harvesterSystemNamespace       = "harvester-system"
 	harvesterVersionLabel          = "harvesterhci.io/version"

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -84,7 +84,7 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 		var err error
 		actual.upgrade, actual.err = handler.OnChanged(tc.given.key, tc.given.upgrade)
 		if tc.expected.plan != nil {
-			actual.plan, err = handler.planClient.Get(k3osSystemNamespace, tc.expected.plan.Name, metav1.GetOptions{})
+			actual.plan, err = handler.planClient.Get(upgradeNamespace, tc.expected.plan.Name, metav1.GetOptions{})
 			assert.Nil(t, err)
 			//skip hash comparison
 			actual.plan.Status.LatestHash = ""


### PR DESCRIPTION
- System Upgrade Controller is in `cattle-system` namespace
- Do not process jobs and pods that are not in upgrade namespace.



