### PR TITLE
Add auto prov setting and controller

### DIFF
--- a/pkg/controller/master/setting/auto_disk_provision.go
+++ b/pkg/controller/master/setting/auto_disk_provision.go
@@ -1,0 +1,49 @@
+package setting
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+)
+
+const (
+	ManagedChartNamespace     = "fleet-local"
+	HarvesterManagedChartName = "harvester"
+	NDMName                   = "harvester-node-disk-manager"
+)
+
+func (h *Handler) syncNDMAutoProvisionPaths(setting *harvesterv1.Setting) error {
+	mChart, err := h.managedChartCache.Get(ManagedChartNamespace, HarvesterManagedChartName)
+	if err != nil {
+		return err
+	}
+	mChartCopy := mChart.DeepCopy()
+
+	NDMValues, ok := mChartCopy.Spec.Values.Data[NDMName]
+	if !ok {
+		return fmt.Errorf("NDM chart value not found in ManagedChart")
+	}
+
+	NDMValuesMap, ok := NDMValues.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("NDM chart value is not a map[string]interface{}")
+	}
+
+	autoProvFilters := strings.Split(setting.Value, ",")
+	for i, filter := range autoProvFilters {
+		autoProvFilters[i] = strings.TrimSpace(filter)
+	}
+
+	NDMValuesMap["autoProvisionFilter"] = autoProvFilters
+	mChartCopy.Spec.Values.Data[NDMName] = NDMValuesMap
+
+	logrus.Debugf("NDM values to be updated to ManagedChart: %v", mChartCopy.Spec.Values.Data[NDMName])
+	if _, err := h.managedCharts.Update(mChartCopy); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	provisioningv1 "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/apply"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
@@ -37,6 +38,8 @@ type Handler struct {
 	longhornSettingCache ctllonghornv1.SettingCache
 	configmaps           ctlcorev1.ConfigMapClient
 	configmapCache       ctlcorev1.ConfigMapCache
+	managedCharts        mgmtv3.ManagedChartClient
+	managedChartCache    mgmtv3.ManagedChartCache
 }
 
 func (h *Handler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -20,6 +20,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	deployments := management.AppsFactory.Apps().V1().Deployment()
 	configmaps := management.CoreFactory.Core().V1().ConfigMap()
 	lhs := management.LonghornFactory.Longhorn().V1beta1().Setting()
+	managedCharts := management.RancherManagementFactory.Management().V3().ManagedChart()
 	controller := &Handler{
 		namespace:            options.Namespace,
 		apply:                management.Apply,
@@ -34,6 +35,8 @@ func Register(ctx context.Context, management *config.Management, options config
 		longhornSettingCache: lhs.Cache(),
 		configmaps:           configmaps,
 		configmapCache:       configmaps.Cache(),
+		managedCharts:        managedCharts,
+		managedChartCache:    managedCharts.Cache(),
 		httpClient: http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -45,12 +48,13 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 
 	syncers = map[string]syncerFunc{
-		"additional-ca":            controller.syncAdditionalTrustedCAs,
-		"cluster-registration-url": controller.registerCluster,
-		"http-proxy":               controller.syncHTTPProxy,
-		"log-level":                controller.setLogLevel,
-		"overcommit-config":        controller.syncOvercommitConfig,
-		"vip-pools":                controller.syncVipPoolsConfig,
+		"additional-ca":             controller.syncAdditionalTrustedCAs,
+		"cluster-registration-url":  controller.registerCluster,
+		"http-proxy":                controller.syncHTTPProxy,
+		"log-level":                 controller.setLogLevel,
+		"overcommit-config":         controller.syncOvercommitConfig,
+		"vip-pools":                 controller.syncVipPoolsConfig,
+		"auto-disk-provision-paths": controller.syncNDMAutoProvisionPaths,
 	}
 
 	settings.OnChange(ctx, controllerName, controller.settingOnChanged)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -36,6 +36,7 @@ var (
 	VMForceDeletionPolicySet     = NewSetting(VMForceDeletionPolicySettingName, InitVMForceDeletionPolicy())
 	OvercommitConfig             = NewSetting("overcommit-config", `{"cpu":1600,"memory":150,"storage":200}`)
 	VipPools                     = NewSetting("vip-pools", "")
+	AutoDiskProvisionPaths       = NewSetting("auto-disk-provision-paths", "")
 )
 
 const (

--- a/tests/integration/runtime/crds.go
+++ b/tests/integration/runtime/crds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	wcrd "github.com/rancher/wrangler/pkg/crd"
 	"k8s.io/client-go/rest"
 
@@ -19,6 +20,7 @@ func createCRDs(ctx context.Context, restConfig *rest.Config) error {
 	return factory.
 		BatchCreateCRDsIfNotExisted(
 			createNetworkAttachmentDefinitionCRD(),
+			createManagedChartCRD(),
 		).
 		BatchWait()
 }
@@ -28,4 +30,11 @@ func createNetworkAttachmentDefinitionCRD() wcrd.CRD {
 	nad.PluralName = "network-attachment-definitions"
 	nad.SingularName = "network-attachment-definition"
 	return nad
+}
+
+func createManagedChartCRD() wcrd.CRD {
+	mChart := crd.FromGV(mgmtv3.SchemeGroupVersion, "ManagedChart", mgmtv3.ManagedChart{})
+	mChart.PluralName = "managedcharts"
+	mChart.SingularName = "managedchart"
+	return mChart
 }


### PR DESCRIPTION
**Problem:**
We need to add the host's disks as VM storage automatically if the disks' device path matches a given shell glob pattern. This pattern can be given by the remote config during the installation process, and can be modified afterward using CustomResource Setting `auto-disk-provision-paths`.

Do notice that using the remote config to set up the pattern **only works when creating a new cluster**. Installing in join mode **cannot** overwrite any system settings, even with remote config provided.

After disks are added, changing the pattern won't affect any added disks.

**Solution:**
Add a controller to detect changes on Setting "auto-disk-provision-paths" and update NDM chart value in harvester `ManagedChart` accordingly.

**Related Issue:**
https://github.com/harvester/harvester/issues/1241

**Test plan:**

> :information_source: **Note: Testing on KVM** :information_source: 
> If you are using KVM to test this feature, you might notice that disks are not added automatically. You might see something like this in Node Disk Manager's log:
> ```
> # kubectl logs -n harvester-system harvester-node-disk-manager-XXXXX
> ...
> time="2021-11-19T07:20:40Z" level=warning msg="failed to read disk uuid of /dev/sdd : exit status 2\n"
> time="2021-11-19T07:20:40Z" level=warning msg="failed to read disk uuid of /dev/sdd : exit status 2\n"
> time="2021-11-19T07:20:40Z" level=warning msg="failed to read disk uuid of /dev/sdd : exit status 2\n"
> time="2021-11-19T07:20:41Z" level=warning msg="failed to generate GUID for device sdd"
> ...
> ```
> This is because the disks created by KVM (QEMU) have no identifiable ID, so Node Disk Manager cannot recognize them. You have several options to work around this issue:
> - Manually creating GPT for the disk using `parted` or `gdisk` during the installation process (Use `Ctrl+Alt+F2` to switch to another terminal), so we could use the UUID generated by GPT.
> - Enable Node Disk Manager feature [`autoGPTGenerate`](https://github.com/harvester/charts/blob/153951f5eccc352a812afa74dd4f74b3b0420997/charts/harvester-node-disk-manager/values.yaml#L75)
> - (Not tested) Adding disk WWN. See https://libvirt.org/manpages/virsh.html#attach-disk
>
> This should **not** happen on bare-metal systems (If so, please file a bug). Since I only tested on KVM, I'm not sure how other Hypervisors would behave.

The key idea here is that all the disks on the machine (besides the one used to install Harvester) that match the Glob pattern (`/dev/sd*`) would be added automatically. For example, if you have **four** SCSI/SATA drives on the machine, one of them will be used to install Harvester and the other three should be added automatically.

1. Prepare a VM or bare-metal machine with **two** SATA/SCSI drives. One for installing Harvester and the other for VM storage.
2. Install Harvester **with a remote config** to overwrite `auto-disk-provision-paths` system setting:
    ```
    system_settings:
      auto-disk-provision-paths: /dev/sd*
    ```
3. Wait for Harvester to be ready. Go to GUI and verify **the second drive is added automatically**
    ![image](https://user-images.githubusercontent.com/5047724/141099641-b9d93a33-d82a-427f-824e-b8362c0725a2.png)
4. Prepare another VM or bare-metal machine with **two** SATA/SCSI drives.
5. Install Harvester onto the second machine, in **join** mode.
6. Wait for the second machine to be ready. Go to GUI and verify that for the second machine, the other disk is also added automatically.

**Dependencies:**
- https://github.com/harvester/node-disk-manager/pull/18
- https://github.com/harvester/harvester-installer/pull/169
- https://github.com/harvester/docs/pull/74