### PR TITLE
Upgrade: Preload image again with new harvester-upgrade image

### DIFF
--- a/package/upgrade/migrations/upgrade_manifests/v1.0.0/pre-hook.sh
+++ b/package/upgrade/migrations/upgrade_manifests/v1.0.0/pre-hook.sh
@@ -1,0 +1,78 @@
+#!/bin/bash -e
+
+prepare_plan_manifest=$(mktemp --suffix=.yaml)
+plan_name=${HARVESTER_UPGRADE_NAME}-prepare-again
+plan_version=${HARVESTER_UPGRADE_NAME}
+
+cat > $prepare_plan_manifest <<EOF
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: ${plan_name}
+  namespace: cattle-system
+spec:
+  concurrency: 2
+  nodeSelector:
+    matchLabels:
+      harvesterhci.io/managed: "true"
+  serviceAccountName: system-upgrade-controller
+  tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - effect: NoSchedule
+    key: kubevirt.io/drain
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+  - effect: NoSchedule
+    key: kubernetes.io/arch
+    operator: Equal
+    value: amd64
+  - effect: NoSchedule
+    key: kubernetes.io/arch
+    operator: Equal
+    value: arm64
+  - effect: NoSchedule
+    key: kubernetes.io/arch
+    operator: Equal
+    value: arm
+  upgrade:
+    args:
+    - prepare
+    command:
+    - upgrade_node.sh
+    envs:
+    - name: HARVESTER_UPGRADE_NAME
+      value: ${HARVESTER_UPGRADE_NAME}
+    image: rancher/harvester-upgrade:${REPO_HARVESTER_VERSION}
+  version: ${plan_version}
+EOF
+
+echo "Creating plan $plan_name to preload images again..."
+kubectl create -f $prepare_plan_manifest
+
+# Wait for all nodes complete
+
+while [ true ]; do
+  plan_label="plan.upgrade.cattle.io/${plan_name}"
+  plan_latest_version=$(kubectl get plans.upgrade.cattle.io "$plan_name" -n cattle-system -ojsonpath="{.status.latestVersion}")
+
+  if [ "$plan_latest_version" = "$plan_version" ]; then
+    plan_latest_hash=$(kubectl get plans.upgrade.cattle.io "$plan_name" -n cattle-system -ojsonpath="{.status.latestHash}")
+    total_nodes_count=$(kubectl get nodes -o json | jq '.items | length')
+    complete_nodes_count=$(kubectl get nodes --selector="plan.upgrade.cattle.io/${plan_name}=$plan_latest_hash" -o json | jq '.items | length')
+
+    if [ "$total_nodes_count" = "$complete_nodes_count" ]; then
+      echo "Plan ${plan_name} completes."
+      break
+    fi
+  fi
+
+  echo "Waiting for plan ${plan_name} to complete..."
+  sleep 10
+done
+
+echo "Deleting plan $plan_name..."
+kubectl delete plans.upgrade.cattle.io "$plan_name" -n cattle-system
+rm -f $prepare_plan_manifest

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -134,7 +134,7 @@ wait_kubevirt()
       fi
     fi
 
-    echo "Libvirt current version: $current_target_version, target version: $version"
+    echo "KubeVirt current version: $current_target_version, target version: $version"
     sleep 5
   done
 }

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 UPGRADE_TMP_DIR="/tmp/upgrade"
@@ -121,6 +121,7 @@ wait_kubevirt()
   version=$3
 
 
+  echo "Waiting for KubeVirt to upgraded to $version..."
   while [ true ]; do
     kubevirt=$(kubectl get kubevirts.kubevirt.io $name -n $namespace -o yaml)
 
@@ -133,6 +134,7 @@ wait_kubevirt()
       fi
     fi
 
+    echo "Libvirt current version: $current_target_version, target version: $version"
     sleep 5
   done
 }

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -5,6 +5,15 @@ UPGRADE_TMP_DIR="/tmp/upgrade"
 
 source $SCRIPT_DIR/lib.sh
 
+pre_upgrade_manifest()
+{
+  if [ -e "/usr/local/share/migrations/upgrade_manifests/${UPGRADE_PREVIOUS_VERSION}/pre-hook.sh" ]; then
+    echo "Executing ${UPGRADE_PREVIOUS_VERSION} pre-hook..."
+    # Use source to pass current shell's variables to target script
+    source "/usr/local/share/migrations/upgrade_manifests/${UPGRADE_PREVIOUS_VERSION}/pre-hook.sh"
+  fi
+}
+
 wait_managed_chart()
 {
   namespace=$1
@@ -378,6 +387,7 @@ pause_all_charts()
 wait_repo
 detect_repo
 detect_upgrade
+pre_upgrade_manifest
 pause_all_charts
 upgrade_rancher
 upgrade_harvester_cluster_repo


### PR DESCRIPTION

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

**Note**: this is a special fix to v1.0.0.

RKE2 upgrade is done node by node, after upgrading RKE2 runtime on a node, there might be some RKE2 pods schedules on the non-upgraded nodes. In air-gapped environments, pods might error because RKE2 images are not loaded yet (they are loaded only when RKE2 agent/server restarts).
<img width="1888" alt="Screen Shot 2022-03-18 at 11 13 22 AM" src="https://user-images.githubusercontent.com/1691518/160375375-c38d46cc-3f92-4b7e-ad79-94443255b2fd.png">



**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR create a plan to preload image with the new `harvester-ugprade` image again. We can guarantee [RKE2 images preload](https://github.com/harvester/harvester/blob/3c3004ed372cc6f0ac1e0e0d8f41ad79f7237689/package/upgrade/upgrade_node.sh#L71).

In the next release, we'll always preload RKE2 images first.


**Related Issue:**
https://github.com/harvester/harvester/issues/1861
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
