### PR TITLE
Ignore "timestamp: nil Timestamp" error in VMBackup

### DIFF
--- a/pkg/controller/master/backup/backup_status.go
+++ b/pkg/controller/master/backup/backup_status.go
@@ -33,6 +33,13 @@ func (h *Handler) updateConditions(vmBackup *harvesterv1.VirtualMachineBackup) e
 		}
 
 		if vb.Error != nil {
+			// LH CSI shows "timestamp: nil Timestamp" error before LH backup.SnapshotCreated has a value.
+			// However, this is a tempoary error, so we ignore it here.
+			// We will remove this after LH issue 3392 is resolved.
+			// https://github.com/longhorn/longhorn/issues/3392
+			if vb.Error.Message != nil && strings.Contains(*vb.Error.Message, "timestamp: nil Timestamp") {
+				continue
+			}
 			errorMessage = fmt.Sprintf("VolumeSnapshot %s in error state", *vb.Name)
 			break
 		}


### PR DESCRIPTION
**Problem:**
VMBackup shows an error message `timestamp: nil Timestamp` from VolumeSnapshot, but it's temporary. It will be removed after `backup.snapshotCreatedAt` has a non-empty value. Also, the VMBackup is healthy and can be used to restore an existing/ new VM.

**Solution:**
Ignore the `timestamp: nil Timestamp` error message, so users don't see the weird behavior.

**Related Issue:**
https://github.com/harvester/harvester/issues/1650
https://github.com/longhorn/longhorn/issues/3392

**Test plan:**
1. Create a VM.
2. Create a VMBackup for it.
3. UI should not show Error status before VMBackup is Ready.
