### PR TITLE
Upgrade: concatenate node jobs names safely

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+	"github.com/rancher/wrangler/pkg/name"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -197,7 +198,7 @@ func applyNodeJob(upgrade *harvesterv1.Upgrade, repoInfo *UpgradeRepoInfo, nodeN
 	privileged := true
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s-%s", upgrade.Name, jobType, nodeName),
+			Name:      name.SafeConcatName(upgrade.Name, jobType, nodeName),
 			Namespace: upgrade.Namespace,
 			Labels: map[string]string{
 				harvesterUpgradeLabel:          upgrade.Name,
@@ -300,7 +301,7 @@ func applyManifestsJob(upgrade *harvesterv1.Upgrade, repoInfo *UpgradeRepoInfo) 
 	imageVersion := repoInfo.Release.Harvester
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-apply-manifests", upgrade.Name),
+			Name:      name.SafeConcatName(upgrade.Name, "apply-manifests"),
 			Namespace: upgrade.Namespace,
 			Labels: map[string]string{
 				harvesterUpgradeLabel:          upgrade.Name,


### PR DESCRIPTION
**Deps**
- I'd suggest testing with https://github.com/harvester/harvester/pull/2166 to make an upgrade complete.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Fail to create node job if node name is too long.
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Safely concatenate node job names. The idea is to add some hash in the name.

**Related Issue:**
https://github.com/harvester/harvester/issues/2114

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Build Harvester ISO, the rancher/harvester image should contain the change
- Create a Harvester v1.0.1 cluster. At least one node should contain a long enough hostname. An example is `harvester-101upgrade-node1`.
- Upgrade to the build ISO.
