### PR TITLE
Add v1.0.3 release

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper -n rm container-suseconnect && \
 
 WORKDIR /var/lib/harvester/harvester
 
-ENV HARVESTER_UI_VERSION v1.0.3-rc2
+ENV HARVESTER_UI_VERSION v1.0.3
 ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=v1.0.3-rc2
+HARVESTER_INSTALLER_VERSION=v1.0.3
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
**Description:**
Add Harvester v1.0.3 release. Both UI and installer version bumps are identical to the `v1.0.3-rc2` releases.