### PR TITLE
Patch existing guest memory on all occasions

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -116,10 +116,11 @@ func (m *vmMutator) patchResourceOvercommit(vm *kubevirtv1.VirtualMachine) ([]st
 		}
 		// Reserve 100MiB (104857600 Bytes) for QEMU on guest memory
 		// Ref: https://github.com/harvester/harvester/issues/1234
+		// TODO: handle hugepage memory
 		guestMemory := resource.NewQuantity(mem.Value()-104857600, mem.Format)
 		if vm.Spec.Template.Spec.Domain.Memory == nil {
 			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"%s"}}`, guestMemory))
-		} else if vm.Spec.Template.Spec.Domain.Memory.Guest == nil {
+		} else {
 			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/memory/guest", "value": "%s"}`, guestMemory))
 		}
 	}


### PR DESCRIPTION
**Problem:**
Guest memory does not reflect the memory change in either UI dashboard or API

**Solution:**
Should not check `memory.guest` existence if we always want to patch the guest memory.

**Related Issue:**
#1637

**Test plan:**
See #1637
