### PR TITLE
fix(webhook/backup-target): check in progressing vmrestore

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -58,11 +58,13 @@ func NewValidator(
 	settingCache ctlv1beta1.SettingCache,
 	vmBackupCache ctlv1beta1.VirtualMachineBackupCache,
 	snapshotClassCache ctlsnapshotv1.VolumeSnapshotClassCache,
+	vmRestoreCache ctlv1beta1.VirtualMachineRestoreCache,
 ) types.Validator {
 	validator := &settingValidator{
 		settingCache:       settingCache,
 		vmBackupCache:      vmBackupCache,
 		snapshotClassCache: snapshotClassCache,
+		vmRestoreCache:     vmRestoreCache,
 	}
 	validateSettingFuncs[settings.BackupTargetSettingName] = validator.validateBackupTarget
 	validateSettingFuncs[settings.VolumeSnapshotClassSettingName] = validator.validateVolumeSnapshotClass
@@ -75,6 +77,7 @@ type settingValidator struct {
 	settingCache       ctlv1beta1.SettingCache
 	vmBackupCache      ctlv1beta1.VirtualMachineBackupCache
 	snapshotClassCache ctlsnapshotv1.VolumeSnapshotClassCache
+	vmRestoreCache     ctlv1beta1.VirtualMachineRestoreCache
 }
 
 func (v *settingValidator) Resource() types.Resource {
@@ -228,10 +231,18 @@ func (v *settingValidator) validateBackupTarget(setting *v1beta1.Setting) error 
 
 	vmBackups, err := v.vmBackupCache.List(metav1.NamespaceAll, labels.Everything())
 	if err != nil {
-		return werror.NewInternalError(err.Error())
+		return werror.NewInternalError(fmt.Sprintf("can't list vmbackup, err: %+v", err.Error()))
 	}
 	if hasVMBackupInCreatingOrDeletingProgress(vmBackups) {
 		return werror.NewBadRequest("There is VMBackup in creating or deleting progress")
+	}
+
+	vmRestores, err := v.vmRestoreCache.List(metav1.NamespaceAll, labels.Everything())
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("can't list vmrestore, err: %+v", err.Error()))
+	}
+	if hasVMRestoreInCreatingOrDeletingProgress(vmRestores) {
+		return werror.NewBadRequest("There is VMRestore in creating or deleting progress")
 	}
 
 	// It is allowed to reset the current backup target setting to the default value
@@ -421,6 +432,15 @@ func getSystemCerts() *x509.CertPool {
 func hasVMBackupInCreatingOrDeletingProgress(vmBackups []*v1beta1.VirtualMachineBackup) bool {
 	for _, vmBackup := range vmBackups {
 		if vmBackup.DeletionTimestamp != nil || vmBackup.Status == nil || !*vmBackup.Status.ReadyToUse {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVMRestoreInCreatingOrDeletingProgress(vmRestores []*v1beta1.VirtualMachineRestore) bool {
+	for _, vmRestore := range vmRestores {
+		if vmRestore.DeletionTimestamp != nil || vmRestore.Status == nil || !*vmRestore.Status.Complete {
 			return true
 		}
 	}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -47,6 +47,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
 			clients.SnapshotFactory.Snapshot().V1beta1().VolumeSnapshotClass().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 		),
 		templateversion.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate().Cache(),


### PR DESCRIPTION
**Problem:**
Users can change backup target when there is in progressing vmrestore.

**Solution:**
Add a webhook to prevent it.

**Related Issue:**
https://github.com/harvester/harvester/issues/2560

**Test plan:**

1. Install Harvester with any nodes
2. Login to Dashboard then navigate to _Advanced/Settings_, setup `backup-target` with NFS or S3
3. Create Image for VM creation
4. Create VM `vm1`
5. Take Backup `vm1b` from `vm1`
6. Restore the backup `vm1b` to New/Existing VM
7. When the VM still in `restoring` state, update **backup-target** settings to _Use the default value_ then setup it back. Webhook should return an invalid message.

### Additional context
Since v1.0.3 released date is close, I create the PR for `v1.0` first. I will cherry-pick it to `master` branch.
