### PR TITLE
add addition-ca secret and plan

### DIFF
--- a/deploy/charts/harvester/templates/cattle-system.yaml
+++ b/deploy/charts/harvester/templates/cattle-system.yaml
@@ -1,0 +1,24 @@
+# system-upgrade-controller(https://github.com/rancher/system-upgrade-controller) watches secret and node change.
+# If there is a new node, system-upgrade-controller creates a job on the node to change CA certificates.
+# If additional-ca is changed, system-upgrade-controller creates a job on each node to change CA certificates.
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: sync-additional-ca
+  namespace: cattle-system
+spec:
+  concurrency: 1
+  nodeSelector:
+    matchLabels:
+      harvesterhci.io/managed: "true"
+  serviceAccountName: system-upgrade-controller
+  secrets:
+    - name: harvester-additional-ca
+      path: /ca
+  version: v1.0.2
+  upgrade:
+    image: {{ .Values.generalJob.image.repository }}:{{ .Values.generalJob.image.tag }}
+    command: ["/bin/sh", "-c"]
+    args:
+      - cp /ca/additional-ca.pem /host/etc/pki/trust/anchors;
+      - chroot /host update-ca-certificates

--- a/deploy/charts/harvester/templates/longhorn-device-cleaner.yaml
+++ b/deploy/charts/harvester/templates/longhorn-device-cleaner.yaml
@@ -50,8 +50,8 @@ spec:
                 echo "INFO: sleeping for ${sleepingTime}s"
                 sleep $sleepingTime
             done
-        image: {{ index .Values "loop-device-cleaner" "image" "repository" }}:{{ index .Values "loop-device-cleaner" "image" "tag" }}
-        imagePullPolicy: {{ index .Values "loop-device-cleaner" "image" "imagePullPolicy" }}
+        image: {{ .Values.generalJob.image.repository }}:{{ .Values.generalJob.image.tag }}
+        imagePullPolicy: {{ .Values.generalJob.image.imagePullPolicy }}
         securityContext:
           privileged: true
   updateStrategy:

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -445,8 +445,8 @@ support-bundle-kit:
     repository: rancher/support-bundle-kit
     tag: master-head
 
-loop-device-cleaner:
+generalJob:
   image:
     imagePullPolicy: IfNotPresent
-    repository: alpine
-    tag: 3.12
+    repository: registry.suse.com/bci/bci-base
+    tag: 15.3

--- a/pkg/data/add.go
+++ b/pkg/data/add.go
@@ -22,6 +22,12 @@ func Init(ctx context.Context, mgmtCtx *config.Management, options config.Option
 		return err
 	}
 
-	// Not applying the built-in templates in case users have edited them.
-	return createTemplates(mgmtCtx, publicNamespace)
+	// Not applying the built-in templates and secrets in case users have edited them.
+	if err := createTemplates(mgmtCtx, publicNamespace); err != nil {
+		return err
+	}
+	if err := createSecrets(mgmtCtx); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/data/crd.go
+++ b/pkg/data/crd.go
@@ -7,6 +7,7 @@ import (
 	fleetv1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	rancherv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"k8s.io/client-go/rest"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -28,6 +29,7 @@ func createCRDs(ctx context.Context, restConfig *rest.Config) error {
 			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "GroupMember", rancherv3.GroupMember{}),
 			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "Token", rancherv3.Token{}),
 			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "NodeDriver", rancherv3.NodeDriver{}),
+			crd.NonNamespacedFromGV(upgradev1.SchemeGroupVersion, "Plan", upgradev1.Plan{}),
 		).
 		BatchCreateCRDsIfNotExisted(
 			crd.FromGV(harvesterv1.SchemeGroupVersion, "KeyPair", harvesterv1.KeyPair{}),

--- a/pkg/data/secret.go
+++ b/pkg/data/secret.go
@@ -1,0 +1,32 @@
+package data
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func createSecrets(mgmt *config.Management) error {
+	secrets := mgmt.CoreFactory.Core().V1().Secret()
+
+	// Initializing the secret for Plan cattle-system/sync-additional-ca,
+	// so sync-additional-ca doesn't fail to mount harvester-additional-ca secret to jobs.
+	additionalCA := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: util.CattleSystemNamespaceName,
+			Name:      util.AdditionalCASecretName,
+		},
+		Data: map[string][]byte{
+			util.AdditionalCAFileName: []byte(""),
+		},
+	}
+	if _, err := secrets.Create(&additionalCA); err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "Failed to create secret %s/%s", additionalCA.Namespace, additionalCA.Name)
+	}
+
+	return nil
+}

--- a/tests/integration/runtime/construct.go
+++ b/tests/integration/runtime/construct.go
@@ -18,15 +18,14 @@ func Construct(ctx context.Context, kubeConfig *restclient.Config) error {
 		return nil
 	}
 
-	// create namespace
-	err := client.CreateNamespace(kubeConfig, testHarvesterNamespace)
-	if err != nil {
-		return fmt.Errorf("failed to create target namespace, %v", err)
-	}
-
-	err = client.CreateNamespace(kubeConfig, testLonghornNamespace)
-	if err != nil {
-		return fmt.Errorf("failed to create target namespace, %v", err)
+	// create namespaces
+	var err error
+	namespaces := []string{testHarvesterNamespace, testLonghornNamespace, testCattleNamespace}
+	for _, namespace := range namespaces {
+		err = client.CreateNamespace(kubeConfig, namespace)
+		if err != nil {
+			return fmt.Errorf("failed to create target namespace %s, %v", namespace, err)
+		}
 	}
 
 	err = createCRDs(ctx, kubeConfig)

--- a/tests/integration/runtime/crds.go
+++ b/tests/integration/runtime/crds.go
@@ -7,6 +7,7 @@ import (
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	wcrd "github.com/rancher/wrangler/pkg/crd"
 	"k8s.io/client-go/rest"
 
@@ -25,6 +26,7 @@ func createCRDs(ctx context.Context, restConfig *rest.Config) error {
 			createNetworkAttachmentDefinitionCRD(),
 			createManagedChartCRD(),
 			createAppCRD(),
+			createPlanCRD(),
 		).
 		BatchWait()
 }
@@ -55,4 +57,11 @@ func createAppCRD() wcrd.CRD {
 	app.PluralName = "apps"
 	app.SingularName = "app"
 	return app
+}
+
+func createPlanCRD() wcrd.CRD {
+	plan := crd.FromGV(upgradev1.SchemeGroupVersion, "Plan", upgradev1.Plan{})
+	plan.PluralName = "plans"
+	plan.SingularName = "plan"
+	return plan
 }

--- a/tests/integration/runtime/runtime.go
+++ b/tests/integration/runtime/runtime.go
@@ -17,6 +17,7 @@ const (
 	testCRDChartDir         = "../../../deploy/charts/harvester-crd"
 	testHarvesterNamespace  = "harvester-system"
 	testLonghornNamespace   = "longhorn-system"
+	testCattleNamespace     = "cattle-system"
 	testChartReleaseName    = "harvester"
 	testCRDChartReleaseName = "harvester-crd"
 )


### PR DESCRIPTION
**Problem:**
When users add an additional-ca, they also expect this can be applied to the host. For example, pulling images can also use this ca.

**Solution:**
Using SUC plan to change ca on the host.

**Related Issue:**
https://github.com/harvester/harvester/issues/2175

**Test plan:**

Setup:
* Create a harvester cluster and a ubuntu server. Make sure they can reach each other.
* On the ubuntu server, install docker and run the following commands.
```
mkdir -p certs
openssl req \
  -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
  -addext "subjectAltName = DNS:myregistry.local" \
  -x509 -days 365 -out certs/domain.crt
sudo mkdir -p /etc/docker/certs.d/myregistry.local:5000
sudo cp certs/domain.crt /etc/docker/certs.d/myregistry.local:5000/domain.crt
docker run -d \
  -p 5000:5000 \
  --restart=always \
  --name registry \
  -v "$(pwd)"/certs:/certs \
  -v "$(pwd)"/registry:/var/lib/registry \
  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
  -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
  registry:2
docker pull rancher/rancher-agent:v2.6.5
docker tag rancher/rancher-agent:v2.6.5 myregistry.local:5000/rancher/rancher-agent:v2.6.5
docker push myregistry.local:5000/rancher/rancher-agent:v2.6.5
```
* On each harvester node, add ubuntu IP to `/etc/hosts`.
```
# vim /etc/hosts
192.168.0.50 myregistry.local
```
* Create a rancher v2.6.5 (it's can be a docker container or VM). After it starts, update `system-default-registry` setting to `myregistry.local:5000`

Case 1: Import Harvester to Rancher
* Import harvester cluster to the rancher and doesn't have any error.
* Check image in `cattle-system/cattle-cluster-agent` deployment is `myregistry.test:5000/rancher/rancher-agent:v2.6.5`.

Case 2: Add another node to Harvester cluster
* Add another node to harvester cluster and add `192.168.0.50 myregistry.local` to `/etc/hosts`.
* Login to the new node and run the following command. It should not have error.
```
curl https://myregistry.local:5000
```

Case 3: Remove additional-ca
* Set `additional-ca` setting as default.
* Wait for new `cattle-system/apply-sync-additional-ca-on-xxx` jobs finish.
* Login to any harvester node. It should have `SSL certificate problem` with the following command.
```
curl https://myregistry.local:5000
```