### PR TITLE
Simplify resource overcommit calculation

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -1,6 +1,7 @@
 package virtualmachine
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,14 +32,15 @@ func Test_virtualmachine_mutator(t *testing.T) {
 			name: "has memory limit and other requests",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+					v1.ResourceMemory: *resource.NewQuantity(int64(math.Pow(2, 30)), resource.BinarySI), // 1Gi
 				},
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU: *resource.NewMilliQuantity(1000, resource.DecimalSI),
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "250M"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "256Mi"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"924Mi"}}`, // 1Gi - 100Mi
 			},
 			setting: "",
 		},
@@ -49,7 +51,7 @@ func Test_virtualmachine_mutator(t *testing.T) {
 					v1.ResourceCPU: *resource.NewMilliQuantity(1000, resource.DecimalSI),
 				},
 				Requests: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+					v1.ResourceMemory: *resource.NewQuantity(int64(math.Pow(2, 30)), resource.BinarySI), // 1Gi
 				},
 			},
 			patchOps: []string{
@@ -62,11 +64,12 @@ func Test_virtualmachine_mutator(t *testing.T) {
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+					v1.ResourceMemory: *resource.NewQuantity(int64(math.Pow(2, 30)), resource.BinarySI), // 1Gi
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"500m","memory":"250M"}}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"924Mi"}}`, // 1Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"500m","memory":"256Mi"}}`,
 			},
 		},
 		{
@@ -74,11 +77,12 @@ func Test_virtualmachine_mutator(t *testing.T) {
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+					v1.ResourceMemory: *resource.NewQuantity(int64(math.Pow(2, 30)), resource.BinarySI), // 1Gi
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"100m","memory":"100M"}}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"924Mi"}}`, // 1Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"100m","memory":"102Mi"}}`,
 			},
 			setting: `{"cpu":1000,"memory":1000,"storage":800}`,
 		},

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -22,22 +22,13 @@ func Test_virtualmachine_mutator(t *testing.T) {
 		setting     string
 	}{
 		{
-			name: "has no limit",
-			resourceReq: kubevirtv1.ResourceRequirements{
-				Requests: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
-					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
-				},
-			},
-			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "500m"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "250M"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits", "value": {"cpu":"1","memory":"1G"}}`,
-			},
-			setting: "",
+			name:        "has no limits",
+			resourceReq: kubevirtv1.ResourceRequirements{},
+			patchOps:    nil,
+			setting:     "",
 		},
 		{
-			name: "has memory limit",
+			name: "has memory limit and other requests",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
@@ -47,13 +38,12 @@ func Test_virtualmachine_mutator(t *testing.T) {
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "500m"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits/cpu", "value": "1"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "250M"}`,
 			},
 			setting: "",
 		},
 		{
-			name: "has cpu limit",
+			name: "has cpu limit and other requests",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU: *resource.NewMilliQuantity(1000, resource.DecimalSI),
@@ -63,34 +53,32 @@ func Test_virtualmachine_mutator(t *testing.T) {
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "250M"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits/memory", "value": "1G"}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "500m"}`,
 			},
 			setting: "",
 		},
 		{
-			name: "has both cpu and memory limits",
+			name: "has both cpu and memory limits but not requests",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
 					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
 				},
 			},
-			patchOps: nil,
-			setting:  "",
+			patchOps: []string{
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"500m","memory":"250M"}}`,
+			},
 		},
 		{
 			name: "use value instead of default setting",
 			resourceReq: kubevirtv1.ResourceRequirements{
-				Requests: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
+				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga),
 				},
 			},
 			patchOps: []string{
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "100m"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "100M"}`,
-				`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits", "value": {"cpu":"1","memory":"1G"}}`,
+				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"100m","memory":"100M"}}`,
 			},
 			setting: `{"cpu":1000,"memory":1000,"storage":800}`,
 		},

--- a/tests/integration/api/vm_apis_test.go
+++ b/tests/integration/api/vm_apis_test.go
@@ -137,7 +137,7 @@ var _ = Describe("verify vm APIs", func() {
 				spec := vm.Spec.Template.Spec
 				MustEqual(len(spec.Domain.Devices.Disks), 3)
 				MustEqual(spec.Domain.CPU.Cores, uint32(testVMUpdatedCPUCore))
-				MustEqual(spec.Domain.Resources.Requests[corev1.ResourceMemory], resource.MustParse(testVMUpdatedMemory))
+				MustEqual(spec.Domain.Resources.Limits[corev1.ResourceMemory], resource.MustParse(testVMUpdatedMemory))
 				return true
 			})
 
@@ -159,7 +159,7 @@ var _ = Describe("verify vm APIs", func() {
 					spec := vmi.Spec
 					MustEqual(len(spec.Domain.Devices.Disks), 3)
 					MustEqual(spec.Domain.CPU.Cores, uint32(testVMUpdatedCPUCore))
-					MustEqual(spec.Domain.Resources.Requests[corev1.ResourceMemory], resource.MustParse(testVMUpdatedMemory))
+					MustEqual(spec.Domain.Resources.Limits[corev1.ResourceMemory], resource.MustParse(testVMUpdatedMemory))
 					return true
 				})
 


### PR DESCRIPTION
**Problem:**
Simplify the overcommit calculation logic, as well as format the unit to MiB for memory.


**Solution:**

- Calculate `resources.requests` from `resource.limits` passed in from API client with overcommit percentage.
- Move [QEMU reservation logic from the frontend](https://github.com/harvester/dashboard/blob/171f5efdde2fd37f09e67f102a6ad86cbb8ed1a5/mixins/harvester-vm/index.js#L431-L436) to the backend and set `spec.domain.memory.guest` if needed.
- `pkg/builder/vm.go` now sets `resources.limits` instead of requests.

> Note that in order to display the value set by the user, dashboard UI need to change to display `resource.limits` of VM instead.


**Related Issue:**

- #1429 
- #1534
- #1537

**Test plan:**

1. Deploy a VM with the following manifest

```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: vm-cirros
spec:
  running: true
  template:
    spec:
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: rootdisk
        resources:
          limits:
            memory: 512Mi
            cpu: 1
      volumes:
      - containerDisk:
          image: cirros:0.5.2
        name: rootdisk
```

2. Check if 
    - The overcommitted `domain.resources.requests` is 341Mi.
    - The `domain.memory.guest` is about 412MiB.
    - The virt-launcher pod gets the correct resources limits and requests inherited from VMI.