### PR TITLE
Bump windows vmdp driver image

### DIFF
--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -330,7 +330,7 @@ spec:
               claimName: pvc-rootdisk
             name: rootdisk
           - containerDisk:
-              image: registry.suse.com/harvester-beta/vmdp:latest
+              image: registry.suse.com/suse/vmdp/vmdp:2.5.3
               imagePullPolicy: IfNotPresent
             name: virtio-container-disk
 `


### PR DESCRIPTION
Bump Windows VMDP driver image due to old image will encounter the `not verified digital signature` issue.
![image](https://user-images.githubusercontent.com/4569037/156563262-7ec25cbe-1e36-4840-84c0-656f52004d41.png)
Related Issue: https://github.com/harvester/harvester/issues/1767
Related PR: https://github.com/harvester/harvester-installer/pull/238