### PR TITLE
Upgrade: allow adding version-specific changes to ManagedCharts

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -19,3 +19,4 @@ COPY upgrade_node.sh /usr/local/bin/
 COPY upgrade_manifests.sh /usr/local/bin/
 COPY lib.sh /usr/local/bin
 COPY extra_manifests /usr/local/share/extra_manifests
+COPY migrations /usr/local/share/migrations

--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -1,5 +1,5 @@
-
-UPGRADE_REPO_URL=http://upgrade-repo-$HARVESTER_UPGRADE_NAME.harvester-system/harvester-iso
+UPGRADE_NAMESPACE="harvester-system"
+UPGRADE_REPO_URL=http://upgrade-repo-$HARVESTER_UPGRADE_NAME.$UPGRADE_NAMESPACE/harvester-iso
 UPGRADE_REPO_RELEASE_FILE="$UPGRADE_REPO_URL/harvester-release.yaml"
 UPGRADE_REPO_SQUASHFS_IMAGE="$UPGRADE_REPO_URL/rootfs.squashfs"
 UPGRADE_REPO_BUNDLE_ROOT="$UPGRADE_REPO_URL/bundle"
@@ -88,4 +88,11 @@ download_image_archives_from_repo() {
     done
   
   rm -f $metadata
+}
+
+detect_upgrade()
+{
+  upgrade_obj=$(kubectl get upgrades.harvesterhci.io $HARVESTER_UPGRADE_NAME -n $UPGRADE_NAMESPACE -o yaml)
+
+  UPGRADE_PREVIOUS_VERSION=$(echo "$upgrade_obj" | yq e .status.previousVersion -)
 }

--- a/package/upgrade/migrations/README.md
+++ b/package/upgrade/migrations/README.md
@@ -1,0 +1,15 @@
+The directory contains drop-ins to fix things when upgrading from a previous version. 
+
+# `./managed_charts/`
+
+Say you need to do something to a ManagedChart if the previous version is `v1.0.0`.
+You can create a file `v1.0.0.sh` in `./managed_charts/` directory to apply the fixes you need.
+
+If the upgrade_manifests.sh script detects the system is upgraded from `v1.0.0`, it will call the script with:
+
+```
+v1.0.0.sh <chart_name> <chart_manifest>
+```
+
+- The `<chart_name>` could be `harvester`, `harvester-crd`, `rancher-monitoring`, etc.
+- The `<chart_manifest>` is the manifest file that contains the current managed chart dump.

--- a/package/upgrade/migrations/managed_charts/v1.0.0.sh
+++ b/package/upgrade/migrations/managed_charts/v1.0.0.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+remove_vip_config()
+{
+  # VIP interface isn't needed after kube-vip v0.4.1 (https://github.com/harvester/harvester-installer/pull/216)
+  yq e 'del(.spec.values.kube-vip.config)' $CHART_MANIFEST -i
+}
+
+
+add_longhorn_settings()
+{
+  # Add config "DataDisk" to specify the default Longhorn partition (https://github.com/harvester/harvester-installer/pull/217)
+  yq e '.spec.values.defaultDataPath.defaultSettings.defaultDataPath = "/var/lib/harvester/defaultdisk"' $CHART_MANIFEST -i
+}
+
+case $CHART_NAME in
+  harvester)
+    remove_vip_config
+    add_longhorn_settings
+    ;;
+esac

--- a/package/upgrade/migrations/managed_charts/v1.0.0.sh
+++ b/package/upgrade/migrations/managed_charts/v1.0.0.sh
@@ -13,7 +13,7 @@ remove_vip_config()
 add_longhorn_settings()
 {
   # Add config "DataDisk" to specify the default Longhorn partition (https://github.com/harvester/harvester-installer/pull/217)
-  yq e '.spec.values.defaultDataPath.defaultSettings.defaultDataPath = "/var/lib/harvester/defaultdisk"' $CHART_MANIFEST -i
+  yq e '.spec.values.longhorn.defaultSettings.defaultDataPath = "/var/lib/harvester/defaultdisk"' $CHART_MANIFEST -i
 }
 
 case $CHART_NAME in


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Sometimes when we upgrade from a previous version, we need to alter `values` in ManagedCharts.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Provide a hook mechanism to allow changing values.

Say you need to do something to a ManagedChart if the previous version is `v1.0.0`.
You can create a file `v1.0.0.sh` in `./managed_charts/` directory to apply the fixes you need.

If the upgrade_manifests.sh script detects the system is upgraded from `v1.0.0`, it will call the script with:

```
v1.0.0.sh <chart_name> <chart_manifest>
```

- The `<chart_name>` could be `harvester`, `harvester-crd`, `rancher-monitoring`, etc.
- The `<chart_manifest>` is the manifest file that contains the current managed chart dump.



**Related Issue:**
https://github.com/harvester/harvester/issues/1810

**Test plan:**
- Upgrade from v1.0.0 to master-head.
- Dump the harvester ManagedChart, there should be no changes:
  - `spec.values.kube-vip.config` field is removed.
  - `.spec.values.longhorn.defaultSettings.defaultDataPath` should be `"/var/lib/harvester/defaultdisk"`.