### PR TITLE
Release v1.1.0-rc1

### DIFF
--- a/deploy/charts/harvester-crd/Chart.yaml
+++ b/deploy/charts/harvester-crd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: harvester-crd
-version: 0.0.0-dev
-appVersion: 0.1.x
+version: 1.1.0-dev
+appVersion: v1.1.0-dev
 description: Helm chart for deploying Harvester CRDs.
 icon: https://harvester.github.io/images/logo_horizontal.svg
 keywords:

--- a/deploy/charts/harvester/Chart.yaml
+++ b/deploy/charts/harvester/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: harvester
-version: 0.0.0-dev
-appVersion: 0.1.x
+version: 1.1.0-dev
+appVersion: v1.1.0-dev
 description: Harvester is an open source Hyper-Converged Infrastructure(HCI) solution based on Kubernetes.
 icon: https://harvester.github.io/images/logo_horizontal.svg
 type: application

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -147,7 +147,7 @@ containers:
 
       ## Specify the pull policy of image.
       ##
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
 
       ## Specify the repository of image.
       ##
@@ -155,7 +155,7 @@ containers:
 
       ## Specify the tag of image.
       ##
-      tag: master-head
+      tag: v1.1-head
 
     ## Specify whether to run in HCI mode. This option enables additional controllers.
     ## defaults to "false", this will be enabled in ISO mode installation.
@@ -359,16 +359,16 @@ harvester-node-disk-manager:
 
   image:
     repository: rancher/harvester-node-disk-manager
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: master-head
+    tag: v0.4.5
 
 csi-snapshotter:
   ## Specify whether to install the csi-snapshotter
   enabled: true
 
   image:
-    repository: k8s.gcr.io/sig-storage/snapshot-controller
+    repository: csiplugin/snapshot-controller
     tag: v4.0.0
 
 longhorn:
@@ -403,7 +403,7 @@ webhook:
 
     ## Specify the pull policy of image.
     ##
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
 
     ## Specify the repository of image.
     ##
@@ -411,21 +411,21 @@ webhook:
 
     ## Specify the tag of image.
     ##
-    tag: master-head
+    tag: v1.1-head
 
   httpsPort: 9443
 
 upgrade:
   image:
     repository: rancher/harvester-upgrade
-    tag: master-head
+    tag: v1.1-head
 
 harvester-load-balancer:
   enabled: false
   image:
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     repository: rancher/harvester-load-balancer
-    tag: master-head
+    tag: v0.1.2
 
 kube-vip:
   enabled: false
@@ -445,7 +445,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: master-head
+    tag: v0.0.11
 
 generalJob:
   image:

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper -n rm container-suseconnect && \
 
 WORKDIR /var/lib/harvester/harvester
 
-ENV HARVESTER_UI_VERSION latest
+ENV HARVESTER_UI_VERSION v1.1.0-rc1
 ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -15,7 +15,7 @@ ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9
 
-ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION latest
+ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION 1.1.0-rc1
 
 ARG ARCH=amd64
 ARG VERSION=dev

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=master
+HARVESTER_INSTALLER_VERSION=v1.1.0-rc1
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 

--- a/scripts/check-dep-image-tags
+++ b/scripts/check-dep-image-tags
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+
+TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+VALUES_FILE=$TOP_DIR/deploy/charts/harvester/values.yaml
+
+: ${INSTALLER_BRANCH:="v1.0"}
+
+if [ -z ${WORK_DIR+x} ]; then
+  WORK_DIR=$(mktemp -d)
+  trap "rm -rf $WORK_DIR" EXIT
+fi
+
+META_FILE=$WORK_DIR/deps.txt
+
+
+get_installer_tag() {
+  local line=$(grep -e "^HARVESTER_INSTALLER_VERSION=" $TOP_DIR/scripts/build-iso)
+  echo ${line#"HARVESTER_INSTALLER_VERSION="}
+}
+
+
+build_meta() {
+  # metadata format 
+  # <git_URL> <branch_name> <version>
+  # version:
+  # (1) Just a version number with quote ("")
+  # (2) A YAML key in values.yaml file
+  cat > $META_FILE <<EOF
+https://github.com/harvester/harvester-installer $INSTALLER_BRANCH "$(get_installer_tag)"
+https://github.com/harvester/network-controller-harvester master .harvester-network-controller.image.tag
+https://github.com/harvester/node-disk-manager master .harvester-node-disk-manager.image.tag
+https://github.com/harvester/load-balancer-harvester master .harvester-load-balancer.image.tag
+https://github.com/kube-vip/kube-vip main .kube-vip.image.tag
+https://github.com/kube-vip/kube-vip-cloud-provider main .kube-vip-cloud-provider.image.tag
+https://github.com/rancher/support-bundle-kit master .support-bundle-kit.image.tag
+EOF
+}
+
+echo_warn() {
+  printf "\033[1;31m[WARN]\033[0m $1\n"
+}
+
+echo_error() {
+  printf "\033[0;31m[ERROR]\033[0m $1\n"
+}
+
+build_meta
+
+fail_count=0
+
+while read git_url branch image_path; do
+
+  cd $WORK_DIR
+  TAG=$(yq -e e $image_path $VALUES_FILE)
+  echo ">> $git_url"
+  echo ">> branch: $branch"
+  echo ">> configured version: $TAG"
+
+  project_dir=$(basename $git_url)
+  if [ ! -d $project_dir ]; then
+    echo "Clone $git_url..."
+    git clone $git_url --quiet
+    cd $project_dir
+  else
+    cd $project_dir && git pull --quiet
+  fi
+
+  if ! git diff $TAG origin/$branch --quiet; then
+    echo_warn "Detect new commit(s) after tag ${TAG}! Latest 3 commits:"
+    git --no-pager log $TAG..origin/$branch --oneline | head -n 3
+    fail_count=$((fail_count+1))
+  fi
+  echo ""
+
+done < $META_FILE
+
+
+if [ $fail_count -gt 0 ]; then
+  echo_error "There are $fail_count failing check(s)."
+  exit 1
+fi

--- a/scripts/check-dep-image-tags
+++ b/scripts/check-dep-image-tags
@@ -3,7 +3,7 @@
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 VALUES_FILE=$TOP_DIR/deploy/charts/harvester/values.yaml
 
-: ${INSTALLER_BRANCH:="v1.0"}
+: ${INSTALLER_BRANCH:="master"}
 
 if [ -z ${WORK_DIR+x} ]; then
   WORK_DIR=$(mktemp -d)


### PR DESCRIPTION
**Description:**
Add Harvester `v1.1.0-rc1` head.
Update chart version to `v1.1.0-dev`.

Dependencies:
- [x] bump Harvester-installer to `v1.1.0-rc1`.
- [x] bump Harvester GUI version to `v1.1.0-rc1`.
- [x] Bump Support bundle kit to `v0.0.11`.
- [x] **New**: whereabouts chart: `v0.5.4-amd64`
- [x] **New**: harvester-pcidevices-controller chart: `v0.2.1-rc1`
- [x] **New**:  harvester-node-manager chart: `v0.1.0`.
- [x] harvester-network-controller: v0.3.0-rc1. Add new webhook.