### PR TITLE
Add missing package for webhook container image

### DIFF
--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -1,7 +1,7 @@
 FROM registry.suse.com/bci/bci-base:15.3
 
 RUN zypper -n rm container-suseconnect && \
-    zypper -n install curl && \
+    zypper -n install curl nfs-client && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 
 ARG ARCH=amd64


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The container for running webhook is missing package "nfs-client", causing the validation of NFS backup target to fail.

**Solution:**
Add package "nfs-client".

**Related Issue:**
- https://github.com/harvester/harvester/issues/1952

**Test plan:**
1. Set up NFS backup target and make sure no error is reported.
