### PR TITLE
Make sure there are enough zones in node promotion

### DIFF
--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -382,9 +382,30 @@ func Test_selectPromoteNode(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "one management in zone1 and one worker in zone2",
+			name: "one management in zone1 and one worker in zone1",
 			args: args{
 				nodeList: []*corev1.Node{m1z1, w1z1},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one worker in zone2",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, w2z2, w3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and two worker",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, w1, w2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management and one worker in zone1 and one worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, w1z1, w3z3},
 			},
 			want: nil,
 		},
@@ -406,6 +427,13 @@ func Test_selectPromoteNode(t *testing.T) {
 			name: "one management in zone1 and one not ready worker in zone2 and one ready worker in zone3",
 			args: args{
 				nodeList: []*corev1.Node{m1z1, wnr1z2, w3z3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management in zone1 and one not ready worker in zone2 and two ready worker in zone3",
+			args: args{
+				nodeList: []*corev1.Node{m1z1, wnr1z2, w3z3, w4z3},
 			},
 			want: nil,
 		},


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
2 etcd is unstable
we should only promote nodes if there has enough zones

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Add unit tests to make sure only promote nodes if there has enough zones
2. Optimize code to improve performance and make it easier to read

**Related Issue:**
https://github.com/harvester/harvester/issues/2325

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install first node, the role of this node should be `Management Node`
2. Install second node, the role of this node should be `Compute Node`, the second node shouldn't be promoted to `Management Node`
3. Add label `topology.kubernetes.io/zone=zone1` to the first node
4. Install third node, the second node and third node shouldn't be promoted
5. Add label `topology.kubernetes.io/zone=zone1` to the second node, the second node and third node shouldn't be promoted 
6. Add label `topology.kubernetes.io/zone=zone3` to the third node, the second node and third node shouldn't be promoted
7. Change the value of label `topology.kubernetes.io/zone` from `zone1` to `zone2` in the second node, the second node and third node will be promoted to `Management Node` one by one