### PR TITLE
Add Setting: SSL Parameters

### DIFF
--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -63,6 +63,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		"vip-pools":                 controller.syncVipPoolsConfig,
 		"auto-disk-provision-paths": controller.syncNDMAutoProvisionPaths,
 		"ssl-certificates":          controller.syncSSLCertificate,
+		"ssl-parameters":            controller.syncSSLParameters,
 	}
 
 	settings.OnChange(ctx, controllerName, controller.settingOnChanged)

--- a/pkg/controller/master/setting/ssl_parameters.go
+++ b/pkg/controller/master/setting/ssl_parameters.go
@@ -1,0 +1,64 @@
+package setting
+
+import (
+	"encoding/json"
+
+	"github.com/rancher/wrangler/pkg/data"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func (h *Handler) syncSSLParameters(setting *harvesterv1.Setting) error {
+	sslParameter := &settings.SSLParameter{}
+	value := setting.Value
+	if value == "" {
+		value = setting.Default
+	}
+	if err := json.Unmarshal([]byte(value), sslParameter); err != nil {
+		return err
+	}
+
+	return h.updateSSLParameters(sslParameter)
+}
+
+func (h *Handler) updateSSLParameters(sslParameter *settings.SSLParameter) error {
+	logrus.Infof("Update SSL Parameters: Ciphers: %s, Protocols: %s", sslParameter.Ciphers, sslParameter.Protocols)
+
+	helmChartConfig, err := h.helmChartConfigCache.Get(util.KubeSystemNamespace, util.Rke2IngressNginxAppName)
+	if err != nil {
+		return err
+	}
+	toUpdateHelmChartConfig := helmChartConfig.DeepCopy()
+
+	var values = make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(helmChartConfig.Spec.ValuesContent), &values); err != nil {
+		return err
+	}
+
+	if sslParameter.Ciphers == "" {
+		data.RemoveValue(values, "controller", "config", "ssl-ciphers")
+	} else {
+		data.PutValue(values, sslParameter.Ciphers, "controller", "config", "ssl-ciphers")
+	}
+	if sslParameter.Protocols == "" {
+		data.RemoveValue(values, "controller", "config", "ssl-protocols")
+	} else {
+		data.PutValue(values, sslParameter.Protocols, "controller", "config", "ssl-protocols")
+	}
+
+	newValuesContent, err := yaml.Marshal(values)
+	if err != nil {
+		return err
+	}
+
+	toUpdateHelmChartConfig.Spec.ValuesContent = string(newValuesContent)
+	if _, err := h.helmChartConfigs.Update(toUpdateHelmChartConfig); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -30,6 +30,7 @@ var (
 	UpgradeCheckerURL            = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
 	LogLevel                     = NewSetting("log-level", "info") // options are info, debug and trace
 	SSLCertificates              = NewSetting(SSLCertificatesSettingName, "{}")
+	SSLParameters                = NewSetting(SSLParametersName, "{}")
 	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.4")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
 	SupportBundleTimeout         = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
@@ -49,6 +50,7 @@ const (
 	HttpProxySettingName             = "http-proxy"
 	OvercommitConfigSettingName      = "overcommit-config"
 	SSLCertificatesSettingName       = "ssl-certificates"
+	SSLParametersName                = "ssl-parameters"
 	VipPoolsConfigSettingName        = "vip-pools"
 	DefaultDashboardUIURL            = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
 )
@@ -224,4 +226,9 @@ type SSLCertificate struct {
 	CA                string `json:"ca"`
 	PublicCertificate string `json:"publicCertificate"`
 	PrivateKey        string `json:"privateKey"`
+}
+
+type SSLParameter struct {
+	Protocols string `json:"protocols"`
+	Ciphers   string `json:"ciphers"`
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -120,3 +120,53 @@ func Test_validateSupportBundleTimeout(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateSSLProtocols(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *settings.SSLParameter
+		expectedErr bool
+	}{
+		{
+			name:        "Supported protocol 'TLSv1.2'",
+			args:        &settings.SSLParameter{Protocols: "TLSv1.2"},
+			expectedErr: false,
+		},
+		{
+			name:        "Unsupported protocol 'MyTLSv99.9'",
+			args:        &settings.SSLParameter{Protocols: "MyTLSv99.9"},
+			expectedErr: true,
+		},
+		{
+			name:        "A list of supported protocols separated by whitespace",
+			args:        &settings.SSLParameter{Protocols: "TLSv1.1 TLSv1.2"},
+			expectedErr: false,
+		},
+		{
+			name:        "A list of supported protocols separated by multiple whitespace",
+			args:        &settings.SSLParameter{Protocols: "  TLSv1.1    TLSv1.2  "},
+			expectedErr: false,
+		},
+		{
+			name:        "One unsupported protocol in a list",
+			args:        &settings.SSLParameter{Protocols: "TLSv1.2 TLSv1.1 MyTLSv99.9"},
+			expectedErr: true,
+		},
+		{
+			name:        "Protocols separate by characters other than whitespace is invalid",
+			args:        &settings.SSLParameter{Protocols: "TLSv1.1,TLSv1.2,TLSv1.3"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSSLProtocols(tt.args)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Need to be able to change the SSL/TLS Ciphers and Protocols.

**Solution:**
Add a Setting CR "ssl-parameters" and corresponding controllers to update HelmChartConfig of `rke2-ingress-nginx` once settings changed:
```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-ingress-nginx
  namespace: kube-system
  ...
spec:
  valuesContent: |
    controller:
        ...
        config:
            ssl-protocols: "TLSv1 TLSv1.1 TLSv1.2 TLSv1.3"
            ssl-ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:..."
```

**Related Issue:**
https://github.com/harvester/harvester/issues/1046

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
The value of `ssl-parameters` setting should be a JSON encoded string with the following format:
```
{
  "protocols": "TLSv1.2 TLSv1.3",
  "ciphers": "ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384"
}
```
- `protocols`: Specify the SSL/TLS protocols, separated by whitespace characters. This string will be passed to [ingress-nginx ConfigMap "ssl-protocols" config](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-protocols).
- `ciphers`: Specify the SSL/TLS ciphers, separated by colon characters. This string will be passed to [ingress-nginx ConfigMap "ssl-ciphers" config](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-ciphers).

Once you've changed the setting, use command `nmap --script ssl-enum-ciphers -p <PORT> <IP>` to see the supported SSL/TLS ciphers and protocols, or use other tools such as https://testssl.sh/ to verify the result.

- **NOTE**: We only validate `protocols` input. `ciphers` is not validated and will be passed to ingress-nginx directly.

**TODOs**
- [x] Add validation webhook