### PR TITLE
prevent users to stop or restart vm if there is processing backup

### DIFF
--- a/pkg/controller/master/backup/backup_status.go
+++ b/pkg/controller/master/backup/backup_status.go
@@ -20,7 +20,7 @@ import (
 
 func (h *Handler) updateConditions(vmBackup *harvesterv1.VirtualMachineBackup) error {
 	var vmBackupCpy = vmBackup.DeepCopy()
-	if isBackupProgressing(vmBackupCpy) {
+	if IsBackupProgressing(vmBackupCpy) {
 		updateBackupCondition(vmBackupCpy, newProgressingCondition(corev1.ConditionTrue, "", "Operation in progress"))
 		updateBackupCondition(vmBackupCpy, newReadyCondition(corev1.ConditionFalse, "", "Not ready"))
 	}

--- a/pkg/controller/master/backup/util.go
+++ b/pkg/controller/master/backup/util.go
@@ -18,8 +18,8 @@ func isBackupReady(backup *harvesterv1.VirtualMachineBackup) bool {
 	return backup.Status != nil && backup.Status.ReadyToUse != nil && *backup.Status.ReadyToUse
 }
 
-func isBackupProgressing(backup *harvesterv1.VirtualMachineBackup) bool {
-	return getVMBackupError(backup) == nil &&
+func IsBackupProgressing(backup *harvesterv1.VirtualMachineBackup) bool {
+	return GetVMBackupError(backup) == nil &&
 		(backup.Status == nil || backup.Status.ReadyToUse == nil || !*backup.Status.ReadyToUse)
 }
 
@@ -51,7 +51,7 @@ func isNewVMOrHasRetainPolicy(vmRestore *harvesterv1.VirtualMachineRestore) bool
 	return vmRestore.Spec.NewVM || vmRestore.Spec.DeletionPolicy == harvesterv1.VirtualMachineRestoreRetain
 }
 
-func getVMBackupError(vmBackup *harvesterv1.VirtualMachineBackup) *harvesterv1.Error {
+func GetVMBackupError(vmBackup *harvesterv1.VirtualMachineBackup) *harvesterv1.Error {
 	if vmBackup.Status != nil && vmBackup.Status.Error != nil {
 		return vmBackup.Status.Error
 	}

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -1,0 +1,22 @@
+package indexeres
+
+import (
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/webhook/clients"
+)
+
+const (
+	VMBackupBySourceUIDIndex = "harvesterhci.io/vmbackup-by-source-uid"
+)
+
+func RegisterIndexers(clients *clients.Clients) {
+	vmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
+	vmBackupCache.AddIndexer(VMBackupBySourceUIDIndex, vmBackupBySourceUID)
+}
+
+func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
+	if obj.Status != nil && obj.Status.SourceUID != nil {
+		return []string{string(*obj.Status.SourceUID)}, nil
+	}
+	return []string{}, nil
+}

--- a/pkg/webhook/resources/keypair/validator.go
+++ b/pkg/webhook/resources/keypair/validator.go
@@ -30,7 +30,7 @@ type keyPairValidator struct {
 
 func (v *keyPairValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       v1beta1.KeyPairResourceName,
+		Names:      []string{v1beta1.KeyPairResourceName},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   v1beta1.SchemeGroupVersion.Group,
 		APIVersion: v1beta1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/network/validator.go
+++ b/pkg/webhook/resources/network/validator.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	cniv1 "github.com/containernetworking/cni/pkg/types"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	cniv1 "github.com/containernetworking/cni/pkg/types"
-	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
@@ -41,7 +40,7 @@ type networkAttachmentDefinitionValidator struct {
 
 func (v *networkAttachmentDefinitionValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       "network-attachment-definitions",
+		Names:      []string{"network-attachment-definitions"},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   v1.SchemeGroupVersion.Group,
 		APIVersion: v1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -25,7 +25,7 @@ type nodeValidator struct {
 
 func (v *nodeValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       "nodes",
+		Names:      []string{"nodes"},
 		Scope:      admissionregv1.ClusterScope,
 		APIGroup:   corev1.SchemeGroupVersion.Group,
 		APIVersion: corev1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -31,7 +31,7 @@ type pvcValidator struct {
 
 func (v *pvcValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       "persistentvolumeclaims",
+		Names:      []string{"persistentvolumeclaims"},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   corev1.SchemeGroupVersion.Group,
 		APIVersion: corev1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/pod/mutator.go
+++ b/pkg/webhook/resources/pod/mutator.go
@@ -44,7 +44,7 @@ type podMutator struct {
 
 func newResource(ops []admissionregv1.OperationType) types.Resource {
 	return types.Resource{
-		Name:           string(corev1.ResourcePods),
+		Names:          []string{string(corev1.ResourcePods)},
 		Scope:          admissionregv1.NamespacedScope,
 		APIGroup:       corev1.SchemeGroupVersion.Group,
 		APIVersion:     corev1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/restore/validator.go
+++ b/pkg/webhook/resources/restore/validator.go
@@ -45,7 +45,7 @@ type restoreValidator struct {
 
 func (v *restoreValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       v1beta1.VirtualMachineRestoreResourceName,
+		Names:      []string{v1beta1.VirtualMachineRestoreResourceName},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   v1beta1.SchemeGroupVersion.Group,
 		APIVersion: v1beta1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -71,7 +71,7 @@ type settingValidator struct {
 
 func (v *settingValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       v1beta1.SettingResourceName,
+		Names:      []string{v1beta1.SettingResourceName},
 		Scope:      admissionregv1.ClusterScope,
 		APIGroup:   v1beta1.SchemeGroupVersion.Group,
 		APIVersion: v1beta1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/templateversion/mutator.go
+++ b/pkg/webhook/resources/templateversion/mutator.go
@@ -22,7 +22,7 @@ type templateVersionMutator struct {
 
 func newResource(ops []admissionregv1.OperationType) types.Resource {
 	return types.Resource{
-		Name:           v1beta1.VirtualMachineTemplateVersionResourceName,
+		Names:          []string{v1beta1.VirtualMachineTemplateVersionResourceName},
 		Scope:          admissionregv1.NamespacedScope,
 		APIGroup:       v1beta1.SchemeGroupVersion.Group,
 		APIVersion:     v1beta1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -33,7 +33,7 @@ type upgradeValidator struct {
 
 func (v *upgradeValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       v1beta1.UpgradeResourceName,
+		Names:      []string{v1beta1.UpgradeResourceName},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   v1beta1.SchemeGroupVersion.Group,
 		APIVersion: v1beta1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -31,7 +31,7 @@ type vmMutator struct {
 
 func (m *vmMutator) Resource() types.Resource {
 	return types.Resource{
-		Name:       "virtualmachines",
+		Names:      []string{"virtualmachines"},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   kubevirtv1.SchemeGroupVersion.Group,
 		APIVersion: kubevirtv1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -12,26 +12,32 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
-func NewValidator(pvcCache v1.PersistentVolumeClaimCache) types.Validator {
+func NewValidator(
+	pvcCache v1.PersistentVolumeClaimCache,
+	vmBackupCache ctlharvesterv1.VirtualMachineBackupCache,
+) types.Validator {
 	return &vmValidator{
-		pvcCache: pvcCache,
+		pvcCache:      pvcCache,
+		vmBackupCache: vmBackupCache,
 	}
 }
 
 type vmValidator struct {
 	types.DefaultValidator
-	pvcCache v1.PersistentVolumeClaimCache
+	pvcCache      v1.PersistentVolumeClaimCache
+	vmBackupCache ctlharvesterv1.VirtualMachineBackupCache
 }
 
 func (v *vmValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       "virtualmachines",
+		Names:      []string{"virtualmachines"},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   kubevirtv1.SchemeGroupVersion.Group,
 		APIVersion: kubevirtv1.SchemeGroupVersion.Version,

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
+	webhookutil "github.com/harvester/harvester/pkg/webhook/util"
 )
 
 func NewValidator(
@@ -37,7 +38,7 @@ type vmValidator struct {
 
 func (v *vmValidator) Resource() types.Resource {
 	return types.Resource{
-		Names:      []string{"virtualmachines"},
+		Names:      []string{"virtualmachines", "virtualmachines/status"},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   kubevirtv1.SchemeGroupVersion.Group,
 		APIVersion: kubevirtv1.SchemeGroupVersion.Version,
@@ -51,6 +52,9 @@ func (v *vmValidator) Resource() types.Resource {
 
 func (v *vmValidator) Create(request *types.Request, newObj runtime.Object) error {
 	vm := newObj.(*kubevirtv1.VirtualMachine)
+	if vm == nil {
+		return nil
+	}
 
 	if err := v.checkVMSpec(vm); err != nil {
 		return err
@@ -59,10 +63,30 @@ func (v *vmValidator) Create(request *types.Request, newObj runtime.Object) erro
 }
 
 func (v *vmValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
-	vm := newObj.(*kubevirtv1.VirtualMachine)
+	newVM := newObj.(*kubevirtv1.VirtualMachine)
+	if newVM == nil {
+		return nil
+	}
 
-	if err := v.checkVMSpec(vm); err != nil {
+	if err := v.checkVMSpec(newVM); err != nil {
 		return err
+	}
+
+	oldVM := oldObj.(*kubevirtv1.VirtualMachine)
+	if oldVM == nil {
+		return nil
+	}
+
+	// Prevent users to stop/restart VM when there is VMBackup in progress.
+	// KubeVirt send stop request or change running from true to false when users stop a VM.
+	// KubeVirt send restart request (stop and start combination request) when users restart a VM.
+	// Stop reference: https://github.com/kubevirt/kubevirt/blob/c9e87c4cb6292af33ccad8faa5fb9bf269c0fbf4/pkg/virt-api/rest/subresource.go#L508-L511
+	// Restart reference: https://github.com/kubevirt/kubevirt/blob/c9e87c4cb6292af33ccad8faa5fb9bf269c0fbf4/pkg/virt-api/rest/subresource.go#L260-L263
+	if (*oldVM.Spec.Running && !*newVM.Spec.Running) ||
+		(len(newVM.Status.StateChangeRequests) != 0 && newVM.Status.StateChangeRequests[0].Action == kubevirtv1.StopRequest) {
+		if err := v.checkVMBackup(newVM); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -79,9 +103,6 @@ func (v *vmValidator) checkVMSpec(vm *kubevirtv1.VirtualMachine) error {
 }
 
 func (v *vmValidator) checkVolumeClaimTemplatesAnnotation(vm *kubevirtv1.VirtualMachine) error {
-	if vm == nil {
-		return nil
-	}
 	volumeClaimTemplates, ok := vm.Annotations[util.AnnotationVolumeClaimTemplates]
 	if !ok || volumeClaimTemplates == "" {
 		return nil
@@ -99,9 +120,6 @@ func (v *vmValidator) checkVolumeClaimTemplatesAnnotation(vm *kubevirtv1.Virtual
 }
 
 func (v *vmValidator) checkOccupiedPVCs(vm *kubevirtv1.VirtualMachine) error {
-	if vm == nil {
-		return nil
-	}
 	vmID := ref.Construct(vm.Namespace, vm.Name)
 	for _, volume := range vm.Spec.Template.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
@@ -127,5 +145,14 @@ func (v *vmValidator) checkOccupiedPVCs(vm *kubevirtv1.VirtualMachine) error {
 		}
 	}
 
+	return nil
+}
+
+func (v *vmValidator) checkVMBackup(vm *kubevirtv1.VirtualMachine) error {
+	if exist, err := webhookutil.HasInProgressingVMBackupBySourceUID(v.vmBackupCache, string(vm.UID)); err != nil {
+		return werror.NewInternalError(err.Error())
+	} else if exist {
+		return werror.NewBadRequest(fmt.Sprintf("there is vmbackup in progress for vm %s/%s, please wait for the vmbackup or remove it before stop/restart the vm", vm.Namespace, vm.Name))
+	}
 	return nil
 }

--- a/pkg/webhook/resources/virtualmachineimage/validator.go
+++ b/pkg/webhook/resources/virtualmachineimage/validator.go
@@ -40,7 +40,7 @@ type virtualMachineImageValidator struct {
 
 func (v *virtualMachineImageValidator) Resource() types.Resource {
 	return types.Resource{
-		Name:       v1beta1.VirtualMachineImageResourceName,
+		Names:      []string{v1beta1.VirtualMachineImageResourceName},
 		Scope:      admissionregv1.NamespacedScope,
 		APIGroup:   v1beta1.SchemeGroupVersion.Group,
 		APIVersion: v1beta1.SchemeGroupVersion.Version,

--- a/pkg/webhook/server/mutation.go
+++ b/pkg/webhook/server/mutation.go
@@ -36,5 +36,5 @@ func addHandler(router *webhook.Router, admissionType string, admitter types.Adm
 	rsc := admitter.Resource()
 	kind := reflect.Indirect(reflect.ValueOf(rsc.ObjectType)).Type().Name()
 	router.Kind(kind).Group(rsc.APIGroup).Type(rsc.ObjectType).Handle(types.NewAdmissionHandler(admitter, admissionType, options))
-	logrus.Infof("add %s handler for %s.%s (%s)", admissionType, rsc.Name, rsc.APIGroup, kind)
+	logrus.Infof("add %s handler for %+v.%s (%s)", admissionType, rsc.Names, rsc.APIGroup, kind)
 }

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook"
 	"github.com/harvester/harvester/pkg/webhook/clients"
 	"github.com/harvester/harvester/pkg/webhook/config"
+	"github.com/harvester/harvester/pkg/webhook/indexeres"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
@@ -50,6 +51,10 @@ func New(ctx context.Context, restConfig *rest.Config, options *config.Options) 
 func (s *AdmissionWebhookServer) ListenAndServe() error {
 	clients, err := clients.New(s.context, s.restConfig, s.options.Threadiness)
 	if err != nil {
+		return err
+	}
+
+	if err = indexeres.RegisterIndexers(clients); err != nil {
 		return err
 	}
 
@@ -167,7 +172,7 @@ func (s *AdmissionWebhookServer) buildRules(resources []types.Resource) []v1.Rul
 			Rule: v1.Rule{
 				APIGroups:   []string{rsc.APIGroup},
 				APIVersions: []string{rsc.APIVersion},
-				Resources:   []string{rsc.Name},
+				Resources:   rsc.Names,
 				Scope:       &scope,
 			},
 		})

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -54,9 +54,7 @@ func (s *AdmissionWebhookServer) ListenAndServe() error {
 		return err
 	}
 
-	if err = indexeres.RegisterIndexers(clients); err != nil {
-		return err
-	}
+	indexeres.RegisterIndexers(clients)
 
 	validationHandler, validationResources, err := Validation(clients, s.options)
 	if err != nil {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -27,7 +27,9 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		network.NewValidator(clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache(), clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()),
 		persistentvolumeclaim.NewValidator(clients.Core.PersistentVolumeClaim().Cache(), clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()),
 		keypair.NewValidator(clients.HarvesterFactory.Harvesterhci().V1beta1().KeyPair().Cache()),
-		virtualmachine.NewValidator(clients.Core.PersistentVolumeClaim().Cache()),
+		virtualmachine.NewValidator(
+			clients.Core.PersistentVolumeClaim().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()),
 		virtualmachineimage.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
 			clients.Core.PersistentVolumeClaim().Cache(),

--- a/pkg/webhook/types/resource.go
+++ b/pkg/webhook/types/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Resource struct {
-	Name           string
+	Names          []string
 	Scope          admissionregv1.ScopeType
 	APIGroup       string
 	APIVersion     string
@@ -17,8 +17,13 @@ type Resource struct {
 }
 
 func (r Resource) Validate() error {
-	if r.Name == "" {
-		return errUndefined("Name")
+	if len(r.Names) == 0 {
+		return errUndefined("Names")
+	}
+	for _, name := range r.Names {
+		if name == "" {
+			return errUndefined("Names")
+		}
 	}
 	if r.Scope == "" {
 		return errUndefined("Scope")

--- a/pkg/webhook/util/filter.go
+++ b/pkg/webhook/util/filter.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	ctlbackup "github.com/harvester/harvester/pkg/controller/master/backup"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/webhook/indexeres"
+)
+
+func HasInProgressingVMBackupBySourceUID(cache ctlharvesterv1.VirtualMachineBackupCache, sourceUID string) (bool, error) {
+	vmBackups, err := cache.GetByIndex(indexeres.VMBackupBySourceUIDIndex, sourceUID)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	for _, vmBackup := range vmBackups {
+		if ctlbackup.IsBackupProgressing(vmBackup) || ctlbackup.GetVMBackupError(vmBackup) != nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
**Problem:**
If users stop/restart a VM when there is a processing backup for the VM, it may fail to create the backup.

**Solution:**
* Add webhook for VM to prevent users from stopping/restarting a VM if there is a processing backup.

**Related Issue:**
https://github.com/harvester/harvester/issues/1702

**Test plan:**

Stop/Restart a VM when there is a processing backup for it:
* Create a VM.
* Create a VMBackup for it.
* Before VMBackup is done, stop/restart the VM. Verify VM can't be stopped/restarted.
