### PR TITLE
Revert "Upgrade: workaround for rancher `v2.6.4-harvester1`"

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -198,9 +198,6 @@ upgrade_rancher()
   kubectl delete clusterrepos.catalog.cattle.io rancher-partner-charts
   kubectl delete settings.management.cattle.io chart-default-branch
 
-  # Workaround of https://github.com/rancher/rancher/issues/37113
-  yq e '.extraEnv = [{"name": "CATTLE_RANCHER_WEBHOOK_MIN_VERSION", "value": "1.0.3+up0.2.5"}]' values.yaml -i
-
   REPO_RANCHER_VERSION=$REPO_RANCHER_VERSION yq -e e '.rancherImageTag = strenv(REPO_RANCHER_VERSION)' values.yaml -i
   ./helm upgrade rancher ./*.tgz --namespace cattle-system -f values.yaml --wait
 


### PR DESCRIPTION
Reverts harvester/harvester#2097

This is no longer needed because Rancher resolves the known issues.

NOTE: Sorry I was not aware using Github's revert feature creates a branch in the harvester repo, will avoid this in the future.