### PR TITLE
Use nodename in promote script

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -34,13 +34,13 @@ data:
     {{`KUBECTL="/host/$(readlink /host/var/lib/rancher/rke2/bin)/kubectl"
 
     get_machine_from_node() {
-      $KUBECTL get node $HOSTNAME -o jsonpath='{.metadata.annotations.cluster\.x-k8s\.io/machine}'
+      $KUBECTL get node $HARVESTER_PROMOTE_NODE_NAME -o jsonpath='{.metadata.annotations.cluster\.x-k8s\.io/machine}'
     }
 
     CUSTOM_MACHINE=$(get_machine_from_node)
     until [ -n "$CUSTOM_MACHINE" ]
     do
-      echo Waiting for custom machine label of $HOSTNAME ...
+      echo Waiting for custom machine label of $HARVESTER_PROMOTE_NODE_NAME ...
       sleep 2
       CUSTOM_MACHINE=$(get_machine_from_node)
     done

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -473,6 +473,12 @@ func buildPromoteJob(namespace string, node *corev1.Node) *batchv1.Job {
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: pointer.BoolPtr(true),
 			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "HARVESTER_PROMOTE_NODE_NAME",
+					Value: node.Name,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This fixes promotion failure when a node's hostname is somehow changed.



**Related Issue:**

https://github.com/harvester/harvester/issues/1778

**Test plan:**
- Create a cluster that contains more than or equal to 3 nodes.
- 3 nodes should become control nodes. The role is `control-plane,etcd,master` in `kubectl get nodes` output.