### PR TITLE
add volume.beta.kubernetes.io/storage-provisioner

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -40,7 +40,6 @@ import (
 var (
 	restoreAnnotationsToDelete = []string{
 		"pv.kubernetes.io",
-		"volume.beta.kubernetes.io",
 		ref.AnnotationSchemaOwnerKeyName,
 	}
 )


### PR DESCRIPTION
**Problem:**
`volume.beta.kubernetes.io/storage-provisioner` is not automatically added in newer k8s. K8s will automatically add `volume.kubernetes.io/storage-provisioner` now. However, `volume.kubernetes.io/storage-provisioner` is not supported in provisioner [release-2.1](https://github.com/kubernetes-csi/external-provisioner/blob/afca22d79f718300f851de0d8912330cf8b8b04a/pkg/controller/controller.go#L136). We need to wait for LH to bump provisioner to [release-3.1](https://github.com/kubernetes-csi/external-provisioner/blob/fdfd8a39fce5391f7e8737cf3c373b118ef40957/pkg/controller/controller.go#L131-L132).

**Solution:**
Don't remove `volume.beta.kubernetes.io/storage-provisioner` in the current version.

**Related Issue:**
https://github.com/harvester/harvester/issues/2336
