### PR TITLE
fix 1692 set backup target is configured flag after setting

### DIFF
--- a/pkg/controller/master/backup/backup_target.go
+++ b/pkg/controller/master/backup/backup_target.go
@@ -111,6 +111,9 @@ func (h *TargetHandler) OnBackupTargetChange(key string, setting *harvesterv1.Se
 			return nil, err
 		}
 
+		// set configured flag, as s3 does
+		harvesterv1.SettingConfigured.SetError(setting, "", nil)
+
 		return nil, nil
 
 	default:
@@ -137,6 +140,9 @@ func (h *TargetHandler) reUpdateBackupTargetSettingSecret(setting *harvesterv1.S
 	if target.Type != settings.S3BackupType {
 		return nil, nil
 	}
+
+	// set configured flag
+	harvesterv1.SettingConfigured.SetError(setting, "", nil)
 
 	// reset the s3 credentials to prevent controller reconcile and not to expose secret key
 	target.SecretAccessKey = ""


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Without setting the flag, the "take backup" action is refused



**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Set the configured flag when setting backup target
Then it is allowed to "take backup"


**Related Issue:**
#1692

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install Harvester
2. Set backup target
3. "take backup" on VM, and is allowed
![image](https://user-images.githubusercontent.com/31133476/146416031-842a8f68-9563-401d-a15c-5731d0538364.png)

4. Edit backup target to default value
5. "take backup" on VM, and is refused

![image](https://user-images.githubusercontent.com/31133476/146416368-2059615a-1607-41d7-b648-246edd21e2f7.png)
