### PR TITLE
fix(restore): make vmNameLabel consistent after restore

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -55,7 +55,7 @@ const (
 	lastRestoreAnnotation = "restore.harvesterhci.io/last-restore-uid"
 
 	vmCreatorLabel = "harvesterhci.io/creator"
-	vmNameLabel    = "harvesterhci.io/vm-name"
+	vmNameLabel    = "harvesterhci.io/vmName"
 
 	restoreErrorEvent    = "VirtualMachineRestoreError"
 	restoreCompleteEvent = "VirtualMachineRestoreComplete"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**

Restoring new VMs using created backup results in "VM name label inconsistency" issue as described in detail in #2662.

**Solution:**

Changing `vmNameLabel`'s value from `harvesterhci.io/vm-name` to `harvesterhci.io/vmName`.

**Related Issue:**

#2662 

**Test plan:**

1. Create one VM (use defaults)
1. Make sure that the label name is `harvesterhci.io/vmName` by checking its YAML
1. Wait for the VM to fully boot up then take a backup
1. After the backup task is done, delete the VM
1. Restore a new VM with the same name using the newly created backup
1. After the restore task is completed, check its YAML for the label name, it should still be `harvesterhci.io/vmName`
