### PR TITLE
Node promotion: wait until custom machine label exists

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -32,7 +32,18 @@ metadata:
 data:
   promote.sh: |-
     {{`KUBECTL="/host/$(readlink /host/var/lib/rancher/rke2/bin)/kubectl"
-    CUSTOM_MACHINE=$($KUBECTL get node $HOSTNAME -o go-template=$'{{index .metadata.annotations "cluster.x-k8s.io/machine"}}\n')
+
+    get_machine_from_node() {
+      $KUBECTL get node $HOSTNAME -o jsonpath='{.metadata.annotations.cluster\.x-k8s\.io/machine}'
+    }
+
+    CUSTOM_MACHINE=$(get_machine_from_node)
+    until [ -n "$CUSTOM_MACHINE" ]
+    do
+      echo Waiting for custom machine label of $HOSTNAME ...
+      sleep 2
+      CUSTOM_MACHINE=$(get_machine_from_node)
+    done
 
     until $KUBECTL get machines.cluster.x-k8s.io $CUSTOM_MACHINE -n fleet-local &> /dev/null
     do


### PR DESCRIPTION
The label `cluster.x-k8s.io/machine` of a node might be set after the node promotion script is run. Wait until it's set.

**Related Issue:**
https://github.com/harvester/harvester/issues/1763

**Test plan:**
- Create a cluster that contains more than or equal to 3 nodes.
- 3 nodes should become control nodes. Role is `control-plane,etcd,master` in `kubectl get nodes` output.

Note: there is no reliable way to repro this issue, we can keep monitoring if this is fixed.