### PR TITLE
Upgrade patch of rancher-monitoring

### DIFF
--- a/package/upgrade/migrations/managed_charts/v1.0.3.sh
+++ b/package/upgrade/migrations/managed_charts/v1.0.3.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_grafana_resources()
+{
+  # Increase grafana pod limit and request (https://github.com/harvester/harvester-installer/pull/287)
+  yq e '.spec.values.grafana.resources = {"limits": {"cpu": "200m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "200Mi"}}' $CHART_MANIFEST -i
+}
+
+case $CHART_NAME in
+  rancher-monitoring)
+    patch_grafana_resources
+    ;;
+esac


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/2361
https://github.com/harvester/harvester-installer/pull/287   fix2361 increase grafana resource limit
<del>
https://github.com/harvester/harvester/issues/2282
https://github.com/harvester/harvester-installer/pull/327  adjust grafana POD PVC size to 2GiB
</del>
Signed-off-by: Jian Wang <w13915984028@gmail.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Resources change of rancher-monitoring grafana should be applied to old version when upgrading.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add upgrade patch for rancher-monitoring POD

**Related Issue:**
Per title

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. The POD resources chagne will be effective after upgrading.
https://github.com/harvester/harvester-installer/pull/287   fix2361 increase grafana resource limit

<del>

2. The grafana PVC size change will not be effective right after upgrading.
https://github.com/harvester/harvester-installer/pull/327  adjust grafana POD PVC size to 2GiB

This patch will make sure the `PVC size` is 2Gi after upgrading.
How to patch existing PVC, needs more investigation. 
(more scripts like disable grafana, delete PVC, re-enable grafana;  or accordging to PVC reset steps as per LH's document;  both of them are more than quick inheritage from current upgrading framework @bk201 @guangbochen 
)

</del>

The patch to PR:https://github.com/harvester/harvester-installer/pull/327 is removed.

Will update `Harvester doc` and `release-notes` about how to extend running PVC size, the limitation and workaround.
https://github.com/harvester/harvester/issues/2724
