### PR TITLE
Add vip pools config syncer

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/rancher/wrangler/pkg/apply"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
-	corev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -26,12 +26,14 @@ type Handler struct {
 	httpClient           http.Client
 	apply                apply.Apply
 	settings             v1beta1.SettingClient
-	secrets              corev1.SecretClient
-	secretCache          corev1.SecretCache
+	secrets              ctlcorev1.SecretClient
+	secretCache          ctlcorev1.SecretCache
 	deployments          v1.DeploymentClient
 	deploymentCache      v1.DeploymentCache
 	longhornSettings     ctllonghornv1.SettingClient
 	longhornSettingCache ctllonghornv1.SettingCache
+	configmaps           ctlcorev1.ConfigMapClient
+	configmapCache       ctlcorev1.ConfigMapCache
 }
 
 func (h *Handler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -18,6 +18,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	secrets := management.CoreFactory.Core().V1().Secret()
 	deployments := management.AppsFactory.Apps().V1().Deployment()
+	configmaps := management.CoreFactory.Core().V1().ConfigMap()
 	lhs := management.LonghornFactory.Longhorn().V1beta1().Setting()
 	controller := &Handler{
 		namespace:            options.Namespace,
@@ -29,6 +30,8 @@ func Register(ctx context.Context, management *config.Management, options config
 		deploymentCache:      deployments.Cache(),
 		longhornSettings:     lhs,
 		longhornSettingCache: lhs.Cache(),
+		configmaps:           configmaps,
+		configmapCache:       configmaps.Cache(),
 		httpClient: http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -50,6 +53,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		"http-proxy":               controller.syncHTTPProxy,
 		"log-level":                controller.setLogLevel,
 		"overcommit-config":        controller.syncOvercommitConfig,
+		"vip-pools":                controller.syncVipPoolsConfig,
 	}
 
 	settings.OnChange(ctx, settingControllerName, controller.settingOnChanged)

--- a/pkg/controller/master/setting/vip_pools_config.go
+++ b/pkg/controller/master/setting/vip_pools_config.go
@@ -1,0 +1,70 @@
+package setting
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const KubevipConfigmapName = "kubevip"
+
+func (h *Handler) syncVipPoolsConfig(setting *harvesterv1.Setting) error {
+	pools := map[string]string{}
+	err := json.Unmarshal([]byte(setting.Value), &pools)
+	if err != nil {
+		return err
+	}
+
+	poolsData := make(map[string]string, len(pools))
+	for ns, pool := range pools {
+		k := fmt.Sprintf("cidr-%s", ns)
+		poolsData[k] = pool
+	}
+
+	vipConfigmap, err := h.configmapCache.Get(util.KubeSystemNamespace, KubevipConfigmapName)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if vipConfigmap == nil {
+		cf := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      KubevipConfigmapName,
+				Namespace: util.KubeSystemNamespace,
+			},
+			Data: poolsData,
+		}
+		if _, err := h.configmaps.Create(cf); err != nil {
+			return err
+		}
+	} else {
+		vipConfigmapCpy := vipConfigmap.DeepCopy()
+		vipConfigmapCpy.Data = pools
+		if _, err := h.configmaps.Update(vipConfigmapCpy); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func ValidateCIDRs(pools map[string]string) error {
+	for ns, v := range pools {
+		cidrs := strings.Split(v, ",")
+		for _, cidr := range cidrs {
+			if _, _, err := net.ParseCIDR(cidr); err != nil {
+				return fmt.Errorf("invalid CIDR value %s of %s, error: %s", v, ns, err.Error())
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controller/master/setting/vip_pools_config_test.go
+++ b/pkg/controller/master/setting/vip_pools_config_test.go
@@ -1,0 +1,127 @@
+package setting
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corefake "k8s.io/client-go/kubernetes/fake"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestSyncVipPoolsConfig(t *testing.T) {
+	const vipPools = "vip-pools"
+	type input struct {
+		key     string
+		setting *harvesterv1.Setting
+	}
+	type output struct {
+		pools map[string]string
+		err   error
+	}
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "correct ip pools input, should pass",
+			given: input{
+				key: vipPools,
+				setting: &harvesterv1.Setting{
+					ObjectMeta: v1.ObjectMeta{
+						Name: vipPools,
+					},
+					Value: `{"default":"172.16.1.0/24","test":"172.16.2.0/24"}`,
+				},
+			},
+			expected: output{
+				pools: map[string]string{
+					"cidr-default": "172.16.1.0/24",
+					"cidr-test":    "172.16.2.0/24",
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "multiple CIDRs per ns pools, should pass",
+			given: input{
+				key: vipPools,
+				setting: &harvesterv1.Setting{
+					ObjectMeta: v1.ObjectMeta{
+						Name: vipPools,
+					},
+					Value: `{"default":"172.16.1.0/24,192.168.10.0/24","test":"172.16.2.0/24,192.168.20.0/24"}`,
+				},
+			},
+			expected: output{
+				pools: map[string]string{
+					"cidr-default": "172.16.1.0/24,192.168.10.0/24",
+					"cidr-test":    "172.16.2.0/24,192.168.20.0/24",
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "incorrect ip pools input, should fail",
+			given: input{
+				setting: &harvesterv1.Setting{
+					Value: `{"default": "172.16.1.0/242", "test": "1000.16.2.0/24"}`,
+				},
+			},
+			expected: output{
+				pools: nil,
+				err:   errors.New("invalid CIDR value"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+
+		pools := map[string]string{}
+		err := json.Unmarshal([]byte(tc.given.setting.Value), &pools)
+		assert.Nil(t, err)
+
+		var actual output
+		actual.err = ValidateCIDRs(pools)
+		if strings.Contains(tc.name, "fail") {
+			assert.Errorf(t, actual.err, "invalid CIDR value")
+			continue
+		} else {
+			assert.NoError(t, actual.err)
+		}
+
+		var clientset = fake.NewSimpleClientset()
+		if tc.given.setting != nil {
+			var err = clientset.Tracker().Add(tc.given.setting)
+			assert.Nil(t, err, "mock resource should add into fake controller tracker")
+		}
+
+		// validate syncVipPoolsConfig func
+		var coreclientset = corefake.NewSimpleClientset()
+		var handler = &Handler{
+			settings:       fakeSettingClient(clientset.HarvesterhciV1beta1().Settings),
+			configmaps:     fakeclients.ConfigmapClient(coreclientset.CoreV1().ConfigMaps),
+			configmapCache: fakeclients.ConfigmapCache(coreclientset.CoreV1().ConfigMaps),
+		}
+		syncers = map[string]syncerFunc{
+			"vip-pools": handler.syncVipPoolsConfig,
+		}
+
+		var syncActual output
+		_, syncActual.err = handler.settingOnChanged(tc.given.key, tc.given.setting)
+		assert.Nil(t, syncActual.err)
+
+		// check if the kube-vip configmap is configured properly
+		cnf, err := handler.configmaps.Get(util.KubeSystemNamespace, KubevipConfigmapName, v1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected.pools, cnf.Data)
+	}
+}

--- a/pkg/controller/master/upgrade/pod_controller_test.go
+++ b/pkg/controller/master/upgrade/pod_controller_test.go
@@ -10,6 +10,7 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
 
@@ -92,7 +93,7 @@ func TestPodHandler_OnChanged(t *testing.T) {
 				pod: &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-chart-pod",
-						Namespace: kubeSystemNamespace,
+						Namespace: util.KubeSystemNamespace,
 						Labels: map[string]string{
 							helmChartLabel: harvesterChartname,
 						},

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -17,7 +17,6 @@ const (
 	//system upgrade controller is deployed in cattle-system namespace
 	upgradeNamespace               = "cattle-system"
 	upgradeServiceAccount          = "system-upgrade-controller"
-	kubeSystemNamespace            = "kube-system"
 	harvesterSystemNamespace       = "harvester-system"
 	harvesterVersionLabel          = "harvesterhci.io/version"
 	harvesterUpgradeLabel          = "harvesterhci.io/upgrade"

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -35,6 +35,7 @@ var (
 	HTTPProxy                    = NewSetting("http-proxy", "{}")
 	VMForceDeletionPolicySet     = NewSetting(VMForceDeletionPolicySettingName, InitVMForceDeletionPolicy())
 	OvercommitConfig             = NewSetting("overcommit-config", `{"cpu":1600,"memory":150,"storage":200}`)
+	VipPools                     = NewSetting("vip-pools", "")
 )
 
 const (

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -16,4 +16,5 @@ const (
 
 	BackupTargetSecretName      = "harvester-backup-target-secret"
 	LonghornSystemNamespaceName = "longhorn-system"
+	KubeSystemNamespace         = "kube-system"
 )

--- a/pkg/util/fakeclients/configmap.go
+++ b/pkg/util/fakeclients/configmap.go
@@ -1,0 +1,63 @@
+package fakeclients
+
+import (
+	"context"
+
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1type "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type ConfigmapClient func(namespace string) corev1type.ConfigMapInterface
+
+func (c ConfigmapClient) Create(configMap *v1.ConfigMap) (*v1.ConfigMap, error) {
+	return c(configMap.Namespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+}
+
+func (c ConfigmapClient) Update(configMap *v1.ConfigMap) (*v1.ConfigMap, error) {
+	return c(configMap.Namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+}
+
+func (c ConfigmapClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	panic("implement me")
+}
+
+func (c ConfigmapClient) Get(namespace, name string, opts metav1.GetOptions) (*v1.ConfigMap, error) {
+	return c(namespace).Get(context.TODO(), name, opts)
+}
+
+func (c ConfigmapClient) List(namespace string, opts metav1.ListOptions) (*v1.ConfigMapList, error) {
+	return c(namespace).List(context.TODO(), opts)
+}
+
+func (c ConfigmapClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c ConfigmapClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error) {
+	panic("implement me")
+}
+
+type ConfigmapCache func(namespace string) corev1type.ConfigMapInterface
+
+func (c ConfigmapCache) Get(namespace, name string) (*v1.ConfigMap, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c ConfigmapCache) List(namespace string, selector labels.Selector) ([]*v1.ConfigMap, error) {
+	panic("implement me")
+}
+
+func (c ConfigmapCache) AddIndexer(indexName string, indexer ctlcorev1.ConfigMapIndexer) {
+	panic("implement me")
+}
+
+func (c ConfigmapCache) GetByIndex(indexName, key string) ([]*v1.ConfigMap, error) {
+	panic("implement me")
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Add support of VIP CIDR pool config on the Harvester UI settings

**Solution:**
Add support of VIP CIDR pool config on the Harvester UI settings

**Related Issue:**
https://github.com/harvester/harvester/issues/1458

**Test plan:**
- Config the CIDR pools via the UI settings(per namespace or `global`)
- Check if the user was able to create LoadBalancer type of service with the `pool` option in the guest k8s cluster, also the service should get the IP assigned correctly within the IP pools config.