### PR TITLE
Access control for resource actions

### DIFF
--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -30,6 +30,10 @@ const (
 
 func Formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.Actions = make(map[string]string, 1)
+	if request.AccessControl.CanUpdate(request, resource.APIObject, resource.Schema) != nil {
+		return
+	}
+
 	if resource.APIObject.Data().String("spec", "sourceType") == apisv1beta1.VirtualMachineImageSourceTypeUpload {
 		resource.AddAction(request, actionUpload)
 	}

--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -25,6 +25,9 @@ const (
 
 func Formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.Actions = make(map[string]string, 1)
+	if request.AccessControl.CanUpdate(request, resource.APIObject, resource.Schema) != nil {
+		return
+	}
 
 	if resource.APIObject.Data().String("metadata", "annotations", ctlnode.MaintainStatusAnnotationKey) != "" {
 		resource.AddAction(request, disableMaintenanceModeAction)

--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -34,6 +34,9 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 	// reset resource actions, because action map already be set when add actions handler,
 	// but current framework can't support use formatter to remove key from action map
 	resource.Actions = make(map[string]string, 1)
+	if request.AccessControl.CanUpdate(request, resource.APIObject, resource.Schema) != nil {
+		return
+	}
 
 	vm := &kv1.VirtualMachine{}
 	err := convert.ToObj(resource.APIObject.Data(), vm)

--- a/pkg/api/volume/formatter.go
+++ b/pkg/api/volume/formatter.go
@@ -23,6 +23,10 @@ const (
 
 func Formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.Actions = make(map[string]string, 1)
+	if request.AccessControl.CanUpdate(request, resource.APIObject, resource.Schema) != nil {
+		return
+	}
+
 	resource.AddAction(request, actionExport)
 }
 


### PR DESCRIPTION
**Problem:**
Read-only users can invoke actions

**Solution:**
Add access control in formatter

**Related Issue:**
https://github.com/harvester/harvester/issues/1406
