### PR TITLE
Add clone vm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	k8s.io/api v0.22.3
 	k8s.io/apiextensions-apiserver v0.22.3
 	k8s.io/apimachinery v0.22.3
+	k8s.io/apiserver v0.22.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
@@ -255,7 +256,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiserver v0.22.3 // indirect
 	k8s.io/cli-runtime v0.22.3 // indirect
 	k8s.io/code-generator v0.21.5 // indirect
 	k8s.io/component-base v0.21.5 // indirect

--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -26,6 +26,7 @@ const (
 	createTemplate = "createTemplate"
 	addVolume      = "addVolume"
 	removeVolume   = "removeVolume"
+	cloneVM        = "clone"
 )
 
 type vmformatter struct {
@@ -48,6 +49,7 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 
 	resource.AddAction(request, addVolume)
 	resource.AddAction(request, removeVolume)
+	resource.AddAction(request, cloneVM)
 
 	if canEjectCdRom(vm) {
 		resource.AddAction(request, ejectCdRom)

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -19,11 +19,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/rest"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	volumeapi "github.com/harvester/harvester/pkg/api/volume"
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/builder"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/settings"
@@ -169,6 +171,20 @@ func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) erro
 			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `volumeName` are required")
 		}
 		return h.removeVolume(r.Context(), namespace, name, input)
+	case cloneVM:
+		var input CloneInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+		}
+
+		if input.TargetVM == "" {
+			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter targetVm are required")
+		}
+
+		if err := h.cloneVM(name, namespace, input); err != nil {
+			return err
+		}
+		return nil
 	default:
 		return apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
 	}
@@ -626,6 +642,109 @@ func (h *vmActionHandler) removeVolume(ctx context.Context, namespace, name stri
 		Error()
 }
 
+// cloneVM creates a VM which uses volume cloning from the source VM.
+func (h *vmActionHandler) cloneVM(name string, namespace string, input CloneInput) error {
+	vm, err := h.vmCache.Get(namespace, name)
+	if err != nil {
+		return fmt.Errorf("cannot get vm %s/%s, err: %w", namespace, name, err)
+	}
+	newVM := getClonedVMYamlFromSourceVM(input.TargetVM, vm)
+
+	newPVCs, secretNameMap, err := h.cloneVolumes(newVM)
+	if err != nil {
+		return fmt.Errorf("clone volumes error for new vm %s/%s, err %w", newVM.Namespace, newVM.Name, err)
+	}
+	newPVCsString, err := json.Marshal(newPVCs)
+	if err != nil {
+		return fmt.Errorf("cannot marshal value %+v, err: %w", newPVCs, err)
+	}
+
+	newVM.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = string(newPVCsString)
+	if newVM, err = h.vms.Create(newVM); err != nil {
+		return fmt.Errorf("cannot create newVM %+v, err: %w", newVM, err)
+	}
+
+	for oldSecretName, newSecretName := range secretNameMap {
+		secret, err := h.secretCache.Get(namespace, oldSecretName)
+		if err != nil {
+			return fmt.Errorf("cannot get secret %s/%s, err: %w", namespace, oldSecretName, err)
+		}
+
+		newSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      newSecretName,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: newVM.APIVersion,
+						Kind:       newVM.Kind,
+						Name:       newVM.Name,
+						UID:        newVM.UID,
+					},
+				},
+			},
+			Data:       secret.Data,
+			StringData: secret.StringData,
+			Type:       secret.Type,
+		}
+		if _, err = h.secretClient.Create(&newSecret); err != nil {
+			return fmt.Errorf("cannot create a new secret from %s/%s, err: %w", namespace, oldSecretName, err)
+		}
+	}
+	return nil
+}
+
+func (h *vmActionHandler) cloneVolumes(newVM *kubevirtv1.VirtualMachine) ([]corev1.PersistentVolumeClaim, map[string]string, error) {
+	var (
+		err           error
+		newPVCs       []corev1.PersistentVolumeClaim
+		secretNameMap = map[string]string{} // sourceVM secret name to newVM secret name
+	)
+
+	for i, volume := range newVM.Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			var pvc *corev1.PersistentVolumeClaim
+			pvc, err = h.pvcCache.Get(newVM.Namespace, volume.PersistentVolumeClaim.ClaimName)
+			if err != nil {
+				return nil, nil, fmt.Errorf("cannot get pvc %s, err: %w", volume.PersistentVolumeClaim.ClaimName, err)
+			}
+			newPVC := corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: newVM.Namespace,
+					Name:      names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%s-", newVM.Name, volume.Name)),
+				},
+				Spec: *pvc.Spec.DeepCopy(),
+			}
+			newPVC.Spec.VolumeName = ""
+			newPVC.Spec.DataSource = &corev1.TypedLocalObjectReference{
+				Kind: "PersistentVolumeClaim",
+				Name: pvc.Name,
+			}
+			newPVCs = append(newPVCs, newPVC)
+			volume.PersistentVolumeClaim.ClaimName = newPVC.Name
+		} else if volume.CloudInitNoCloud != nil {
+			if volume.CloudInitNoCloud.UserDataSecretRef != nil {
+				if _, ok := secretNameMap[volume.CloudInitNoCloud.UserDataSecretRef.Name]; !ok {
+					secretNameMap[volume.CloudInitNoCloud.UserDataSecretRef.Name] = names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", newVM.Name))
+				}
+				volume.CloudInitNoCloud.UserDataSecretRef.Name = secretNameMap[volume.CloudInitNoCloud.UserDataSecretRef.Name]
+			}
+			if volume.CloudInitNoCloud.NetworkDataSecretRef != nil {
+				if _, ok := secretNameMap[volume.CloudInitNoCloud.NetworkDataSecretRef.Name]; !ok {
+					secretNameMap[volume.CloudInitNoCloud.NetworkDataSecretRef.Name] = names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", newVM.Name))
+				}
+				volume.CloudInitNoCloud.NetworkDataSecretRef.Name = secretNameMap[volume.CloudInitNoCloud.NetworkDataSecretRef.Name]
+			}
+		} else if volume.ContainerDisk != nil {
+			continue
+		} else {
+			return nil, nil, fmt.Errorf("invalid volume %s, only support PersistentVolumeClaim, CloudInitNoCloud, and ContainerDisk", volume.Name)
+		}
+		newVM.Spec.Template.Spec.Volumes[i] = volume
+	}
+	return newPVCs, secretNameMap, nil
+}
+
 func sanitizeVirtualMachineForTemplateVersion(templateVersionName string, vm *kubevirtv1.VirtualMachine) harvesterv1.VirtualMachineSourceSpec {
 	sanitizedVm := removeMacAddresses(vm)
 	sanitizedVm = replaceSecrets(templateVersionName, sanitizedVm)
@@ -702,4 +821,22 @@ func getTemplateVersionSSHPublicKeySecretName(templateVersionName string, creden
 
 func getTemplateVersionUserPasswordSecretName(templateVersionName string, credentialIndex int) string {
 	return wranglername.SafeConcatName("templateversion", templateVersionName, fmt.Sprintf("credential-%d", credentialIndex), "userpassword")
+}
+
+func getClonedVMYamlFromSourceVM(newVMName string, sourceVM *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine {
+	newVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        newVMName,
+			Namespace:   sourceVM.Namespace,
+			Annotations: map[string]string{},
+			Labels:      sourceVM.Labels,
+		},
+		Spec: *sourceVM.Spec.DeepCopy(),
+	}
+	newVM.Spec.Template.Spec.Hostname = newVM.Name
+	newVM.Spec.Template.ObjectMeta.Labels[builder.LabelKeyVirtualMachineName] = newVM.Name
+	for i := range newVM.Spec.Template.Spec.Domain.Devices.Interfaces {
+		newVM.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = ""
+	}
+	return newVM
 }

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -35,6 +35,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	server.BaseSchemas.MustImportAndCustomize(CreateTemplateInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(AddVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(RemoveVolumeInput{}, nil)
+	server.BaseSchemas.MustImportAndCustomize(CloneInput{}, nil)
 
 	vms := scaled.VirtFactory.Kubevirt().V1().VirtualMachine()
 	vmis := scaled.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
@@ -112,6 +113,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				createTemplate: &actionHandler,
 				addVolume:      &actionHandler,
 				removeVolume:   &actionHandler,
+				cloneVM:        &actionHandler,
 			}
 			apiSchema.ResourceActions = map[string]schemas.Action{
 				startVM:    {},
@@ -141,6 +143,9 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				},
 				removeVolume: {
 					Input: "removeVolumeInput",
+				},
+				cloneVM: {
+					Input: "cloneInput",
 				},
 			}
 		},

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -37,3 +37,7 @@ type AddVolumeInput struct {
 type RemoveVolumeInput struct {
 	DiskName string `json:"diskName"`
 }
+
+type CloneInput struct {
+	TargetVM string `json:"targetVm"`
+}

--- a/vendor/k8s.io/apiserver/pkg/storage/names/generate.go
+++ b/vendor/k8s.io/apiserver/pkg/storage/names/generate.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"fmt"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+)
+
+// NameGenerator generates names for objects. Some backends may have more information
+// available to guide selection of new names and this interface hides those details.
+type NameGenerator interface {
+	// GenerateName generates a valid name from the base name, adding a random suffix to the
+	// the base. If base is valid, the returned name must also be valid. The generator is
+	// responsible for knowing the maximum valid name length.
+	GenerateName(base string) string
+}
+
+// simpleNameGenerator generates random names.
+type simpleNameGenerator struct{}
+
+// SimpleNameGenerator is a generator that returns the name plus a random suffix of five alphanumerics
+// when a name is requested. The string is guaranteed to not exceed the length of a standard Kubernetes
+// name (63 characters)
+var SimpleNameGenerator NameGenerator = simpleNameGenerator{}
+
+const (
+	// TODO: make this flexible for non-core resources with alternate naming rules.
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+)
+
+func (simpleNameGenerator) GenerateName(base string) string {
+	if len(base) > maxGeneratedNameLength {
+		base = base[:maxGeneratedNameLength]
+	}
+	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1286,6 +1286,7 @@ k8s.io/apiserver/pkg/endpoints/request
 k8s.io/apiserver/pkg/features
 k8s.io/apiserver/pkg/server/egressselector
 k8s.io/apiserver/pkg/server/egressselector/metrics
+k8s.io/apiserver/pkg/storage/names
 k8s.io/apiserver/pkg/util/feature
 k8s.io/apiserver/pkg/util/webhook
 k8s.io/apiserver/plugin/pkg/authenticator/token/webhook


### PR DESCRIPTION
**Problem:**
Move clone VM logic to backend, so we don't need to put too much business logic in frontend. Also, using [CSI volume cloning](https://longhorn.io/docs/1.2.4/snapshots-and-backups/csi-volume-clone/) to support cloning a VM with data.

**Solution:**
Add a `clone` handler in backend.

**Related Issue:**
https://github.com/harvester/harvester/issues/569

**Test plan:**

1. Create a harvester cluster.
2. Create a VM `source-vm` with 3 volumes:
  * Image Volume
  * Volume
  * Container Volume
3. After VM starts, run command `echo "123" > test.txt && sync`.
4. Enable Developer tools & Features.
5. Click `View in API` for the `source-vm`.
![Screen Shot 2022-06-02 at 11 39 28 AM](https://user-images.githubusercontent.com/4927361/171548259-7ebeed40-5e8a-41a6-928c-510ba67f2e9a.png)
6. Click `clone` button.
![Screen Shot 2022-06-02 at 11 40 14 AM](https://user-images.githubusercontent.com/4927361/171548339-03d17c9e-0ed9-4051-8f43-058b9e5e4f98.png)
7. Input `target-vm` and click `Show Request` and `Send Request`.
![Screen Shot 2022-06-02 at 11 41 27 AM](https://user-images.githubusercontent.com/4927361/171548464-ac5f0a2c-8cf6-4941-987e-0a3ba323ff9b.png)
8. A new VM `target-vm` can run.
9. Check `target-vm` YAML. There should have `dataSource` field in `harvesterhci.io/volumeClaimTemplates` annotation. Also format of PVC name should be `<vm-name>-<volume-name>-<random-string>` and format of secret reference should be `<vm-name>-<random-string>`.
![Screen Shot 2022-06-02 at 11 45 40 AM](https://user-images.githubusercontent.com/4927361/171548898-6cbf59e2-9fd2-4dbb-ba3e-e95de62907c6.png)
![Screen Shot 2022-06-02 at 11 46 45 AM](https://user-images.githubusercontent.com/4927361/171549014-52753794-fc76-416f-a75b-9aabd928ebff.png)
10. Run command `cat ~/test.txt` in the `target-vm`. The result should be `123`.
