### PR TITLE
Bump support-bundle-kit to v0.0.9

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -445,7 +445,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.8
+    tag: v0.0.9
 
 generalJob:
   image:


### PR DESCRIPTION
Support SLE Micro for Rancher.

**Related Issue:**
https://github.com/harvester/harvester/issues/2464

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Reviewer:
- Crate a cluster that is provisioned by v1.0 ISO.
- Edit setting
  ```
  kubectl edit settings.harvesterhci.io support-bundle-image
  ```
  change value to:
  ```
  value: '{"repository":"rancher/support-bundle-kit","tag":"v0.0.9","imagePullPolicy":"IfNotPresent"}'
  ```
- Generate a support bundle from GUI, there should be node logs in `nodes`. Please extract zip files to check.