### PR TITLE
fix indexer panic and remove unused indexers

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -13,7 +13,6 @@ import (
 	"github.com/harvester/harvester/pkg/api/volume"
 	"github.com/harvester/harvester/pkg/api/volumesnapshot"
 	"github.com/harvester/harvester/pkg/config"
-	"github.com/harvester/harvester/pkg/indexeres"
 )
 
 type registerSchema func(scaled *config.Scaled, server *server.Server, options config.Options) error
@@ -29,7 +28,6 @@ func registerSchemas(scaled *config.Scaled, server *server.Server, options confi
 
 func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
-	indexeres.RegisterAPIIndexers(scaled)
 	return registerSchemas(scaled, server, options,
 		image.RegisterSchema,
 		keypair.RegisterSchema,

--- a/pkg/controller/global/setup.go
+++ b/pkg/controller/global/setup.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/controller/global/settings"
-	"github.com/harvester/harvester/pkg/indexeres"
 )
 
 type registerFunc func(context.Context, *config.Scaled, *server.Server, config.Options) error
@@ -18,7 +17,7 @@ var registerFuncs = []registerFunc{
 
 func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
-	indexeres.RegisterScaledIndexers(scaled)
+
 	for _, f := range registerFuncs {
 		if err := f(ctx, scaled, server, options); err != nil {
 			return err

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -18,7 +18,6 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/template"
 	"github.com/harvester/harvester/pkg/controller/master/upgrade"
 	"github.com/harvester/harvester/pkg/controller/master/virtualmachine"
-	"github.com/harvester/harvester/pkg/indexeres"
 )
 
 type registerFunc func(context.Context, *config.Management, config.Options) error
@@ -54,8 +53,6 @@ func register(ctx context.Context, management *config.Management, options config
 
 func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
-
-	indexeres.RegisterManagementIndexers(scaled.Management)
 
 	go leader.RunOrDie(ctx, "", "harvester-controllers", controllers.K8s, func(ctx context.Context) {
 		if err := register(ctx, scaled.Management, options); err != nil {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -35,6 +35,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/global"
 	"github.com/harvester/harvester/pkg/controller/master"
 	"github.com/harvester/harvester/pkg/data"
+	"github.com/harvester/harvester/pkg/indexeres"
 	"github.com/harvester/harvester/pkg/server/ui"
 )
 
@@ -235,6 +236,7 @@ func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 	s.Handler = authMiddleware(s.steve)
 
 	s.startHooks = []StartHook{
+		indexeres.Setup,
 		master.Setup,
 		global.Setup,
 		api.Setup,


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

panic: cannot add indexers to running index

current logic:
1. RegisterManagementIndexers 
contains vmBackupInformer.AddIndexer(VMBackupBySourceVMNameIndex, VMBackupBySourceVMName)
1. start Management (in go goroutine)
1. RegisterScaledIndexers
1. RegisterAPIIndexers
vmBackupInformer.AddIndexer(VMBackupBySourceVMUIDIndex, VMBackupBySourceVMUID) 
but maybe vmBackupInformer has been started in step 2
1. start Scaled

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
change logic to
1. RegisterIndexers 
2. start Management
3. start Scaled

**Related Issue:**
https://github.com/harvester/harvester/issues/2778

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
