### PR TITLE
Add node exporter limit migration

### DIFF
--- a/package/upgrade/migrations/managed_charts/v1.0.0.sh
+++ b/package/upgrade/migrations/managed_charts/v1.0.0.sh
@@ -16,9 +16,21 @@ add_longhorn_settings()
   yq e '.spec.values.longhorn.defaultSettings.defaultDataPath = "/var/lib/harvester/defaultdisk"' $CHART_MANIFEST -i
 }
 
+adjust_prometheus_resources()
+{
+  # Increate prometheus pod limit and request (https://github.com/harvester/harvester-installer/pull/240)
+  yq e '.spec.values.prometheus.prometheusSpec.resources = {"limits": {"cpu": "1000m", "memory": "2500Mi"}, "requests": {"cpu": "750m", "memory": "1750Mi"}}' $CHART_MANIFEST -i
+
+  # Increase limits.memory (https://github.com/harvester/harvester-installer/pull/250)
+  yq e '.spec.values.prometheus-node-exporter.resources = {"limits": {"cpu": "200m", "memory": "180Mi"}, "requests": {"cpu": "100m", "memory": "30Mi"}}' $CHART_MANIFEST -i
+}
+
 case $CHART_NAME in
   harvester)
     remove_vip_config
     add_longhorn_settings
+    ;;
+  rancher-monitoring)
+    adjust_prometheus_resources
     ;;
 esac


### PR DESCRIPTION
The node exporter limit is changed in https://github.com/harvester/harvester-installer/pull/250, this PR makes sure the values are also applied when upgrading from v1.0.0.

**Test plan**
<!-- Make sure tests pass on the Circle CI. -->
- Perform an upgrade
- Check ManagedChart `rancher-monitoring`, values should reflect:
```
$ kubectl get managedchart rancher-monitoring -n fleet-local -ojsonpath="{.spec.values.prometheus-node-exporter}" | jq
{
  "resources": {
    "limits": {
      "cpu": "200m",
      "memory": "180Mi"           <-- previously, it's `50Mi`
    },
    "requests": {
      "cpu": "100m",
      "memory": "30Mi"
    }
  }
}
```

```
╰─$  kubectl get managedchart rancher-monitoring -n fleet-local -ojsonpath="{.spec.values.prometheus.prometheusSpec.resources}" | jq

{
  "limits": {
    "cpu": "1000m",
    "memory": "2500Mi"
  },
  "requests": {
    "cpu": "750m",
    "memory": "1750Mi"
  }
}
```

- Check `prometheus-rancher-monitoring-prometheus-0` pod and `rancher-monitoring-prometheus-node-exporter-xxx` pods, their limit should change too.