### PR TITLE
Fix exported image can't be deleted after volume removed

### DIFF
--- a/pkg/webhook/resources/virtualmachineimage/validator.go
+++ b/pkg/webhook/resources/virtualmachineimage/validator.go
@@ -55,7 +55,14 @@ func (v *virtualMachineImageValidator) Resource() types.Resource {
 
 func (v *virtualMachineImageValidator) Create(request *types.Request, newObj runtime.Object) error {
 	newImage := newObj.(*v1beta1.VirtualMachineImage)
+	if err := v.CheckImageDisplayNameAndURL(newImage); err != nil {
+		return err
+	}
 
+	return v.CheckImagePVC(request, newImage)
+}
+
+func (v *virtualMachineImageValidator) CheckImageDisplayNameAndURL(newImage *v1beta1.VirtualMachineImage) error {
 	if newImage.Spec.DisplayName == "" {
 		return werror.NewInvalidError("displayName is required", fieldDisplayName)
 	}
@@ -75,50 +82,80 @@ func (v *virtualMachineImageValidator) Create(request *types.Request, newObj run
 
 	if newImage.Spec.SourceType == v1beta1.VirtualMachineImageSourceTypeDownload && newImage.Spec.URL == "" {
 		return werror.NewInvalidError(`url is required when image source type is "download"`, "spec.url")
-	} else if newImage.Spec.SourceType != v1beta1.VirtualMachineImageSourceTypeDownload && newImage.Spec.URL != "" {
+	}
+
+	if newImage.Spec.SourceType != v1beta1.VirtualMachineImageSourceTypeDownload && newImage.Spec.URL != "" {
 		return werror.NewInvalidError(`url should be empty when image source type is not "download"`, "spec.url")
-	} else if newImage.Spec.SourceType == v1beta1.VirtualMachineImageSourceTypeExportVolume {
-		if newImage.Spec.PVCNamespace == "" {
-			return werror.NewInvalidError(`pvcNamespace is required when image source type is "export-from-volume"`, "spec.pvcNamespace")
-		}
-		if newImage.Spec.PVCName == "" {
-			return werror.NewInvalidError(`pvcName is required when image source type is "export-from-volume"`, "spec.pvcName")
-		}
+	}
 
-		ssar, err := v.ssar.Create(request.Context, &authorizationv1.SelfSubjectAccessReview{
-			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
-				ResourceAttributes: &authorizationv1.ResourceAttributes{
-					Namespace: newImage.Spec.PVCNamespace,
-					Verb:      "get",
-					Group:     "",
-					Version:   "*",
-					Resource:  "persistentvolumeclaims",
-					Name:      newImage.Spec.PVCName,
-				},
+	return nil
+}
+
+func (v *virtualMachineImageValidator) CheckImagePVC(request *types.Request, newImage *v1beta1.VirtualMachineImage) error {
+	if newImage.Spec.SourceType != v1beta1.VirtualMachineImageSourceTypeExportVolume {
+		return nil
+	}
+
+	if newImage.Spec.PVCNamespace == "" {
+		return werror.NewInvalidError(`pvcNamespace is required when image source type is "export-from-volume"`, "spec.pvcNamespace")
+	}
+	if newImage.Spec.PVCName == "" {
+		return werror.NewInvalidError(`pvcName is required when image source type is "export-from-volume"`, "spec.pvcName")
+	}
+
+	ssar, err := v.ssar.Create(request.Context, &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: newImage.Spec.PVCNamespace,
+				Verb:      "get",
+				Group:     "",
+				Version:   "*",
+				Resource:  "persistentvolumeclaims",
+				Name:      newImage.Spec.PVCName,
 			},
-		}, metav1.CreateOptions{})
-		if err != nil {
-			message := fmt.Sprintf("failed to check user permission, error: %s", err.Error())
-			return werror.NewInvalidError(message, "")
-		}
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		message := fmt.Sprintf("failed to check user permission, error: %s", err.Error())
+		return werror.NewInvalidError(message, "")
+	}
 
-		if !ssar.Status.Allowed || ssar.Status.Denied {
-			message := fmt.Sprintf("user has no permission to get the pvc resource %s/%s", newImage.Spec.PVCName, newImage.Spec.PVCNamespace)
-			return werror.NewInvalidError(message, "")
-		}
+	if !ssar.Status.Allowed || ssar.Status.Denied {
+		message := fmt.Sprintf("user has no permission to get the pvc resource %s/%s", newImage.Spec.PVCName, newImage.Spec.PVCNamespace)
+		return werror.NewInvalidError(message, "")
+	}
 
-		_, err = v.pvcCache.Get(newImage.Spec.PVCNamespace, newImage.Spec.PVCName)
-		if err != nil {
-			message := fmt.Sprintf("failed to get pvc %s/%s, error: %s", newImage.Spec.PVCName, newImage.Spec.PVCNamespace, err.Error())
-			return werror.NewInvalidError(message, "")
-		}
+	_, err = v.pvcCache.Get(newImage.Spec.PVCNamespace, newImage.Spec.PVCName)
+	if err != nil {
+		message := fmt.Sprintf("failed to get pvc %s/%s, error: %s", newImage.Spec.PVCName, newImage.Spec.PVCNamespace, err.Error())
+		return werror.NewInvalidError(message, "")
 	}
 
 	return nil
 }
 
 func (v *virtualMachineImageValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
-	return v.Create(request, newObj)
+	newImage := newObj.(*v1beta1.VirtualMachineImage)
+	oldImage := oldObj.(*v1beta1.VirtualMachineImage)
+
+	if !newImage.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	if oldImage.Spec.SourceType != newImage.Spec.SourceType {
+		return werror.NewInvalidError("sourceType cannot be modified", "spec.sourceType")
+	}
+
+	if newImage.Spec.SourceType == v1beta1.VirtualMachineImageSourceTypeExportVolume {
+		if oldImage.Spec.PVCNamespace != newImage.Spec.PVCNamespace {
+			return werror.NewInvalidError("pvcNamespace cannot be modified", "spec.pvcNamespace")
+		}
+		if oldImage.Spec.PVCName != newImage.Spec.PVCName {
+			return werror.NewInvalidError("pvcName cannot be modified", "spec.pvcName")
+		}
+	}
+
+	return v.CheckImageDisplayNameAndURL(newImage)
 }
 
 func (v *virtualMachineImageValidator) Delete(request *types.Request, oldObj runtime.Object) error {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
deletionTimestamp will be updated when vmImage is deleted, which triggers webhook of vmimage. Since PVC no longer exists, validate failed.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. if deletionTimestamp is not zero(deleting vmimage), ignore vmimage update validate
2. only check pvc exist when vm create
3. user cannot change spec.sourceType, spec.pvcNamespace, spec.pvcName

**Related Issue:**
#1602

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
case 1：
1. create vm "vm-1"
2. create a image "img-1" by export the volume used by vm "vm-1"
3. delete vm "vm-1"
4. delete image "img-1"
image "img-1" will be deleted

case 2：
1. create vm "vm-1"
2. create a image "img-1" by export the volume used by vm "vm-1"
3. delete vm "vm-1"
4. update image "img-1" labels
image "img-1" will be updated
