### PR TITLE
Fix run strategy mutual-exclusive error on webhook

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -79,6 +79,11 @@ func (m *vmMutator) Update(request *types.Request, oldObj runtime.Object, newObj
 }
 
 func needUpdateRunStrategy(oldVm, newVm *kubevirtv1.VirtualMachine) (bool, error) {
+	// no need to patch the run strategy if user uses the spec.running filed.
+	if newVm.Spec.Running != nil {
+		return false, nil
+	}
+
 	newRunStrategy, err := newVm.RunStrategy()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Running and RunStrategy are mutually exclusive of the VM spec.

**Solution:**
Do not patch the run strategy when the `spec.running` filed is specified by the users.

**Related Issue:**
https://github.com/harvester/harvester/issues/2252


**Test plan:**
- patch the webhook image via `$kubectl set image deployment/harvester-webhook harvester-webhook=guangbo/harvester-webhook:fix-wh`
- create an RKE2 cluster with the Harvester node driver, and wait for the cluster to be up and running. (previously it will encounter the `mutual-exclusive` error)
- check the VM YAML and its `spec.running` value is kept.

<img width="2297" alt="image" src="https://user-images.githubusercontent.com/4569037/167764564-2afcfd00-7116-4d35-bcce-20e34a0647be.png">
