### PR TITLE
add annotations to pvc when cloning vm

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -708,10 +708,16 @@ func (h *vmActionHandler) cloneVolumes(newVM *kubevirtv1.VirtualMachine) ([]core
 			if err != nil {
 				return nil, nil, fmt.Errorf("cannot get pvc %s, err: %w", volume.PersistentVolumeClaim.ClaimName, err)
 			}
+
+			annotations := map[string]string{}
+			if imageId, ok := pvc.Annotations[util.AnnotationImageID]; ok {
+				annotations[util.AnnotationImageID] = imageId
+			}
 			newPVC := corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: newVM.Namespace,
-					Name:      names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%s-", newVM.Name, volume.Name)),
+					Namespace:   newVM.Namespace,
+					Name:        names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%s-", newVM.Name, volume.Name)),
+					Annotations: annotations,
 				},
 				Spec: *pvc.Spec.DeepCopy(),
 			}


### PR DESCRIPTION
**Change:**
Add annotation to PVCs in `harvesterhci.io/volumeClaimTemplates`, so UI can know which one is image volume.

**Related Issue:**
https://github.com/harvester/harvester/issues/569

**Test plan:**
* Create `source-vm` with an image volume and a normal volume.
* Run `echo "123" > test.txt && sync` in `source-vm`.
* Click `View in API`.
* Click `Clone` button and input `target-vm`.
* Check whether disk volume of `target-vm` in `harvesterhci.io/volumeClaimTemplates` has annotation `harvesterhci.io/imageId`.
