### PR TITLE
fix 2615, cease alert VirtOperatorDown

### DIFF
--- a/deploy/charts/harvester/dependency_charts/kubevirt-operator/templates/deployment.yaml
+++ b/deploy/charts/harvester/dependency_charts/kubevirt-operator/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/name: virt-operator
         app.kubernetes.io/component: operator
         kubevirt.io: virt-operator
-        prometheus.kubevirt.io: ""
+        prometheus.kubevirt.io: "true"
     spec:
       priorityClassName: kubevirt-cluster-critical
       serviceAccountName: kubevirt-operator


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
`VirtOperatorDown` alert comes up in Harvester v1.0 and master-head.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add proper label to let `prometheus` monitor the related POD and cease alert.

**Related Issue:**
https://github.com/harvester/harvester/issues/2615

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Per issue.