### PR TITLE
version script: unset the DIRTY variable because it might be set

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+unset DIRTY
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"
 fi


### PR DESCRIPTION
The `version` script is [sourced by harvester-installer](https://github.com/harvester/harvester-installer/blob/ededb753e24b2b345c7643da2a66b9912cbbf5c8/scripts/package-harvester-os#L11-L15) and if harvester-installer repo is dirty, harvester repo will also
be treated as dirty. Unset the DIRTY variable to avoid this.


