### PR TITLE
Reuse SettingsProvider between webhook and main controller

### DIFF
--- a/pkg/controller/global/settings/register.go
+++ b/pkg/controller/global/settings/register.go
@@ -2,144 +2,23 @@ package settings
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/rancher/steve/pkg/server"
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
-	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
 )
 
 func Register(ctx context.Context, scaled *config.Scaled, server *server.Server, options config.Options) error {
-	sp := &settingsProvider{
-		context:        ctx,
-		settings:       scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting(),
-		settingsLister: scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
-		fallback:       map[string]string{},
-	}
+	sp := settings.NewSettingsProvider(
+		ctx,
+		scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting(),
+		scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
+	)
 
-	if err := settings.SetProvider(sp); err != nil {
+	if err := settings.SetProvider(&sp); err != nil {
 		return err
 	}
-
-	return nil
-}
-
-type settingsProvider struct {
-	context        context.Context
-	settings       ctlharvesterv1.SettingClient
-	settingsLister ctlharvesterv1.SettingCache
-	fallback       map[string]string
-}
-
-func (s *settingsProvider) Get(name string) string {
-	value := os.Getenv(settings.GetEnvKey(name))
-	if value != "" {
-		return value
-	}
-	obj, err := s.settingsLister.Get(name)
-	if err != nil {
-		val, err := s.settings.Get(name, v1.GetOptions{})
-		if err != nil {
-			return s.fallback[name]
-		}
-		obj = val
-	}
-	if obj.Value == "" {
-		return obj.Default
-	}
-	return obj.Value
-}
-
-func (s *settingsProvider) Set(name, value string) error {
-	envValue := os.Getenv(settings.GetEnvKey(name))
-	if envValue != "" {
-		return fmt.Errorf("setting %s can not be set because it is from environment variable", name)
-	}
-	obj, err := s.settings.Get(name, v1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	obj.Value = value
-	_, err = s.settings.Update(obj)
-	return err
-}
-
-func (s *settingsProvider) SetIfUnset(name, value string) error {
-	obj, err := s.settings.Get(name, v1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	if obj.Value != "" {
-		return nil
-	}
-
-	obj.Value = value
-	_, err = s.settings.Update(obj)
-	return err
-}
-
-func (s *settingsProvider) SetAll(settingsMap map[string]settings.Setting) error {
-	fallback := map[string]string{}
-
-	for name, setting := range settingsMap {
-		key := settings.GetEnvKey(name)
-		value := os.Getenv(key)
-
-		obj, err := s.settings.Get(setting.Name, v1.GetOptions{})
-		if errors.IsNotFound(err) {
-			newSetting := &harvesterv1.Setting{
-				ObjectMeta: v1.ObjectMeta{
-					Name: setting.Name,
-				},
-				Default: setting.Default,
-			}
-			if value != "" {
-				newSetting.Value = value
-			}
-			if newSetting.Value == "" {
-				fallback[newSetting.Name] = newSetting.Default
-			} else {
-				fallback[newSetting.Name] = newSetting.Value
-			}
-			_, err := s.settings.Create(newSetting)
-			if err != nil {
-				return err
-			}
-		} else if err != nil {
-			return err
-		} else {
-			update := false
-			if obj.Default != setting.Default {
-				obj.Default = setting.Default
-				update = true
-			}
-			if value != "" && obj.Value != value {
-				obj.Value = value
-				update = true
-			}
-			if obj.Value == "" {
-				fallback[obj.Name] = obj.Default
-			} else {
-				fallback[obj.Name] = obj.Value
-			}
-			if update {
-				_, err := s.settings.Update(obj)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	s.fallback = fallback
 
 	return nil
 }

--- a/pkg/settings/provider.go
+++ b/pkg/settings/provider.go
@@ -1,0 +1,147 @@
+package settings
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+)
+
+type Provider interface {
+	Get(name string) string
+	Set(name, value string) error
+	SetIfUnset(name, value string) error
+	SetAll(settings map[string]Setting) error
+}
+
+type SettingsProvider struct {
+	context       context.Context
+	settings      ctlharvesterv1.SettingClient
+	settingsCache ctlharvesterv1.SettingCache
+	fallback      map[string]string
+}
+
+func NewSettingsProvider(
+	ctx context.Context,
+	settings ctlharvesterv1.SettingClient,
+	settingsCache ctlharvesterv1.SettingCache,
+) SettingsProvider {
+	return SettingsProvider{
+		context:       ctx,
+		settings:      settings,
+		settingsCache: settingsCache,
+		fallback:      map[string]string{},
+	}
+}
+
+func (s *SettingsProvider) Get(name string) string {
+	value := os.Getenv(GetEnvKey(name))
+	if value != "" {
+		return value
+	}
+	obj, err := s.settingsCache.Get(name)
+	if err != nil {
+		val, err := s.settings.Get(name, v1.GetOptions{})
+		if err != nil {
+			return s.fallback[name]
+		}
+		obj = val
+	}
+	if obj.Value == "" {
+		return obj.Default
+	}
+	return obj.Value
+}
+
+func (s *SettingsProvider) Set(name, value string) error {
+	envValue := os.Getenv(GetEnvKey(name))
+	if envValue != "" {
+		return fmt.Errorf("setting %s can not be set because it is from environment variable", name)
+	}
+	obj, err := s.settings.Get(name, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	obj.Value = value
+	_, err = s.settings.Update(obj)
+	return err
+}
+
+func (s *SettingsProvider) SetIfUnset(name, value string) error {
+	obj, err := s.settings.Get(name, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if obj.Value != "" {
+		return nil
+	}
+
+	obj.Value = value
+	_, err = s.settings.Update(obj)
+	return err
+}
+
+func (s *SettingsProvider) SetAll(settingsMap map[string]Setting) error {
+	fallback := map[string]string{}
+
+	for name, setting := range settingsMap {
+		key := GetEnvKey(name)
+		value := os.Getenv(key)
+
+		obj, err := s.settings.Get(setting.Name, v1.GetOptions{})
+		if errors.IsNotFound(err) {
+			newSetting := &harvesterv1.Setting{
+				ObjectMeta: v1.ObjectMeta{
+					Name: setting.Name,
+				},
+				Default: setting.Default,
+			}
+			if value != "" {
+				newSetting.Value = value
+			}
+			if newSetting.Value == "" {
+				fallback[newSetting.Name] = newSetting.Default
+			} else {
+				fallback[newSetting.Name] = newSetting.Value
+			}
+			_, err := s.settings.Create(newSetting)
+			if err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		} else {
+			update := false
+			if obj.Default != setting.Default {
+				obj.Default = setting.Default
+				update = true
+			}
+			if value != "" && obj.Value != value {
+				obj.Value = value
+				update = true
+			}
+			if obj.Value == "" {
+				fallback[obj.Name] = obj.Default
+			} else {
+				fallback[obj.Name] = obj.Value
+			}
+			if update {
+				_, err := s.settings.Update(obj)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	s.fallback = fallback
+
+	return nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -59,13 +59,6 @@ func init() {
 	}
 }
 
-type Provider interface {
-	Get(name string) string
-	Set(name, value string) error
-	SetIfUnset(name, value string) error
-	SetAll(settings map[string]Setting) error
-}
-
 type Setting struct {
 	Name     string
 	Default  string

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -6,27 +6,20 @@ import (
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 
-	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
-func NewMutator(
-	setting ctlharvesterv1.SettingCache,
-) types.Mutator {
-	return &vmMutator{
-		setting: setting,
-	}
+func NewMutator() types.Mutator {
+	return &vmMutator{}
 }
 
 type vmMutator struct {
 	types.DefaultMutator
-	setting ctlharvesterv1.SettingCache
 }
 
 func (m *vmMutator) Resource() types.Resource {
@@ -104,18 +97,12 @@ func (m *vmMutator) patchResourceOvercommit(vm *kubevirtv1.VirtualMachine) ([]st
 }
 
 func (m *vmMutator) getOvercommit() (*settings.Overcommit, error) {
-	s, err := m.setting.Get("overcommit-config")
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	if s.Value == "" {
+	value := settings.OvercommitConfig.Get()
+	if value == "" {
 		return nil, nil
 	}
 	overcommit := &settings.Overcommit{}
-	if err := json.Unmarshal([]byte(s.Value), overcommit); err != nil {
+	if err := json.Unmarshal([]byte(value), overcommit); err != nil {
 		return overcommit, err
 	}
 	return overcommit, nil

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -8,10 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
-
-	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
-	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
 
 func Test_virtualmachine_mutator(t *testing.T) {
@@ -24,72 +20,62 @@ func Test_virtualmachine_mutator(t *testing.T) {
 			name: "has no limit",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
-					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewScaledQuantity(150, resource.Mega),
+					v1.ResourceCPU:    *resource.NewMilliQuantity(1600, resource.DecimalSI),
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "500m"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "250M"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits", "value": {"cpu":"1","memory":"1G"}}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "100m"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "100M"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits", "value": {"cpu":"1600m","memory":"150M"}}`,
 			},
 		},
 		{
 			name: "has memory limit",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+					v1.ResourceMemory: *resource.NewScaledQuantity(150, resource.Mega),
 				},
 				Requests: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceCPU: *resource.NewMilliQuantity(1000, resource.DecimalSI),
+					v1.ResourceCPU: *resource.NewMilliQuantity(1600, resource.DecimalSI),
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "500m"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits/cpu", "value": "1"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "100m"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits/cpu", "value": "1600m"}`,
 			},
 		},
 		{
 			name: "has cpu limit",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceCPU: *resource.NewMilliQuantity(1000, resource.DecimalSI),
+					v1.ResourceCPU: *resource.NewMilliQuantity(1600, resource.DecimalSI),
 				},
 				Requests: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+					v1.ResourceMemory: *resource.NewScaledQuantity(150, resource.Mega),
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "250M"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits/memory", "value": "1G"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "100M"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits/memory", "value": "150M"}`,
 			},
 		},
 		{
 			name: "has both cpu and memory limits",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+					v1.ResourceCPU:    *resource.NewMilliQuantity(1600, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewScaledQuantity(150, resource.Mega),
 				},
 			},
 			patchOps: nil,
 		},
 	}
 
-	setting := &harvesterv1.Setting{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "overcommit-config",
-		},
-		Value: `{"cpu":200,"memory":400,"storage":800}`,
-	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// arrage
-			clientset := fake.NewSimpleClientset()
-			err := clientset.Tracker().Add(setting)
-			mutator := NewMutator(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings))
-			assert.Nil(t, err, "Mock resource should add into fake controller tracker")
+			mutator := NewMutator()
 			vm := &kubevirtv1.VirtualMachine{
 				Spec: kubevirtv1.VirtualMachineSpec{
 					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{

--- a/pkg/webhook/server/mutation.go
+++ b/pkg/webhook/server/mutation.go
@@ -20,7 +20,7 @@ func Mutation(clients *clients.Clients, options *config.Options) (http.Handler, 
 	mutators := []types.Mutator{
 		pod.NewMutator(clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		templateversion.NewMutator(),
-		virtualmachine.NewMutator(clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
+		virtualmachine.NewMutator(),
 	}
 
 	router := webhook.NewRouter()

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
+	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/webhook"
 	"github.com/harvester/harvester/pkg/webhook/clients"
 	"github.com/harvester/harvester/pkg/webhook/config"
@@ -50,6 +51,15 @@ func New(ctx context.Context, restConfig *rest.Config, options *config.Options) 
 func (s *AdmissionWebhookServer) ListenAndServe() error {
 	clients, err := clients.New(s.context, s.restConfig, s.options.Threadiness)
 	if err != nil {
+		return err
+	}
+
+	sp := settings.NewSettingsProvider(
+		s.context,
+		clients.HarvesterFactory.Harvesterhci().V1beta1().Setting(),
+		clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
+	)
+	if err := settings.SetProvider(&sp); err != nil {
 		return err
 	}
 


### PR DESCRIPTION


**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Per https://github.com/harvester/harvester/pull/1492#discussion_r742904953, the `setting.Default` is not used even when `setting.Value` is empty. 

**Solution:**
The cause is that mutator does not reuse existing `settings` module and `settingsProvider`. In order not to duplicate code, we extract `settingsProvider` from controller and reuse the logic between webhook and main controller

**Related Issue:**
#1429 

**Test plan:**
Same as #1492 but do not edit `overcommit-config` setting. Leave its `value` field empty.
