### PR TITLE
feat(setting): add support bundle timeout

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -31,6 +31,7 @@ var (
 	LogLevel                     = NewSetting("log-level", "info") // options are info, debug and trace
 	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.3")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
+	SupportBundleTimeout         = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
 	DefaultStorageClass          = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                    = NewSetting("http-proxy", "{}")
 	VMForceDeletionPolicySet     = NewSetting(VMForceDeletionPolicySettingName, InitVMForceDeletionPolicy())
@@ -42,6 +43,7 @@ var (
 const (
 	BackupTargetSettingName          = "backup-target"
 	VMForceDeletionPolicySettingName = "vm-force-deletion-policy"
+	SupportBundleTimeoutSettingName  = "support-bundle-timeout"
 	DefaultDashboardUIURL            = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
 )
 

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/longhorn/backupstore"
 	_ "github.com/longhorn/backupstore/nfs"
@@ -34,6 +35,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.VMForceDeletionPolicySettingName: validateVMForceDeletionPolicy,
 	overcommitConfigSettingName:               validateOvercommitConfig,
 	vipPoolsConfigSettingName:                 validateVipPoolsConfig,
+	settings.SupportBundleTimeoutSettingName:  validateSupportBundleTimeout,
 }
 
 func NewValidator(settingCache ctlv1beta1.SettingCache) types.Validator {
@@ -197,5 +199,20 @@ func validateVipPoolsConfig(setting *v1beta1.Setting) error {
 		return werror.NewInvalidError(err.Error(), "value")
 	}
 
+	return nil
+}
+
+func validateSupportBundleTimeout(setting *v1beta1.Setting) error {
+	if setting.Value == "" {
+		return nil
+	}
+
+	i, err := strconv.Atoi(setting.Value)
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), "value")
+	}
+	if i < 0 {
+		return werror.NewInvalidError("timeout can't be negative", "value")
+	}
 	return nil
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
 )
 
 func Test_validateOvercommitConfig(t *testing.T) {
@@ -57,5 +58,65 @@ func Test_validateOvercommitConfig(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func Test_validateSupportBundleTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
+	}{
+		{
+			name: "invalid int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleTimeoutSettingName},
+				Value:      "not int",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "negative int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleTimeoutSettingName},
+				Value:      "-1",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "input 0",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleTimeoutSettingName},
+				Value:      "0",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "empty input",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleTimeoutSettingName},
+				Value:      "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "positive int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleTimeoutSettingName},
+				Value:      "1",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSupportBundleTimeout(tt.args)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**Problem:**
Support Bundle failed to create due to timeout, but the file has generated successfully on the support bundle's pod after a period of time.

**Solution:**
Add support bundle timeout setting. If users input 0, we disable the timeout.

**Related Issue:**
https://github.com/harvester/harvester/issues/1585

**Test plan:**

Case 1 - Support bundle timeout webhook
* Set `support-bundle-timeout` setting as a negative integer string. We should get an error response.
* Set `support-bundle-timeout` setting as an invalid integer string. We should get an error response.
* Set `support-bundle-timeout` setting as an empty string. We should pass.
* Set `support-bundle-timeout` setting as a positive integer string. We should pass.

Case 2 - Support bundle controller
* Set `support-bundle-timeout` setting as "1" and generate a support bundle. We shouldn't get any timeout error if the duration is less than 1 minute.
* Set `support-bundle-timeout` setting as "0" and generate a support bundle. We shouldn't get any timeout error.