### PR TITLE
fix test TestPlanHandler_OnChanged sometimes fails

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -167,8 +167,8 @@ func fakeImageExist(imageCache ctlharvesterv1.VirtualMachineImageCache, displayN
 }
 
 func emptyConditionsTime(conditions []harvesterv1.Condition) {
-	for _, c := range conditions {
-		c.LastTransitionTime = ""
-		c.LastUpdateTime = ""
+	for k := range conditions {
+		conditions[k].LastTransitionTime = ""
+		conditions[k].LastUpdateTime = ""
 	}
 }


### PR DESCRIPTION
**Problem:**
Test failure occurs when TestPlanHandler_OnChanged is executed.

**Solution:**
Fix the problem of function `emptyConditionsTime`.

**Related Issue:**
#2101 

**Test plan:**
Execute several unit tests.
