### PR TITLE
Update kube-vip image version

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -429,7 +429,7 @@ kube-vip:
   enabled: false
   image:
     repository: ghcr.io/kube-vip/kube-vip
-    tag: v0.4.1
+    tag: v0.4.2
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Related Issue:** https://github.com/harvester/harvester/issues/2033

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Spin up Harvester with v1.0.1 rc1
- Enable VLAN with default network interface `harvester-mgmt`
- The kube-vip pod will be crash and restart. Execute `kubectl logs -p -n harvester-system <kube-vip-pod>` to see the log like that
```
time="2022-03-18T02:42:28Z" level=fatal msg="crash: default route deleted and the default interface may be invalid"
```
- Disable VLAN. The kube-vip pod will be crash and restart