### PR TITLE
VM builder support configuring affinity feature

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -166,6 +166,15 @@ func (v *VMBuilder) EvictionStrategy(liveMigrate bool) *VMBuilder {
 	return v
 }
 
+func (v *VMBuilder) Affinity(affinity *corev1.Affinity) *VMBuilder {
+	if affinity == nil {
+		return v.DefaultPodAntiAffinity()
+	}
+
+	v.VirtualMachine.Spec.Template.Spec.Affinity = affinity
+	return v
+}
+
 func (v *VMBuilder) DefaultPodAntiAffinity() *VMBuilder {
 	podAffinityTerm := corev1.PodAffinityTerm{
 		LabelSelector: &metav1.LabelSelector{


### PR DESCRIPTION
Used by PR https://github.com/harvester/docker-machine-driver-harvester/pull/33

The node driver needs to support configuring affinity objects, and add the affinity of the VM, terraform can reuse this method.

**Related Issue:**
#2316 

**Test plan:**