### PR TITLE
Revise the way to promote nodes

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -39,6 +39,19 @@ data:
       sleep 2
     done
 
+    PLAN_SECRET="${CUSTOM_MACHINE}-machine-plan"
+    until $KUBECTL get secret $PLAN_SECRET -n fleet-local &> /dev/null
+    do
+      echo Waiting for machine plan of $CUSTOM_MACHINE...
+      sleep 2
+    done
+
+    until $KUBECTL get rkebootstraps.rke.cattle.io "${CUSTOM_MACHINE}" -n fleet-local &> /dev/null
+    do
+      echo Waiting for bootstrap object of $CUSTOM_MACHINE...
+      sleep 2
+    done
+
     VIP=$($KUBECTL get configmap vip -n harvester-system -o=jsonpath='{.data.ip}')
     cat > /host/etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml <<EOF
     cni: multus,canal
@@ -49,7 +62,11 @@ data:
       - $VIP
     EOF
 
-    $KUBECTL label -n fleet-local machines.cluster.x-k8s.io $CUSTOM_MACHINE rke.cattle.io/control-plane-role=true rke.cattle.io/etcd-role=true
+    # For how to promote nodes, see: https://github.com/rancher/rancher/issues/36480#issuecomment-1039253499
+    ROLE_LABELS="rke.cattle.io/control-plane-role=true rke.cattle.io/etcd-role=true"
+    $KUBECTL label -n fleet-local machines.cluster.x-k8s.io $CUSTOM_MACHINE $ROLE_LABELS
+    $KUBECTL label -n fleet-local secret $PLAN_SECRET $ROLE_LABELS
+    $KUBECTL label -n fleet-local rkebootstraps.rke.cattle.io $CUSTOM_MACHINE $ROLE_LABELS
 
     while true
     do


### PR DESCRIPTION
Rancher removes the support to promote agents by labeling
CAPI machines. Use the new suggested way to promote agent
nodes:
- Adding role labels to machine plan secrets.
- Adding role labels to bootstrap objects.
- Still Adding role labels to CAPI machines.

**Related Issue:**
https://github.com/harvester/harvester/issues/1920

**Test plan:**

- For reviewer: this PR needs to be tested with https://github.com/harvester/harvester-installer/pull/229

Steps to test:
- Create a harvester cluster that has at least 3 nodes.
- Exact 3 nodes (Include the first server) will have server roles (`control-plane,etcd,master`):
```
╰─$ kubectl get nodes
NAME    STATUS   ROLES                       AGE    VERSION
node1   Ready    control-plane,etcd,master   130m   v1.21.7+rke2r1
node2   Ready    control-plane,etcd,master   125m   v1.21.7+rke2r1
node3   Ready    control-plane,etcd,master   125m   v1.21.7+rke2r1
node4   Ready    <none>                      125m   v1.21.7+rke2r1
```

<!-- Make sure tests pass on the Circle CI. -->
