### PR TITLE
Add longhorn-loop-device-cleaner

### DIFF
--- a/deploy/charts/harvester/templates/longhorn-device-cleaner.yaml
+++ b/deploy/charts/harvester/templates/longhorn-device-cleaner.yaml
@@ -1,0 +1,59 @@
+# This daemon set is to remove loop device
+# ref: https://github.com/harvester/harvester/issues/2137
+{{ if .Values.longhorn.enabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: longhorn-loop-device-cleaner
+  namespace: {{ .Values.longhorn.namespaceOverride }}
+  labels:
+    app: longhorn-loop-device-cleaner
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-loop-device-cleaner
+  template:
+    metadata:
+      labels:
+        app: longhorn-loop-device-cleaner
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+      - name: longhorn-loop-device-cleaner
+        command:
+          - nsenter
+          - --mount=/proc/1/ns/mnt
+          - --
+          - bash
+          - -c
+          - |
+            while true ;
+            do
+                for device in /sys/block/loop* ; do
+                        echo "INFO: checking loop device $device"
+                        if test -f "$device/loop/backing_file"; then
+                                backingFile=`cat "$device/loop/backing_file"`
+                                # removing trailling spaces
+                                backingFile=`echo $backingFile | sed 's/ *$//g'`
+                                if [[ $backingFile == *"(deleted)" ]] ; then
+                                        loopDevice="/dev/$(echo $device | cut -d"/" -f4)"
+                                        echo "WARN: detected removed backing file $backingFile"
+                                        echo "WARN: detaching the loop device $loopDevice"
+                                        losetup -d $loopDevice
+                                fi
+                        else
+                                echo "INFO: skipping loop device $device: backing file $device/loop/backing_file doesn't exist"
+                        fi
+                done
+                sleepingTime=60
+                echo "INFO: sleeping for ${sleepingTime}s"
+                sleep $sleepingTime
+            done
+        image: {{ index .Values "loop-device-cleaner" "image" "repository" }}:{{ index .Values "loop-device-cleaner" "image" "tag" }}
+        imagePullPolicy: {{ index .Values "loop-device-cleaner" "image" "imagePullPolicy" }}
+        securityContext:
+          privileged: true
+  updateStrategy:
+    type: RollingUpdate
+{{- end -}}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -444,3 +444,9 @@ support-bundle-kit:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
     tag: master-head
+
+loop-device-cleaner:
+  image:
+    imagePullPolicy: IfNotPresent
+    repository: alpine
+    tag: 3.12


### PR DESCRIPTION
**Problem:**
LH's block device volume failed to unmount when it is detached unexpectedly (e.g. during Kubernetes upgrade, Docker reboot, or network disconnect), and therefore the pod is stuck in the terminating state.

**Solution:**
Add a daemonset to remove loop device.

**Related Issue:**
https://github.com/harvester/harvester/issues/2137

**Test plan:**
**Case 1: VM is not stuck in terminating**
1. Build ISO.
```
cp -r ~/.docker .
export REPO=<dockerhub-username>
export PUSH=true
make
make build-iso
```
2. Create a 3-node cluster with our ISO.
3. Check daemonset `longhorn/longhorn-loop-device-cleaner` is existent.
4. Create a VM.
5. Add a file `test.txt` with content `123` in the VM.
6. Check VM on which node and delete `instance-manager-e-xxxx` on that node.
7. Wait a minute, VM pod will go into terminating.
8. Wait a minute, a new VM pod will be created.
9. Check whether the content of the file `test.txt` is `123` in the VM.

**Case 2: Upgrade harvester and check whether longhorn-loop-device-cleaner is removed**
1. Apply a new Version like:
```
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: v1.0.1
  namespace: harvester-system
spec:
  isoChecksum: d5dc42a7422d677a07059be1fc0cf7caec70c172cfb4e7829f753b26ead91ee8616ba0fcf994c8b3ccc8aa4b2a791c3f505cba1a78780d8a21e38c307cdf1340
  isoURL: https://releases.rancher.com/harvester/v1.0.1/harvester-v1.0.1-amd64.iso
  minUpgradableVersion: e99db1d5
  releaseDate: "20220415"
  tags:
  - dev
  - test
```
2. Click Upgrade on the dashboard.
3. Upgrade may not finish because we have an issue https://github.com/harvester/harvester/issues/2162 but daemonset `longhorn/longhorn-loop-device-cleaner` can be removed.
