### PR TITLE
Fix node OS can't be upgraded

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -235,12 +235,6 @@ wait_rke2_upgrade() {
   done
 }
 
-rebrand_grub () {
-  mount -o remount,rw $HOST_DIR/run/initramfs/cos-state/
-  chroot $HOST_DIR grub2-editenv /run/initramfs/cos-state/grub_oem_env set "default_menu_entry=$REPO_OS_PRETTY_NAME"
-  mount -o remount,ro $HOST_DIR/host/run/initramfs/cos-state/
-}
-
 clean_rke2_archives() {
   yq -e -o=json e ".images.rke2" "$CACHED_BUNDLE_METADATA" | jq -r '.[] | [.list, .archive] | @tsv' |
     while IFS=$'\t' read -r list archive; do
@@ -276,9 +270,6 @@ upgrade_os() {
   rm -rf $tmp_rootfs_squashfs
 
   umount -R /run
-
-  # https://github.com/rancher-sandbox/cOS-toolkit/issues/928
-  rebrand_grub || true
 
   reboot_if_job_succeed
 }

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -268,10 +268,10 @@ upgrade_os() {
     curl -fL $UPGRADE_REPO_SQUASHFS_IMAGE -o $tmp_rootfs_squashfs
   fi
 
-  tmp_rootfs_mount=$(mktemp -d) 
+  tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
   mount $tmp_rootfs_squashfs $tmp_rootfs_mount
 
-  bash -x $HOST_DIR/usr/sbin/cos upgrade --directory $tmp_rootfs_mount
+  chroot $HOST_DIR cos upgrade --directory ${tmp_rootfs_mount#"$HOST_DIR"}
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -265,7 +265,7 @@ upgrade_os() {
   tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
   mount $tmp_rootfs_squashfs $tmp_rootfs_mount
 
-  chroot $HOST_DIR cos upgrade --directory ${tmp_rootfs_mount#"$HOST_DIR"}
+  chroot $HOST_DIR elemental upgrade --directory ${tmp_rootfs_mount#"$HOST_DIR"}
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The cos upgrade command relies on some files in the host.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
We need to chroot to /host first to get those files paths right.
The PR also removed unused GRUB rebranding workaround.

**Related Issue:**
https://github.com/harvester/harvester/issues/2162

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
