### PR TITLE
add webhook for support-bundle-image

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -45,6 +45,7 @@ type validateSettingFunc func(setting *v1beta1.Setting) error
 var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.HttpProxySettingName:            validateHTTPProxy,
 	settings.VMForceResetPolicySettingName:   validateVMForceResetPolicy,
+	settings.SupportBundleImageName:          validateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName: validateSupportBundleTimeout,
 	settings.OvercommitConfigSettingName:     validateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:       validateVipPoolsConfig,
@@ -416,4 +417,20 @@ func hasVMBackupInCreatingOrDeletingProgress(vmBackups []*v1beta1.VirtualMachine
 		}
 	}
 	return false
+}
+
+func validateSupportBundleImage(setting *v1beta1.Setting) error {
+	if setting.Value == "" {
+		return nil
+	}
+
+	var image settings.Image
+	err := json.Unmarshal([]byte(setting.Value), &image)
+	if err != nil {
+		return err
+	}
+	if image.Repository == "" || image.Tag == "" || image.ImagePullPolicy == "" {
+		return fmt.Errorf("image field can't be blank")
+	}
+	return nil
 }


### PR DESCRIPTION
**Problem:**
We didn't validate support-bundle-image setting value.

**Solution:**
Add webhook for it.

**Related Issue:**
https://github.com/harvester/harvester/issues/1727

**Test plan:**
1. Empty value should pass.
2. Non-JSON value should fail.
3. Value with any blank field (repository, tag, or imagePullPolicy) should fail.
4. `'{"repository": "rancher/support-bundle-kit","tag":"v0.0.5","imagePullPolicy":"IfNotPresent"}'` should pass.