### PR TITLE
Bump support-bundle-kit to v0.0.4

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -29,7 +29,7 @@ var (
 	UpgradeCheckerEnabled        = NewSetting("upgrade-checker-enabled", "true")
 	UpgradeCheckerURL            = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
 	LogLevel                     = NewSetting("log-level", "info") // options are info, debug and trace
-	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.3")
+	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.4")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
 	DefaultStorageClass          = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                    = NewSetting("http-proxy", "{}")


### PR DESCRIPTION
**Problem:**
Can't create support bundle if one node is off

**Solution:**
rancher/support-bundle-kit#27

**Related Issue:**
#1524
harvester/harvester-installer#176

**Test plan:**
1. Create a multi-node cluster
2. Shutoff one node
3. Should download the support bundle successfully