### PR TITLE
Sync image display_name to image labels

### DIFF
--- a/pkg/controller/master/image/vm_image_controller.go
+++ b/pkg/controller/master/image/vm_image_controller.go
@@ -53,6 +53,17 @@ func (h *vmImageHandler) OnChanged(_ string, image *harvesterv1.VirtualMachineIm
 		}
 		return h.initialize(image)
 	}
+
+	// sync display_name to labels in order to list by labelSelector
+	if image.Spec.DisplayName != image.Labels[util.LabelImageDisplayName] {
+		toUpdate := image.DeepCopy()
+		if toUpdate.Labels == nil {
+			toUpdate.Labels = map[string]string{}
+		}
+		toUpdate.Labels[util.LabelImageDisplayName] = image.Spec.DisplayName
+		return h.images.Update(toUpdate)
+	}
+
 	return image, nil
 }
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -14,6 +14,7 @@ const (
 	AnnotationReservedMemory       = prefix + "/reservedMemory"
 	AnnotationHash                 = prefix + "/hash"
 	AnnotationRunStrategy          = prefix + "/vmRunStrategy"
+	LabelImageDisplayName          = prefix + "/imageDisplayName"
 
 	BackupTargetSecretName      = "harvester-backup-target-secret"
 	InternalTLSSecretName       = "tls-rancher-internal"


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
In some [case](https://github.com/harvester/terraform-provider-harvester/blob/126661ff5cf35c8992c03198009c0fde50168d2c/internal/provider/image/datasource_image.go#L37),  we need get image by image's displayName:

currently, we have to list all images and check displayName one by one

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
If we sync image displayName to image's labels, we can use `labelSelector` to get images we needed

**Related Issue:**
https://github.com/harvester/harvester/issues/2630

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
replace harvester image to `futuretea/harvester:sync-display-name-head`

1. check the labels of existing images by `View In Api`, label `harvesterhci.io/imageDisplayName` will be added to labels, and it's value should be the displayName value

2. create an image by specify an existing displayName
for example, there is an image `harvester-public/ubuntu-20.04-minimal-cloudimg-amd64.img` exist in the cluster, we create a new image `harvester-public/ubuntu-20.04-minimal-cloudimg-amd64.img` again
![image](https://user-images.githubusercontent.com/15064560/185059827-29a52fb1-f7db-4e61-a937-7b5a5c942646.png)
the request should be denied by admission webhook "validator.harvesterhci.io"
