### PR TITLE
Restore VM to specified namespace

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -26,7 +26,7 @@ var (
 	UIIndex                 = NewSetting("ui-index", DefaultDashboardUIURL)
 	UIPath                  = NewSetting("ui-path", "/usr/share/harvester/harvester")
 	UISource                = NewSetting("ui-source", "auto") // Options are 'auto', 'external' or 'bundled'
-	VolumeSnapshotClass     = NewSetting("volume-snapshot-class", "longhorn")
+	VolumeSnapshotClass     = NewSetting(VolumeSnapshotClassSettingName, "longhorn")
 	BackupTargetSet         = NewSetting(BackupTargetSettingName, InitBackupTargetToString())
 	UpgradableVersions      = NewSetting("upgradable-versions", "")
 	UpgradeCheckerEnabled   = NewSetting("upgrade-checker-enabled", "true")
@@ -55,6 +55,7 @@ const (
 	SSLCertificatesSettingName      = "ssl-certificates"
 	SSLParametersName               = "ssl-parameters"
 	VipPoolsConfigSettingName       = "vip-pools"
+	VolumeSnapshotClassSettingName  = "volume-snapshot-class"
 	DefaultDashboardUIURL           = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
 	SupportBundleImageName          = "support-bundle-image"
 )

--- a/pkg/webhook/clients/clients.go
+++ b/pkg/webhook/clients/clients.go
@@ -11,6 +11,7 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io"
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io"
+	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io"
 )
 
 type Clients struct {
@@ -19,6 +20,7 @@ type Clients struct {
 	HarvesterFactory *ctlharvesterv1.Factory
 	KubevirtFactory  *ctlkubevirtv1.Factory
 	CNIFactory       *ctlcniv1.Factory
+	SnapshotFactory  *ctlsnapshotv1.Factory
 }
 
 func New(ctx context.Context, rest *rest.Config, threadiness int) (*Clients, error) {
@@ -58,10 +60,20 @@ func New(ctx context.Context, rest *rest.Config, threadiness int) (*Clients, err
 		return nil, err
 	}
 
+	snapshotFactory, err := ctlsnapshotv1.NewFactoryFromConfigWithOptions(rest, clients.FactoryOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = snapshotFactory.Start(ctx, threadiness); err != nil {
+		return nil, err
+	}
+
 	return &Clients{
 		Clients:          *clients,
 		HarvesterFactory: harvesterFactory,
 		KubevirtFactory:  kubevirtFactory,
 		CNIFactory:       cniFactory,
+		SnapshotFactory:  snapshotFactory,
 	}, nil
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -43,6 +43,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		setting.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
+			clients.SnapshotFactory.Snapshot().V1beta1().VolumeSnapshotClass().Cache(),
 		),
 		templateversion.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate().Cache(),


### PR DESCRIPTION
**Problem:**
We can only restore VM to the original namespace. We would like to restore VM to another namespace.

**Solution:**
Create VolumeSnapshot and VolumeSnapshotContent in another namespace to support the feature.

**Related Issue:**
https://github.com/harvester/harvester/issues/1027

**Test plan:**

Restore VM in another namespace.
* Create a VM `vm` in namespace `default`.
* Create a VMBackup `default-vm-backup` for it.
* Create a new namepsace `new-ns`.
* Create a VMRestore `restore-default-vm-backup-to-new-ns` in `new-ns` namespace based on the VMBackup `default-vm-backup`.
```
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineRestore
metadata:
  name: restore-default-vm-backup-to-new-ns
  namespace: new-ns
spec:
  newVM: true
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: new-ns-vm
  virtualMachineBackupName: default-vm-backup
  virtualMachineBackupNamespace: default
```
* A new VM in `new-ns` namespace should be created.