### PR TITLE
Update `resources.lmits` for pre-defined VM templates

### DIFF
--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -173,8 +173,9 @@ spec:
               - name: default
                 masquerade: {}
             resources:
-              requests:
+              limits:
                 memory: 2048Mi
+                cpu: 1
           networks:
           - name: default
             pod: {}
@@ -232,8 +233,9 @@ spec:
               - name: default
                 masquerade: {}
             resources:
-              requests:
+              limits:
                 memory: 2048Mi
+                cpu: 1
           networks:
           - name: default
             pod: {}
@@ -314,8 +316,9 @@ spec:
                 name: tablet
                 type: tablet
             resources:
-              requests:
+              limits:
                 memory: 2048Mi
+                cpu: 1
           networks:
           - name: default
             pod: {}


### PR DESCRIPTION
**Problem:**
Pre-defined VM templates still specify `resources.requests`.

**Solution:**
Due to the change of resource overcommit feature, every pre-defined VM
templates now sepcify `resources.limits` instead of requests. As a
result, it can compute overcommit percentage correctly.

**Related Issue:**
#1537 

**Test plan:**
As #1537 described
