### PR TITLE
Added setting about CSI and CCM version.

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -47,6 +47,9 @@ var (
 	AutoDiskProvisionPaths  = NewSetting("auto-disk-provision-paths", "")
 	CSIDriverConfig         = NewSetting(CSIDriverConfigSettingName, `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}`)
 	ContainerdRegistry      = NewSetting(ContainerdRegistrySettingName, "")
+
+	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
+	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.1.14","harvester-csi-provider":">=0.0.1 <0.1.15"}`)
 )
 
 const (
@@ -70,6 +73,7 @@ const (
 	UIPluginBundledVersionSettingName = "ui-plugin-bundled-version"
 	DefaultUIPluginURL                = "https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js"
 	ContainerdRegistrySettingName     = "containerd-registry"
+	HarvesterCSICCMSettingName        = "harvester-csi-ccm-versions"
 )
 
 func init() {


### PR DESCRIPTION
**Problem**
Frontend needs an extra setting item to check supported CSI and CCM version range.

**Solution**
Add a setting item in `settings/settings.go` with fixed json value

**Related Issue:**
[#2753](https://github.com/harvester/harvester/issues/2753)

**Test plan**
1. Access `https://<harvester-mgmt-url>/apis/harvesterhci.io/v1beta1/settings/harvester-csi-ccm-version`
2. Check the json value returned, and see key `default` value is `{"harvester-cloud-provider":">=0.0.1 <0.1.14","harvester-csi-provider":">=0.0.1 <0.1.15"}`