### PR TITLE
Load settings provided by installer

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -64,3 +64,16 @@ data:
       sleep 2
     done
     `}}
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: installer-provided-settings
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+immutable: true
+data:
+{{- range $key, $value := .Values.service.installerProvidedSettings }}
+  {{ $key }}: {{ $value | printf "%q" -}}
+{{ end }}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -260,6 +260,7 @@ service:
     mode: "static"
     ip: ""
     hwAddress: ""
+  installerProvidedSettings: {}
 
 ## Specify the lifecycle jobs.
 ##

--- a/pkg/controller/master/setting/controller.go
+++ b/pkg/controller/master/setting/controller.go
@@ -1,13 +1,29 @@
 package setting
 
 import (
+	appsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
+	corev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harvctlv1beta1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	systemSetting "github.com/harvester/harvester/pkg/settings"
+)
+
+const (
+	harvesterSystemNamespace = "harvester-system"
+	installerSettingsCmName  = "installer-provided-settings"
 )
 
 // Handler updates the log level on setting changes
 type Handler struct {
+	dsClient          appsv1.DaemonSetClient
+	dsCache           appsv1.DaemonSetCache
+	cmClient          corev1.ConfigMapClient
+	cmCache           corev1.ConfigMapCache
+	settingController harvctlv1beta1.SettingController
+	settingCache      harvctlv1beta1.SettingCache
 }
 
 func (h *Handler) LogLevelOnChanged(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
@@ -23,4 +39,97 @@ func (h *Handler) LogLevelOnChanged(key string, setting *harvesterv1.Setting) (*
 	logrus.Infof("set log level to %s", level)
 	logrus.SetLevel(level)
 	return setting, nil
+}
+
+func (h *Handler) AutoAddDiskPathsOnChanged(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != systemSetting.AutoAddDiskPaths.Name {
+		return setting, nil
+	}
+
+	logrus.Debug("AudoAddDiskPathOnChanged")
+	ds, err := h.dsCache.Get(harvesterSystemNamespace, "harvester-node-disk-manager")
+	if err != nil {
+		return setting, nil
+	}
+
+	dsCopy := ds.DeepCopy()
+
+	for i, cont := range dsCopy.Spec.Template.Spec.Containers {
+		if cont.Name == "harvester-node-disk-manager" {
+			for j, env := range cont.Env {
+				if env.Name == "NDM_AUTO_ADD_PATH" {
+					logrus.Infof("update NDM_AUTO_ADD_PATH to '%s'", setting.Value)
+					dsCopy.Spec.Template.Spec.Containers[i].Env[j].Value = setting.Value
+				}
+			}
+		}
+	}
+
+	logrus.Info(dsCopy.Spec.Template.Spec.Containers)
+
+	_, err = h.dsClient.Update(dsCopy)
+	if err != nil {
+		logrus.Errorf("unable to update NDM daemonset: %v", err)
+		return setting, err
+	}
+
+	return nil, nil
+}
+
+func (h *Handler) LoadSettingsFromInstallerOnChanged(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != systemSetting.LoadSettingsFromInstaller.Name {
+		return setting, nil
+	}
+
+	settingCopy := setting.DeepCopy()
+
+	var loadFromInstaller string
+	if settingCopy.Value == "" {
+		loadFromInstaller = settingCopy.Default
+	} else {
+		loadFromInstaller = settingCopy.Value
+	}
+
+	if loadFromInstaller == "true" {
+		logrus.Info("load settings provided by installer")
+		cm, err := h.cmCache.Get(harvesterSystemNamespace, installerSettingsCmName)
+		if err != nil {
+			logrus.Error("failed to get installer settings ConfigMap:", err)
+			return nil, err
+		}
+
+		for settingName, settingValue := range cm.Data {
+			logrus.Infof("overwrite setting '%s' with '%s'", settingName, settingValue)
+			if err := h.updateSetting(settingName, settingValue); err != nil {
+				if errors.IsNotFound(err) {
+					logrus.Warningf("no such setting '%s', skip update", settingName)
+				} else {
+					logrus.Errorf("failed to update setting '%s': '%s'", settingName, err)
+				}
+			}
+		}
+
+		logrus.Info("installer settings loaded, disable loading")
+		settingCopy.Value = "false"
+		if _, err := h.settingController.Update(settingCopy); err != nil {
+			logrus.Error("failed to disable loading:", err)
+		}
+	}
+
+	return nil, nil
+}
+
+func (h *Handler) updateSetting(name, value string) error {
+	settingToUpdate, err := h.settingCache.Get(name)
+	if err != nil {
+		return err
+	}
+
+	settingToUpdate = settingToUpdate.DeepCopy()
+	settingToUpdate.Value = value
+	if _, err := h.settingController.Update(settingToUpdate); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -12,8 +12,22 @@ const (
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
 	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
-	controller := &Handler{}
+
+	var dsClient = management.AppsFactory.Apps().V1().DaemonSet()
+	var dsCache = dsClient.Cache()
+	var cmClient = management.CoreFactory.Core().V1().ConfigMap()
+	var cmCache = cmClient.Cache()
+	controller := &Handler{
+		dsClient:          dsClient,
+		dsCache:           dsCache,
+		settingController: settings,
+		settingCache:      settings.Cache(),
+		cmClient:          cmClient,
+		cmCache:           cmCache,
+	}
 
 	settings.OnChange(ctx, controllerName, controller.LogLevelOnChanged)
+	settings.OnChange(ctx, controllerName, controller.AutoAddDiskPathsOnChanged)
+	settings.OnChange(ctx, controllerName, controller.LoadSettingsFromInstallerOnChanged)
 	return nil
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -29,6 +29,8 @@ var (
 	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.3")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
 	DefaultStorageClass          = NewSetting("default-storage-class", "longhorn")
+	AutoAddDiskPaths             = NewSetting("auto-add-disk-paths", "")
+	LoadSettingsFromInstaller    = NewSetting("load-settings-from-installer", "true")
 )
 
 const (


### PR DESCRIPTION
Add settings controller to load setting into Setting CR, and restart workloads if needed.

* Add immutable ConfigMap "installer-provided-settings" to store settings provided by the installer. This ConfigMap is updated by installer using HelmChartConfig value `service.installerProvidedSettings`.

* Add a new setting CR "LoadSettingsFromInstaller" to indicate whether the controller should update settings from the installer-provided values (the ConfigMap).

* Add controller reconcile function "LoadSettingsFromInstallerOnChanged" to update settings from installer-provided values. It only updates once during the Helm chart deployment by manipulating the "LoadSettingFromInstaller" CR.

* Update NDM DaemonSet when settings changed. If users change settings related to NDM, update the DaemonSet to ensure pods are reloaded. Currently only "AutoAddDiskPaths" setting is associated with NDM.

See https://github.com/harvester/harvester-installer/pull/158 for how to add settings from Installer.

**Related issues**
- #1241
- https://github.com/harvester/harvester-installer/pull/158