### PR TITLE
feat(node): add controller to handle node down

### DIFF
--- a/pkg/controller/master/node/node_down_controller.go
+++ b/pkg/controller/master/node/node_down_controller.go
@@ -1,0 +1,159 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kv1 "kubevirt.io/client-go/api/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/config"
+	v1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/settings"
+)
+
+const (
+	nodeDownControllerName = "node-down-controller"
+	vmCreatorLabel         = "harvesterhci.io/creator"
+)
+
+// nodeDownHandler force deletes VMI's pod when a node is down, so VMI can be reschduled to anothor healthy node
+type nodeDownHandler struct {
+	nodes                       ctlcorev1.NodeController
+	nodeCache                   ctlcorev1.NodeCache
+	pods                        ctlcorev1.PodClient
+	virtualMachineInstanceCache v1.VirtualMachineInstanceCache
+}
+
+// NodeDownRegister registers a controller to delete VMI when node is down
+func NodeDownRegister(ctx context.Context, management *config.Management, options config.Options) error {
+	nodes := management.CoreFactory.Core().V1().Node()
+	pods := management.CoreFactory.Core().V1().Pod()
+	setting := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
+	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
+	nodeDownHandler := &nodeDownHandler{
+		nodes:                       nodes,
+		nodeCache:                   nodes.Cache(),
+		pods:                        pods,
+		virtualMachineInstanceCache: vmis.Cache(),
+	}
+
+	nodes.OnChange(ctx, nodeDownControllerName, nodeDownHandler.OnNodeChanged)
+	setting.OnChange(ctx, nodeDownControllerName, nodeDownHandler.OnVMForceDeletionPolicyChanged)
+
+	return nil
+}
+
+// OnNodeChanged monitors whether a node is ready or not
+// Force delete a pod when all of the below conditions are meet:
+// 1. VMDeletionPolicy is enabled.
+// 2. A node has been down for more than VMDeletionPolicy.Period seconds
+// 3. The owner of Pod is VirtualMachineInstance.
+// 4. The Pod is on a down node.
+func (h *nodeDownHandler) OnNodeChanged(key string, node *corev1.Node) (*corev1.Node, error) {
+	if node == nil || node.DeletionTimestamp != nil {
+		return node, nil
+	}
+
+	// get Ready condition
+	cond := getNodeCondition(node.Status.Conditions, corev1.NodeReady)
+	if cond == nil {
+		return node, fmt.Errorf("can't find %s condition in node %s", corev1.NodeReady, node.Name)
+	}
+
+	// check whether node is healthy
+	if cond.Status == corev1.ConditionTrue {
+		return node, nil
+	}
+
+	// get VMForceDeletionPolicy setting
+	vmForceDeletionPolicy, err := settings.DecodeVMForceDeletionPolicy(settings.VMForceDeletionPolicySet.Get())
+	if err != nil {
+		return node, err
+	}
+
+	if !vmForceDeletionPolicy.Enable {
+		return node, nil
+	}
+
+	// if we haven't waited for vmForceDeletionPolicy.Period seconds, we enqueue event again
+	if time.Since(cond.LastTransitionTime.Time) < time.Duration(vmForceDeletionPolicy.Period)*time.Second {
+		deadline := cond.LastTransitionTime.Add(time.Duration(vmForceDeletionPolicy.Period) * time.Second)
+		logrus.Debugf("Enqueue node event again at %v", deadline)
+		h.nodes.EnqueueAfter(node.Name, time.Until(deadline))
+		return node, nil
+	}
+
+	// get VMI pods on unhealthy node
+	pods, err := h.pods.List(corev1.NamespaceAll, metav1.ListOptions{
+		LabelSelector: labels.Set{
+			kv1.AppLabel:   "virt-launcher",
+			vmCreatorLabel: "harvester",
+		}.String(),
+		FieldSelector: "spec.nodeName=" + node.Name,
+	})
+	if err != nil {
+		return node, err
+	}
+
+	gracePeriod := int64(0)
+	for _, pod := range pods.Items {
+		if err := h.pods.Delete(
+			pod.Namespace,
+			pod.Name,
+			&metav1.DeleteOptions{
+				GracePeriodSeconds: &gracePeriod,
+			}); err != nil {
+			return node, err
+		}
+
+	}
+	return node, nil
+}
+
+func (h *nodeDownHandler) OnVMForceDeletionPolicyChanged(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil ||
+		setting.Name != settings.VMForceDeletionPolicySettingName || setting.Value == "" {
+		return setting, nil
+	}
+
+	// get VMForceDeletionPolicy setting
+	vmForceDeletionPolicy, err := settings.DecodeVMForceDeletionPolicy(setting.Value)
+	if err != nil {
+		return setting, err
+	}
+
+	if !vmForceDeletionPolicy.Enable {
+		return setting, nil
+	}
+
+	nodes, err := h.nodeCache.List(labels.Everything())
+	if err != nil {
+		return setting, err
+	}
+
+	for _, node := range nodes {
+		cond := getNodeCondition(node.Status.Conditions, corev1.NodeReady)
+		if cond != nil && cond.Status != corev1.ConditionTrue {
+			h.nodes.Enqueue(node.Name)
+		}
+	}
+	return setting, nil
+}
+
+func getNodeCondition(conditions []corev1.NodeCondition, conditionType corev1.NodeConditionType) *corev1.NodeCondition {
+	var cond *corev1.NodeCondition
+	for _, c := range conditions {
+		if c.Type == conditionType {
+			cond = &c
+			break
+		}
+	}
+	return cond
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -29,6 +29,7 @@ var registerFuncs = []registerFunc{
 	migration.Register,
 	node.PromoteRegister,
 	node.MaintainRegister,
+	node.NodeDownRegister,
 	setting.Register,
 	template.Register,
 	virtualmachine.Register,


### PR DESCRIPTION
**Problem:**
If a node is shut down, the VMI controller creates a new Pod only if the prior one has been deleted.  Also, the node can't report Pods' status, so VMI Pods will be stuck in `Terminating` status. We can't migrate or terminate them.

**Solution:**
We add a setting `vm-force-deletion-policy` for users to force delete VMI Pods that are on an unhealthy node.

**Related Issue:**
https://github.com/harvester/harvester/issues/982

**Test plan:**

Case 1: `vm-force-deletion-policy` has already been enabled.
* Create a 2-node environment.
* Set `vm-force-deletion-policy` as `'{"enable": true, "period": 60}'`.
* Create a VM on the agent node.
* When the VM is running, turn off the agent node.
* It will take a few minutes to reschedule the Pod. Check the Pod starts rescheduling.

Case 2: Enable `vm-force-deletion-policy` after a node is down.
* Create a 2-node environment.
* Create a VM on the agent node.
* When the VM is running, turn off the agent node.
* Wait a few minutes. We can only see the Pod is `Terminating`, but rescheduling does not happen.
* Set `vm-force-deletion-policy` as `'{"enable": true, "period": 60}'`.
* Wait a few minutes. We can see the Pod is rescheduling.

**Experiment Result**
```
> kubectl get pods -w
NAME                     READY   STATUS      RESTARTS   AGE
virt-launcher-vm-tg5cj   1/1     Running     0          5m27s
virt-launcher-vm-tg5cj   1/1     Terminating   0          6m46s
virt-launcher-vm-ckplj   0/1     Pending       0          0s
virt-launcher-vm-ckplj   0/1     ContainerCreating   0          6m12s
virt-launcher-vm-ckplj   1/1     Running             0          6m13s
```

```
> kubectl get vmi -w
NAME   AGE   PHASE     IP           NODENAME           READY
vm     45m   Running   10.52.1.34   harvester-node-1   True
vm     45m   Running   10.52.1.34   harvester-node-1   False
vm     50m   Failed    10.52.1.34   harvester-node-1   False
vm     0s    Pending
vm     1s    Pending                                   False
vm     1s    Scheduling                                   False
vm     6m15s   Scheduled                 harvester-node-0   False
vm     6m15s   Running      10.52.0.135   harvester-node-0   True
```