### PR TITLE
fix(vmi): restrict users to migrate VM when it is not ready

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/wrangler/pkg/data/convert"
+	corev1 "k8s.io/api/core/v1"
 	kv1 "kubevirt.io/client-go/api/v1"
 
 	"github.com/harvester/harvester/pkg/controller/master/migration"
@@ -169,6 +170,15 @@ func canMigrate(vmi *kv1.VirtualMachineInstance) bool {
 	if vmi != nil && vmi.IsRunning() &&
 		vmi.Annotations[util.AnnotationMigrationUID] == "" {
 		return true
+	}
+	return false
+}
+
+func isReady(vmi *kv1.VirtualMachineInstance) bool {
+	for _, cond := range vmi.Status.Conditions {
+		if cond.Type == kv1.VirtualMachineInstanceReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -255,6 +255,9 @@ func (h *vmActionHandler) migrate(ctx context.Context, namespace, vmName string,
 	if !vmi.IsRunning() {
 		return errors.New("The VM is not in running state")
 	}
+	if !isReady(vmi) {
+		return errors.New("Can't migrate the VM, the VM is not in ready status")
+	}
 	if !canMigrate(vmi) {
 		return errors.New("The VM is already in migrating state")
 	}

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -72,6 +72,58 @@ func TestMigrateAction(t *testing.T) {
 			},
 		},
 		{
+			name: "VMI's ready status is false",
+			given: input{
+				namespace: "default",
+				name:      "test",
+				vmInstance: &kubevirtapis.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Status: kubevirtapis.VirtualMachineInstanceStatus{
+						Phase: kubevirtapis.Running,
+						Conditions: []kubevirtapis.VirtualMachineInstanceCondition{
+							{
+								Type:   kubevirtapis.VirtualMachineInstanceReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			expected: output{
+				vmInstanceMigrations: []*kubevirtapis.VirtualMachineInstanceMigration{},
+				err:                  errors.New("Can't migrate the VM, the VM is not in ready status"),
+			},
+		},
+		{
+			name: "VMI's ready status is unknown",
+			given: input{
+				namespace: "default",
+				name:      "test",
+				vmInstance: &kubevirtapis.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Status: kubevirtapis.VirtualMachineInstanceStatus{
+						Phase: kubevirtapis.Running,
+						Conditions: []kubevirtapis.VirtualMachineInstanceCondition{
+							{
+								Type:   kubevirtapis.VirtualMachineInstanceReady,
+								Status: corev1.ConditionUnknown,
+							},
+						},
+					},
+				},
+			},
+			expected: output{
+				vmInstanceMigrations: []*kubevirtapis.VirtualMachineInstanceMigration{},
+				err:                  errors.New("Can't migrate the VM, the VM is not in ready status"),
+			},
+		},
+		{
 			name: "Migration is triggered",
 			given: input{
 				namespace: "default",
@@ -83,6 +135,12 @@ func TestMigrateAction(t *testing.T) {
 					},
 					Status: kubevirtapis.VirtualMachineInstanceStatus{
 						Phase: kubevirtapis.Running,
+						Conditions: []kubevirtapis.VirtualMachineInstanceCondition{
+							{
+								Type:   kubevirtapis.VirtualMachineInstanceReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
**Problem:**
VM can be migrated when it is not Ready.

**Solution:**
Restrict users to migrate a VM when it is not Ready.

**Related Issue:**
https://github.com/harvester/harvester/issues/983

**Test plan:**

* Create a 2-node environment
* Create a VM on the agent node.
* Turn off the agent node and wait for the VMI controller to update the Ready field of VMI to `False`.
* Try to migrate the VM to the server node. Check there is an error message like the following
![Screen Shot 2021-11-01 at 4 22 16 PM](https://user-images.githubusercontent.com/4927361/139642719-5b8d1ede-9c2e-40f4-815f-75aa585cbbc0.png)
