### PR TITLE
Use default overcommit value for CPU/memory

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -111,11 +111,15 @@ func (m *vmMutator) getOvercommit() (*settings.Overcommit, error) {
 		}
 		return nil, err
 	}
-	if s.Value == "" {
+	value := s.Value
+	if value == "" {
+		value = s.Default
+	}
+	if value == "" {
 		return nil, nil
 	}
 	overcommit := &settings.Overcommit{}
-	if err := json.Unmarshal([]byte(s.Value), overcommit); err != nil {
+	if err := json.Unmarshal([]byte(value), overcommit); err != nil {
 		return overcommit, err
 	}
 	return overcommit, nil


### PR DESCRIPTION
**Problem:**
Use default overcommit value for CPU/memory.

**Solution:**
Add ad-hoc logic to use default overcommit values. Favor this over #1514

**Related Issue:**
#1429

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
