### PR TITLE
Bump installer packaged version to v1.0.1

### DIFF
--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=v1.0.1-rc7
+HARVESTER_INSTALLER_VERSION=v1.0.1
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
Bump installer packaged version to v1.0.1 and it is identical to the [v1.0.1-rc7](https://drone-publish.rancher.io/harvester/harvester-installer)