### PR TITLE
Record error message when image upload request fails

### DIFF
--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -119,7 +119,9 @@ func (h UploadActionHandler) uploadImage(rw http.ResponseWriter, req *http.Reque
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 	if uploadResp.StatusCode >= http.StatusBadRequest {
-		return fmt.Errorf("upload failed: %s", string(body))
+		// err will be recorded in image condition in the defer function
+		err = fmt.Errorf("upload failed: %s", string(body))
+		return err
 	}
 
 	return nil

--- a/pkg/controller/master/image/backing_image_controller.go
+++ b/pkg/controller/master/image/backing_image_controller.go
@@ -36,7 +36,7 @@ func (h *backingImageHandler) OnChanged(_ string, backingImage *lhv1beta1.Backin
 	} else if err != nil {
 		return nil, err
 	}
-	if !harvesterv1beta1.ImageInitialized.IsTrue(vmImage) {
+	if !harvesterv1beta1.ImageInitialized.IsTrue(vmImage) || !harvesterv1beta1.ImageImported.IsUnknown(vmImage) {
 		return nil, nil
 	}
 	toUpdate := vmImage.DeepCopy()


### PR DESCRIPTION
**Problem:**
When the upload request to Longhorn fails, the error is not recorded in image status.

**Solution:**
Set returned message in image status on upload request failure.

**Related Issue:**
https://github.com/harvester/harvester/issues/1380

