### PR TITLE
Remove upgrade repo VM and image when upgrade is done

### DIFF
--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -35,6 +35,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	clusters := management.ProvisioningFactory.Provisioning().V1().Cluster()
 	machines := management.ClusterFactory.Cluster().V1alpha4().Machine()
 	secrets := management.CoreFactory.Core().V1().Secret()
+	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
 
 	controller := &upgradeHandler{
 		ctx:           ctx,
@@ -50,7 +51,9 @@ func Register(ctx context.Context, management *config.Management, options config
 		vmImageClient: vmImages,
 		vmImageCache:  vmImages.Cache(),
 		vmClient:      vms,
+		vmCache:       vms.Cache(),
 		serviceClient: services,
+		pvcClient:     pvcs,
 		clusterClient: clusters,
 		clusterCache:  clusters.Cache(),
 	}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Upgrade repo VM and image are not removed after finishing an upgrade.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

When an upgrade is done:
- Delete the upgrade repo VM.
- Remove the upgrade repo image. This can't be deleted immediately because upgrade repo VM's PVC still has reference to the image and Harvester webhook will forbid the deleting. We use the following approaches:
  - If PVC of the upgrade repo VM exists, we add the PVC as the OwnerReference to the repo image. Once the repo VM is deleted and VM's PVC is deleted, the repo image will be garbage collected.
  - If PVC of the upgrade repo VM doesn't exist, we delete the image immediately.


**Related Issue:**
https://github.com/harvester/harvester/issues/1855

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

For reviewer:
- Create a cluster. Either from master or 1.0.0 ISO.
- Build the backend and replace the harvester pod.
- This part is tricky, we need to tag a current-version harvester-upgrade image:
  - Get current version:
  ```
  $ kubectl get settings server-version
  NAME             VALUE
  server-version   2ff5a0cb-dirty
  ```
  - **On each node**
  ```
  $ docker tag rancher/harvester-upgrade:master-head rancher/harvester-upgrade:2ff5a0cb-dirty
  ```


- Create a version:
```
$ cat version.yaml
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: 1.0.2
  namespace: harvester-system
spec:
  isoChecksum: xxx                              <-- the build ISO sha512 checksum
  isoURL: http://10.10.0.1/harvester/harvester.iso      <-- the build ISO
  minUpgradableVersion: 0.3.0
  releaseDate: "20211231"
  tags:
  - dev                 <--- `dev` tag is important
  - test

 $ kubectl create -f version.yaml
```

- Create an upgrade:
```
$ cat upgrade.yaml
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  generateName: hvst-upgrade-
  namespace: harvester-system
spec:
  version: "1.0.2"

$ kubectl create -f upgrade.yaml
```

- After upgrade is done, there should be no VM and image exists in `harvester-system` namespace.