### PR TITLE
fix(setting): add harvester-system as additional noProxy value

### DIFF
--- a/pkg/util/proxy.go
+++ b/pkg/util/proxy.go
@@ -14,6 +14,7 @@ var builtInNoProxy = []string{
 	"longhorn-system",
 	"cattle-system",
 	"cattle-system.svc",
+	"harvester-system",
 	".svc",
 	".cluster.local",
 }

--- a/pkg/util/proxy_test.go
+++ b/pkg/util/proxy_test.go
@@ -15,17 +15,17 @@ func Test_AddBuiltInNoProxy(t *testing.T) {
 		{
 			name:   "single item",
 			input:  "192.168.1.0/24",
-			output: "192.168.1.0/24,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
+			output: "192.168.1.0/24,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
 		},
 		{
 			name:   "multiple items",
 			input:  "192.168.1.0/24,example.com",
-			output: "192.168.1.0/24,example.com,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
+			output: "192.168.1.0/24,example.com,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
 		},
 		{
 			name:   "overlapped items",
 			input:  "10.0.0.0/8,127.0.0.1",
-			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
+			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
 		},
 	}
 


### PR DESCRIPTION

Signed-off-by: Zespre Chang <zespre.chang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

If users choose to enable and configure the http(s)Proxy but leave the noProxy field empty, they will encounter failure while upgrading Harvester. This is not an air-gapped specific problem. If users do not configure http proxy, they won't face this issue even in an air-gapped environment. The problem is when the repo VM is spun up, a corresponding launcher Pod will continue to monitor its healthiness by hitting a certain endpoint periodically, this is the so-called "readiness probe". According to the access log on the HTTP proxy server, the readiness probes are hitting `http://upgrade-repo-hvst-upgrade-xxxxx.harvester-system:80/harvester-iso/harvester-release.yaml`. Since the `harvester-system` domain is not excluded, the probes are being proxied. The HTTP proxy has no clue where it can reach that URL because it's only reachable inside the Kubernetes cluster.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Simply adding `harvester-system` as another noProxy domain can solve the problem. The noProxy environment variable will propagate to the launcher Pod of the repo VM. We have to do this secretly while users configure their own http(s)Proxy and noProxy values.

This makes sure the internal traffic of Kubernetes like readiness probes of repo VM is not proxied.

**Related Issue:**

#2782 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Set up a Harvester node with an older version, e.g. v1.0.2, which is then able to upgrade
2. Set up an HTTP proxy, e.g. Squid
3. Configure HTTP proxy in the Setting page of Harvester UI
4. Wait until the backends are back (single node will have to wait)
5. Start the upgrade
6. The upgrade should be successful