### PR TITLE
Get iso url and checksum from GitHub

### DIFF
--- a/pkg/controller/master/upgrade/version_syncer_test.go
+++ b/pkg/controller/master/upgrade/version_syncer_test.go
@@ -4,11 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 )
 
 func TestGetUpgradableVersions(t *testing.T) {
 	type input struct {
-		newVersions    []Version
+		newVersions    []harvesterv1.Version
 		currentVersion string
 	}
 	type output struct {
@@ -23,113 +26,197 @@ func TestGetUpgradableVersions(t *testing.T) {
 			name: "test1",
 			given: input{
 				currentVersion: "v0.1.0",
-				newVersions: []Version{
+				newVersions: []harvesterv1.Version{
 					{
-						Name:                 "v0.3.0",
-						ReleaseDate:          "2021-01-01T00:00:00Z",
-						MinUpgradableVersion: "v0.2.0",
-						Tags:                 []string{"latest"},
-						ISOChecksum:          "xxx",
-						ISOURL:               "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.3.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2021-01-01T00:00:00Z",
+							MinUpgradableVersion: "v0.2.0",
+							Tags:                 []string{"latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 					{
-						Name:                 "v0.3.0",
-						ReleaseDate:          "2021-01-01T00:00:00Z",
-						MinUpgradableVersion: "v0.2.0",
-						Tags:                 []string{"dev", "latest"},
-						ISOChecksum:          "xxx",
-						ISOURL:               "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.3.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2021-01-01T00:00:00Z",
+							MinUpgradableVersion: "v0.2.0",
+							Tags:                 []string{"dev", "latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 					{
-						Name:                 "v0.2.0",
-						ReleaseDate:          "2020-01-01T00:00:00Z",
-						MinUpgradableVersion: "v0.1.0",
-						Tags:                 []string{"v0.2-latest"},
-						ISOChecksum:          "xxx",
-						ISOURL:               "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.2.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2020-01-01T00:00:00Z",
+							MinUpgradableVersion: "v0.1.0",
+							Tags:                 []string{"v0.2-latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 					// Lack of ISOURL and ISOChecksum
 					{
-						Name:                 "v0.2.0",
-						ReleaseDate:          "2020-01-01T00:00:00Z",
-						MinUpgradableVersion: "v0.1.0",
-						Tags:                 []string{"v0.2-latest"},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.2.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2020-01-01T00:00:00Z",
+							MinUpgradableVersion: "v0.1.0",
+							Tags:                 []string{"v0.2-latest"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.3.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2021-01-01T00:00:00Z",
+							MinUpgradableVersion: "",
+							Tags:                 []string{"latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{false, true, true, false},
+				canUpgrades: []bool{false, true, true, false, true},
 			},
 		},
 		{
 			name: "test2",
 			given: input{
 				currentVersion: "dev",
-				newVersions: []Version{
+				newVersions: []harvesterv1.Version{
 					{
-						Name:                 "v0.1.0",
-						ReleaseDate:          "2021-01-01T00:00:00Z",
-						MinUpgradableVersion: "v0.1.0-rc1",
-						Tags:                 []string{"v0.1.0"},
-						ISOChecksum:          "xxx",
-						ISOURL:               "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.1.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2021-01-01T00:00:00Z",
+							MinUpgradableVersion: "v0.1.0-rc1",
+							Tags:                 []string{"v0.1.0"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 					{
-						Name:                 "v0.2.0",
-						ReleaseDate:          "2020-01-01T00:00:00Z",
-						MinUpgradableVersion: "dev",
-						Tags:                 []string{"v0.2.0"},
-						ISOChecksum:          "xxx",
-						ISOURL:               "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.2.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2020-01-01T00:00:00Z",
+							MinUpgradableVersion: "dev",
+							Tags:                 []string{"v0.2.0"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 					{
-						Name:                 "v0.2.1",
-						ReleaseDate:          "2020-06-01T00:00:00Z",
-						MinUpgradableVersion: "dev",
-						Tags:                 []string{"v0.2.1", "latest"},
-						ISOChecksum:          "xxx",
-						ISOURL:               "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.2.1",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2020-06-01T00:00:00Z",
+							MinUpgradableVersion: "dev",
+							Tags:                 []string{"v0.2.1", "latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.2.1",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2020-06-01T00:00:00Z",
+							MinUpgradableVersion: "",
+							Tags:                 []string{"v0.2.1", "latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{false, true, true},
+				canUpgrades: []bool{false, true, true, true},
 			},
 		},
 		{
 			name: "test3",
 			given: input{
 				currentVersion: "v0.3.0",
-				newVersions: []Version{
+				newVersions: []harvesterv1.Version{
 					{
-						Name:        "v0.4.0",
-						ReleaseDate: "2021-01-01T00:00:00Z",
-						Tags:        []string{"latest"},
-						ISOChecksum: "xxx",
-						ISOURL:      "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.4.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate: "2021-01-01T00:00:00Z",
+							Tags:        []string{"latest"},
+							ISOChecksum: "xxx",
+							ISOURL:      "https://somehwere/harvester.iso",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.4.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2021-01-01T00:00:00Z",
+							MinUpgradableVersion: "v0.3.0",
+							Tags:                 []string{"latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{true},
+				canUpgrades: []bool{true, true},
 			},
 		},
 		{
 			name: "test4",
 			given: input{
 				currentVersion: "v0.2.0",
-				newVersions: []Version{
+				newVersions: []harvesterv1.Version{
 					{
-						Name:        "v0.2.0",
-						ReleaseDate: "2021-01-01T00:00:00Z",
-						Tags:        []string{"latest"},
-						ISOChecksum: "xxx",
-						ISOURL:      "https://somehwere/harvester.iso",
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.2.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate: "2021-01-01T00:00:00Z",
+							Tags:        []string{"latest"},
+							ISOChecksum: "xxx",
+							ISOURL:      "https://somehwere/harvester.iso",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v0.2.0",
+						},
+						Spec: harvesterv1.VersionSpec{
+							ReleaseDate:          "2021-01-01T00:00:00Z",
+							MinUpgradableVersion: "v0.2.0",
+							Tags:                 []string{"latest"},
+							ISOChecksum:          "xxx",
+							ISOURL:               "https://somehwere/harvester.iso",
+						},
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{false},
+				canUpgrades: []bool{false, false},
 			},
 		},
 	}
@@ -138,7 +225,7 @@ func TestGetUpgradableVersions(t *testing.T) {
 		var actual output
 
 		for _, newV := range tc.given.newVersions {
-			actual.canUpgrades = append(actual.canUpgrades, canUpgrade(tc.given.currentVersion, newV.createVersionCR("test")))
+			actual.canUpgrades = append(actual.canUpgrades, canUpgrade(tc.given.currentVersion, &newV))
 		}
 
 		assert.Equal(t, tc.expected, actual, "case %q", tc.name)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -31,6 +31,7 @@ var (
 	UpgradableVersions      = NewSetting("upgradable-versions", "")
 	UpgradeCheckerEnabled   = NewSetting("upgrade-checker-enabled", "true")
 	UpgradeCheckerURL       = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
+	ReleaseDownloadURL      = NewSetting("release-download-url", "https://releases.rancher.com/harvester")
 	LogLevel                = NewSetting("log-level", "info") // options are info, debug and trace
 	SSLCertificates         = NewSetting(SSLCertificatesSettingName, "{}")
 	SSLParameters           = NewSetting(SSLParametersName, "{}")


### PR DESCRIPTION
**Problem:**
Currently, upgrade-responder can't return `isoURL` and `isoChecksum`, so we need to get them from GitHub released artifacts.

**Solution:**
Get latest version from upgrade-responder and fetch related files from GitHub.

**Related Issue:**
https://github.com/harvester/harvester/issues/2091
Depend on: https://github.com/harvester/harvester-installer/pull/256

### Test plan
**Phase 1: setup harvester-installer**
1. Clone harvester-installer branch https://github.com/harvester/harvester-installer/pull/256.
2. Run `export DRONE_TAG=v1.0.1`
3. Run `make ci`
4. Run `mv dist/artifacts v1.0.1`
5. Run `python3 -m http.server`

**Phase 2: setup upgrade-responder**
1. Run influexdb.
2. Clone https://github.com/harvester/upgrade-responder.
3. Set `config/response.json` as following.
```
{
	"Versions": [{
		"Name": "v1.0.1",
		"ReleaseDate": "2022-03-29T22:00:00Z",
		"Tags": ["dev","latest"]
	}]
}
```
4. Run `go run main.go --debug start --upgrade-response-config config/response.json --influxdb-url http://localhost:8086 --geodb geodb/GeoLite2-City.mmdb`.
5. Run `curl -X POST http://<private-ip-which-harvester-can-fetch>:8314/v1/checkupgrade -d '{ "appVersion": "v0.8.1", "extraInfo": {}}'` to check whether can get data from upgrade-responder.

**Phase 3: test the function**
1. Setup a harvester cluster.
2. Build docker image for this branch.
3. Replace deployment `harvester-system/harvester` with this branch.
4. Update `release-download-url` settings to python server URL like `http://192.168.0.98:8000`.
5. Update `upgrade-checker-url` settings to upgrade-responder URL like `http://192.168.0.202:8314/v1/checkupgrade`.
6. Normally, harvester check upgrade information once a hour. We can delete harvester pod to trigger harvester to query upgrade-responder and see whether a new `Version` is in the cluster.