### PR TITLE
Ignore AlreadyExists error during node delete

### DIFF
--- a/pkg/controller/master/node/delete_controller.go
+++ b/pkg/controller/master/node/delete_controller.go
@@ -83,7 +83,7 @@ func (h *deleteNodeHandler) OnNodeRemove(key string, node *corev1.Node) (*corev1
 	}
 
 	if node.DeletionTimestamp != nil {
-		if _, err := h.createDeleteNodeJob(node); err != nil {
+		if _, err := h.createDeleteNodeJob(node); err != nil && !apierrors.IsAlreadyExists(err) {
 			return node, err
 		}
 	}


### PR DESCRIPTION
**Problem:**
There are finalizers linger that prevents node from being deleted.

**Solution:**
Sometimes [`OnNodeRemove`] is called multiple times. When it fails,
wrangler re-syncs it later. To ensure that the finalizer 
`wrangler.cattle.io/delete-node-controller` can be removed smoothly,
Harvester should preent the call on [`OnNodeRemove`] from failure.


**Related Issue:**
#1497 

**Test plan:**
See https://github.com/harvester/harvester/issues/1497#issuecomment-982487682

[`OnNodeRemove`]:https://github.com/harvester/harvester/blob/c28427a34ce0b43f6b915260d177a86ae927561a/pkg/controller/master/node/delete_controller.go#L80-L92
