### PR TITLE
fix HARVESTER_INSTALLER_VERSION

### DIFF
--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=v1.0.2
+HARVESTER_INSTALLER_VERSION=v1.0
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
**Problem:**
Harvester v1.0 branch keeps using harvester-installer v1.0.2 to build ISO.

**Solution:**
Use v1.0 branch.

**Related Issue:**
https://github.com/harvester/harvester/issues/2332

