### PR TITLE
fix 1051: reset backup target to default

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -380,9 +380,16 @@ func (h *vmActionHandler) restoreBackup(vmName, vmNamespace string, input Restor
 }
 
 func (h *vmActionHandler) checkBackupTargetConfigured() error {
-	target, err := h.settingCache.Get(settings.BackupTargetSettingName)
-	if err == nil && harvesterv1.SettingConfigured.IsTrue(target) {
-		return nil
+	targetSetting, err := h.settingCache.Get(settings.BackupTargetSettingName)
+	if err == nil && harvesterv1.SettingConfigured.IsTrue(targetSetting) {
+		// backup target may be reset to initial/default, the SettingConfigured.IsTrue meets
+		target, err := settings.DecodeBackupTarget(targetSetting.Value)
+		if err != nil {
+			return err
+		}
+		if !target.IsDefaultBackupTarget() {
+			return nil
+		}
 	}
 	return fmt.Errorf("backup target is invalid")
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -194,6 +195,15 @@ func DecodeBackupTarget(value string) (*BackupTarget, error) {
 	}
 
 	return target, nil
+}
+
+func (target *BackupTarget) IsDefaultBackupTarget() bool {
+	if target == nil || target.Type != "" {
+		return false
+	}
+
+	defaultTarget := &BackupTarget{}
+	return reflect.DeepEqual(target, defaultTarget)
 }
 
 func InitVMForceResetPolicy() string {

--- a/pkg/webhook/resources/restore/validator.go
+++ b/pkg/webhook/resources/restore/validator.go
@@ -1,7 +1,6 @@
 package restore
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -102,9 +101,14 @@ func (v *restoreValidator) checkBackupTarget(vmRestore *v1beta1.VirtualMachineRe
 	if err != nil {
 		return fmt.Errorf("can't get backup target setting, err: %w", err)
 	}
-	backupTarget := &settings.BackupTarget{}
-	if err := json.Unmarshal([]byte(backupTargetSetting.Value), backupTarget); err != nil {
+
+	backupTarget, err := settings.DecodeBackupTarget(backupTargetSetting.Value)
+	if err != nil {
 		return fmt.Errorf("unmarshal backup target failed, value: %s, err: %w", backupTargetSetting.Value, err)
+	}
+
+	if backupTarget.IsDefaultBackupTarget() {
+		return fmt.Errorf("backup target is invalid")
 	}
 
 	// get vmbackup

--- a/pkg/webhook/types/admission.go
+++ b/pkg/webhook/types/admission.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	AdmissionTypeMutation   = "mutation"
-	AdmissionTypeValidation = "validaton"
+	AdmissionTypeValidation = "validation"
 )
 
 // JSON Patch operations to mutate input data. See https://jsonpatch.com/ for more information.


### PR DESCRIPTION
Problem:

After PR of #1447, the "Use the default value" of "backup target" will be refused by webhook, the error message is:

admission webhook "validator.harvesterhci.io" denied the request: Destination URL hasn't been specified

It is not possible to reset backup target to the default value in the web UI.

Solution:

In webhook, check the backup target as per specific requirements to each field,  S3, NFS, Default are different.
For S3, there is an re-update operation, needs special check to identify it is from user input or internal

In controller, add process of default backup target.

Related Issue:
#1051

Test plan:

Setup a harvester cluster (one node is also OK)

1. The initial backup target is blank (default), when you create a VM and operate the "take backup", will be refused.

2. Set the backup target
2.1 When backup target has error (endpoint is not reachable/bucket name is wrong/bad credentials...), "save" will be refused with an error message, and after refreshing the web page, the backup target is still the last setting
2.2 When backup target is correct, it is saved. 
2.2.1 "take backup" on VM will be allowed
 (another commit will block user change the backup target if a backup target is ongoing)
 
2.3 "Edit" again, click "Use the default value" button and "save", it will be success, and backup target is reset to default value.
2.3.1 "take backup" on VM will be refused

2.4 Set a correct backup target of S3/minio, then "edit", if you leave input access key / ID  blank, and change the bucket name/region/endpoint,  save will NOT be allowed,   before this commit, you can do it, it is a BUG

2.5 Set a correct backup target of S3/minio, use kubectl can check a related secret created
```
kubectl get secrets -A | grep backup
longhorn-system                          harvester-backup-target-secret                                       Opaque                                8      57s
```
change the backup target to NFS or reset to default, this secret will be deleted.  Before this commit, it is leaved there.




