### PR TITLE
Add Harvester v1.0.1-rc3 head

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -431,8 +431,7 @@ kube-vip:
   enabled: false
   image:
     repository: ghcr.io/kube-vip/kube-vip
-    # target commit https://github.com/kube-vip/kube-vip/commit/344cb491eb84c0a8dc73e54fa043ebf4ea44bf02
-    tag: main
+    tag: v0.4.3
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper -n rm container-suseconnect && \
 
 WORKDIR /var/lib/harvester/harvester
 
-ENV HARVESTER_UI_VERSION v1.0.1-rc1
+ENV HARVESTER_UI_VERSION v1.0.1
 ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -108,7 +108,7 @@ func (v *pvcValidator) Update(request *types.Request, oldObj runtime.Object, new
 			return fmt.Errorf("failed to get VM: %v", err)
 		}
 		if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusProvisioning && vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
-			message := fmt.Sprintf("resizing is only supported for detached volumes. The volueme is being used by VM %s. Please stop the VM first.", vmID)
+			message := fmt.Sprintf("resizing is only supported for detached volumes. The volume is being used by VM %s. Please stop the VM first.", vmID)
 			return werror.NewInvalidError(message, "")
 		}
 	}

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=v1.0.1-rc6
+HARVESTER_INSTALLER_VERSION=v1.0.1-rc7
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
Add Harvester v1.0.1-rc3 head
- bump kube-vip from main to https://github.com/kube-vip/kube-vip/releases/tag/v0.4.3
- bump installer to `v1.0.1-rc7`
- bump embedded UI tag to `v1.0.1`