### PR TITLE
[feat578] Harvester add kube-audit policy file to rke2 when node is promoted

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -66,6 +66,7 @@ data:
     cluster-dns: 10.53.0.10
     tls-san:
       - $VIP
+    audit-policy-file: /etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
     EOF
 
     # For how to promote nodes, see: https://github.com/rancher/rancher/issues/36480#issuecomment-1039253499


### PR DESCRIPTION
[feat578] Harvester add kube-audit policy file to rke2 when node is promoted

Signed-off-by: Jian Wang <w13915984028@gmail.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

In the new feature https://github.com/harvester/harvester/issues/578, `Harvester` will enable kube-audit by default.

Meanwhile, when a node is promoted, it should also enable `kube-audit`.

This PR comes from review comment: https://github.com/harvester/harvester-installer/pull/333#discussion_r974304962

> If there are nodes being promoted to the server role, do they need to specify the file as well?
We create this config file when promoting an agent node to a server node. Ref: https://github.com/harvester/harvester/blob/47a3af235e41d37bc661af4f07d87b82c6b99345/deploy/charts/harvester/templates/configmap.yaml#L61-L69

[note]

This PR depends on `harvester-installer` PR https://github.com/harvester/harvester-installer/pull/333, only after which is merged, then this PR  can ge merged.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add related code in promotion script.

**Related Issue:**

related EPIC
https://github.com/harvester/harvester/issues/578

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Per EPIC