### PR TITLE
Add preconfig loading controller

### DIFF
--- a/pkg/apis/harvesterhci.io/v1beta1/settings.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/settings.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-	SettingConfigured condition.Cond = "configured"
+	SettingConfigured      condition.Cond = "configured"
+	SettingPreconfigLoaded condition.Cond = "preconfigLoaded"
 )
 
 // +genclient

--- a/pkg/controller/master/setting/load_from_config.go
+++ b/pkg/controller/master/setting/load_from_config.go
@@ -1,0 +1,36 @@
+package setting
+
+import (
+	"github.com/sirupsen/logrus"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+type LoadingPreconfigHandler struct {
+	namespace string
+	settings  v1beta1.SettingClient
+}
+
+func (h *LoadingPreconfigHandler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	if value, ok := h.getPreconfigValue(setting); ok && !harvesterv1.SettingPreconfigLoaded.IsTrue(setting) {
+		settingCpy := setting.DeepCopy()
+		logrus.Infof("loading preconfig value for setting '%s'", setting.Name)
+		settingCpy.Value = value
+		harvesterv1.SettingPreconfigLoaded.SetStatusBool(settingCpy, true)
+
+		return h.settings.Update(settingCpy)
+	}
+
+	return nil, nil
+}
+
+func (h *LoadingPreconfigHandler) getPreconfigValue(setting *harvesterv1.Setting) (string, bool) {
+	value, ok := setting.Annotations[util.AnnotationSettingFromConfig]
+	return value, ok
+}

--- a/pkg/controller/master/setting/load_from_config_test.go
+++ b/pkg/controller/master/setting/load_from_config_test.go
@@ -1,0 +1,160 @@
+package setting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	typeharv1 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/harvesterhci.io/v1beta1"
+)
+
+func TestTemplateHandler_OnChanged(t *testing.T) {
+	type input struct {
+		key     string
+		setting *harvesterv1.Setting
+	}
+	type output struct {
+		setting *harvesterv1.Setting
+		err     error
+	}
+
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "No preconfig annotation, do nothing",
+			given: input{
+				setting: &harvesterv1.Setting{
+					Default: "fooDefault",
+					Value:   "fooValue",
+				},
+			},
+			expected: output{
+				setting: nil,
+			},
+		},
+		{
+			name: "Got preconfig annotation and no loaded condition, update setting CR",
+			given: input{
+				setting: &harvesterv1.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooSetting",
+						Annotations: map[string]string{
+							"harvesterhci.io/preconfigValue": "fooPreconfigured",
+						},
+					},
+					Default: "fooDefault",
+					Value:   "fooValue",
+				},
+			},
+			expected: output{
+				setting: &harvesterv1.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooSetting",
+						Annotations: map[string]string{
+							"harvesterhci.io/preconfigValue": "fooPreconfigured",
+						},
+					},
+					Status: harvesterv1.SettingStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   harvesterv1.SettingPreconfigLoaded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					Default: "fooDefault",
+					Value:   "fooPreconfigured",
+				},
+			},
+		},
+		{
+			name: "Preconfig is loaded, will not overwrite Value",
+			given: input{
+				setting: &harvesterv1.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooSetting",
+						Annotations: map[string]string{
+							"harvesterhci.io/preconfigValue": "fooPreconfigured",
+						},
+					},
+					Status: harvesterv1.SettingStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   harvesterv1.SettingPreconfigLoaded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					Default: "fooDefault",
+					Value:   "fooModifiedAfterPreconfigLoaded",
+				},
+			},
+			expected: output{},
+		},
+	}
+
+	for _, tc := range testCases {
+		var clientset = fake.NewSimpleClientset()
+		if tc.given.setting != nil {
+			var err = clientset.Tracker().Add(tc.given.setting)
+			assert.Nil(t, err, "mock resource should add into fake controller tracker")
+		}
+
+		var handler = &LoadingPreconfigHandler{
+			settings: fakeSettingClient(clientset.HarvesterhciV1beta1().Settings),
+		}
+		var actual output
+		actual.setting, actual.err = handler.settingOnChanged(tc.given.key, tc.given.setting)
+		if actual.setting != nil {
+			for i := range actual.setting.Status.Conditions {
+				actual.setting.Status.Conditions[i].LastUpdateTime = ""
+				actual.setting.Status.Conditions[i].LastTransitionTime = ""
+			}
+		}
+		assert.Equal(t, tc.expected, actual, "case %q", tc.name)
+	}
+}
+
+type fakeSettingClient func() typeharv1.SettingInterface
+
+func (c fakeSettingClient) Create(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	return c().Create(context.TODO(), setting, metav1.CreateOptions{})
+}
+
+func (c fakeSettingClient) Update(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	return c().Update(context.TODO(), setting, metav1.UpdateOptions{})
+}
+
+func (c fakeSettingClient) UpdateStatus(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	return c().UpdateStatus(context.TODO(), setting, metav1.UpdateOptions{})
+}
+
+func (c fakeSettingClient) Delete(name string, opts *metav1.DeleteOptions) error {
+	return c().Delete(context.TODO(), name, *opts)
+}
+
+func (c fakeSettingClient) Get(name string, opts metav1.GetOptions) (*harvesterv1.Setting, error) {
+	return c().Get(context.TODO(), name, opts)
+}
+
+func (c fakeSettingClient) List(opts metav1.ListOptions) (*harvesterv1.SettingList, error) {
+	return c().List(context.TODO(), opts)
+}
+
+func (c fakeSettingClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	return c().Watch(context.TODO(), opts)
+}
+
+func (c fakeSettingClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *harvesterv1.Setting, err error) {
+	return c().Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	controllerName = "harvester-setting-controller"
+	settingControllerName   = "harvester-setting-controller"
+	preconfigControllerName = "harvester-setting-preconfig-controller"
 )
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
@@ -23,11 +24,17 @@ func Register(ctx context.Context, management *config.Management, options config
 		deploymentCache: deployments.Cache(),
 	}
 
+	preconfigController := &LoadingPreconfigHandler{
+		namespace: options.Namespace,
+		settings:  settings,
+	}
+
 	syncers = map[string]syncerFunc{
 		"http-proxy": controller.syncHTTPProxy,
 		"log-level":  controller.setLogLevel,
 	}
 
-	settings.OnChange(ctx, controllerName, controller.settingOnChanged)
+	settings.OnChange(ctx, settingControllerName, controller.settingOnChanged)
+	settings.OnChange(ctx, preconfigControllerName, preconfigController.settingOnChanged)
 	return nil
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -10,6 +10,7 @@ const (
 	AnnotationVolumeClaimTemplates = prefix + "/volumeClaimTemplates"
 	AnnotationImageID              = prefix + "/imageId"
 	AnnotationHash                 = prefix + "/hash"
+	AnnotationSettingFromConfig    = prefix + "/preconfigValue"
 
 	BackupTargetSecretName      = "harvester-backup-target-secret"
 	LonghornSystemNamespaceName = "longhorn-system"


### PR DESCRIPTION


**Problem:**
Users want to modify some settings of Harvester during the installation process, so we need a way to pull those modifications into the `Setting` CRs while bootstrapping Harvester cluster.

Note: RKE2 has the ability to [auto-deploy manifests](https://docs.rke2.io/advanced/#auto-deploying-manifests) stored in `/var/lib/rancher/rke2/server/manifests`, but these manifests will be re-applied whenever the RKE2 system service restarted (happens when Node rebooted). If we put Setting CRs manifest directly in the directory, data stored in the cluster will be overwritten by these manifests.

**Solution:**
These "preconfigs" will be stored as manifest files in `/var/lib/rancher/rke2/server/manifests` during the installation process. These files **only contain annotations**. Fields like `value` or `default` are absent so they won't be re-applied while Node rebooted. The `PreconfigController` reads the annotation, then determines whether to overwrite `value` from the preconfig based on conditions of the CR.

**Related Issue:**
https://github.com/harvester/harvester/issues/1241

**Test plan:**
Currently, it's not easy to test this because we don't have the ability to add preconfig Setting CR to `/var/lib/rancher/rke2/server/manifests` yet. Here's the manual step to test the controller:

1. Install Harvester using ISO and wait for it to be Ready
2. SSH into the system and add a file named `settings.yaml` to `/var/lib/rancher/rke2/server/manifests`:
  ```
  ---
  apiVersion: harvesterhci.io/v1beta1
  kind: Setting
  metadata:
    annotations:
      harvesterhci.io/preconfigValue: DEBUG
    name: log-level
  ```
3. Restart the `harvester` Pod, either kill the Pod or restart its Deployment should work.
4. Wait until the `harvester` Pod to be Running.
5. Check the `log-level` Setting CR in the cluster and **verify its value is now `DEBUG`**.
6. Use Harvester GUI or `kubectl` to update the `log-level` Setting CR again, with value `Info`
7. Restart the Node
8. Wait until it's Ready again, and verify the value of `log-level` is still `Info`. This shows that the value **will not be overwritten by manifest files` after rebooted.