### PR TITLE
fix: mounting cloud-init user data and network data via secrets

### DIFF
--- a/pkg/builder/cloudinit.go
+++ b/pkg/builder/cloudinit.go
@@ -42,7 +42,7 @@ func (v *VMBuilder) CloudInit(diskName string, cloudInitSource CloudInitSource) 
 			}
 		}
 		if cloudInitSource.NetworkDataSecretName != "" {
-			volume.VolumeSource.CloudInitNoCloud.UserDataSecretRef = &corev1.LocalObjectReference{
+			volume.VolumeSource.CloudInitNoCloud.NetworkDataSecretRef = &corev1.LocalObjectReference{
 				Name: cloudInitSource.NetworkDataSecretName,
 			}
 		}
@@ -64,7 +64,7 @@ func (v *VMBuilder) CloudInit(diskName string, cloudInitSource CloudInitSource) 
 			}
 		}
 		if cloudInitSource.NetworkDataSecretName != "" {
-			volume.VolumeSource.CloudInitConfigDrive.UserDataSecretRef = &corev1.LocalObjectReference{
+			volume.VolumeSource.CloudInitConfigDrive.NetworkDataSecretRef = &corev1.LocalObjectReference{
 				Name: cloudInitSource.NetworkDataSecretName,
 			}
 		}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Fix inconsistency with mounting network and user data via Kubernetes secret. Network data was overwriting user data leaving network data empty and causing user data to function incorrectly. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Fix the mappings with the cloud-init data.

**Related Issue:**
https://github.com/harvester/harvester/issues/1878

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
