### PR TITLE
change to runStrategy: Manual by default

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -6,7 +6,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
@@ -46,7 +45,7 @@ func NewVMBuilder(creator string) *VMBuilder {
 		Labels:       vmLabels,
 		Annotations:  map[string]string{},
 	}
-	running := pointer.BoolPtr(false)
+	runStrategy := kubevirtv1.RunStrategyHalted
 	cpu := &kubevirtv1.CPU{
 		Cores: defaultVMCPUCores,
 	}
@@ -78,8 +77,8 @@ func NewVMBuilder(creator string) *VMBuilder {
 	vm := &kubevirtv1.VirtualMachine{
 		ObjectMeta: objectMeta,
 		Spec: kubevirtv1.VirtualMachineSpec{
-			Running:  running,
-			Template: template,
+			RunStrategy: &runStrategy,
+			Template:    template,
 		},
 	}
 	return &VMBuilder{
@@ -198,7 +197,11 @@ func (v *VMBuilder) PodAntiAffinity(podAffinityTerm corev1.PodAffinityTerm, soft
 }
 
 func (v *VMBuilder) Run(start bool) *VMBuilder {
-	v.VirtualMachine.Spec.Running = pointer.BoolPtr(start)
+	runStrategy := kubevirtv1.RunStrategyHalted
+	if start {
+		runStrategy = kubevirtv1.RunStrategyAlways
+	}
+	v.VirtualMachine.Spec.RunStrategy = &runStrategy
 	return v
 }
 

--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -151,7 +151,7 @@ spec:
             }
           }]
     spec:
-      running: true
+      runStrategy: Manual
       template:
         spec:
           evictionStrategy: LiveMigrate
@@ -216,7 +216,7 @@ spec:
             }
           }]
     spec:
-      running: true
+      runStrategy: Manual
       template:
         spec:
           evictionStrategy: LiveMigrate
@@ -287,7 +287,7 @@ spec:
             }
           }]
     spec:
-      running: true
+      runStrategy: Manual
       template:
         spec:
           evictionStrategy: LiveMigrate


### PR DESCRIPTION
runStrategy: Manual is more close to common hypervisor's behavior
restore to new will start with runStrategy: Manual

depends:
https://github.com/harvester/harvester/pull/1963
https://github.com/harvester/harvester/pull/2050
https://github.com/harvester/dashboard/pull/271
still need harvester template PR for "acpi enable by default"
still need dashboard template PR for "acpi enable by default"
still need dashboard PR for "default runStrategy: Manual in UI"
still need dashboard PR for "Start virtual machine on creation"

Signed-off-by: Date Huang <date.huang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
https://github.com/harvester/harvester/issues/2060

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**
https://github.com/harvester/harvester/issues/2060

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
please refer test plan in https://github.com/harvester/harvester/issues/2060
