### PR TITLE
Do not include sensitive data in support bundle

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -32,7 +32,7 @@ var (
 	LogLevel                     = NewSetting("log-level", "info") // options are info, debug and trace
 	SSLCertificates              = NewSetting(SSLCertificatesSettingName, "{}")
 	SSLParameters                = NewSetting(SSLParametersName, "{}")
-	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.4")
+	SupportBundleImage           = NewSetting("support-bundle-image", "rancher/support-bundle-kit:v0.0.5")
 	SupportBundleImagePullPolicy = NewSetting("support-bundle-image-pull-policy", "IfNotPresent")
 	SupportBundleNamespaces      = NewSetting("support-bundle-namespaces", "")
 	SupportBundleTimeout         = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.


### PR DESCRIPTION
**Problem:**
Exclude sensitive resources from packaging into support bundle. 

**Solution:**
https://github.com/rancher/support-bundle-kit/pull/29

There might be resources not included. Please help me verify if something is missing.

**Related Issue:**

**Test plan:**
1. Build an image of support-bundle-kit from support bundle PR aforementioned.
2. Build an image of harvester and run it in a cluster
3. Edit the `settings.harvesterhci.io` resources accordingly:
    - `support-bundle-image` -> your-image
    - `support-bundle-image-pull-policy` -> `Always`
4. Head to Dashboard and click **Support** at the right bottom corner.
5. Generate one support bundle and check the list of excluded resrouces not inside.
