### PR TITLE
Upgrade: fix upgrade temporary directory path

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-UPGRADE_TMP_DIR=$HOST_DIR/usr/local/upgrade_tmp
 
 source $SCRIPT_DIR/lib.sh
+UPGRADE_TMP_DIR=$HOST_DIR/usr/local/upgrade_tmp
 
 # Create a systemd service on host to reboot the host if this running pod succeeds.
 # This prevents job become from entering `Error`.


### PR DESCRIPTION
The upgrade temporary directory is supposed to be on a node's`/usr/local/upgrade_tmp`, not in container's file system.
Although it makes no difference at this moment, let's fix the bad refactor.

The original intention was to use a directory in node's `/usr/local`, because:
- It's easier to debug. Files are not gone with the container's termination.
- It will reside in the persistent storage from our design.

