### PR TITLE
fix(setting): don't set condition when there is no syncer function

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -87,9 +87,9 @@ func (h *Handler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*har
 	var err error
 	if syncer, ok := syncers[setting.Name]; ok {
 		err = syncer(setting)
-	}
-	if updateErr := h.setConfiguredCondition(toUpdate, err); updateErr != nil {
-		return setting, updateErr
+		if updateErr := h.setConfiguredCondition(toUpdate, err); updateErr != nil {
+			return setting, updateErr
+		}
 	}
 
 	return setting, err


### PR DESCRIPTION
**Problem:**
The setting controller always [sets a condition to a setting](https://github.com/harvester/harvester/blob/18e09a261848a320d97364fda79f96942bcc1112/pkg/controller/master/setting/handler.go#L88-L93) even if there is no `syncer` function. This may cause some error like [another handler](https://github.com/harvester/harvester/blob/master/pkg/controller/master/backup/backup_target.go) gets wrong, but the condition is already set to ready.

**Solution:**
The setting controller only sets conditions when there is `syncer` function. Also, a controller which manages a setting by itself needs to handle conditions too.

**Related Issue:**
https://github.com/harvester/harvester/issues/2725

**Test plan:**

Setup:
* Create a harvester cluster.
* [Set up a Local Mino Testing Backupstore](https://longhorn.io/docs/1.3.0/snapshots-and-backups/backup-and-restore/set-backup-target/#set-up-a-local-testing-backupstore).
* [Set up a Local NFS Testing Backupstre](https://longhorn.io/docs/1.3.0/snapshots-and-backups/backup-and-restore/set-backup-target/#nfs-backupstore).

Case 1: Set the `backup-target` setting to NFS.
* Set `backup-target` setting to `nfs://longhorn-test-nfs-svc.default:/opt/backupstore`.
* The `configured` condition of `backup-target` setting is `True`.

Case 2: Set the `backup-target` setting to default.
* Use the default value for `backup-target` settting.
* The `configured` condition of `backup-target` setting is `False`.

Case 3: Set the `backup-target` setting to S3.
* Set `additional-ca`.
```
-----BEGIN CERTIFICATE-----
MIIDLDCCAhSgAwIBAgIRAMdo42phTeyk17/bLrZ5YDswDQYJKoZIhvcNAQELBQAw
GjEYMBYGA1UEChMPTG9uZ2hvcm4gLSBUZXN0MCAXDTIwMDQyNzIzMDAxMVoYDzIx
MjAwNDAzMjMwMDExWjAaMRgwFgYDVQQKEw9Mb25naG9ybiAtIFRlc3QwggEiMA0G
CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDXzUurgPZDgzT3DYuaebgewqowdeAD
84VYazfSuQ+7+mNkiiQPozUU2foQaF/PqzBbQmegoaOyy5Xj3UExmFretx0ZF5NV
JN/9eaI5dWFOmxxi0IOPb6ODilMjquDmEOIycv4Sh+/Ij9fMgKKWP7IdlC5BOy8d
w09WdrLqhOVcpJjcqb3z+xHHwyCNXxhhFomolPVzInyTPBSfDnH0nKIGQyvlhB0k
TpGK61sjkfqS+xi59IxuklvHEsPr1WnTsaOhiXz7yPJZ+q3A1fhW0UkRZDYgZsEm
/gNJ3rp8XYuDgki3gE+8IWAdAXq1yhjD7RJB8TSIa5tHjJQKjgCeHnGzAgMBAAGj
azBpMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMB
Af8EBTADAQH/MDEGA1UdEQQqMCiCCWxvY2FsaG9zdIIVbWluaW8tc2VydmljZS5k
ZWZhdWx0hwR/AAABMA0GCSqGSIb3DQEBCwUAA4IBAQCmFL39MHuY31a11Dj4p25c
qPEC4DvIQj3NOdSGV2d+f6sgzFz1WL8VrqvB1B1S6r4Jb2PEuIBD84YpUrHORMSc
wubLJiHKDkBfoe9Ab5p/UjJrKKnj34DlvsW/Gp0Y6XsPViWiUj+oRKmGVI24CBHv
g+BmW3CyNQGTKj94xM6s3AWlGEoyaqWPe5xyeUe3f1AZF97tCjIJReVlCmhCF+Bm
aTcTRQcwqWoCp0bbYpyDDYpRlq8GPlIE9o2Z6AsNfLrUpamgqX2kXkh1kysJQ+jP
zQZtrR0mmtur3DnEm2bi4NKHAQHpW9Mu16GQjE1NbXqQtTB88jK76ctH934Cal6V
-----END CERTIFICATE-----
```
* Set `backup-target` to S3.
```
{
  "type":"s3",
  "endpoint":"https://minio-service.default:9000",
  "accessKeyId":"longhorn-test-access-key",
  "secretAccessKey":"longhorn-test-secret-key",
  "bucketName":"backupbucket",
  "bucketRegion":"us-east-1",
  "virtualHostedStyle":false
}
```
* The `configured` condition of `backup-target` setting is `True`. Also, the `accessKeyId` and `secretAccessKey` become empty.