### PR TITLE
Support configuring additional trusted CA

### DIFF
--- a/pkg/controller/master/setting/additional_ca.go
+++ b/pkg/controller/master/setting/additional_ca.go
@@ -1,0 +1,63 @@
+package setting
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func (h *Handler) syncAdditionalTrustedCAs(setting *harvesterv1.Setting) error {
+	// Add envs to the backup secret used by Longhorn backups
+	backupConfig := map[string]string{
+		"AWS_CERT": setting.Value,
+	}
+	if err := h.updateBackupSecret(backupConfig); err != nil {
+		return err
+	}
+
+	// Distribute CA secrets to required system namespaces
+	if err := h.syncAdditionalCASecrets(setting); err != nil {
+		return err
+	}
+
+	//redeploy system services. The CA certs will be injected by the mutation webhook.
+	return h.redeployDeployment(h.namespace, "harvester")
+}
+
+func (h *Handler) syncAdditionalCASecrets(setting *harvesterv1.Setting) error {
+	namespaces := []string{h.namespace, util.LonghornSystemNamespaceName}
+
+	for _, namespace := range namespaces {
+		secret, err := h.secretCache.Get(namespace, util.AdditionalCASecretName)
+		if errors.IsNotFound(err) {
+			newSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.AdditionalCASecretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					util.AdditionalCAFileName: []byte(setting.Value),
+				},
+			}
+
+			if _, err := h.secrets.Create(newSecret); err != nil {
+				return err
+			}
+			continue
+		} else if err != nil {
+			return err
+		}
+
+		toUpdate := secret.DeepCopy()
+		toUpdate.Data = map[string][]byte{
+			util.AdditionalCAFileName: []byte(setting.Value),
+		}
+		if _, err := h.secrets.Update(toUpdate); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -27,6 +27,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 
 	syncers = map[string]syncerFunc{
+		"additional-ca":     controller.syncAdditionalTrustedCAs,
 		"http-proxy":        controller.syncHTTPProxy,
 		"log-level":         controller.setLogLevel,
 		"overcommit-config": controller.syncOvercommitConfig,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -16,6 +16,7 @@ var (
 	provider       Provider
 	InjectDefaults string
 
+	AdditionalCA                 = NewSetting("additional-ca", "")
 	APIUIVersion                 = NewSetting("api-ui-version", "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
 	ServerVersion                = NewSetting("server-version", "dev")
 	UIIndex                      = NewSetting("ui-index", DefaultDashboardUIURL)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -3,6 +3,8 @@ package util
 const (
 	prefix                         = "harvesterhci.io"
 	RemovedPVCsAnnotationKey       = prefix + "/removedPersistentVolumeClaims"
+	AdditionalCASecretName         = "harvester-additional-ca"
+	AdditionalCAFileName           = "additional-ca.pem"
 	AnnotationMigrationTarget      = prefix + "/migrationTargetNodeName"
 	AnnotationMigrationUID         = prefix + "/migrationUID"
 	AnnotationMigrationState       = prefix + "/migrationState"

--- a/pkg/webhook/resources/pod/mutator_test.go
+++ b/pkg/webhook/resources/pod/mutator_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
@@ -81,6 +83,117 @@ func Test_envPatches(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		result, err := envPatches(testCase.input.targetEnvs, testCase.input.proxyEnvs, testCase.input.basePath)
+		assert.Equal(t, testCase.output, result)
+		assert.Empty(t, err)
+	}
+}
+
+func Test_volumePatch(t *testing.T) {
+
+	type input struct {
+		target []corev1.Volume
+		volume corev1.Volume
+	}
+	var testCases = []struct {
+		name   string
+		input  input
+		output string
+	}{
+		{
+			name: "add additional ca volume",
+			input: input{
+				target: []corev1.Volume{
+					{
+						Name: "foo",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+				volume: corev1.Volume{
+					Name: "additional-ca-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							DefaultMode: pointer.Int32(400),
+							SecretName:  util.AdditionalCASecretName,
+						},
+					},
+				},
+			},
+			output: `{"op": "add", "path": "/spec/volumes/-", "value": {"name":"additional-ca-volume","secret":{"secretName":"harvester-additional-ca","defaultMode":400}}}`,
+		},
+		{
+			name: "add additional ca volume to empty volumes",
+			input: input{
+				target: []corev1.Volume{},
+				volume: corev1.Volume{
+					Name: "additional-ca-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							DefaultMode: pointer.Int32(400),
+							SecretName:  util.AdditionalCASecretName,
+						},
+					},
+				},
+			},
+			output: `{"op": "add", "path": "/spec/volumes", "value": [{"name":"additional-ca-volume","secret":{"secretName":"harvester-additional-ca","defaultMode":400}}]}`,
+		},
+	}
+	for _, testCase := range testCases {
+		result, err := volumePatch(testCase.input.target, testCase.input.volume)
+		assert.Equal(t, testCase.output, result)
+		assert.Empty(t, err)
+	}
+}
+
+func Test_volumeMountPatch(t *testing.T) {
+
+	type input struct {
+		target      []corev1.VolumeMount
+		volumeMount corev1.VolumeMount
+		path        string
+	}
+	var testCases = []struct {
+		name   string
+		input  input
+		output string
+	}{
+		{
+			name: "add additional ca volume mount",
+			input: input{
+				target: []corev1.VolumeMount{
+					{
+						Name:      "foo",
+						MountPath: "/bar",
+					},
+				},
+				volumeMount: corev1.VolumeMount{
+					Name:      "additional-ca-volume",
+					MountPath: "/etc/ssl/certs/" + util.AdditionalCAFileName,
+					SubPath:   util.AdditionalCAFileName,
+					ReadOnly:  true,
+				},
+				path: "/spec/containers/0/volumeMounts",
+			},
+			output: `{"op": "add", "path": "/spec/containers/0/volumeMounts/-", "value": {"name":"additional-ca-volume","readOnly":true,"mountPath":"/etc/ssl/certs/additional-ca.pem","subPath":"additional-ca.pem"}}`,
+		},
+		{
+			name: "add additional ca volume mount to empty volumeMounts",
+			input: input{
+				target: []corev1.VolumeMount{},
+				volumeMount: corev1.VolumeMount{
+					Name:      "additional-ca-volume",
+					MountPath: "/etc/ssl/certs/" + util.AdditionalCAFileName,
+					SubPath:   util.AdditionalCAFileName,
+					ReadOnly:  true,
+				},
+				path: "/spec/containers/0/volumeMounts",
+			},
+			output: `{"op": "add", "path": "/spec/containers/0/volumeMounts", "value": [{"name":"additional-ca-volume","readOnly":true,"mountPath":"/etc/ssl/certs/additional-ca.pem","subPath":"additional-ca.pem"}]}`,
+		},
+	}
+	for _, testCase := range testCases {
+		result, err := volumeMountPatch(testCase.input.target, testCase.input.path, testCase.input.volumeMount)
 		assert.Equal(t, testCase.output, result)
 		assert.Empty(t, err)
 	}


### PR DESCRIPTION
**Related Issue:**
https://github.com/harvester/harvester/issues/1260

**Test plan:**
1. Set up self-signed-cert HTTP/S3 servers
2. Configure CA cert in Harvester settings
3. Verify image download and VM backup/restore to the self-signed-cert server works

Notes:
This is based on the work in PR https://github.com/harvester/harvester/pull/1337
With the setting available we can remove the certificate option in backup target setting in the UI.
