### PR TITLE
update longhorn/backupstore dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200331171230-d50e42f2b669
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1
 	github.com/kubernetes/dashboard v1.10.1
-	github.com/longhorn/backupstore v0.0.0-20211109055147-56ddc538b859
+	github.com/longhorn/backupstore v0.0.0-20220913112826-5f5c95274f2a
 	github.com/longhorn/longhorn-manager v1.3.1
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2

--- a/go.sum
+++ b/go.sum
@@ -1193,8 +1193,9 @@ github.com/longhorn/backing-image-manager v0.0.0-20220609065820-a08f7f47442f h1:
 github.com/longhorn/backing-image-manager v0.0.0-20220609065820-a08f7f47442f/go.mod h1:J6PTXyXw5Dvzx+0Aeixl+7TPBWPWQzdIQHh+GeSCjsg=
 github.com/longhorn/backupstore v0.0.0-20201203004625-fdbdd88b09d6/go.mod h1:9O5tXHnI0KfLXHl+YVey17h9DNq6EIJmBCnNfZH1e18=
 github.com/longhorn/backupstore v0.0.0-20210817080617-8ea3843e6b0d/go.mod h1:FUjQNWqcEXSFIrQpfWLxFFHXywk14mM5w9TNRuBrKzY=
-github.com/longhorn/backupstore v0.0.0-20211109055147-56ddc538b859 h1:Xff8617ecmLI8tYnWvgpY8aI2sZz4v3lTa353IVyijs=
 github.com/longhorn/backupstore v0.0.0-20211109055147-56ddc538b859/go.mod h1:hvIVsrpjPey7KupirAh0WoPMg0ArWnE6fA5bI30X7AI=
+github.com/longhorn/backupstore v0.0.0-20220913112826-5f5c95274f2a h1:f+mLqp3A5M7plw1pBgf8K1nvJxSU7mrGtU7bii+W5Bk=
+github.com/longhorn/backupstore v0.0.0-20220913112826-5f5c95274f2a/go.mod h1:hvIVsrpjPey7KupirAh0WoPMg0ArWnE6fA5bI30X7AI=
 github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/go-iscsi-helper v0.0.0-20220805034259-7b59e22574bb h1:zwAHsMzVfHNEMwAO3Mu2il0dcPGyJsZZuYED7ASbvfc=

--- a/vendor/github.com/longhorn/backupstore/nfs/nfs.go
+++ b/vendor/github.com/longhorn/backupstore/nfs/nfs.go
@@ -3,9 +3,9 @@ package nfs
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/longhorn/backupstore"
 	"github.com/longhorn/backupstore/fsops"
@@ -64,7 +64,7 @@ func initFunc(destURL string) (backupstore.BackupStoreDriver, error) {
 
 	b.serverPath = u.Host + u.Path
 	b.mountDir = filepath.Join(MountDir, strings.TrimRight(strings.Replace(u.Host, ".", "_", -1), ":"), u.Path)
-	if err := os.MkdirAll(b.mountDir, os.ModeDir|0700); err != nil {
+	if _, err = util.ExecuteWithCustomTimeout("mkdir", []string{"-m", "700", "-p", b.mountDir}, 3*time.Second); err != nil {
 		return nil, fmt.Errorf("Cannot create mount directory %v for NFS server: %v", b.mountDir, err)
 	}
 

--- a/vendor/github.com/longhorn/backupstore/util/util.go
+++ b/vendor/github.com/longhorn/backupstore/util/util.go
@@ -127,11 +127,20 @@ func ValidateName(name string) bool {
 }
 
 func Execute(binary string, args []string) (string, error) {
-	var output []byte
-	var err error
-
 	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 	defer cancel()
+	return execute(ctx, binary, args)
+}
+
+func ExecuteWithCustomTimeout(binary string, args []string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return execute(ctx, binary, args)
+}
+
+func execute(ctx context.Context, binary string, args []string) (string, error) {
+	var output []byte
+	var err error
 
 	cmd := exec.CommandContext(ctx, binary, args...)
 	done := make(chan struct{})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -421,7 +421,7 @@ github.com/longhorn/backing-image-manager/pkg/meta
 github.com/longhorn/backing-image-manager/pkg/rpc
 github.com/longhorn/backing-image-manager/pkg/types
 github.com/longhorn/backing-image-manager/pkg/util
-# github.com/longhorn/backupstore v0.0.0-20211109055147-56ddc538b859
+# github.com/longhorn/backupstore v0.0.0-20220913112826-5f5c95274f2a
 ## explicit; go 1.13
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
**Problem:**
When NFS can't be connected, we will get stuck in backupstore initialization.

**Solution:**
Update longhorn/backupstore dependency.

**Related Issue:**
https://github.com/harvester/harvester/issues/2631
https://github.com/longhorn/backupstore/pull/89

**Test plan:**
Case 1: empty backup-target
* Create a new harvester cluster and a rancher server.
* Import harvester to rancher.
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return a message "backup-target setting is not set" with HTTP status 400.

Case 2: happy path
* Set up a NFS server. `kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/backupstores/nfs-backupstore.yaml`
* Set backup-target to NFS type with `nfs://longhorn-test-nfs-svc.default:/opt/backupstore` endpoint.
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return HTTP status 200.

Case 3: set backup-target to default
* Set backup-target as default value. The value will become `{type: "", ...}`.
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return a message "backup-target setting is not set" with HTTP status 400.

Case 4: remove NFS server.
* Set backup-target to NFS type with `nfs://longhorn-test-nfs-svc.default:/opt/backupstore` endpoint.
* Remove NFS server. `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/backupstores/nfs-backupstore.yaml`
* Query `https://<ip>:<port>/k8s/clusters/<cluster-id>/v1/harvester/backuptarget/healthz`. The server should return a message like "can't connect to backup-target ..." with HTTP status 503.
