### PR TITLE
Dynamic Chart version

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -5,6 +5,8 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 COMMIT=$(git rev-parse --short HEAD)
+COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMIT_BRANCH_FORMATTED=$(echo "${COMMIT_BRANCH}" | sed -E 's/[^a-zA-Z0-9]+/-/g')
 GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
@@ -12,6 +14,20 @@ if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
 else
     VERSION="${COMMIT}${DIRTY}"
 fi
+
+# Chart tag.
+if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    IMAGE_PUSH_TAG="${GIT_TAG}"
+    APP_VERSION="${GIT_TAG}"
+    CHART_VERSION="${GIT_TAG}"
+else
+    IMAGE_PUSH_TAG="${COMMIT_BRANCH}-head"
+    APP_VERSION="${COMMIT_BRANCH}-${COMMIT}${DIRTY}"
+    CHART_VERSION="v0.0.0-${COMMIT_BRANCH_FORMATTED}-${COMMIT}${DIRTY}"
+fi
+
+# Drop the v prefix for Chart Version to follow existing pattern.
+CHART_VERSION="$(echo ${CHART_VERSION} | sed -E 's/^v//')"
 
 if [ -z "$ARCH" ]; then
     ARCH=$(go env GOHOSTARCH)
@@ -25,3 +41,12 @@ REPO=${REPO:-rancher}
 if echo $TAG | grep -q dirty; then
     TAG=dev
 fi
+
+echo "ARCH: $ARCH"
+echo "VERSION: $VERSION"
+echo "CHART_VERSION: $CHART_VERSION"
+echo "APP_VERSION: $APP_VERSION"
+echo "SUFFIX: $SUFFIX"
+echo "REPO: $REPO"
+echo "TAG: $TAG"
+echo "IMAGE_PUSH_TAG: $IMAGE_PUSH_TAG"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
1. If not a harvester-installer release, the default version of harvester-installer is always `master`. 
each iso build on different branches has the same name.
1. If not a harvester release, the default image tag of harvester chart is always `master-head`. 
1. If not a harvester release, the default chart version of harvester chart is always `0.0.0-dev`. 
1. If not a harvester release, the default chart  appVersion of harvester chart is always `v0.0.0-dev`. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. In harvester, build chart version, image tag in `script/version`
1. In harvester-installer, try to use `DRONE_BRANCH` as the iso version
1. In harvester-installer, Add a script `patch-harvester` to patch harvester chart version and harvester image tag uses the harvester code info.

**Related Issue:**
https://github.com/harvester/harvester/issues/1817

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

**Except output of script version**
1. master branch
```bash
ARCH: amd64
VERSION: 4ddd3623
CHART_VERSION: 0.0.0-master-4ddd3623
APP_VERSION: master-4ddd3623
SUFFIX: -amd64
REPO: rancher
TAG: 4ddd3623-amd64
IMAGE_PUSH_TAG: master-head
```

2.  v1.0 branch + not release 
```bash
ARCH: amd64
VERSION: 4ddd3623
CHART_VERSION: 0.0.0-v1-0-4ddd3623
APP_VERSION: v1.0-4ddd3623
SUFFIX: -amd64
REPO: rancher
TAG: 4ddd3623-amd64
IMAGE_PUSH_TAG: v1.0-head
```

3. v1.0 branch + release
```bash
ARCH: amd64
VERSION: v1.0.1
CHART_VERSION: 1.0.1
APP_VERSION: v1.0.1
SUFFIX: -amd64
REPO: rancher
TAG: v1.0.1-amd64
IMAGE_PUSH_TAG: v1.0.1
```