### PR TITLE
feat(upgrade): block upgrades from unsupported versions

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,7 +19,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # install yq
-RUN GO111MODULE=on go install github.com/mikefarah/yq/v4@v4.6.0
+RUN GO111MODULE=on go install github.com/mikefarah/yq/v4@v4.27.5
 # set up helm
 ENV HELM_VERSION v3.5.4
 ENV HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,7 @@ github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.0.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,0 +1,9 @@
+versions:
+- name: v1.1.0
+  minUpgradableVersion: v1.0.3
+- name: v1.0.3
+  minUpgradableVersion: v1.0.2
+- name: v1.0.2
+  minUpgradableVersion: v1.0.1
+- name: v1.0.1
+  minUpgradableVersion: v1.0.0

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -388,6 +388,7 @@ pause_all_charts()
 wait_repo
 detect_repo
 detect_upgrade
+check_version
 pre_upgrade_manifest
 pause_all_charts
 upgrade_rancher

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -184,6 +184,8 @@ command_prepare()
 {
   wait_repo
   detect_repo
+  detect_upgrade
+  check_version
   preload_images
 }
 

--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -36,12 +36,13 @@ stages:
 )
 
 type HarvesterRelease struct {
-	Harvester       string `yaml:"harvester,omitempty"`
-	HarvesterChart  string `yaml:"harvesterChart,omitempty"`
-	OS              string `yaml:"os,omitempty"`
-	Kubernetes      string `yaml:"kubernetes,omitempty"`
-	Rancher         string `yaml:"rancher,omitempty"`
-	MonitoringChart string `yaml:"monitoringChart,omitempty"`
+	Harvester            string `yaml:"harvester,omitempty"`
+	HarvesterChart       string `yaml:"harvesterChart,omitempty"`
+	OS                   string `yaml:"os,omitempty"`
+	Kubernetes           string `yaml:"kubernetes,omitempty"`
+	Rancher              string `yaml:"rancher,omitempty"`
+	MonitoringChart      string `yaml:"monitoringChart,omitempty"`
+	MinUpgradableVersion string `yaml:"minUpgradableVersion,omitempty"`
 }
 
 type UpgradeRepoInfo struct {
@@ -442,16 +443,4 @@ func (r *UpgradeRepo) getInfo() (*UpgradeRepoInfo, error) {
 		return nil, err
 	}
 	return &info, nil
-}
-
-func (r *UpgradeRepo) getInfoStr() (string, error) {
-	info, err := r.getInfo()
-	if err != nil {
-		return "", err
-	}
-	out, err := info.Marshall()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }

--- a/scripts/version
+++ b/scripts/version
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+PACKAGE_DIR="${TOP_DIR}/package"
+
 unset DIRTY
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"
@@ -12,8 +15,13 @@ GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
+    # Search for minimum upgradable version.
+    # If the release does not come with a corresponding minimum upgradable version, the build will error out.
+    MIN_UPGRADABLE_VERSION=$(yq -e e ".versions | map(select(.name == \"$VERSION\")) | .[0].minUpgradableVersion" "${PACKAGE_DIR}"/upgrade-matrix.yaml)
 else
     VERSION="${COMMIT}${DIRTY}"
+    # Dev builds do not come with this restriction.
+    MIN_UPGRADABLE_VERSION=""
 fi
 
 # Chart tag.
@@ -51,3 +59,4 @@ echo "SUFFIX: $SUFFIX"
 echo "REPO: $REPO"
 echo "TAG: $TAG"
 echo "IMAGE_PUSH_TAG: $IMAGE_PUSH_TAG"
+echo "MIN_UPGRADABLE_VERSION: $MIN_UPGRADABLE_VERSION"


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Users can upgrade from any version as long as they have the ISO image. They can host the image and create a Version resource that points the URL to the image location or even upload the image from the dashboard to directly trigger the upgrade. There is no version support matrix provided nor version checking logic implemented. The unsupported upgrade path might introduce unpredictable issues and burden the team with a heavy load.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Users who upgrade from the version older than the specified minimum version required, which was retrieved from `harvester_release.yaml`, will be errored out in phase 2 right before the image preloading step of the entire upgrade flow.

The current strategy is by introducing a support matrix YAML file and picking a version as the minimum required version to do the upgrade in each release, put that version string into a file, and package the info into the ISO image. While upgrading, a repo VM will be spun up and hosted `harvester-release.yaml` which contains the minimum upgradable version string. Then we put version checking logic in the `upgrade_node.sh` & `upgrade_manifest.sh` scripts, right before the image preloading step and manifests upgrading, respectively. If the checking fails, the upgrade Job will fail.

And to further improve the waiting time for an unsupported upgrade to fail, we also do the checking logic inside the upgrade controller so that the upgrade will fail even before the upgrade Plan resource is created. The relevant code path is only effective in future upgrades after the code has been deployed on the target clusters since Harvester uses the currently running version of the controller in the earlier upgrade process (until the images have been preloaded).

Assumed v1.1.0 release:

- cur_ver=v1.0.0, min_upgradable_ver=v1.0.3 => check failed
- cur_ver=v1.0.3, min_upgradable_ver=v1.0.3 => check pass
- cur_ver=v1.0.4, min_upgradable_ver=v1.0.3 => check pass

**Related Issue:**

The original issue is #2431, and this PR also required PR harvester/harvester-installer#338 to work.

**Test plan:**

The test plan includes two parts: 

The first part is the ISO image building. This is to check whether the corresponding `minUpgradableVersion` is correctly injected into the ISO image (However, this depends on PR harvester/harvester-installer#338. Without it being merged, the test cannot continue). Here we should at least test two scenarios:

1. Build an ISO image with a release tag, say v1.1.0 (the resulting ISO image name will be like `harvester-v1.1.0-amd64.iso`)
2. Build an ISO image without a release tag (the resulting ISO image name will be like `harvester-xxxxxxx-dirty-amd64.iso`)

To check the value of `minUpgradableVersion`, execute `isoinfo -J -i harvester-xxxxxxx-amd64.iso -x /harvester-release.yaml | yq e ".minUpgradableVersion"`. It should return "v1.0.3" as a result for the first case and an empty string for the second case.

---

The second part of the test plan is focusing on the upgrade behaviors with different ISO images. There will be 3 test scenarios in total. The first test is to upgrade an unsupported version of cluster with a release ISO image. The second test is to upgrade a supported version of cluster with a release ISO image. The last test is to upgrade a cluster with a dev-built ISO image, i.e. using an ISO image built without a release tag.

Test 1: Build an ISO image **with** release tag, say v1.1.0 (provided minUpgradableVersion: v1.0.3), then upgrade a **v1.0.2** cluster

1. Prepare a v1.0.2 cluster
2. Host the ISO image on an HTTP server
3. Create a `Version` resource

```bash
# cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: v1.1.0
  namespace: harvester-system
spec:
  isoURL: "http://192.168.122.1:8000/harvester-c76dfbd-dirty-amd64.iso"
EOF
```

4. Click the "Upgrade" button and choose "v1.1.0"
5. Upgrade should **fail** with the following logs and UI should indicate the upgrade Job has failed

```bash
# kubectl -n harvester-system get po -l harvesterhci.io/upgradeComponent=manifest
NAME                                       READY   STATUS   RESTARTS   AGE
hvst-upgrade-tc9sm-apply-manifests-6hxw7   0/1     Error    0          14m
hvst-upgrade-tc9sm-apply-manifests-82tx9   0/1     Error    0          18m
hvst-upgrade-tc9sm-apply-manifests-n2khj   0/1     Error    0          8m29s
hvst-upgrade-tc9sm-apply-manifests-vfccp   0/1     Error    0          19m
hvst-upgrade-tc9sm-apply-manifests-vhp6r   0/1     Error    0          19m
hvst-upgrade-tc9sm-apply-manifests-wdl4g   0/1     Error    0          18m
hvst-upgrade-tc9sm-apply-manifests-wk2t9   0/1     Error    0          17m
# kubectl -n harvester-system logs hvst-upgrade-tc9sm-apply-manifests-6hxw7
...
harvester: v1.1.0
harvesterChart: 1.1.0
os: Harvester c76dfbd-dirty
kubernetes: v1.22.12+rke2r1
rancher: v2.6.4-harvester3
monitoringChart: 100.1.0+up19.0.3
kubevirt: 0.54.0
minUpgradableVersion: v1.0.3
rancherDependencies:
  fleet:
    chart: 100.0.3+up0.3.9
    app: 0.3.9
  fleet-crd:
    chart: 100.0.3+up0.3.9
    app: 0.3.9
  rancher-webhook:
    chart: 1.0.4+up0.2.5
    app: 0.2.5
Current version: 1.0.2
Minimum upgradable version: 1.0.3
Current version is not supported. Abort the upgrade.
```

<img width="571" alt="image" src="https://user-images.githubusercontent.com/1827717/190972634-1e4cdf13-8ee3-4fb4-835f-17e5f5de07d4.png">

TEST 2: Build an ISO image **with** release tag, say v1.1.0 (provided minUpgradableVersion: v1.0.3), then upgrade a **v1.0.3** cluster

1. Prepare a v1.0.3 cluster
2. Host the target ISO image on an HTTP server
3. Create a `Version` resource on the cluster

```bash
# cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: v1.1.0
  namespace: harvester-system
spec:
  isoURL: "http://192.168.122.1:8000/harvester-c76dfbd-dirty-amd64.iso"
EOF
```

4. Click the "Upgrade" button and choose "v1.1.0"
5. Upgrade should **success**

TEST 3: Build an ISO image **without** release tag then upgrade a **v1.0.2** cluster

1. Prepare a v1.0.2 cluster
2. Host the target ISO image on an HTTP server
3. Create a `Version` resource on the cluster

```bash
# cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: v1.1.0
  namespace: harvester-system
spec:
  isoURL: "http://192.168.122.1:8000/harvester-c76dfbd-dirty-amd64.iso"
EOF
```

4. Click the "Upgrade" button and choose "v1.1.0" on the UI
5. Upgrade should **success** since upgrading to any dev builds is not in restriction for dev purposes