### PR TITLE
fix(api): check whether vm has backups before allowing restore

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harvester/harvester/pkg/api/vmtemplate"
 	"github.com/harvester/harvester/pkg/api/volume"
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/indexeres"
 )
 
 type registerSchema func(scaled *config.Scaled, server *server.Server, options config.Options) error
@@ -27,6 +28,7 @@ func registerSchemas(scaled *config.Scaled, server *server.Server, options confi
 
 func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
+	indexeres.RegisterAPIIndexers(scaled)
 	return registerSchemas(scaled, server, options,
 		image.RegisterSchema,
 		keypair.RegisterSchema,

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -404,7 +404,7 @@ func (h *vmActionHandler) restoreBackup(vmName, vmNamespace string, input Restor
 		return err
 	}
 	apiGroup := kubevirtv1.SchemeGroupVersion.Group
-	backup := &harvesterv1.VirtualMachineRestore{
+	restore := &harvesterv1.VirtualMachineRestore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      input.Name,
 			Namespace: vmNamespace,
@@ -415,11 +415,12 @@ func (h *vmActionHandler) restoreBackup(vmName, vmNamespace string, input Restor
 				Kind:     kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 				Name:     vmName,
 			},
-			VirtualMachineBackupName: input.BackupName,
-			NewVM:                    false,
+			VirtualMachineBackupNamespace: vmNamespace,
+			VirtualMachineBackupName:      input.BackupName,
+			NewVM:                         false,
 		},
 	}
-	_, err := h.restores.Create(backup)
+	_, err := h.restores.Create(restore)
 	if err != nil {
 		return fmt.Errorf("failed to create restore, error: %s", err.Error())
 	}

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -84,7 +84,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	}
 
 	vmformatter := vmformatter{
-		vmiCache: vmis.Cache(),
+		vmiCache:      vmis.Cache(),
+		vmBackupCache: backups.Cache(),
 	}
 
 	vmStore := &vmStore{

--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -7,16 +7,18 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/ref"
 )
 
 const (
-	UserNameIndex           = "auth.harvesterhci.io/user-username-index"
-	RbByRoleAndSubjectIndex = "auth.harvesterhci.io/crb-by-role-and-subject"
-	PVCByVMIndex            = "harvesterhci.io/pvc-by-vm-index"
-	VMByNetworkIndex        = "vm.harvesterhci.io/vm-by-network"
-	PodByNodeNameIndex      = "harvesterhci.io/pod-by-nodename"
+	UserNameIndex              = "auth.harvesterhci.io/user-username-index"
+	RbByRoleAndSubjectIndex    = "auth.harvesterhci.io/crb-by-role-and-subject"
+	PVCByVMIndex               = "harvesterhci.io/pvc-by-vm-index"
+	VMByNetworkIndex           = "vm.harvesterhci.io/vm-by-network"
+	PodByNodeNameIndex         = "harvesterhci.io/pod-by-nodename"
+	VMBackupBySourceVMUIDIndex = "harvesterhci.io/vmbackup-by-source-vm-uid"
 )
 
 func RegisterScaledIndexers(scaled *config.Scaled) {
@@ -31,6 +33,11 @@ func RegisterManagementIndexers(management *config.Management) {
 	pvcInformer.AddIndexer(PVCByVMIndex, pvcByVM)
 	podInformer := management.CoreFactory.Core().V1().Pod().Cache()
 	podInformer.AddIndexer(PodByNodeNameIndex, PodByNodeName)
+}
+
+func RegisterAPIIndexers(scaled *config.Scaled) {
+	vmBackupInformer := scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
+	vmBackupInformer.AddIndexer(VMBackupBySourceVMUIDIndex, VMBackupBySourceVMUID)
 }
 
 func rbByRoleAndSubject(obj *rbacv1.ClusterRoleBinding) ([]string, error) {
@@ -67,4 +74,11 @@ func VMByNetwork(obj *kubevirtv1.VirtualMachine) ([]string, error) {
 
 func PodByNodeName(obj *corev1.Pod) ([]string, error) {
 	return []string{obj.Spec.NodeName}, nil
+}
+
+func VMBackupBySourceVMUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
+	if obj.Status == nil || obj.Status.SourceUID == nil {
+		return []string{}, nil
+	}
+	return []string{string(*obj.Status.SourceUID)}, nil
 }


### PR DESCRIPTION
**Problem:**
VM shows restore action when there is no backup.

**Solution:**
Fix `canDoRestore` function.

**Related Issue:**
https://github.com/harvester/harvester/issues/2610

**Test plan:**

* Create a cluster.
* Create a VM `vm-test`.
* Run `echo "123" > test.txt && sync` in `vm-test`.
* Take a backup for it.
* After backup finished, run `echo "456" > test.txt && sync` in `vm-test`.
* Stop the VM `vm-test`.
* After the related VMI is gone, we can see `Restore` action in the list. Restore the backup to `vm-test`.
<img width="1019" alt="Screen Shot 2022-08-03 at 5 55 33 PM" src="https://user-images.githubusercontent.com/4927361/182580550-5e934179-93a1-4fa8-909b-6587791401b5.png">

* Run `cat test.txt` in `vm-test`. It should show `123`.
* Delete the VM `vm-test`.
* Create a new VM with the same name `vm-test`.
* Stop the VM `vm-test`. After the related VMI is gone, we _can't_ see `Restore` action in the list, because they don't have the same `UID`.

<img width="1026" alt="Screen Shot 2022-08-03 at 6 05 09 PM" src="https://user-images.githubusercontent.com/4927361/182582487-cf8651ed-13af-459d-91bb-2828e7eabc1a.png">
