### PR TITLE
trigger the ISO build with the new Harvester commit

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -246,10 +246,32 @@ steps:
   when:
     instance:
       - drone-publish.rancher.io
+    event:
+      - tag
+
+- name: upload_iso_release_master
+  image: plugins/gcs
+  settings:
+    acl:
+      - allUsers:READER
+    cache_control: "public,no-cache,proxy-revalidate"
+    source: dist/artifacts
+    target: releases.rancher.com/harvester/master
+    token:
+      from_secret: google_auth_key
+  when:
+    instance:
+      - drone-publish.rancher.io
+    event:
+      - push
 
 trigger:
   event:
-  - tag
+    - tag
+    - push
+  ref:
+    - "refs/heads/master"
+    - "refs/heads/release/v*"
 
 volumes:
 - name: docker


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently, the ISO only builds on either harvester/harvester-installer change or the nightly build. It should be triggered (and gated in the future) the harvester/harvester build as well. Otherwise, we will get the latest ISO with an older version of Harvester.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add trigger on "push" event in the drone ci, when "merge pull request" happens, the "build-iso" will happen, and put the final iso into "releases.rancher.com/harvester/master-head".

As per discussion with @guangbochen , we do not keep history ISOs here, only put the latest one in master-head. In future, when necessary, we can also put each ISO into folders like 
"VERSION=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head
target: releases.rancher.com/harvester/${VERSION}"

**Related Issue:**
task: trigger the ISO build with the new Harvester commit #1395 
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Locally tested with Drone server and Gitea. After the merge of this pull request, the drone server will be triggered to build and upload harvester ISO, by check the drone CI, this commit will be verified.