### PR TITLE
Upgrade: workaround for rancher `v2.6.4-harvester1`

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -198,6 +198,9 @@ upgrade_rancher()
   kubectl delete clusterrepos.catalog.cattle.io rancher-partner-charts
   kubectl delete settings.management.cattle.io chart-default-branch
 
+  # Workaround of https://github.com/rancher/rancher/issues/37113
+  yq e '.extraEnv = [{"name": "CATTLE_RANCHER_WEBHOOK_MIN_VERSION", "value": "1.0.3+up0.2.5"}]' values.yaml -i
+
   REPO_RANCHER_VERSION=$REPO_RANCHER_VERSION yq -e e '.rancherImageTag = strenv(REPO_RANCHER_VERSION)' values.yaml -i
   ./helm upgrade rancher ./*.tgz --namespace cattle-system -f values.yaml --wait
 


### PR DESCRIPTION
The specified minimum rancher-webhook chart (1.0.4+up0.2.5) is not in
the rancher image, we can work around by lowering the required version.

**Related issue**
https://github.com/rancher/rancher/issues/37113


