### PR TITLE
bump kubevirt to 0.49.0-2

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -27,7 +27,7 @@ kubevirt-operator:
     operator:
       image:
         repository: registry.suse.com/harvester-beta/virt-operator
-        tag: &kubevirtVersion 0.49.0-1
+        tag: &kubevirtVersion 0.49.0-2
     ## The following images are placeholder for images in use.
     ## They are not used by the kubevirt-operator chart.
     controller:


### PR DESCRIPTION
**Problem:**
Stop a VM shows a temporary failure message.

**Solution:**
Bump KubeVirt to 0.49.0-2 to include https://github.com/kubevirt/kubevirt/pull/7340 change.

**Related Issue:**
https://github.com/harvester/harvester/issues/1987

**Test plan:**

1. Create a VM with `runStrategy: RunStrategyAlways`.
2. Stop the VM.
3. Check there is no `Failure attempting to delete VMI: <nil>` in VM status.