### PR TITLE
rename: vm-force-deletion-policy to vm-force-reset-policy

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -36,23 +36,23 @@ var (
 	SupportBundleTimeout         = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
 	DefaultStorageClass          = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                    = NewSetting(HttpProxySettingName, "{}")
-	VMForceDeletionPolicySet     = NewSetting(VMForceDeletionPolicySettingName, InitVMForceDeletionPolicy())
+	VMForceResetPolicySet        = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
 	OvercommitConfig             = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":150,"storage":200}`)
 	VipPools                     = NewSetting(VipPoolsConfigSettingName, "")
 	AutoDiskProvisionPaths       = NewSetting("auto-disk-provision-paths", "")
 )
 
 const (
-	AdditionalCASettingName          = "additional-ca"
-	BackupTargetSettingName          = "backup-target"
-	VMForceDeletionPolicySettingName = "vm-force-deletion-policy"
-	SupportBundleTimeoutSettingName  = "support-bundle-timeout"
-	HttpProxySettingName             = "http-proxy"
-	OvercommitConfigSettingName      = "overcommit-config"
-	SSLCertificatesSettingName       = "ssl-certificates"
-	SSLParametersName                = "ssl-parameters"
-	VipPoolsConfigSettingName        = "vip-pools"
-	DefaultDashboardUIURL            = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
+	AdditionalCASettingName         = "additional-ca"
+	BackupTargetSettingName         = "backup-target"
+	VMForceResetPolicySettingName   = "vm-force-reset-policy"
+	SupportBundleTimeoutSettingName = "support-bundle-timeout"
+	HttpProxySettingName            = "http-proxy"
+	OvercommitConfigSettingName     = "overcommit-config"
+	SSLCertificatesSettingName      = "ssl-certificates"
+	SSLParametersName               = "ssl-parameters"
+	VipPoolsConfigSettingName       = "vip-pools"
+	DefaultDashboardUIURL           = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
 )
 
 func init() {
@@ -171,7 +171,7 @@ type BackupTarget struct {
 	VirtualHostedStyle bool       `json:"virtualHostedStyle"`
 }
 
-type VMForceDeletionPolicy struct {
+type VMForceResetPolicy struct {
 	Enable bool `json:"enable"`
 	// Period means how many seconds to wait for a node get back.
 	Period int64 `json:"period"`
@@ -195,20 +195,20 @@ func DecodeBackupTarget(value string) (*BackupTarget, error) {
 	return target, nil
 }
 
-func InitVMForceDeletionPolicy() string {
-	policy := &VMForceDeletionPolicy{
+func InitVMForceResetPolicy() string {
+	policy := &VMForceResetPolicy{
 		Enable: true,
 		Period: 5 * 60, // 5 minutes
 	}
 	policyStr, err := json.Marshal(policy)
 	if err != nil {
-		logrus.Errorf("failed to init %s, error: %s", VMForceDeletionPolicySettingName, err.Error())
+		logrus.Errorf("failed to init %s, error: %s", VMForceResetPolicySettingName, err.Error())
 	}
 	return string(policyStr)
 }
 
-func DecodeVMForceDeletionPolicy(value string) (*VMForceDeletionPolicy, error) {
-	policy := &VMForceDeletionPolicy{}
+func DecodeVMForceResetPolicy(value string) (*VMForceResetPolicy, error) {
+	policy := &VMForceResetPolicy{}
 	if err := json.Unmarshal([]byte(value), policy); err != nil {
 		return nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, value)
 	}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -42,13 +42,13 @@ var supportedSSLProtocols = []string{"SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv
 type validateSettingFunc func(setting *v1beta1.Setting) error
 
 var validateSettingFuncs = map[string]validateSettingFunc{
-	settings.HttpProxySettingName:             validateHTTPProxy,
-	settings.VMForceDeletionPolicySettingName: validateVMForceDeletionPolicy,
-	settings.SupportBundleTimeoutSettingName:  validateSupportBundleTimeout,
-	settings.OvercommitConfigSettingName:      validateOvercommitConfig,
-	settings.VipPoolsConfigSettingName:        validateVipPoolsConfig,
-	settings.SSLCertificatesSettingName:       validateSSLCertificates,
-	settings.SSLParametersName:                validateSSLParameters,
+	settings.HttpProxySettingName:            validateHTTPProxy,
+	settings.VMForceResetPolicySettingName:   validateVMForceResetPolicy,
+	settings.SupportBundleTimeoutSettingName: validateSupportBundleTimeout,
+	settings.OvercommitConfigSettingName:     validateOvercommitConfig,
+	settings.VipPoolsConfigSettingName:       validateVipPoolsConfig,
+	settings.SSLCertificatesSettingName:      validateSSLCertificates,
+	settings.SSLParametersName:               validateSSLParameters,
 }
 
 func NewValidator(settingCache ctlv1beta1.SettingCache, vmBackupCache ctlv1beta1.VirtualMachineBackupCache) types.Validator {
@@ -134,12 +134,12 @@ func validateOvercommitConfig(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateVMForceDeletionPolicy(setting *v1beta1.Setting) error {
+func validateVMForceResetPolicy(setting *v1beta1.Setting) error {
 	if setting.Value == "" {
 		return nil
 	}
 
-	if _, err := settings.DecodeVMForceDeletionPolicy(setting.Value); err != nil {
+	if _, err := settings.DecodeVMForceResetPolicy(setting.Value); err != nil {
 		return werror.NewInvalidError(err.Error(), "value")
 	}
 


### PR DESCRIPTION
**Problem:**
We don't really delete VM. We just delete the pod of VM and let VM be rescheduled.

**Solution:**
Change `vm-force-deletion-policy` to `vm-force-reset-policy`.

**Related Issue:**
https://github.com/harvester/harvester/issues/1661

**Test plan:**

Case 1: `vm-force-reset-policy` has already been enabled.
* Create a 2-node environment.
* Set `vm-force-reset-policy` as `'{"enable": true, "period": 60}'`.
* Create a VM on the agent node.
* When the VM is running, turn off the agent node.
* It will take a few minutes to reschedule the Pod. Check the Pod starts rescheduling.

Case 2: Enable `vm-force-reset-policy` after a node is down.
* Create a 2-node environment.
* Set `vm-force-reset-policy` as `'{"enable": false, "period": 60}'`.
* Create a VM on the agent node.
* When the VM is running, turn off the agent node.
* Wait a few minutes. We can only see the Pod is `Terminating`, but rescheduling does not happen.
* Set `vm-force-reset-policy` as `'{"enable": true, "period": 60}'`.
* Wait a few minutes. We can see the Pod is rescheduling.
