### PR TITLE
Set configured condition for all settings

### DIFF
--- a/pkg/controller/master/backup/backup_target.go
+++ b/pkg/controller/master/backup/backup_target.go
@@ -111,9 +111,6 @@ func (h *TargetHandler) OnBackupTargetChange(key string, setting *harvesterv1.Se
 			return nil, err
 		}
 
-		// set configured flag, as s3 does
-		harvesterv1.SettingConfigured.SetError(setting, "", nil)
-
 		return nil, nil
 
 	default:
@@ -140,9 +137,6 @@ func (h *TargetHandler) reUpdateBackupTargetSettingSecret(setting *harvesterv1.S
 	if target.Type != settings.S3BackupType {
 		return nil, nil
 	}
-
-	// set configured flag
-	harvesterv1.SettingConfigured.SetError(setting, "", nil)
 
 	// reset the s3 credentials to prevent controller reconcile and not to expose secret key
 	target.SecretAccessKey = ""

--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -78,27 +78,21 @@ func (h *Handler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*har
 		return nil, nil
 	}
 
-	for key, syncer := range syncers {
-		if setting.Name != key {
-			continue
-		}
-
+	if syncer, ok := syncers[setting.Name]; ok {
 		if err := syncer(setting); err != nil {
 			if updateErr := h.setConfiguredCondition(setting.DeepCopy(), err); updateErr != nil {
 				return setting, updateErr
 			}
 			return setting, err
 		}
-
-		toUpdate := setting.DeepCopy()
-		if toUpdate.Annotations == nil {
-			toUpdate.Annotations = make(map[string]string)
-		}
-		toUpdate.Annotations[util.AnnotationHash] = currentHash
-		return setting, h.setConfiguredCondition(toUpdate, nil)
 	}
 
-	return nil, nil
+	toUpdate := setting.DeepCopy()
+	if toUpdate.Annotations == nil {
+		toUpdate.Annotations = make(map[string]string)
+	}
+	toUpdate.Annotations[util.AnnotationHash] = currentHash
+	return setting, h.setConfiguredCondition(toUpdate, nil)
 }
 
 func (h *Handler) setConfiguredCondition(settingCopy *harvesterv1.Setting, err error) error {

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -67,6 +67,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		"auto-disk-provision-paths": controller.syncNDMAutoProvisionPaths,
 		"ssl-certificates":          controller.syncSSLCertificate,
 		"ssl-parameters":            controller.syncSSLParameters,
+		// for "backup-target" syncer, please check harvester-backup-target-controller
 	}
 
 	settings.OnChange(ctx, controllerName, controller.settingOnChanged)


### PR DESCRIPTION
**Problem:**
In before, we only set `configured` condition for some settings which have `syncer` functions. This may break some function like backup which check whether `configured` condition in `backup-target` setting is `True`.

* https://github.com/harvester/harvester/blob/24240d896c1add07de72bfb4fb3d7bd446a6dba0/pkg/controller/master/setting/register.go#L60-L70
* https://github.com/harvester/harvester/blob/24240d896c1add07de72bfb4fb3d7bd446a6dba0/pkg/controller/master/setting/handler.go#L81-L101
* https://github.com/harvester/harvester/blob/7fcf04f8df9797020d51d72e0d2ff9aa8c84b904/pkg/api/vm/handler.go#L414-L427

**Solution:**
Set `configured` condition for all settings.

**Related Issue:**
https://github.com/harvester/harvester/issues/2238

**Test plan:**
1. Setup a harvester cluster.
2. Set `backup-target` setting as NFS. (LH NFS ref: https://longhorn.io/docs/1.2.4/snapshots-and-backups/backup-and-restore/set-backup-target/#nfs-backupstore)
3. Check `configured` condition in `backup-target` setting is `True`.
4. Set `release-download-url` setting as a random URL.
5. Check `configured` condition in `release-download-url` setting is `True`.
