### PR TITLE
Support bundle: collect fleet-agent and fleet-controller logs

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -136,6 +136,8 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string, pullPolicy
 func (m *Manager) getCollectNamespaces() string {
 	namespaces := []string{
 		"cattle-dashboards",
+		"cattle-fleet-local-system",
+		"cattle-fleet-system",
 		"cattle-fleet-clusters-system",
 		"cattle-monitoring-system",
 		"fleet-local",


### PR DESCRIPTION
Add more namespaces:

- cattle-fleet-local-system
- cattle-fleet-system

to collect fleet-controller/fleet-agent logs.


**Related Issue:**

https://github.com/harvester/harvester/issues/2297

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

- Create a support bundle.
- Check  fleet-agent and fleet-controller logs are collected:
<img width="412" alt="Screen Shot 2022-05-20 at 4 51 46 PM" src="https://user-images.githubusercontent.com/1691518/169491923-e135718b-caa5-4959-9b36-6e37fddb61e5.png">
