### PR TITLE
UI should not show the stop button when users already run `poweroff` in the VM

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -177,7 +177,13 @@ func (vf *vmformatter) canStop(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.Vi
 			if vmi == nil {
 				return false
 			}
-			return true
+
+			switch vmi.Status.Phase {
+			case kubevirtv1.Pending, kubevirtv1.Scheduling, kubevirtv1.Scheduled, kubevirtv1.Running:
+				return true
+			default:
+				return false
+			}
 		case kubevirtv1.RunStrategyAlways:
 			return true
 		default:


### PR DESCRIPTION
**Problem:**
Users can stop a VM through UI when we already run `poweroff` in the VM.

**Solution:**
Check `vmi.status.phase`. Only if it is `Pending`, `Scheduling`, `Scheduled`, or `Running`, we can send a stop request.

**Related Issue:**
https://github.com/harvester/harvester/issues/2265

**Test plan:**
1. Create a harvester cluster.
2. Create a Linux VM.
3. Run `sudo poweroff` in it.
4. UI should not show `stop` button.
