### PR TITLE
add node admission webhook

### DIFF
--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -1,0 +1,73 @@
+package node
+
+import (
+	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(nodeCache v1.NodeCache) types.Validator {
+	return &nodeValidator{
+		nodeCache: nodeCache,
+	}
+}
+
+type nodeValidator struct {
+	types.DefaultValidator
+	nodeCache v1.NodeCache
+}
+
+func (v *nodeValidator) Resource() types.Resource {
+	return types.Resource{
+		Name:       "nodes",
+		Scope:      admissionregv1.ClusterScope,
+		APIGroup:   corev1.SchemeGroupVersion.Group,
+		APIVersion: corev1.SchemeGroupVersion.Version,
+		ObjectType: &corev1.Node{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (v *nodeValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	oldNode := oldObj.(*corev1.Node)
+	newNode := newObj.(*corev1.Node)
+
+	nodeList, err := v.nodeCache.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	return validateCordonAndMaintenanceMode(oldNode, newNode, nodeList)
+}
+
+func validateCordonAndMaintenanceMode(oldNode, newNode *corev1.Node, nodeList []*corev1.Node) error {
+	// if old node already have "maintain-status" annotation or Unscheduleable=true,
+	// it has already been enabled, so we skip it
+	if _, ok := oldNode.Annotations[ctlnode.MaintainStatusAnnotationKey]; ok || oldNode.Spec.Unschedulable {
+		return nil
+	}
+	// if new node doesn't have "maintain-status" annotation and Unscheduleable=false, we skip it
+	if _, ok := newNode.Annotations[ctlnode.MaintainStatusAnnotationKey]; !ok && !newNode.Spec.Unschedulable {
+		return nil
+	}
+
+	for _, node := range nodeList {
+		if node.Name == oldNode.Name {
+			continue
+		}
+
+		// Return when we find another available node
+		if _, ok := node.Annotations[ctlnode.MaintainStatusAnnotationKey]; !ok && !node.Spec.Unschedulable {
+			return nil
+		}
+	}
+	return werror.NewBadRequest("can't enable maintenance mode or cordon on the last available node")
+}

--- a/pkg/webhook/resources/node/validator_test.go
+++ b/pkg/webhook/resources/node/validator_test.go
@@ -1,0 +1,217 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+)
+
+func TestValidateCordonAndMaintenanceMode(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		oldNode       *corev1.Node
+		newNode       *corev1.Node
+		nodeList      []*corev1.Node
+		expectedError bool
+	}{
+		{
+			name: "user can cordon a node when there is another available node",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: true,
+				},
+			},
+			nodeList: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "user can enable maintenance mode when there is another available node",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+					},
+				},
+			},
+			nodeList: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "user cannot cordon a node when the other node is in maintenance mode",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: true,
+				},
+			},
+			nodeList: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Annotations: map[string]string{
+							ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusComplete,
+						},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "user cannot cordon a node when the other node is unschedulable",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: true,
+				},
+			},
+			nodeList: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+					Spec: corev1.NodeSpec{
+						Unschedulable: true,
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "user cannot enable maintenance mode when the other node is in maintenance mode",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+					},
+				},
+			},
+			nodeList: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Annotations: map[string]string{
+							ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+						},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "user cannot enable maintenance mode when the other node is unschedulable",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			newNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+					},
+				},
+			},
+			nodeList: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+					Spec: corev1.NodeSpec{
+						Unschedulable: true,
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validateCordonAndMaintenanceMode(tc.oldNode, tc.newNode, tc.nodeList)
+		if tc.expectedError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/config"
 	"github.com/harvester/harvester/pkg/webhook/resources/keypair"
 	"github.com/harvester/harvester/pkg/webhook/resources/network"
+	"github.com/harvester/harvester/pkg/webhook/resources/node"
 	"github.com/harvester/harvester/pkg/webhook/resources/persistentvolumeclaim"
 	"github.com/harvester/harvester/pkg/webhook/resources/restore"
 	"github.com/harvester/harvester/pkg/webhook/resources/templateversion"
@@ -21,6 +22,7 @@ import (
 func Validation(clients *clients.Clients, options *config.Options) (http.Handler, []types.Resource, error) {
 	resources := []types.Resource{}
 	validators := []types.Validator{
+		node.NewValidator(clients.Core.Node().Cache()),
 		network.NewValidator(clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache(), clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()),
 		persistentvolumeclaim.NewValidator(clients.Core.PersistentVolumeClaim().Cache(), clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()),
 		keypair.NewValidator(clients.HarvesterFactory.Harvesterhci().V1beta1().KeyPair().Cache()),


### PR DESCRIPTION
**Problem:**
The last available node can enable maintenance mode.

**Solution:**
Add a node admission webhook to restrict that.

**Related Issue:**
https://github.com/harvester/harvester/issues/1014

**Test plan:**

The last available node can't be marked as maintenance mode.

* Create a 2-node environment.
* Enable maintenance mode on the agent node.
* Enable maintenance mode on the server node. Check it is a bad request and the server node can't enable maintenance mode.

The maintenance mode can be disabled.

* Follow the test case above.
* Disable maintenance mode on agent node should not get error and maintenance mode on the agent node will be removed.

The server node can enable maintenance mode if there is another available node.

* Follow the test cases above.
* Enable maintenance mode on the server node. Check it can turn into maintenance mode.

**Other information:**
It looks like frontend can't show webhook error message on the Hosts page. We may need another PR from frontend.
![Kapture 2021-10-28 at 17 24 44](https://user-images.githubusercontent.com/4927361/139230966-f42014d0-e94f-4722-86a4-8f47be60b96f.gif)

