### PR TITLE
bump kube-vip 03/25 main

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -429,7 +429,7 @@ kube-vip:
   enabled: false
   image:
     repository: ghcr.io/kube-vip/kube-vip
-    tag: v0.4.2
+    tag: main
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
 


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/1985

Bump the kube-vip main version into master-head
