### PR TITLE
Fix http proxy

### DIFF
--- a/pkg/controller/master/setting/additional_ca.go
+++ b/pkg/controller/master/setting/additional_ca.go
@@ -28,7 +28,7 @@ func (h *Handler) syncAdditionalTrustedCAs(setting *harvesterv1.Setting) error {
 }
 
 func (h *Handler) syncAdditionalCASecrets(setting *harvesterv1.Setting) error {
-	namespaces := []string{h.namespace, util.LonghornSystemNamespaceName}
+	namespaces := []string{h.namespace, util.LonghornSystemNamespaceName, util.CattleSystemNamespaceName}
 
 	for _, namespace := range namespaces {
 		secret, err := h.secretCache.Get(namespace, util.AdditionalCASecretName)

--- a/pkg/controller/master/setting/http_proxy.go
+++ b/pkg/controller/master/setting/http_proxy.go
@@ -34,6 +34,9 @@ func (h *Handler) syncHTTPProxy(setting *harvesterv1.Setting) error {
 	}
 
 	//redeploy system services. The proxy envs will be injected by the mutation webhook.
+	if err := h.redeployDeployment(util.CattleSystemNamespaceName, "rancher"); err != nil {
+		return err
+	}
 	return h.redeployDeployment(h.namespace, "harvester")
 }
 

--- a/pkg/controller/master/setting/http_proxy.go
+++ b/pkg/controller/master/setting/http_proxy.go
@@ -22,9 +22,9 @@ func (h *Handler) syncHTTPProxy(setting *harvesterv1.Setting) error {
 		return err
 	}
 	backupConfig := map[string]string{
-		"HTTP_PROXY":  httpProxyConfig.HTTPProxy,
-		"HTTPS_PROXY": httpProxyConfig.HTTPSProxy,
-		"NO_PROXY":    util.AddBuiltInNoProxy(httpProxyConfig.NoProxy),
+		util.HTTPProxyEnv:  httpProxyConfig.HTTPProxy,
+		util.HTTPSProxyEnv: httpProxyConfig.HTTPSProxy,
+		util.NoProxyEnv:    util.AddBuiltInNoProxy(httpProxyConfig.NoProxy),
 	}
 	if err := h.updateBackupSecret(backupConfig); err != nil {
 		return err
@@ -50,13 +50,13 @@ func (h *Handler) syncRke2HTTPProxy(httpProxyConfig util.HTTPProxyConfig) error 
 		}
 	}
 	newEnvVars = append(newEnvVars, v1.EnvVar{
-		Name:  "HTTP_PROXY",
+		Name:  util.HTTPProxyEnv,
 		Value: httpProxyConfig.HTTPProxy,
 	}, v1.EnvVar{
-		Name:  "HTTPS_PROXY",
+		Name:  util.HTTPSProxyEnv,
 		Value: httpProxyConfig.HTTPSProxy,
 	}, v1.EnvVar{
-		Name:  "NO_PROXY",
+		Name:  util.NoProxyEnv,
 		Value: util.AddBuiltInNoProxy(httpProxyConfig.NoProxy),
 	})
 	toUpdate.Spec.AgentEnvVars = newEnvVars

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -40,6 +40,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		httpClient: http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -16,4 +16,8 @@ const (
 	BackupTargetSecretName      = "harvester-backup-target-secret"
 	LonghornSystemNamespaceName = "longhorn-system"
 	KubeSystemNamespace         = "kube-system"
+
+	HTTPProxyEnv  = "HTTP_PROXY"
+	HTTPSProxyEnv = "HTTPS_PROXY"
+	NoProxyEnv    = "NO_PROXY"
 )

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -15,6 +15,7 @@ const (
 
 	BackupTargetSecretName      = "harvester-backup-target-secret"
 	LonghornSystemNamespaceName = "longhorn-system"
+	CattleSystemNamespaceName   = "cattle-system"
 	KubeSystemNamespace         = "kube-system"
 
 	HTTPProxyEnv  = "HTTP_PROXY"

--- a/pkg/webhook/resources/pod/mutator.go
+++ b/pkg/webhook/resources/pod/mutator.go
@@ -105,15 +105,15 @@ func (m *podMutator) httpProxyPatches(pod *corev1.Pod) (types.PatchOps, error) {
 
 	var proxyEnvs = []corev1.EnvVar{
 		{
-			Name:  "HTTP_PROXY",
+			Name:  util.HTTPProxyEnv,
 			Value: httpProxyConfig.HTTPProxy,
 		},
 		{
-			Name:  "HTTPS_PROXY",
+			Name:  util.HTTPSProxyEnv,
 			Value: httpProxyConfig.HTTPSProxy,
 		},
 		{
-			Name:  "NO_PROXY",
+			Name:  util.NoProxyEnv,
 			Value: util.AddBuiltInNoProxy(httpProxyConfig.NoProxy),
 		},
 	}

--- a/pkg/webhook/resources/pod/mutator.go
+++ b/pkg/webhook/resources/pod/mutator.go
@@ -24,6 +24,9 @@ var matchingLabels = []labels.Set{
 		"app.kubernetes.io/name":      "harvester",
 		"app.kubernetes.io/component": "apiserver",
 	},
+	{
+		"app": "rancher",
+	},
 }
 
 func NewMutator(settingCache v1beta1.SettingCache) types.Mutator {

--- a/pkg/webhook/resources/pod/mutator_test.go
+++ b/pkg/webhook/resources/pod/mutator_test.go
@@ -34,15 +34,15 @@ func Test_envPatches(t *testing.T) {
 				},
 				proxyEnvs: []corev1.EnvVar{
 					{
-						Name:  "HTTP_PROXY",
+						Name:  util.HTTPProxyEnv,
 						Value: "http://192.168.0.1:3128",
 					},
 					{
-						Name:  "HTTPS_PROXY",
+						Name:  util.HTTPSProxyEnv,
 						Value: "http://192.168.0.1:3128",
 					},
 					{
-						Name:  "NO_PROXY",
+						Name:  util.NoProxyEnv,
 						Value: "127.0.0.1,0.0.0.0,10.0.0.0/8",
 					},
 				},
@@ -60,15 +60,15 @@ func Test_envPatches(t *testing.T) {
 				targetEnvs: []corev1.EnvVar{},
 				proxyEnvs: []corev1.EnvVar{
 					{
-						Name:  "HTTP_PROXY",
+						Name:  util.HTTPProxyEnv,
 						Value: "http://192.168.0.1:3128",
 					},
 					{
-						Name:  "HTTPS_PROXY",
+						Name:  util.HTTPSProxyEnv,
 						Value: "http://192.168.0.1:3128",
 					},
 					{
-						Name:  "NO_PROXY",
+						Name:  util.NoProxyEnv,
 						Value: "127.0.0.1,0.0.0.0,10.0.0.0/8",
 					},
 				},

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -38,7 +38,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
 		),
-		setting.NewValidator(),
+		setting.NewValidator(clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		templateversion.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion().Cache(),


### PR DESCRIPTION
The PR resolves the following issues:
1. When the HTTP proxy setting is configured before the backup target secret is created, the proxy is not set in the backup secret.
2. Fail to import Harvester because the proxy envs are not applied in custom HTTP transport
3. When Harvester is imported, embedded Rancher needs to connect to upstream Rancher for aggregation API, therefore we need to inject proxy envs to Rancher pods as well.

**Related Issue:**
https://github.com/harvester/harvester/issues/1218
