### PR TITLE
Don't compare upgrade to image to determine an update

### DIFF
--- a/pkg/controller/master/upgrade/image_controller.go
+++ b/pkg/controller/master/upgrade/image_controller.go
@@ -44,7 +44,7 @@ func (h *vmImageHandler) OnChanged(key string, image *harvesterv1.VirtualMachine
 		return image, nil
 	}
 
-	if !reflect.DeepEqual(toUpdate, image) {
+	if !reflect.DeepEqual(toUpdate, upgrade) {
 		_, err := h.upgradeClient.Update(toUpdate)
 		return image, err
 	}


### PR DESCRIPTION


**Problem:**
Wrong comparision between upgrade and image. 

**Solution:**
Should compare the old and the new upgrade object instead

**Related Issue:**
#1861 

**Test plan:**
