### PR TITLE
Add WaitForLease to builder

### DIFF
--- a/pkg/builder/network.go
+++ b/pkg/builder/network.go
@@ -68,3 +68,8 @@ func (v *VMBuilder) Interface(interfaceName, interfaceModel, interfaceMACAddress
 	v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces = interfaces
 	return v
 }
+
+func (v *VMBuilder) WaitForLease(interfaceName string) *VMBuilder {
+	v.WaitForLeaseInterfaceNames = append(v.WaitForLeaseInterfaceNames, interfaceName)
+	return v
+}

--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -16,13 +16,14 @@ const (
 	defaultVMCPUCores = 1
 	defaultVMMemory   = "256Mi"
 
-	HarvesterAPIGroup                    = "harvesterhci.io"
-	LabelAnnotationPrefixHarvester       = HarvesterAPIGroup + "/"
-	LabelKeyVirtualMachineCreator        = LabelAnnotationPrefixHarvester + "creator"
-	LabelKeyVirtualMachineName           = LabelAnnotationPrefixHarvester + "vmName"
-	AnnotationKeyVirtualMachineSSHNames  = LabelAnnotationPrefixHarvester + "sshNames"
-	AnnotationKeyVirtualMachineDiskNames = LabelAnnotationPrefixHarvester + "diskNames"
-	AnnotationKeyImageID                 = LabelAnnotationPrefixHarvester + "imageId"
+	HarvesterAPIGroup                                     = "harvesterhci.io"
+	LabelAnnotationPrefixHarvester                        = HarvesterAPIGroup + "/"
+	LabelKeyVirtualMachineCreator                         = LabelAnnotationPrefixHarvester + "creator"
+	LabelKeyVirtualMachineName                            = LabelAnnotationPrefixHarvester + "vmName"
+	AnnotationKeyVirtualMachineSSHNames                   = LabelAnnotationPrefixHarvester + "sshNames"
+	AnnotationKeyVirtualMachineWaitForLeaseInterfaceNames = LabelAnnotationPrefixHarvester + "waitForLeaseInterfaceNames"
+	AnnotationKeyVirtualMachineDiskNames                  = LabelAnnotationPrefixHarvester + "diskNames"
+	AnnotationKeyImageID                                  = LabelAnnotationPrefixHarvester + "imageId"
 
 	AnnotationPrefixCattleField = "field.cattle.io/"
 	LabelPrefixHarvesterTag     = "tag.harvesterhci.io/"
@@ -30,9 +31,9 @@ const (
 )
 
 type VMBuilder struct {
-	VirtualMachine *kubevirtv1.VirtualMachine
-	SSHNames       []string
-	InterfaceNames []string
+	VirtualMachine             *kubevirtv1.VirtualMachine
+	SSHNames                   []string
+	WaitForLeaseInterfaceNames []string
 }
 
 func NewVMBuilder(creator string) *VMBuilder {
@@ -82,7 +83,9 @@ func NewVMBuilder(creator string) *VMBuilder {
 		},
 	}
 	return &VMBuilder{
-		VirtualMachine: vm,
+		VirtualMachine:             vm,
+		SSHNames:                   []string{},
+		WaitForLeaseInterfaceNames: []string{},
 	}
 }
 
@@ -219,6 +222,12 @@ func (v *VMBuilder) VM() (*kubevirtv1.VirtualMachine, error) {
 		return nil, err
 	}
 	v.VirtualMachine.Spec.Template.ObjectMeta.Annotations[AnnotationKeyVirtualMachineSSHNames] = string(sshNames)
+
+	waitForLeaseInterfaceNames, err := json.Marshal(v.WaitForLeaseInterfaceNames)
+	if err != nil {
+		return nil, err
+	}
+	v.VirtualMachine.Spec.Template.ObjectMeta.Annotations[AnnotationKeyVirtualMachineWaitForLeaseInterfaceNames] = string(waitForLeaseInterfaceNames)
 
 	return v.VirtualMachine, nil
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Used by PR https://github.com/harvester/terraform-provider-harvester/pull/39

add a wait_for_lease option to the VM attached network interface where if true, creating VM will wait not only for correct state but optionally also until IP is reported.

**Related Issue:**
https://github.com/harvester/harvester/issues/2255

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
