### PR TITLE
Github Issue template: Add more ways to share support bundles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,10 +18,16 @@ Steps to reproduce the behavior:
 <!-- A clear and concise description of what you expected to happen. -->
 
 **Support bundle**
-<!-- You can generate a support bundle in the bottom of Harvester UI. It includes logs and configurations that help diagnose the issue.  -->
+<!--
+You can generate a support bundle in the bottom of Harvester UI (https://docs.harvesterhci.io/v1.0/troubleshooting/harvester/#generate-a-support-bundle). It includes logs and configurations that help diagnose the issue.
+
+Tokens, passwords, and secrets are automatically removed from support bundles. If you feel it's not appropriate to share the bundle files publicly, please consider:
+- Wait for a developer to reach you and provide the bundle file by any secure methods.
+- Join our Slack community (https://rancher-users.slack.com/archives/C01GKHKAG0K) to provide the bundle.
+- Send the bundle to harvester-support-bundle@suse.com with the correct issue ID.  -->
 
 
-**Environment:**
+**Environment**
  - Harvester ISO version: 
  - Underlying Infrastructure (e.g. Baremetal with Dell PowerEdge R630):
 


### PR DESCRIPTION
Add more approaches to share support bundles.
- Slack, email, ad-hoc.