### PR TITLE
fix(backup): add backport to v0.3.0 for backup target annotation

### DIFF
--- a/pkg/controller/master/backup/util.go
+++ b/pkg/controller/master/backup/util.go
@@ -31,6 +31,13 @@ func IsBackupTargetSame(vmBackupTarget *harvesterv1.BackupTarget, target *settin
 	return vmBackupTarget.Endpoint == target.Endpoint && vmBackupTarget.BucketName == target.BucketName && vmBackupTarget.BucketRegion == target.BucketRegion
 }
 
+func isBackupTargetOnAnnotation(backup *harvesterv1.VirtualMachineBackup) bool {
+	return backup.Annotations != nil &&
+		(backup.Annotations[backupTargetAnnotation] != "" ||
+			backup.Annotations[backupBucketNameAnnotation] != "" ||
+			backup.Annotations[backupBucketRegionAnnotation] != "")
+}
+
 func isVMRestoreProgressing(vmRestore *harvesterv1.VirtualMachineRestore) bool {
 	return vmRestore.Status == nil || vmRestore.Status.Complete == nil || !*vmRestore.Status.Complete
 }


### PR DESCRIPTION
**Problem:**
We move backup target information in VM Backup from annotation to status. If we upgrade Harvester from v0.3.0 to v1.0.0, we will have panic in Harvester controller.

**Solution:**
Add backport to v0.3.0.

**Related Issue:**
https://github.com/harvester/harvester/issues/1588

**Test plan:**
* Create a VM Backup with v0.3.0 cluster
* Upgrade VM Backup CRD. Add `longhornBackupName` to `volumeBackups`. Add `secretBackups` and `backupTarget` to `status`.
  * https://github.com/harvester/harvester/pull/1447/commits/cb02453bf9aefdb06313438f09376a7e50c52569#diff-91562ef2708a3a87b91f4fc1ccefc8c95954eb8ca2949f1b76e5f16cc40273ce
  * https://github.com/harvester/harvester/pull/1487/commits/4345ab61f6154439f18cfabca816e108ba7d0626#diff-91562ef2708a3a87b91f4fc1ccefc8c95954eb8ca2949f1b76e5f16cc40273ce
![Screen Shot 2021-11-29 at 11 33 02 AM](https://user-images.githubusercontent.com/4927361/143804598-15904611-1ffc-4164-894e-5cef78dc32c1.png)
![Screen Shot 2021-11-29 at 11 33 17 AM](https://user-images.githubusercontent.com/4927361/143804610-9228991d-ddfc-426d-b9b8-130f878d743e.png)

* Upgrade harvester image from v0.3.0 to the master-head version.
  * Check backup target information moved from annotation to status.
  * Check `LonghornBackupName` is in `VolumeBackups`.
  * Check `<namespace>-<name>.cfg` is in remote backup target.
  * Check information in `<namespace>-<name>.cfg` is same as VM Backup resources.
* Upgrade harvester-webhook image from v0.3.0 to the master-head version and grant permission to harvester-webhook like the following.
  * https://github.com/harvester/harvester/pull/1447/commits/2c1b9c2c062dbad5e59df48af675182da1db7a7c#diff-cbaabc6d4bb79d51b3ac588ab97ffb29c95c69ec8b1d49c00ff8544353459b0e
![Screen Shot 2021-11-29 at 11 20 09 AM](https://user-images.githubusercontent.com/4927361/143803544-c7314f3f-b487-4d78-a576-95fa2af506f6.png)
* Restore a VM from VM Backup.
  *  Check VM can be started and data is same.
