### PR TITLE
fix(webhook/vmrestore): check on the same target

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -237,6 +237,10 @@ func (h *RestoreHandler) initStatus(restore *harvesterv1.VirtualMachineRestore) 
 
 	restoreCpy.Status = &harvesterv1.VirtualMachineRestoreStatus{
 		Complete: pointer.BoolPtr(false),
+		Conditions: []harvesterv1.Condition{
+			newProgressingCondition(corev1.ConditionTrue, "", "Initializing VirtualMachineRestore"),
+			newReadyCondition(corev1.ConditionFalse, "", "Initializing VirtualMachineRestore"),
+		},
 	}
 
 	if _, err := h.restores.Update(restoreCpy); err != nil {
@@ -565,8 +569,6 @@ func (h *RestoreHandler) updateOwnerRefAndTargetUID(vmRestore *harvesterv1.Virtu
 
 	// set vmRestore owner reference to the target VM
 	restoreCpy.SetOwnerReferences(configVMOwner(vm))
-	updateRestoreCondition(restoreCpy, newProgressingCondition(corev1.ConditionTrue, "", "Initializing VirtualMachineRestore"))
-	updateRestoreCondition(restoreCpy, newReadyCondition(corev1.ConditionFalse, "", "Initializing VirtualMachineRestore"))
 
 	if _, err := h.restores.Update(restoreCpy); err != nil {
 		return err

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -1,17 +1,22 @@
 package indexeres
 
 import (
+	"fmt"
+
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/webhook/clients"
 )
 
 const (
-	VMBackupBySourceUIDIndex = "harvesterhci.io/vmbackup-by-source-uid"
+	VMBackupBySourceUIDIndex          = "harvesterhci.io/vmbackup-by-source-uid"
+	VMRestoreByTargetNamespaceAndName = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
 )
 
 func RegisterIndexers(clients *clients.Clients) {
 	vmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
+	vmRestoreCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache()
 	vmBackupCache.AddIndexer(VMBackupBySourceUIDIndex, vmBackupBySourceUID)
+	vmRestoreCache.AddIndexer(VMRestoreByTargetNamespaceAndName, vmRestoreByTargetNamespaceAndName)
 }
 
 func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
@@ -19,4 +24,11 @@ func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error
 		return []string{string(*obj.Status.SourceUID)}, nil
 	}
 	return []string{}, nil
+}
+
+func vmRestoreByTargetNamespaceAndName(obj *harvesterv1.VirtualMachineRestore) ([]string, error) {
+	if obj == nil {
+		return []string{}, nil
+	}
+	return []string{fmt.Sprintf("%s-%s", obj.Namespace, obj.Spec.Target.Name)}, nil
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -42,6 +42,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 		),
 		setting.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),

--- a/pkg/webhook/util/filter.go
+++ b/pkg/webhook/util/filter.go
@@ -1,8 +1,12 @@
 package util
 
 import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlbackup "github.com/harvester/harvester/pkg/controller/master/backup"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/webhook/indexeres"
@@ -16,6 +20,24 @@ func HasInProgressingVMBackupBySourceUID(cache ctlharvesterv1.VirtualMachineBack
 	for _, vmBackup := range vmBackups {
 		if ctlbackup.IsBackupProgressing(vmBackup) || ctlbackup.GetVMBackupError(vmBackup) != nil {
 			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func HasInProgressingVMRestoreOnSameTarget(cache ctlharvesterv1.VirtualMachineRestoreCache, targetNamespace, targetName string) (bool, error) {
+	vmRestores, err := cache.GetByIndex(indexeres.VMRestoreByTargetNamespaceAndName, fmt.Sprintf("%s-%s", targetNamespace, targetName))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	for _, vmRestore := range vmRestores {
+		if vmRestore != nil && vmRestore.Status != nil {
+			for _, condition := range vmRestore.Status.Conditions {
+				if condition.Type == harvesterv1.BackupConditionProgressing && condition.Status == v1.ConditionTrue {
+					return true, nil
+				}
+			}
 		}
 	}
 	return false, nil


### PR DESCRIPTION
**Problem:**
When there is a in progressing vmrestore, another vmrestore can run on the same target too.

**Solution:**
Add webhook to prevent it.

**Related Issue:**
https://github.com/harvester/harvester/issues/2559

**Test plan:**
1. Install Harvester with any nodes
2. Login to Dashboard then navigate to _Advanced/Settings_, setup `backup-target` with NFS or S3
3. Create Image for VM creation
4. Create VM `vm1`
5. Take backup from `vm1` as `vm1b`
6. Take backup from `vm1` as `vm1b2`
7. Stop VM `vm1`
8. Restore backup `vm1b2` with **Replace Existing**
9. Restore backup `vm1b` with **Replace Existing** when the VM `vm1` still in state `restoring`. Webhook should return an invalid message.

### Additional context
Since v1.0.3 released date is close, I create the PR for `v1.0` first. I will cherry-pick it to `master` branch.