### PR TITLE
Bump support bundle kit to v0.0.10

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -437,7 +437,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.9
+    tag: v0.0.10
 
 generalJob:
   image:


### PR DESCRIPTION
Test plans for reviewer:
- Crate a cluster that is provisioned by v1.0 ISO.
- Edit setting
  ```
  kubectl edit settings.harvesterhci.io support-bundle-image
  ```
  change value to:
  ```
  value: '{"repository":"rancher/support-bundle-kit","tag":"v0.0.10","imagePullPolicy":"IfNotPresent"}'
  ```