### PR TITLE
added topology zone awareness to harvester control plane

### DIFF
--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -292,13 +292,8 @@ func selectPromoteNode(nodeList []*corev1.Node) *corev1.Node {
 		}
 
 		if !isManagementRole(node) && isHarvesterNode(node) && isHealthyNode(node) {
-			if len(managementNodeTopologyZoneList) > 0 {
-				// only promote the node if the label is set to a new zone
-				if topologyZone := node.Labels[corev1.LabelTopologyZone]; topologyZone != "" &&
-					!slice.ContainsString(managementNodeTopologyZoneList, topologyZone) {
-					return node
-				}
-			} else {
+			topologyZone := node.Labels[corev1.LabelTopologyZone]
+			if len(managementNodeTopologyZoneList) > 0 && topologyZone != "" && !slice.ContainsString(managementNodeTopologyZoneList, topologyZone) || len(managementNodeTopologyZoneList) == 0 {
 				if promoteNode == nil || node.CreationTimestamp.Before(&promoteNode.CreationTimestamp) {
 					promoteNode = node
 				}

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -131,6 +131,7 @@ var (
 	w1z1 = NewDefaultNodeBuilder().Name("w-1-z1").Zone("zone1").Harvester().Worker()
 	w2z2 = NewDefaultNodeBuilder().Name("w-2-z2").Zone("zone2").Harvester().Worker()
 	w3z3 = NewDefaultNodeBuilder().Name("w-3-z3").Zone("zone3").Harvester().Worker()
+	w4z3 = NewDefaultNodeBuilder().Name("w-4-z3").Zone("zone3").Harvester().Worker()
 )
 
 func Test_selectPromoteNode(t *testing.T) {
@@ -433,6 +434,13 @@ func Test_selectPromoteNode(t *testing.T) {
 			name: "two management in zone1 and zone2 and one worker in zone3",
 			args: args{
 				nodeList: []*corev1.Node{m1z1, m2z2, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "two management in zone1 and zone2 and two worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, w4z3, w3z3},
 			},
 			want: w3z3,
 		},

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -34,6 +34,11 @@ func (n *NodeBuilder) Name(name string) *NodeBuilder {
 	return n
 }
 
+func (n *NodeBuilder) Zone(name string) *NodeBuilder {
+	n.node.Labels[corev1.LabelTopologyZone] = name
+	return n
+}
+
 func (n *NodeBuilder) Harvester() *NodeBuilder {
 	n.node.Labels[HarvesterManagedNodeLabelKey] = "true"
 	return n
@@ -65,6 +70,11 @@ func (n *NodeBuilder) Failed() *NodeBuilder {
 	return n
 }
 
+func (n *NodeBuilder) Unknown() *NodeBuilder {
+	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = PromoteStatusUnknown
+	return n
+}
+
 func (n *NodeBuilder) NotReady() *NodeBuilder {
 	ready := corev1.NodeCondition{
 		Type:   corev1.NodeReady,
@@ -75,6 +85,7 @@ func (n *NodeBuilder) NotReady() *NodeBuilder {
 }
 
 var (
+	// normal nodes
 	mu1 = NewDefaultNodeBuilder().Name("m-unmanaged-1").Management()
 
 	m1 = NewDefaultNodeBuilder().Name("m-1").Harvester().Management()
@@ -89,9 +100,37 @@ var (
 	wnr1 = NewDefaultNodeBuilder().Name("w-notready-1").Harvester().NotReady().Worker()
 	wnr2 = NewDefaultNodeBuilder().Name("w-notready-2").Harvester().NotReady().Worker()
 
+	wu1 = NewDefaultNodeBuilder().Name("w-unknown-1").Harvester().Unknown().Worker()
+
+	wc1 = NewDefaultNodeBuilder().Name("w-complete-1").Harvester().Complete().Worker()
+
 	w1 = NewDefaultNodeBuilder().Name("w-1").Harvester().Worker()
 	w2 = NewDefaultNodeBuilder().Name("w-2").Harvester().Worker()
 	w3 = NewDefaultNodeBuilder().Name("w-3").Harvester().Worker()
+
+	// zone aware nodes
+	mu1z2 = NewDefaultNodeBuilder().Name("m-unmanaged-1-z2").Zone("zone2").Management()
+
+	m1z1 = NewDefaultNodeBuilder().Name("m-1-z1").Zone("zone1").Harvester().Management()
+	m2z2 = NewDefaultNodeBuilder().Name("m-2-z2").Zone("zone2").Harvester().Management()
+	m3z3 = NewDefaultNodeBuilder().Name("m-3-z3").Zone("zone3").Harvester().Management()
+	m4z1 = NewDefaultNodeBuilder().Name("m-4-z1").Zone("zone1").Harvester().Management()
+
+	mc1z2 = NewDefaultNodeBuilder().Name("m-complete-1-z2").Zone("zone2").Harvester().Complete().Management()
+
+	wr1z2 = NewDefaultNodeBuilder().Name("w-running-1-z2").Zone("zone2").Harvester().Running().Worker()
+	wf1z2 = NewDefaultNodeBuilder().Name("w-failed-1-z2").Zone("zone2").Harvester().Failed().Worker()
+
+	wnr1z2 = NewDefaultNodeBuilder().Name("w-notready-1-z2").Zone("zone2").Harvester().NotReady().Worker()
+	wnr2z3 = NewDefaultNodeBuilder().Name("w-notready-2-z3").Zone("zone3").Harvester().NotReady().Worker()
+
+	wu1z2 = NewDefaultNodeBuilder().Name("w-unknown-1-z2").Harvester().Unknown().Worker()
+
+	wc1z2 = NewDefaultNodeBuilder().Name("w-complete-1-z2").Harvester().Complete().Worker()
+
+	w1z1 = NewDefaultNodeBuilder().Name("w-1-z1").Zone("zone1").Harvester().Worker()
+	w2z2 = NewDefaultNodeBuilder().Name("w-2-z2").Zone("zone2").Harvester().Worker()
+	w3z3 = NewDefaultNodeBuilder().Name("w-3-z3").Zone("zone3").Harvester().Worker()
 )
 
 func Test_selectPromoteNode(t *testing.T) {
@@ -317,6 +356,230 @@ func Test_selectPromoteNode(t *testing.T) {
 			name: "three management and one worker",
 			args: args{
 				nodeList: []*corev1.Node{m1, m2, m3, w1},
+			},
+			want: nil,
+		},
+		{
+			name: "one management and one promote unknown worker and one worker",
+			args: args{
+				nodeList: []*corev1.Node{m1, wu1, w1},
+			},
+			want: nil,
+		},
+		{
+			name: "one management and one promoted worker and one worker",
+			args: args{
+				nodeList: []*corev1.Node{m1, wc1, w1},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1",
+			args: args{
+				nodeList: []*corev1.Node{m1z1},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one worker in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, w1z1},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and two workers in zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, w2z2, w3z3},
+			},
+			want: w2z2,
+		},
+		{
+			name: "one management in zone1 and one not ready worker in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wnr1z2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one not ready worker in zone2 and one ready worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wnr1z2, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one not ready worker in zone2 and two ready workers in zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wnr1z2, w2z2, w3z3},
+			},
+			want: w2z2,
+		},
+		{
+			name: "one management in zone1 and two not ready workers in zone2 and zone3 and one ready worker in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wnr1z2, wnr2z3, w2z2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and two not ready workers in zone2 and zone3 and two ready workers in zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wnr1z2, wnr2z3, w2z2, w3z3},
+			},
+			want: w2z2,
+		},
+		{
+			name: "two management in zone1 and zone2 and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "two management in zone1 and zone2 and one worker in zone1",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, w1z1},
+			},
+			want: nil,
+		},
+		{
+			name: "two management in zone1 and zone2 and two workers in zone1 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, w1z1, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "two management in zone1 and zone2 and three workers in zone1, zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, w1z1, w2z2, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "one management in zone1 and one promoting worker in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wr1z2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promoting worker in zone2 and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wr1z2, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promoting worker in zone2 and two workers in zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wr1z2, w2z2, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promote failed worker in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wf1z2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promote failed worker in zone2 and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wf1z2, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promote failed worker in zone2 and two workers in zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wf1z2, w2z2, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promoted management in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, mc1z2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promoted management in zone2 and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, mc1z2, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "one management in zone1 and one promoted management in zone2 and two workers in zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, mc1z2, w2z2, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "one management in zone1 and one unmanaged management in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, mu1z2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one unmanaged management in zone2 and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, mu1z2, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "one management in zone1 and one unmanaged management in zone2 and two workers in zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, mu1z2, w2z2, w3z3},
+			},
+			want: w3z3,
+		},
+		{
+			name: "three management in zone1, zone2 and zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, m3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "three management in zone1, zone2 and zone3 and one worker in zone1",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, m3z3, w1z1},
+			},
+			want: nil,
+		},
+		{
+			name: "three management in zone1, zone2 and zone1 (could be before labeling) and one worker in zone1",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, m4z1, w1z1},
+			},
+			want: nil,
+		},
+		{
+			name: "three management in zone1, zone2 and zone1 (could be before labeling) and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, m2z2, m4z1, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promote unknown in zone2 worker and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wu1z2, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one promoted worker in zone2 and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wc1z2, w3z3},
 			},
 			want: nil,
 		},


### PR DESCRIPTION
**Problem:**
Currently the Harvester Control Plane is not topology/zone aware. 

**Solution:**
This PR makes the controller promotion code topology/zone aware. If the topology.kubernetes.io/zone label is set it will form a control plane based on three different zones. If there are less then three zones configured the number of control plane nodes will be limited to the number of zones, this is expected behavior. If there are no zone labels set, it will default in the oldest node behavior.

I tested this code in a running environment and also during a fresh deployment. When the os.labels.topology.kubernetes.io/zone is set in the Harvester create and join configs it will form a zone aware control plane during the deployment as well.

**Related Issue:**
[2325](https://github.com/harvester/harvester/issues/2325)