### PR TITLE
feat(cluster-retistration-url): support set to default

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -104,7 +104,11 @@ func (h *Handler) setConfiguredCondition(settingCopy *harvesterv1.Setting, err e
 			return err
 		}
 	} else if err == nil {
-		harvesterv1.SettingConfigured.True(settingCopy)
+		if settingCopy.Value == "" {
+			harvesterv1.SettingConfigured.False(settingCopy)
+		} else {
+			harvesterv1.SettingConfigured.True(settingCopy)
+		}
 		harvesterv1.SettingConfigured.Message(settingCopy, "")
 		if _, err := h.settings.Update(settingCopy); err != nil {
 			return err


### PR DESCRIPTION
**Problem:**
The setting `cluster-registration-url` cannot be set to empty.

**Solution:**
Check whether the URL is empty in the controller.

**Related Issue:**
https://github.com/harvester/harvester/issues/2650

**Test plan:**
case 1:
1. Create a harvester cluster and rancher v2.6.7.
2. Import the harvester cluster to rancher.
3.  After successful import, reset the `cluster-registration-url` to empty.

case 2:
1. Create a harvester cluster and rancher v2.6.7.
2. Import the harvester cluster to rancher.
3. After successful import, create another rancher v2.6.7.
4. Import the harvester cluster to the new rancher. Import should be successful.
