### PR TITLE
feat: add backup-target healthy check api

### DIFF
--- a/pkg/api/backuptarget/healthy_handler.go
+++ b/pkg/api/backuptarget/healthy_handler.go
@@ -1,0 +1,72 @@
+package backuptarget
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/longhorn/backupstore"
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+
+	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/controller/master/backup"
+	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+type HealthyHandler struct {
+	context      context.Context
+	settingCache v1beta1.SettingCache
+	secretCache  ctlcorev1.SecretCache
+}
+
+func NewHealthyHandler(scaled *config.Scaled) *HealthyHandler {
+	return &HealthyHandler{
+		context:      scaled.Ctx,
+		settingCache: scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
+		secretCache:  scaled.CoreFactory.Core().V1().Secret().Cache(),
+	}
+}
+
+func (h *HealthyHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	backupTargetSetting, err := h.settingCache.Get(settings.BackupTargetSettingName)
+	if err != nil {
+		util.ResponseError(rw, http.StatusInternalServerError, fmt.Errorf("can't get %s setting, error: %w", settings.BackupTargetSettingName, err))
+		return
+	}
+	if backupTargetSetting.Value == "" {
+		util.ResponseError(rw, http.StatusBadRequest, fmt.Errorf("%s setting is not set", settings.BackupTargetSettingName))
+		return
+	}
+
+	target, err := settings.DecodeBackupTarget(backupTargetSetting.Value)
+	if err != nil {
+		util.ResponseError(rw, http.StatusInternalServerError, fmt.Errorf("can't decode %s setting %s, error: %w", settings.BackupTargetSettingName, backupTargetSetting.Value, err))
+		return
+	}
+	if target.IsDefaultBackupTarget() {
+		util.ResponseError(rw, http.StatusBadRequest, fmt.Errorf("can't check the backup target healthy, %s setting is not set", settings.BackupTargetSettingName))
+		return
+	}
+
+	if target.Type == settings.S3BackupType {
+		secret, err := h.secretCache.Get(util.LonghornSystemNamespaceName, util.BackupTargetSecretName)
+		if err != nil {
+			util.ResponseError(rw, http.StatusInternalServerError, fmt.Errorf("can't get backup target secret: %s/%s, error: %w", util.LonghornSystemNamespaceName, util.BackupTargetSecretName, err))
+			return
+		}
+		os.Setenv(backup.AWSAccessKey, string(secret.Data[backup.AWSAccessKey]))
+		os.Setenv(backup.AWSSecretKey, string(secret.Data[backup.AWSSecretKey]))
+		os.Setenv(backup.AWSEndpoints, string(secret.Data[backup.AWSEndpoints]))
+		os.Setenv(backup.AWSCERT, string(secret.Data[backup.AWSCERT]))
+	}
+
+	_, err = backupstore.GetBackupStoreDriver(backup.ConstructEndpoint(target))
+	if err != nil {
+		util.ResponseError(rw, http.StatusServiceUnavailable, fmt.Errorf("can't connect to backup target %+v, error: %w", target, err))
+		return
+	}
+	util.ResponseOK(rw)
+}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 
+	"github.com/harvester/harvester/pkg/api/backuptarget"
 	"github.com/harvester/harvester/pkg/api/kubeconfig"
 	"github.com/harvester/harvester/pkg/api/proxy"
 	"github.com/harvester/harvester/pkg/api/supportbundle"
@@ -48,6 +49,9 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 
 	sbDownloadHandler := supportbundle.NewDownloadHandler(r.scaled, r.options.Namespace)
 	m.Path("/v1/harvester/supportbundles/{bundleName}/download").Methods("GET").Handler(sbDownloadHandler)
+
+	btHealthyHandler := backuptarget.NewHealthyHandler(r.scaled)
+	m.Path("/v1/harvester/backuptarget/healthz").Methods("GET").Handler(btHealthyHandler)
 	// --- END of preposition routes ---
 
 	// adds collection action support


### PR DESCRIPTION
**Problem:**
UI can't know whether the backup target connection is healthy.

**Solution:**
Add an API for it.

**Related Issue:**
https://github.com/harvester/harvester/issues/2631

**Test plan:**

Case 1: empty backup-target
* Create a new harvester cluster and a rancher server.
* Import harvester to rancher.
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return a message "backup-target setting is not set" with HTTP status 400.

Case 2: happy path
* Set up a NFS server. `kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/backupstores/nfs-backupstore.yaml`
* Set backup-target to NFS type with `nfs://longhorn-test-nfs-svc.default:/opt/backupstore` endpoint.
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return HTTP status 200.

Case 3: set backup-target to default
* Set backup-target as default value. The value will become `{type: "", ...}`.
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return a message "backup-target setting is not set" with HTTP status 400.

Case 4: remove NFS server.
* Set backup-target to NFS type with `nfs://longhorn-test-nfs-svc.default:/opt/backupstore` endpoint.
* Remove NFS server. `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/backupstores/nfs-backupstore.yaml`
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return a message like "can't connect to backup-target ..." with HTTP status 503.

