### PR TITLE
A starting VM can be stopped

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -168,10 +168,6 @@ func (vf *vmformatter) canRestart(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1
 }
 
 func (vf *vmformatter) canStop(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance) bool {
-	if vm.Spec.Running != nil && !*vm.Spec.Running {
-		return false
-	}
-
 	runStrategy, err := vm.RunStrategy()
 	if err == nil {
 		switch runStrategy {


### PR DESCRIPTION
**Problem:**
A starting VM cannot be stopped. However, sometime there may be some settings error, so the VM cannot be started. Users should be able to stop a starting VM.

**Solution:**
Update `vmformatter.canStop` function.

**Related Issue:**
https://github.com/harvester/harvester/issues/2263

**Test plan:**

Case 1: RunStartegy Always / RerunOnFailure
1. Create a VM with RunStrategy `Always` or `RerunOnFailure`.
2. VM will get into starting status.
3. Users can click the stop button to stop a starting VM.
4. After VM is off, users can click the start button to start the VM again. Also, the VM should be able to get into running status.

Case 2: RunStartegy Manual / Halted
1. Create a VM with RunStrategy `Manual` or `Halted`.
2. VM will not start. Also, there is no `stop` button on UI.
3. Click the start button and the `stop` button shows on UI.
4. Users can click the stop button to stop a starting VM.
5. After VM is off, users can click the start button to start the VM again. Also, the VM should be able to get into running status.