### PR TITLE
Upg2712 upgrade patch of alertmanager

### DIFF
--- a/package/upgrade/migrations/managed_charts/v1.0.3.sh
+++ b/package/upgrade/migrations/managed_charts/v1.0.3.sh
@@ -9,8 +9,62 @@ patch_grafana_resources()
   yq e '.spec.values.grafana.resources = {"limits": {"cpu": "200m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "200Mi"}}' $CHART_MANIFEST -i
 }
 
+patch_alertmanager_enable()
+{
+  # enable alertmanager by default (https://github.com/harvester/harvester-installer/pull/322)
+  yq e '.spec.values.alertmanager.enabled = true' $CHART_MANIFEST -i
+  yq e '.spec.values.alertmanager.config.global.resolve_timeout = "5m"' $CHART_MANIFEST -i
+  yq e '.spec.values.alertmanager.alertmanagerSpec.retention = "120h"' $CHART_MANIFEST -i
+  yq e '.spec.values.alertmanager.alertmanagerSpec.resources = {"limits": {"cpu": "1000m", "memory": "600Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}' $CHART_MANIFEST -i
+  yq e '.spec.values.alertmanager.alertmanagerSpec.storage.volumeClaimTemplate.spec.storageClassName = "longhorn"' $CHART_MANIFEST -i
+  yq e '.spec.values.alertmanager.alertmanagerSpec.storage.volumeClaimTemplate.spec.accessModes = ["ReadWriteOnce"]' $CHART_MANIFEST -i
+  yq e '.spec.values.alertmanager.alertmanagerSpec.storage.volumeClaimTemplate.spec.resources.requests.storage = "5Gi"' $CHART_MANIFEST -i
+}
+
+patch_alertmanager_externalurl()
+{
+if [ -n "$HARVESTER_VIP" ]; then
+  # enable alertmanager by default (https://github.com/harvester/harvester-installer/pull/322)
+  PORT=9093
+  yq e '.spec.values.alertmanager.service.port = '$PORT $CHART_MANIFEST -i
+  yq e '.spec.values.alertmanager.alertmanagerSpec.externalUrl = "https://'$HARVESTER_VIP'/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:'$PORT'/proxy/"' $CHART_MANIFEST -i
+fi
+}
+
+patch_prometheus_externalurl()
+{
+if [ -n "$HARVESTER_VIP" ]; then
+  # enable alertmanager by default (https://github.com/harvester/harvester-installer/pull/322)
+  PORT=9090
+  yq e '.spec.values.prometheus.service.port = '$PORT $CHART_MANIFEST -i
+  yq e '.spec.values.prometheus.prometheusSpec.externalUrl = "https://'$HARVESTER_VIP'/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:'$PORT'/proxy/"' $CHART_MANIFEST -i
+fi
+}
+
+# get harvester vip from configmap, skip potential error
+get_harvester_vip()
+{
+  EXIT_CODE=0
+  #escape the 'return on error'
+  JSON_DATA=$(kubectl get configmap -n kube-system kubevip -o "jsonpath={.data['kubevip-services']}") || EXIT_CODE=$?;
+  if test $EXIT_CODE = 0; then
+    VIP=$(echo $JSON_DATA | jq -r .services[0].vip) || EXIT_CODE=$?;
+    if test $EXIT_CODE = 0; then
+      HARVESTER_VIP=$VIP;
+    else
+      echo "jq parse kubevip configmap json text failed: $JSON_DATA";
+    fi
+  else
+    echo "kubectl get configmap -n kube-system kubevip failed";
+  fi
+}
+
 case $CHART_NAME in
   rancher-monitoring)
     patch_grafana_resources
+    patch_alertmanager_enable
+    get_harvester_vip
+    patch_alertmanager_externalurl
+    patch_prometheus_externalurl
     ;;
 esac


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Alertmanager will be enabled in v1.1.0 by default, it needs to be enabled when upgrading.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add upgrade patch

**Related Issue:**

https://github.com/harvester/harvester/issues/2712

The code commit PR:
feat2517 Harvester-installer support alertmanager 
https://github.com/harvester/harvester-installer/pull/322

This PR is ontop of PR:  https://github.com/harvester/harvester/pull/2711 <del>, when it is merged, an rebase may be needed, will check then. </del>, code is rebased 2022.09.07.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Before an upgrade image ISO available, this patch could be tested manually:

<details>
<summary>Manually patch rancher-monitoring YAML</summary>

Login into an running Harvester master-head NODE shell:

1. prepare a script:
```
cat << 'EOF' > patch_alertmanager.sh
#!/bin/bash -ex

CHART_NAME=$1
CHART_MANIFEST=$2

patch_grafana_resources()
{
  # Increate grafana pod limit and request (https://github.com/harvester/harvester-installer/pull/287)
  yq e '.spec.values.grafana.resources = {"limits": {"cpu": "200m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "200Mi"}}' $CHART_MANIFEST -i

  # Increate grafana PVC size to 2Gi (https://github.com/harvester/harvester-installer/pull/327)
  yq e '.spec.values.grafana.persistence.size = "2Gi"' $CHART_MANIFEST -i
}

patch_alertmanager_enable()
{
  # enable alertmanager by default (https://github.com/harvester/harvester-installer/pull/322)
  yq e '.spec.values.alertmanager.enabled = true' $CHART_MANIFEST -i
  yq e '.spec.values.alertmanager.config.global.resolve_timeout = "5m"' $CHART_MANIFEST -i
  yq e '.spec.values.alertmanager.alertmanagerSpec.retention = "120h"' $CHART_MANIFEST -i
  yq e '.spec.values.alertmanager.alertmanagerSpec.resources = {"limits": {"cpu": "1000m", "memory": "600Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}' $CHART_MANIFEST -i
  yq e '.spec.values.alertmanager.alertmanagerSpec.storage.volumeClaimTemplate.spec.storageClassName = "longhorn"' $CHART_MANIFEST -i
  yq e '.spec.values.alertmanager.alertmanagerSpec.storage.volumeClaimTemplate.spec.accessModes = ["ReadWriteOnce"]' $CHART_MANIFEST -i
  yq e '.spec.values.alertmanager.alertmanagerSpec.storage.volumeClaimTemplate.spec.resources.requests.storage = "5Gi"' $CHART_MANIFEST -i
}

patch_alertmanager_externalurl()
{
if [ -n "$HARVESTER_VIP" ]; then
  # enable alertmanager by default (https://github.com/harvester/harvester-installer/pull/322)
  PORT=9093
  yq e '.spec.values.alertmanager.service.port = '$PORT $CHART_MANIFEST -i
  yq e '.spec.values.alertmanager.alertmanagerSpec.externalUrl = "https://'$HARVESTER_VIP'/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:'$PORT'/proxy/"' $CHART_MANIFEST -i
fi
}

patch_prometheus_externalurl()
{
if [ -n "$HARVESTER_VIP" ]; then
  # enable alertmanager by default (https://github.com/harvester/harvester-installer/pull/322)
  PORT=9090
  yq e '.spec.values.prometheus.service.port = '$PORT $CHART_MANIFEST -i
  yq e '.spec.values.prometheus.prometheusSpec.externalUrl = "https://'$HARVESTER_VIP'/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:'$PORT'/proxy/"' $CHART_MANIFEST -i
fi
}

# get harvester vip from configmap, skip potential error
get_harvester_vip()
{
  EXIT_CODE=0
  #escape the 'return on error'
  JSON_DATA=$(kubectl get configmap -n kube-system kubevip -o "jsonpath={.data['kubevip-services']}") || EXIT_CODE=$?;
  if test $EXIT_CODE = 0; then
    VIP=$(echo $JSON_DATA | jq -r .services[0].vip) || EXIT_CODE=$?;
    if test $EXIT_CODE = 0; then
      HARVESTER_VIP=$VIP;
    else
      echo "jq parse kubevip configmap json text failed: $JSON_DATA";
    fi
  else
    echo "kubectl get configmap -n kube-system kubevip failed";
  fi
}

case $CHART_NAME in
  rancher-monitoring)
    patch_grafana_resources
    patch_alertmanager_enable
    get_harvester_vip
    patch_alertmanager_externalurl
    patch_prometheus_externalurl
    ;;
esac
EOF
```

chmod +x patch_alertmanager.sh

2. preare a base YAML
```
cat << EOF > monitoring_managedchart_base.yaml
apiVersion: management.cattle.io/v3
kind: ManagedChart
metadata:
  name: rancher-monitoring
  namespace: fleet-local
EOF
```

3.  execute the patch shell to update the `yaml` file

./patch_alertmanager.sh rancher-monitoring ./monitoring_managedchart_base.yaml

</details>