### PR TITLE
Support bundle: collect more namespaces

### DIFF
--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -19,7 +19,6 @@ import (
 type Handler struct {
 	supportBundles          v1beta1.SupportBundleClient
 	supportBundleController v1beta1.SupportBundleController
-	settingCache            v1beta1.SettingCache
 	nodeCache               ctlcorev1.NodeCache
 	podCache                ctlcorev1.PodCache
 	deployments             ctlappsv1.DeploymentClient

--- a/pkg/controller/master/supportbundle/register.go
+++ b/pkg/controller/master/supportbundle/register.go
@@ -14,7 +14,6 @@ const (
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
 	sbs := management.HarvesterFactory.Harvesterhci().V1beta1().SupportBundle()
-	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()
 	nodeCache := management.CoreFactory.Core().V1().Node().Cache()
 	podCache := management.CoreFactory.Core().V1().Pod().Cache()
 	deployments := management.AppsFactory.Apps().V1().Deployment()
@@ -24,7 +23,6 @@ func Register(ctx context.Context, management *config.Management, options config
 	handler := &Handler{
 		supportBundles:          sbs,
 		supportBundleController: sbs,
-		settingCache:            settings,
 		nodeCache:               nodeCache,
 		podCache:                podCache,
 		deployments:             deployments,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -33,6 +33,7 @@ var (
 	SSLParameters                = NewSetting(SSLParametersName, "{}")
 	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.4")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
+	SupportBundleNamespaces      = NewSetting("support-bundle-namespaces", "")
 	SupportBundleTimeout         = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
 	DefaultStorageClass          = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                    = NewSetting(HttpProxySettingName, "{}")


### PR DESCRIPTION
Collect resources from more namespaces and add a setting `support-bundle-namespaces` if users want to include even more.

From:
![Screen Shot 2021-12-14 at 5 50 36 PM](https://user-images.githubusercontent.com/1691518/145974785-08339036-7295-4705-b4e1-d2a2fd179a74.png)

To:
![Screen Shot 2021-12-14 at 11 59 09 PM](https://user-images.githubusercontent.com/1691518/146034031-f478c131-c753-40ff-b2f3-b58e587e3d68.png)



