### PR TITLE
Add the ability to apply resources during upgrade

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -18,3 +18,4 @@ RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v0.45.0/vir
 COPY upgrade_node.sh /usr/local/bin/
 COPY upgrade_manifests.sh /usr/local/bin/
 COPY lib.sh /usr/local/bin
+COPY extra_manifests /usr/local/share/extra_manifests

--- a/package/upgrade/extra_manifests/longhorn-settings-default-data-path.yaml
+++ b/package/upgrade/extra_manifests/longhorn-settings-default-data-path.yaml
@@ -1,0 +1,6 @@
+apiVersion: longhorn.io/v1beta1
+kind: Setting
+metadata:
+  name: default-data-path
+  namespace: longhorn-system
+value: /var/lib/harvester/defaultdisk

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -36,7 +36,7 @@ upgrade_rancher()
   if [ "$RANCHER_CURRENT_VERSION" = "$REPO_RANCHER_VERSION" ]; then
     echo "Skip update Rancher. The version is already $RANCHER_CURRENT_VERSION"
     return
-  fi 
+  fi
 
   REPO_RANCHER_VERSION=$REPO_RANCHER_VERSION yq -e e '.rancherImageTag = strenv(REPO_RANCHER_VERSION)' values.yaml -i
   ./helm upgrade rancher ./*.tgz --namespace cattle-system -f values.yaml
@@ -107,9 +107,19 @@ EOF
   kubectl patch managedcharts.management.cattle.io rancher-monitoring -n fleet-local --patch-file ./rancher-monitoring.yaml --type merge
 }
 
+apply_extra_manifests()
+{
+    shopt -s nullglob
+    for manifest in /usr/local/share/extra_manifests/*.yaml; do
+        kubectl apply -f $manifest
+    done
+    shopt -u nullglob
+}
+
 wait_repo
 detect_repo
 upgrade_rancher
 upgrade_harvester_cluster_repo
 upgrade_harvester
 upgrade_monitoring
+apply_extra_manifests


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Sometimes during the upgrade process, we need to modify some resources that are not managed by the Helm chart, such as custom resources.

For instance, we need to update the Longhorn setting `default-data-path` from the default to `/var/lib/harvester/defaultdisk` for feature https://github.com/harvester/harvester/issues/1728, so that Nodes joining the cluster would have `/var/lib/harvester/defaultdisk` as the default disk.

**Solution:**
Packaging the resources into the `harvester-upgrade` container image, then during the upgrade process, deploy these resources by `kubectl apply`.

**Related Issue:**
- https://github.com/harvester/harvester/issues/1728
- https://github.com/harvester/harvester-installer/pull/217

**Test plan:**
1. Create a 1.0.0 cluster
2. Upgrade it using `master` branch code
3. Verify Longhorn setting `default-data-disk` has been updated to `/var/lib/harvester/defaultdisk`
    ```
    # kubectl get -n longhorn-system setting.longhorn.io default-data-path
    NAME                VALUE                            AGE
    default-data-path   /var/lib/harvester/defaultdisk   62m
    ```

**Dependencies**
- Need to wait for https://github.com/harvester/harvester-installer/pull/217
