### PR TITLE
Node promotion: wait for rancher-webhook roll out

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -25,6 +25,12 @@ data:
       $KUBECTL get node $HARVESTER_PROMOTE_NODE_NAME -o jsonpath='{.metadata.annotations.cluster\.x-k8s\.io/machine}'
     }
 
+    # Wait for rancher-webhook ready. It's default to one replica.
+    # Otherwise lebeling capi resources later might fail.
+    $KUBECTL rollout status --watch=true deployment rancher-webhook -n cattle-system
+    # https://github.com/rancher/webhook/blob/436e359b136b633cb1a6fa7cdedbed4d74821bdb/pkg/server/server.go#L114
+    sleep 20
+
     CUSTOM_MACHINE=$(get_machine_from_node)
     until [ -n "$CUSTOM_MACHINE" ]
     do


### PR DESCRIPTION
**Note**
https://github.com/harvester/harvester/issues/2191 can still occur during the test.

Labeling CAPI resources involves rancher-webhook checks, we need to wait until rancher-webhook pod is ready.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The promotion jobs might fail if rancher-webhook is not ready.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Wait for rancher-webhook pod to be ready.

**Related Issue:**
https://github.com/harvester/harvester/issues/2187

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->


