### PR TITLE
Add vm run strategy enhancement

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -178,8 +178,7 @@ func (vf *vmformatter) canStop(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.Vi
 		case kubevirtv1.RunStrategyHalted:
 			return false
 		case kubevirtv1.RunStrategyManual, kubevirtv1.RunStrategyRerunOnFailure:
-			// need to check VMI status
-			if vmi == nil || vmi.Status.Phase != kubevirtv1.Running {
+			if vmi == nil {
 				return false
 			}
 			return true
@@ -223,9 +222,14 @@ func (vf *vmformatter) canDoBackup(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv
 		return false
 	}
 
-	if vmi != nil && vmi.Status.Phase != kubevirtv1.Running {
+	if vm.DeletionTimestamp != nil || (vmi != nil && vmi.DeletionTimestamp != nil) {
 		return false
 	}
+
+	if vmi != nil && vmi.Status.Phase != kubevirtv1.Running && vmi.Status.Phase != kubevirtv1.Succeeded {
+		return false
+	}
+
 	return true
 }
 
@@ -246,9 +250,14 @@ func (vf *vmformatter) isVMStarting(vm *kubevirtv1.VirtualMachine) bool {
 }
 
 func (vf *vmformatter) canCreateTemplate(vmi *kubevirtv1.VirtualMachineInstance) bool {
-	if vmi != nil && vmi.Status.Phase != kubevirtv1.Running {
+	if vmi != nil && vmi.DeletionTimestamp != nil {
 		return false
 	}
+
+	if vmi != nil && vmi.Status.Phase != kubevirtv1.Running && vmi.Status.Phase != kubevirtv1.Succeeded {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -199,7 +199,7 @@ func (v *VMBuilder) PodAntiAffinity(podAffinityTerm corev1.PodAffinityTerm, soft
 func (v *VMBuilder) Run(start bool) *VMBuilder {
 	runStrategy := kubevirtv1.RunStrategyHalted
 	if start {
-		runStrategy = kubevirtv1.RunStrategyAlways
+		runStrategy = kubevirtv1.RunStrategyRerunOnFailure
 	}
 	v.VirtualMachine.Spec.RunStrategy = &runStrategy
 	return v

--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -12,20 +12,28 @@ const (
 	vmControllerUnsetOwnerOfPVCsControllerName         = "VMController.UnsetOwnerOfPVCs"
 	vmiControllerUnsetOwnerOfPVCsControllerName        = "VMIController.UnsetOwnerOfPVCs"
 	vmControllerSetDefaultManagementNetworkMac         = "VMController.SetDefaultManagementNetworkMacAddress"
+	vmControllerStoreRunStrategyControllerName         = "VMController.StoreRunStrategyToAnnotation"
 )
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
-	var pvcClient = management.CoreFactory.Core().V1().PersistentVolumeClaim()
-	var pvcCache = pvcClient.Cache()
+	var (
+		pvcClient = management.CoreFactory.Core().V1().PersistentVolumeClaim()
+		pvcCache  = pvcClient.Cache()
+		vmClient  = management.VirtFactory.Kubevirt().V1().VirtualMachine()
+		vmCache   = vmClient.Cache()
+	)
 
 	// registers the vm controller
 	var vmCtrl = &VMController{
 		pvcClient: pvcClient,
 		pvcCache:  pvcCache,
+		vmClient:  vmClient,
+		vmCache:   vmCache,
 	}
 	var virtualMachineClient = management.VirtFactory.Kubevirt().V1().VirtualMachine()
 	virtualMachineClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)
 	virtualMachineClient.OnChange(ctx, vmControllerSetOwnerOfPVCsControllerName, vmCtrl.SetOwnerOfPVCs)
+	virtualMachineClient.OnChange(ctx, vmControllerStoreRunStrategyControllerName, vmCtrl.StoreRunStrategy)
 	virtualMachineClient.OnRemove(ctx, vmControllerUnsetOwnerOfPVCsControllerName, vmCtrl.UnsetOwnerOfPVCs)
 
 	// registers the vmi controller
@@ -39,11 +47,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	virtualMachineInstanceClient.OnRemove(ctx, vmiControllerUnsetOwnerOfPVCsControllerName, vmiCtrl.UnsetOwnerOfPVCs)
 
 	// register the vm network controller upon the VMI changes
-	var (
-		vmClient  = management.VirtFactory.Kubevirt().V1().VirtualMachine()
-		vmCache   = management.VirtFactory.Kubevirt().V1().VirtualMachine().Cache()
-		vmiClient = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
-	)
+	var vmiClient = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	var vmNetworkCtl = &VMNetworkController{
 		vmClient:  vmClient,
 		vmCache:   vmCache,

--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -151,7 +151,7 @@ spec:
             }
           }]
     spec:
-      runStrategy: Manual
+      runStrategy: RerunOnFailure
       template:
         spec:
           evictionStrategy: LiveMigrate
@@ -219,7 +219,7 @@ spec:
             }
           }]
     spec:
-      runStrategy: Manual
+      runStrategy: RerunOnFailure
       template:
         spec:
           evictionStrategy: LiveMigrate
@@ -293,7 +293,7 @@ spec:
             }
           }]
     spec:
-      runStrategy: Manual
+      runStrategy: RerunOnFailure
       template:
         spec:
           evictionStrategy: LiveMigrate

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -13,6 +13,7 @@ const (
 	AnnotationImageID              = prefix + "/imageId"
 	AnnotationReservedMemory       = prefix + "/reservedMemory"
 	AnnotationHash                 = prefix + "/hash"
+	AnnotationRunStrategy          = prefix + "/vmRunStrategy"
 
 	BackupTargetSecretName      = "harvester-backup-target-secret"
 	InternalTLSSecretName       = "tls-rancher-internal"

--- a/tests/integration/api/vm_apis_test.go
+++ b/tests/integration/api/vm_apis_test.go
@@ -3,8 +3,10 @@ package api_test
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -79,13 +81,18 @@ var _ = Describe("verify vm APIs", func() {
 
 			// create
 			By("create a virtual machine should fail if name missing")
-			vm, err := NewDefaultTestVMBuilder(testResourceLabels).Name("").
-				NetworkInterface(testVMInterfaceName, testVMInterfaceModel, "", builder.NetworkInterfaceTypeMasquerade, "").
-				PVCDisk(testVMBlankDiskName, testVMDefaultDiskBus, false, false, 1, testVMDiskSize, "", nil).
-				VM()
-			MustNotError(err)
-			respCode, respBody, err := helper.PostObject(vmsAPI, vm)
-			MustRespCodeIs(http.StatusUnprocessableEntity, "create vm", err, respCode, respBody)
+			MustFinallyBeTrue(func() bool {
+				vm, err := NewDefaultTestVMBuilder(testResourceLabels).Name("").
+					NetworkInterface(testVMInterfaceName, testVMInterfaceModel, "", builder.NetworkInterfaceTypeMasquerade, "").
+					PVCDisk(testVMBlankDiskName, testVMDefaultDiskBus, false, false, 1, testVMDiskSize, "", nil).
+					VM()
+				MustNotError(err)
+				respCode, _, err := helper.PostObject(vmsAPI, vm)
+				MustNotError(err)
+				// 404 is because the api server is up but ready to serve with watching the metadata controllers
+				Expect(respCode).To(BeElementOf([]int{http.StatusUnprocessableEntity, http.StatusNotFound}))
+				return respCode == http.StatusUnprocessableEntity
+			}, 1*time.Minute, 3*time.Second)
 
 			By("when create a virtual machine with cloud-init")
 			vmName := testVMGenerateName + fuzz.String(5)
@@ -98,7 +105,7 @@ var _ = Describe("verify vm APIs", func() {
 			}
 			userData := fmt.Sprintf(testVMCloudInitUserDataTemplate, vmCloudInit.UserName, vmCloudInit.Password)
 			networkData := fmt.Sprintf(testVMCloudInitNetworkDataTemplate, vmCloudInit.Address, vmCloudInit.Gateway)
-			vm, err = NewDefaultTestVMBuilder(testResourceLabels).Name(vmName).
+			vm, err := NewDefaultTestVMBuilder(testResourceLabels).Name(vmName).
 				NetworkInterface(testVMInterfaceName, testVMInterfaceModel, "", builder.NetworkInterfaceTypeMasquerade, "").
 				ContainerDisk(testVMContainerDiskName, testVMDefaultDiskBus, false, 1, testVMContainerDiskImageName, testVMContainerDiskImagePullPolicy).
 				CloudInitDisk(testVMCloudInitDiskName, testVMDefaultDiskBus, false, 0, builder.CloudInitSource{
@@ -107,7 +114,7 @@ var _ = Describe("verify vm APIs", func() {
 					NetworkData:   networkData,
 				}).Run(true).VM()
 			MustNotError(err)
-			respCode, respBody, err = helper.PostObject(vmsAPI, vm)
+			respCode, respBody, err := helper.PostObject(vmsAPI, vm)
 			MustRespCodeIs(http.StatusCreated, "create vm", err, respCode, respBody)
 
 			By("then the virtual machine is created and running")


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
- Add workaround of the upstream kubevirt issue https://github.com/kubevirt/kubevirt/issues/7295 (after stopping and starting the VM the original run strategy will be changed to `Always`)
- After restoring a VM the default run strategy is always default to the manual, it should use the run strategy from the backup.

**Solution:**
- store the last run strategy to the annotation and patch the run strategy from the annotation after a VM is restarted from the halted status.
- use the saved run strategy from the backup status and set the default value to `RerunOnFailure` if it is not defined.

**Related Issue:**
https://github.com/harvester/harvester/issues/2172

## **Test plan:**
For local testing, u can patch the harvester and harvester-webhook image with `guangbo/harvester:fix-run2` and `guangbo/harvester-webhook:fix-run2` respectively, thanks. (use the upstream `master-head` image if this PR is merged)

### Test Case 1 - RerunOnFailure
1. create VM and set the run strategy to `RerunOnFailure` via the `Advanced Option` tab.
2. the VM will start by default.
3. stop and restart the VM the run strategy will remain the same.
4. stop the VM inside the guestOS with `sudo shutdown` and it will NOT restart automatically. (need to wait 20-30 seconds for the status change)

### Test Case 2 - Always
1. create VM and set the run strategy to `Always` via the `Advanced Option` tab.
2. the VM will start by default.
3. stop and restart the VM the run strategy will remain the same.
4. stop the VM inside the guestOS with `sudo shutdown` and it will restart automatically.

### Test Case 3 - Manual
1. create VM and set the run strategy to `Manual` via the `Advanced Option` tab.
2. the VM will NOT start by default.
3. stop and restart the VM the run strategy will remain the same.
4. stop the VM inside the guestOS with `sudo shutdown` and it will NOT restart automatically. (need to wait 20-30 seconds for the status change)

### Test Case 4 - Backup
1.  Config the backup target. (e.g. using the [LH minio](https://longhorn.io/docs/1.2.4/snapshots-and-backups/backup-and-restore/set-backup-target/#set-up-a-local-testing-backupstore))
2. Create a VM and take a backup
3. Restore a new VM from the backup, and make sure its run strategy is reminded as same as the backup one.