### PR TITLE
fix(node-down-controller): remove creator label

### DIFF
--- a/pkg/controller/master/node/node_down_controller.go
+++ b/pkg/controller/master/node/node_down_controller.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	nodeDownControllerName = "node-down-controller"
-	vmCreatorLabel         = "harvesterhci.io/creator"
 )
 
 // nodeDownHandler force deletes VMI's pod when a node is down, so VMI can be reschduled to anothor healthy node
@@ -93,8 +92,7 @@ func (h *nodeDownHandler) OnNodeChanged(key string, node *corev1.Node) (*corev1.
 	// get VMI pods on unhealthy node
 	pods, err := h.pods.List(corev1.NamespaceAll, metav1.ListOptions{
 		LabelSelector: labels.Set{
-			kv1.AppLabel:   "virt-launcher",
-			vmCreatorLabel: "harvester",
+			kv1.AppLabel: "virt-launcher",
 		}.String(),
 		FieldSelector: "spec.nodeName=" + node.Name,
 	})
@@ -104,6 +102,7 @@ func (h *nodeDownHandler) OnNodeChanged(key string, node *corev1.Node) (*corev1.
 
 	gracePeriod := int64(0)
 	for _, pod := range pods.Items {
+		logrus.Debugf("force delete pod %s/%s", pod.Namespace, pod.Name)
 		if err := h.pods.Delete(
 			pod.Namespace,
 			pod.Name,


### PR DESCRIPTION
**Problem:**
node-down-controller uses labels to select pods, so it can't get correct pods to force delete.

**Solution:**
Remove the error label for the selector.

**Related Issue:**
https://github.com/harvester/harvester/issues/1360

**Test plan:**

Case 1: `vm-force-deletion-policy` has already been enabled.
* Create a 2-node environment.
* Set `vm-force-deletion-policy` as `'{"enable": true, "period": 60}'`.
* Create a VM on the agent node.
* When the VM is running, turn off the agent node.
* It will take a few minutes to reschedule the Pod. Check the Pod starts rescheduling.

Case 2: Enable `vm-force-deletion-policy` after a node is down.
* Create a 2-node environment.
* Disable vm-force-delete-policy.
* Create a VM on the agent node.
* When the VM is running, turn off the agent node.
* Wait a few minutes. We can only see the Pod is `Terminating`, but rescheduling does not happen.
* Set `vm-force-deletion-policy` as `'{"enable": true, "period": 60}'`.
* Wait a few minutes. We can see the Pod is rescheduling.

