### PR TITLE
fix(webhook/vmrestore): check on the same target

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -237,6 +237,10 @@ func (h *RestoreHandler) initStatus(restore *harvesterv1.VirtualMachineRestore) 
 
 	restoreCpy.Status = &harvesterv1.VirtualMachineRestoreStatus{
 		Complete: pointer.BoolPtr(false),
+		Conditions: []harvesterv1.Condition{
+			newProgressingCondition(corev1.ConditionTrue, "", "Initializing VirtualMachineRestore"),
+			newReadyCondition(corev1.ConditionFalse, "", "Initializing VirtualMachineRestore"),
+		},
 	}
 
 	if _, err := h.restores.Update(restoreCpy); err != nil {
@@ -565,8 +569,6 @@ func (h *RestoreHandler) updateOwnerRefAndTargetUID(vmRestore *harvesterv1.Virtu
 
 	// set vmRestore owner reference to the target VM
 	restoreCpy.SetOwnerReferences(configVMOwner(vm))
-	updateRestoreCondition(restoreCpy, newProgressingCondition(corev1.ConditionTrue, "", "Initializing VirtualMachineRestore"))
-	updateRestoreCondition(restoreCpy, newReadyCondition(corev1.ConditionFalse, "", "Initializing VirtualMachineRestore"))
 
 	if _, err := h.restores.Update(restoreCpy); err != nil {
 		return err

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -1,17 +1,22 @@
 package indexeres
 
 import (
+	"fmt"
+
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/webhook/clients"
 )
 
 const (
-	VMBackupBySourceUIDIndex = "harvesterhci.io/vmbackup-by-source-uid"
+	VMBackupBySourceUIDIndex          = "harvesterhci.io/vmbackup-by-source-uid"
+	VMRestoreByTargetNamespaceAndName = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
 )
 
 func RegisterIndexers(clients *clients.Clients) {
 	vmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
+	vmRestoreCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache()
 	vmBackupCache.AddIndexer(VMBackupBySourceUIDIndex, vmBackupBySourceUID)
+	vmRestoreCache.AddIndexer(VMRestoreByTargetNamespaceAndName, vmRestoreByTargetNamespaceAndName)
 }
 
 func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
@@ -19,4 +24,11 @@ func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error
 		return []string{string(*obj.Status.SourceUID)}, nil
 	}
 	return []string{}, nil
+}
+
+func vmRestoreByTargetNamespaceAndName(obj *harvesterv1.VirtualMachineRestore) ([]string, error) {
+	if obj == nil {
+		return []string{}, nil
+	}
+	return []string{fmt.Sprintf("%s-%s", obj.Namespace, obj.Spec.Target.Name)}, nil
 }

--- a/pkg/webhook/resources/restore/validator.go
+++ b/pkg/webhook/resources/restore/validator.go
@@ -68,10 +68,10 @@ func (v *restoreValidator) Create(request *types.Request, newObj runtime.Object)
 	newVM := newRestore.Spec.NewVM
 
 	if targetVM == "" {
-		return werror.NewInvalidError("target VM name is empty", fieldTargetName)
+		return werror.NewInvalidError("Target VM name is empty", fieldTargetName)
 	}
 	if backupName == "" {
-		return werror.NewInvalidError("backup name is empty", fieldVirtualMachineBackupName)
+		return werror.NewInvalidError("Backup name is empty", fieldVirtualMachineBackupName)
 	}
 
 	if err := v.checkBackupTarget(newRestore); err != nil {
@@ -93,13 +93,13 @@ func (v *restoreValidator) Create(request *types.Request, newObj runtime.Object)
 
 	// restore an existing vm but the vm is still running
 	if !newVM && vm.Status.Ready {
-		return werror.NewInvalidError(fmt.Sprintf("please stop the VM %q before doing a restore", vm.Name), fieldTargetName)
+		return werror.NewInvalidError(fmt.Sprintf("Please stop the VM %q before doing a restore", vm.Name), fieldTargetName)
 	}
 
 	if result, err := util.HasInProgressingVMRestoreOnSameTarget(v.vmRestore, vm.Namespace, vm.Name); err != nil {
-		return werror.NewInternalError(fmt.Sprintf("failed to get the VM-related restores, err: %+v", err))
+		return werror.NewInternalError(fmt.Sprintf("Failed to get the VM-related restores, err: %+v", err))
 	} else if result {
-		return werror.NewInvalidError(fmt.Sprintf("please wait for the previous VM restore on the %s/%s to be complete first.", vm.Namespace, vm.Name), fieldTargetName)
+		return werror.NewInvalidError(fmt.Sprintf("Please wait for the previous VM restore on the %s/%s to be complete first.", vm.Namespace, vm.Name), fieldTargetName)
 	}
 
 	return nil
@@ -109,22 +109,22 @@ func (v *restoreValidator) checkBackupTarget(vmRestore *v1beta1.VirtualMachineRe
 	// get backup target
 	backupTargetSetting, err := v.setting.Get(settings.BackupTargetSettingName)
 	if err != nil {
-		return fmt.Errorf("can't get backup target setting, err: %w", err)
+		return fmt.Errorf("Can't get backup target setting, err: %w", err)
 	}
 
 	backupTarget, err := settings.DecodeBackupTarget(backupTargetSetting.Value)
 	if err != nil {
-		return fmt.Errorf("unmarshal backup target failed, value: %s, err: %w", backupTargetSetting.Value, err)
+		return fmt.Errorf("Unmarshal backup target failed, value: %s, err: %w", backupTargetSetting.Value, err)
 	}
 
 	if backupTarget.IsDefaultBackupTarget() {
-		return fmt.Errorf("backup target is invalid")
+		return fmt.Errorf("Backup target is invalid")
 	}
 
 	// get vmbackup
 	vmBackup, err := v.vmBackup.Get(vmRestore.Spec.VirtualMachineBackupNamespace, vmRestore.Spec.VirtualMachineBackupName)
 	if err != nil {
-		return fmt.Errorf("can't get vmbackup %s/%s, err: %w", vmRestore.Spec.VirtualMachineBackupNamespace, vmRestore.Spec.VirtualMachineBackupName, err)
+		return fmt.Errorf("Can't get vmbackup %s/%s, err: %w", vmRestore.Spec.VirtualMachineBackupNamespace, vmRestore.Spec.VirtualMachineBackupName, err)
 	}
 
 	if vmBackup.Status == nil || vmBackup.Status.BackupTarget == nil || !ctlbackup.IsBackupTargetSame(vmBackup.Status.BackupTarget, backupTarget) {

--- a/pkg/webhook/resources/restore/validator.go
+++ b/pkg/webhook/resources/restore/validator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/harvester/harvester/pkg/settings"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
+	"github.com/harvester/harvester/pkg/webhook/util"
 )
 
 const (
@@ -27,20 +28,23 @@ func NewValidator(
 	vms ctlkubevirtv1.VirtualMachineCache,
 	setting ctlharvesterv1.SettingCache,
 	vmBackup ctlharvesterv1.VirtualMachineBackupCache,
+	vmRestore ctlharvesterv1.VirtualMachineRestoreCache,
 ) types.Validator {
 	return &restoreValidator{
-		vms:      vms,
-		setting:  setting,
-		vmBackup: vmBackup,
+		vms:       vms,
+		setting:   setting,
+		vmBackup:  vmBackup,
+		vmRestore: vmRestore,
 	}
 }
 
 type restoreValidator struct {
 	types.DefaultValidator
 
-	vms      ctlkubevirtv1.VirtualMachineCache
-	setting  ctlharvesterv1.SettingCache
-	vmBackup ctlharvesterv1.VirtualMachineBackupCache
+	vms       ctlkubevirtv1.VirtualMachineCache
+	setting   ctlharvesterv1.SettingCache
+	vmBackup  ctlharvesterv1.VirtualMachineBackupCache
+	vmRestore ctlharvesterv1.VirtualMachineRestoreCache
 }
 
 func (v *restoreValidator) Resource() types.Resource {
@@ -90,6 +94,12 @@ func (v *restoreValidator) Create(request *types.Request, newObj runtime.Object)
 	// restore an existing vm but the vm is still running
 	if !newVM && vm.Status.Ready {
 		return werror.NewInvalidError(fmt.Sprintf("please stop the VM %q before doing a restore", vm.Name), fieldTargetName)
+	}
+
+	if result, err := util.HasInProgressingVMRestoreOnSameTarget(v.vmRestore, vm.Namespace, vm.Name); err != nil {
+		return werror.NewInternalError(fmt.Sprintf("failed to get the VM-related restores, err: %+v", err))
+	} else if result {
+		return werror.NewInvalidError(fmt.Sprintf("please wait for the previous VM restore on the %s/%s to be complete first.", vm.Namespace, vm.Name), fieldTargetName)
 	}
 
 	return nil

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -42,6 +42,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 		),
 		setting.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),

--- a/pkg/webhook/util/filter.go
+++ b/pkg/webhook/util/filter.go
@@ -1,8 +1,12 @@
 package util
 
 import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlbackup "github.com/harvester/harvester/pkg/controller/master/backup"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/webhook/indexeres"
@@ -16,6 +20,24 @@ func HasInProgressingVMBackupBySourceUID(cache ctlharvesterv1.VirtualMachineBack
 	for _, vmBackup := range vmBackups {
 		if ctlbackup.IsBackupProgressing(vmBackup) || ctlbackup.GetVMBackupError(vmBackup) != nil {
 			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func HasInProgressingVMRestoreOnSameTarget(cache ctlharvesterv1.VirtualMachineRestoreCache, targetNamespace, targetName string) (bool, error) {
+	vmRestores, err := cache.GetByIndex(indexeres.VMRestoreByTargetNamespaceAndName, fmt.Sprintf("%s-%s", targetNamespace, targetName))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	for _, vmRestore := range vmRestores {
+		if vmRestore != nil && vmRestore.Status != nil {
+			for _, condition := range vmRestore.Status.Conditions {
+				if condition.Type == harvesterv1.BackupConditionProgressing && condition.Status == v1.ConditionTrue {
+					return true, nil
+				}
+			}
 		}
 	}
 	return false, nil


### PR DESCRIPTION
**Problem:**
When there is a in progressing vmrestore, another vmrestore can run on the same target too.

**Solution:**
Add webhook to prevent it.

**Related Issue:**
https://github.com/harvester/harvester/issues/2559

**Test plan:**
1. Install Harvester with any nodes
2. Login to Dashboard then navigate to _Advanced/Settings_, setup `backup-target` with NFS or S3
3. Create Image for VM creation
4. Create VM `vm1`
5. Take backup from `vm1` as `vm1b`
6. Take backup from `vm1` as `vm1b2`
7. Stop VM `vm1`
8. Restore backup `vm1b2` with **Replace Existing**
9. Restore backup `vm1b` with **Replace Existing** when the VM `vm1` still in state `restoring`. Webhook should return an invalid message.
