### PR TITLE
change volumeBindingMode to WaitForFirstConsumer

### DIFF
--- a/deploy/charts/harvester/templates/longhorn-storageclass-override.yaml
+++ b/deploy/charts/harvester/templates/longhorn-storageclass-override.yaml
@@ -19,7 +19,7 @@ data:
     provisioner: driver.longhorn.io
     allowVolumeExpansion: true
     reclaimPolicy: "{{ .Values.longhorn.persistence.reclaimPolicy }}"
-    volumeBindingMode: Immediate
+    volumeBindingMode: WaitForFirstConsumer
     parameters:
       numberOfReplicas: "{{ .Values.longhorn.persistence.defaultClassReplicaCount }}"
       staleReplicaTimeout: "30"

--- a/pkg/controller/master/image/vm_image_controller.go
+++ b/pkg/controller/master/image/vm_image_controller.go
@@ -148,7 +148,7 @@ func (h *vmImageHandler) createBackingImage(image *harvesterv1.VirtualMachineIma
 
 func (h *vmImageHandler) createStorageClass(image *harvesterv1.VirtualMachineImage) error {
 	recliamPolicy := corev1.PersistentVolumeReclaimDelete
-	volumeBindingMode := storagev1.VolumeBindingImmediate
+	volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
 	sc := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: getImageStorageClassName(image.Name),


### PR DESCRIPTION
**Problem:**
When we create a new VM, it shows a temporary status `ErrorUnschedulable` and error message `unbound immediate PersistentVolumeClaims`.

**Solution:**
Change `volumeBindingMode` in `StorageClass` to `WaitForFirstConsumer`, so we don't get this unscheduled error from pod. Also, VM's first status will change to `WaitingForVolumeBinding`.

**Related Issue:**
https://github.com/harvester/harvester/issues/2221

**Test plan:**
1. Create a Harvester cluster.
2. Import Image and check its `volumeBindingMode` in `StorageClass` is `WaitingForVolumeBinding`.
3. Run `kubectl get vm -w` on the terminal.
4. Create a VM with our imported image.
5. Check there is no `ErrorUnschedulable` shown on the terminal.
```
> kubectl get vm -w
NAME   AGE   STATUS   READY
vm     0s
vm     0s    WaitingForVolumeBinding   False
vm     5s    Starting                  False
vm     23s   Running                   False
vm     23s   Running                   True
```