### PR TITLE
Add ui info api

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -15,6 +15,8 @@ ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9
 
+ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION latest
+
 ARG ARCH=amd64
 ARG VERSION=dev
 ENV HARVESTER_SERVER_VERSION ${VERSION}
@@ -32,6 +34,9 @@ RUN mkdir -p /usr/share/harvester/harvester && \
     mkdir -p /usr/share/harvester/harvester/api-ui && \
     cd /usr/share/harvester/harvester/api-ui && \
     curl -sL https://releases.rancher.com/api-ui/${HARVESTER_API_UI_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
+    mkdir -p /usr/share/harvester/harvester/v1/harvester/plugin-assets && \
+    cd /usr/share/harvester/harvester/v1/harvester/plugin-assets && \
+    curl -sL https://releases.rancher.com/harvester-ui/plugin/harvester-${HARVESTER_UI_PLUGIN_BUNDLED_VERSION}.tar.gz | tar xvzf - --strip-components=1 && \
     cd /var/lib/harvester/harvester
 
 COPY entrypoint.sh harvester /usr/bin/

--- a/pkg/api/uiinfo/ui_info_handler.go
+++ b/pkg/api/uiinfo/ui_info_handler.go
@@ -1,0 +1,38 @@
+package uiinfo
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/harvester/harvester/pkg/config"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+type Handler struct {
+	settingsCache ctlharvesterv1.SettingCache
+}
+
+func NewUIInfoHandler(scaled *config.Scaled, option config.Options) *Handler {
+	return &Handler{
+		settingsCache: scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
+	}
+}
+
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	uiSource := settings.UISource.Get()
+	if uiSource == "auto" {
+		if !settings.IsRelease() {
+			uiSource = "external"
+		} else {
+			uiSource = "bundled"
+		}
+	}
+	util.ResponseOKWithBody(rw, map[string]string{
+		settings.UISourceSettingName:               uiSource,
+		settings.UIIndexSettingName:                settings.UIIndex.Get(),
+		settings.UIPluginIndexSettingName:          settings.UIPluginIndex.Get(),
+		settings.UIPluginBundledVersionSettingName: os.Getenv(settings.GetEnvKey(settings.UIPluginBundledVersionSettingName)),
+	})
+}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/harvester/harvester/pkg/api/kubeconfig"
 	"github.com/harvester/harvester/pkg/api/proxy"
 	"github.com/harvester/harvester/pkg/api/supportbundle"
+	"github.com/harvester/harvester/pkg/api/uiinfo"
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/server/ui"
 )
@@ -45,6 +46,10 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	// Those routes should be above /v1/harvester/{type}, otherwise, the response status code would be 404
 	kcGenerateHandler := kubeconfig.NewGenerateHandler(r.scaled, r.options)
 	m.Path("/v1/harvester/kubeconfig").Methods("POST").Handler(kcGenerateHandler)
+
+	uiInfoHandler := uiinfo.NewUIInfoHandler(r.scaled, r.options)
+	m.Path("/v1/harvester/ui-info").Methods("GET").Handler(uiInfoHandler)
+	m.PathPrefix("/v1/harvester/plugin-assets").Handler(ui.Vue.PluginServeAsset())
 
 	sbDownloadHandler := supportbundle.NewDownloadHandler(r.scaled, r.options.Namespace)
 	m.Path("/v1/harvester/supportbundles/{bundleName}/download").Methods("GET").Handler(sbDownloadHandler)

--- a/pkg/server/ui/ui.go
+++ b/pkg/server/ui/ui.go
@@ -130,3 +130,9 @@ func serveIndex(resp io.Writer, url string) error {
 	_, err = io.Copy(resp, r.Body)
 	return err
 }
+
+func (u *handler) PluginServeAsset() http.Handler {
+	return u.middleware(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		http.FileServer(http.Dir(u.pathSetting())).ServeHTTP(rw, req)
+	}))
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -23,9 +23,10 @@ var (
 	APIUIVersion            = NewSetting("api-ui-version", "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
 	ClusterRegistrationURL  = NewSetting("cluster-registration-url", "")
 	ServerVersion           = NewSetting("server-version", "dev")
-	UIIndex                 = NewSetting("ui-index", DefaultDashboardUIURL)
-	UIPath                  = NewSetting("ui-path", "/usr/share/harvester/harvester")
-	UISource                = NewSetting("ui-source", "auto") // Options are 'auto', 'external' or 'bundled'
+	UIIndex                 = NewSetting(UIIndexSettingName, DefaultDashboardUIURL)
+	UIPath                  = NewSetting(UIPathSettingName, "/usr/share/harvester/harvester")
+	UISource                = NewSetting(UISourceSettingName, "auto") // Options are 'auto', 'external' or 'bundled'
+	UIPluginIndex           = NewSetting(UIPluginIndexSettingName, DefaultUIPluginURL)
 	VolumeSnapshotClass     = NewSetting(VolumeSnapshotClassSettingName, "longhorn")
 	BackupTargetSet         = NewSetting(BackupTargetSettingName, InitBackupTargetToString())
 	UpgradableVersions      = NewSetting("upgradable-versions", "")
@@ -48,19 +49,25 @@ var (
 )
 
 const (
-	AdditionalCASettingName         = "additional-ca"
-	BackupTargetSettingName         = "backup-target"
-	VMForceResetPolicySettingName   = "vm-force-reset-policy"
-	SupportBundleTimeoutSettingName = "support-bundle-timeout"
-	HttpProxySettingName            = "http-proxy"
-	OvercommitConfigSettingName     = "overcommit-config"
-	SSLCertificatesSettingName      = "ssl-certificates"
-	SSLParametersName               = "ssl-parameters"
-	VipPoolsConfigSettingName       = "vip-pools"
-	VolumeSnapshotClassSettingName  = "volume-snapshot-class"
-	DefaultDashboardUIURL           = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
-	SupportBundleImageName          = "support-bundle-image"
-	CSIDriverConfigSettingName      = "csi-driver-config"
+	AdditionalCASettingName           = "additional-ca"
+	BackupTargetSettingName           = "backup-target"
+	VMForceResetPolicySettingName     = "vm-force-reset-policy"
+	SupportBundleTimeoutSettingName   = "support-bundle-timeout"
+	HttpProxySettingName              = "http-proxy"
+	OvercommitConfigSettingName       = "overcommit-config"
+	SSLCertificatesSettingName        = "ssl-certificates"
+	SSLParametersName                 = "ssl-parameters"
+	VipPoolsConfigSettingName         = "vip-pools"
+	VolumeSnapshotClassSettingName    = "volume-snapshot-class"
+	DefaultDashboardUIURL             = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
+	SupportBundleImageName            = "support-bundle-image"
+	CSIDriverConfigSettingName        = "csi-driver-config"
+	UIIndexSettingName                = "ui-index"
+	UIPathSettingName                 = "ui-path"
+	UISourceSettingName               = "ui-source"
+	UIPluginIndexSettingName          = "ui-plugin-index"
+	UIPluginBundledVersionSettingName = "ui-plugin-bundled-version"
+	DefaultUIPluginURL                = "https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js"
 )
 
 func init() {


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

- pack ui plugin tar ball `https://releases.rancher.com/harvester-ui/plugin/harvester-latest.tar.gz` to harvester docker image
- new setting `ui-plugin-index` default to `https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js`
- new api `/v1/harvester/ui-info` expose ui and plugin ui info
- new api `/v1/harvester/plugin-assets` serve bundled harvester ui plugin

**Related Issue:**
https://github.com/harvester/harvester/issues/2654

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

replace harvester image to `futuretea/harvester:ui-info-head`

1. view api `/v1/harvester/ui-info`
![image](https://user-images.githubusercontent.com/15064560/187889157-d22f2d65-2d64-422c-95ee-4c8706515104.png)

2. view api `/v1/harvester/plugin-assets/`
![image](https://user-images.githubusercontent.com/15064560/187889125-affe0f34-a0c2-4321-b9f6-275f87336c81.png)
