### PR TITLE
fix: change backup type to optional

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6683,8 +6683,7 @@
     "harvesterhci.io.v1beta1.VirtualMachineBackupSpec": {
       "type": "object",
       "required": [
-        "source",
-        "type"
+        "source"
       ],
       "properties": {
         "source": {
@@ -6692,8 +6691,7 @@
           "$ref": "#/definitions/k8s.io.v1.TypedLocalObjectReference"
         },
         "type": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },

--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinebackups.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinebackups.yaml
@@ -84,7 +84,6 @@ spec:
                 type: string
             required:
             - source
-            - type
             type: object
           status:
             description: VirtualMachineBackupStatus is the status for a VirtualMachineBackup

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -391,6 +391,7 @@ func (h *vmActionHandler) createVMBackup(vmName, vmNamespace string, input Backu
 				Kind:     kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 				Name:     vmName,
 			},
+			Type: harvesterv1.Backup,
 		},
 	}
 	if _, err := h.backups.Create(backup); err != nil {

--- a/pkg/apis/harvesterhci.io/v1beta1/backup.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/backup.go
@@ -63,7 +63,8 @@ type VirtualMachineBackupSpec struct {
 
 	// +kubebuilder:default:="backup"
 	// +kubebuilder:validation:Enum=backup;snapshot
-	Type BackupType `json:"type"`
+	// +kubebuilder:validation:Optional
+	Type BackupType `json:"type,omitempty" default:"backup"`
 }
 
 // VirtualMachineBackupStatus is the status for a VirtualMachineBackup resource

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -2484,13 +2484,12 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineBackupSpec(ref common.
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
-				Required: []string{"source", "type"},
+				Required: []string{"source"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -889,6 +889,11 @@ func (h *RestoreHandler) constructVolumeSnapshotContentName(restoreNamespace, re
 
 // mountLonghornVolumes helps to mount the volumes to host if it is detached
 func (h *RestoreHandler) mountLonghornVolumes(backup *harvesterv1.VirtualMachineBackup) error {
+	// we only need to mount LH Volumes for snapshot type.
+	if backup.Spec.Type == harvesterv1.Backup {
+		return nil
+	}
+
 	for _, vb := range backup.Status.VolumeBackups {
 		pvcNamespace := vb.PersistentVolumeClaim.ObjectMeta.Namespace
 		pvcName := vb.PersistentVolumeClaim.ObjectMeta.Name

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	fieldSourceName = "spec.source.name"
+	fieldTypeName   = "spec.type"
 )
 
 func NewValidator(
@@ -64,7 +65,7 @@ func (v *virtualMachineBackupValidator) Create(request *types.Request, newObj ru
 		err = v.checkBackupTarget()
 	}
 	if err != nil {
-		return werror.NewInvalidError(err.Error(), fieldSourceName)
+		return werror.NewInvalidError(err.Error(), fieldTypeName)
 	}
 
 	return nil


### PR DESCRIPTION
**Problem:**
1. Can't create VMBackup through UI.
2. If we try to create a VMBackup without setting backup-target, it shows `spec.source.name` error, but it should be `spec.type` error.
3. If we create a VMBackup and delete the source VM, the VMBakcup can't be restored, because it tries to mount source VM Volumes.

**Solution:**
1. Change `VMBackup.spec.type` field as option.
2. Change error field name in webhook.
3. Only mount VM Volumes if it's a VM snapshot.

**Related Issue:**
https://github.com/harvester/harvester/issues/2767

**Test plan:**
Case 1: Webhook can show correct error type.
1. Create a harvester cluster.
2. Create a VM `source-vm`.
3. Try to apply the following YAML, and it should show there is an error on `spec.type`.
```
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineBackup
metadata:
  name: vm-backup
  namespace: default
spec:
  source:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: source-vm
```

Case 2: We can create a VMBackup through UI.
1. Setup backup-target.
2. Click `Take Backup` on the `source-vm`.
3. A new VMBackup should be created successfully.

Case 3: VMBackup can be restored without `source-vm`
1. Delete `source-vm`.
2. Restore a VM from the case 2 VMBackup. VM should be restored successfully.

