### PR TITLE
Upgrade: increase jobs retention time to 7 days

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -20,7 +20,8 @@ const (
 	labelArch               = "kubernetes.io/arch"
 	labelCriticalAddonsOnly = "CriticalAddonsOnly"
 
-	defaultTTLSecondsAfterFinished = 1200
+	// keep jobs for 7 days
+	defaultTTLSecondsAfterFinished = 604800
 )
 
 func setNodeUpgradeStatus(upgrade *harvesterv1.Upgrade, nodeName string, state, reason, message string) {


### PR DESCRIPTION
**Problem:**
Upgrade jobs are gone after 20 minutes. Sometimes it's hard to debug an upgrade.

**Solution:**
Increase it to 7 days.

**Related Issue:**
Partially address:
https://github.com/harvester/harvester/issues/1926


