### PR TITLE
fix(backup): nil BackupTarget pointer

### DIFF
--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -565,6 +565,11 @@ func (h *Handler) deleteVMBackupMetadata(vmBackup *harvesterv1.VirtualMachineBac
 
 func (h *Handler) uploadVMBackupMetadata(vmBackup *harvesterv1.VirtualMachineBackup, target *settings.BackupTarget) error {
 	var err error
+	// if users don't update VMBackup CRD, we may lose backup target data.
+	if vmBackup.Status.BackupTarget == nil {
+		return fmt.Errorf("no backup target in vmbackup.status")
+	}
+
 	if target == nil {
 		if target, err = settings.DecodeBackupTarget(settings.BackupTargetSet.Get()); err != nil {
 			return err
@@ -714,8 +719,5 @@ func (h *Handler) configureBackupTargetOnStatus(vmBackup *harvesterv1.VirtualMac
 		BucketName:   vmBackup.Annotations[backupBucketNameAnnotation],
 		BucketRegion: vmBackup.Annotations[backupBucketRegionAnnotation],
 	}
-	delete(vmBackup.Annotations, backupTargetAnnotation)
-	delete(vmBackup.Annotations, backupBucketNameAnnotation)
-	delete(vmBackup.Annotations, backupBucketRegionAnnotation)
 	return h.vmBackups.Update(vmBackupCpy)
 }


### PR DESCRIPTION
**Problem:**
If we return `h.vmBackups.Update(vmBackupCpy)`, we may lose `status.BackupTarget` in the new object.

**Solution:**
Return `vmBackupCpy`.

**Related Issue:**
https://github.com/harvester/harvester/issues/1588

**Test plan:**

* Create a VM Backup with v0.3.0 cluster
* Upgrade VM Backup CRD. Add `longhornBackupName` to `volumeBackups`. Add `secretBackups` and `backupTarget` to `status`.
  * https://github.com/harvester/harvester/pull/1447/commits/cb02453bf9aefdb06313438f09376a7e50c52569#diff-91562ef2708a3a87b91f4fc1ccefc8c95954eb8ca2949f1b76e5f16cc40273ce
  * https://github.com/harvester/harvester/pull/1487/commits/4345ab61f6154439f18cfabca816e108ba7d0626#diff-91562ef2708a3a87b91f4fc1ccefc8c95954eb8ca2949f1b76e5f16cc40273ce
![Screen Shot 2021-11-29 at 11 33 02 AM](https://user-images.githubusercontent.com/4927361/143804598-15904611-1ffc-4164-894e-5cef78dc32c1.png)
![Screen Shot 2021-11-29 at 11 33 17 AM](https://user-images.githubusercontent.com/4927361/143804610-9228991d-ddfc-426d-b9b8-130f878d743e.png)

* Upgrade harvester image from v0.3.0 to the master-head version.
  * Check backup target information moved from annotation to status.
  * Check `LonghornBackupName` is in `VolumeBackups`.
  * Check `<namespace>-<name>.cfg` is in remote backup target.
  * Check information in `<namespace>-<name>.cfg` is same as VM Backup resources.
* Upgrade harvester-webhook image from v0.3.0 to the master-head version and grant permission to harvester-webhook like the following.
  * https://github.com/harvester/harvester/pull/1447/commits/2c1b9c2c062dbad5e59df48af675182da1db7a7c#diff-cbaabc6d4bb79d51b3ac588ab97ffb29c95c69ec8b1d49c00ff8544353459b0e
![Screen Shot 2021-11-29 at 11 20 09 AM](https://user-images.githubusercontent.com/4927361/143803544-c7314f3f-b487-4d78-a576-95fa2af506f6.png)
* Restore a VM from VM Backup.
  *  Check VM can be started and data is same.

