### PR TITLE
Increase upgrade repo VM readiness timeout

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -292,6 +292,8 @@ func (r *UpgradeRepo) createVM(image *harvesterv1.VirtualMachineImage) (*kv1.Vir
 								Port: intstr.FromInt(80),
 							},
 						},
+						TimeoutSeconds:   30,
+						FailureThreshold: 5,
 					},
 				},
 			},


### PR DESCRIPTION
The default 1s is too aggressive in heavy loading cluster.


**Related issue:**
https://github.com/harvester/harvester/issues/1717
