### PR TITLE
[backport v1.0.3] Add longhorn-system and cattle-system to build-in no_proxy

### DIFF
--- a/pkg/util/proxy.go
+++ b/pkg/util/proxy.go
@@ -11,6 +11,8 @@ var builtInNoProxy = []string{
 	"127.0.0.1",
 	"0.0.0.0",
 	"10.0.0.0/8",
+	"longhorn-system",
+	"cattle-system",
 	"cattle-system.svc",
 	".svc",
 	".cluster.local",

--- a/pkg/util/proxy_test.go
+++ b/pkg/util/proxy_test.go
@@ -15,17 +15,17 @@ func Test_AddBuiltInNoProxy(t *testing.T) {
 		{
 			name:   "single item",
 			input:  "192.168.1.0/24",
-			output: "192.168.1.0/24,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc,.svc,.cluster.local",
+			output: "192.168.1.0/24,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
 		},
 		{
 			name:   "multiple items",
 			input:  "192.168.1.0/24,example.com",
-			output: "192.168.1.0/24,example.com,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,cattle-system.svc,.svc,.cluster.local",
+			output: "192.168.1.0/24,example.com,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
 		},
 		{
 			name:   "overlapped items",
 			input:  "10.0.0.0/8,127.0.0.1",
-			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,cattle-system.svc,.svc,.cluster.local",
+			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
backport PR https://github.com/harvester/harvester/pull/2514

**Related Issue:**
https://github.com/harvester/harvester/issues/2524

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1.  set http-proxy setting, for example
```json
{
  "httpProxy": "http://192.168.5.238:12333",
  "httpsProxy": "http://192.168.5.238:12333"
}
```
2. create image by upload image file
3. the image should be `Active` after a few moment