### PR TITLE
fix: containerd_registry setting

### DIFF
--- a/pkg/controller/master/setting/containerd_registry.go
+++ b/pkg/controller/master/setting/containerd_registry.go
@@ -44,7 +44,7 @@ func (h *Handler) syncContainerdRegistry(setting *harvesterv1.Setting) error {
 		if _, err := h.secrets.Create(newSecret); err != nil {
 			return err
 		}
-		return nil
+		return h.removeCredentialInSetting(setting, registryFromSetting)
 	} else if err != nil {
 		return err
 	}
@@ -139,16 +139,16 @@ func isSameMirrors(fromSetting, fromSecret map[string]registries.Mirror) bool {
 
 	// For map comparison in reflect.DeepEqual, it only same if both are nil or both content are same.
 	for mirrorName, mirror := range fromSetting {
-		if len(mirror.Rewrites) == 0 {
+		if len(mirror.Rewrites) == 0 && mirror.Rewrites != nil {
 			mirror.Rewrites = nil
+			fromSetting[mirrorName] = mirror
 		}
-		fromSetting[mirrorName] = mirror
 	}
 	for mirrorName, mirror := range fromSecret {
-		if len(mirror.Rewrites) == 0 {
+		if len(mirror.Rewrites) == 0 && mirror.Rewrites != nil {
 			mirror.Rewrites = nil
+			fromSecret[mirrorName] = mirror
 		}
-		fromSecret[mirrorName] = mirror
 	}
 	return reflect.DeepEqual(fromSetting, fromSecret)
 }


### PR DESCRIPTION
**Problem:**
When the `harvester-containerd-registry` secret is not in the cluster, and then users set up the `containerd-registry` setting, we didn't remove credentials in the `containerd-registry` setting.

**Solution:**
Remove credentials in setting after creating the `harvester-containerd-registry` secret.

**Related Issue:**
https://github.com/harvester/harvester/issues/2176

**Test plan:**

Setup:
* Use vagrant-pxe-harvester to create a harvester cluster.
* Create another VM `myregistry` and set it in the same virtual network.
* In `myregistry` VM:
  * Install docker.
  * Run following commands:
```
mkdir auth
 docker run \
  --entrypoint htpasswd \
  httpd:2 -Bbn testuser testpassword > auth/htpasswd

mkdir -p certs

openssl req \
  -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
  -addext "subjectAltName = DNS:myregistry.local" \
  -x509 -days 365 -out certs/domain.crt

sudo mkdir -p /etc/docker/certs.d/myregistry.local:5000
sudo cp certs/domain.crt /etc/docker/certs.d/myregistry.local:5000/domain.crt

docker run -d \
  -p 5000:5000 \
  --restart=always \
  --name registry \
  -v "$(pwd)"/certs:/certs \
  -v "$(pwd)"/registry:/var/lib/registry \
  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
  -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
  -v "$(pwd)"/auth:/auth \
  -e "REGISTRY_AUTH=htpasswd" \
  -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
  -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
  registry:2
```
* Set IP and domain in `/etc/hosts` to all VM (harvester and `myregistry`). Remember to change the IP.
```
# vim /etc/hosts
192.168.0.50 myregistry.local
```
* Login, pull, and push nginx image in `myregsitry` VM:
```
# username: testuser, password: testpassword
docker login myregistry.local:5000
docker pull nginx:latest
docker tag nginx:latest myregistry.local:5000:/nginx:latest
docker push myregistry.local:5000/nginx:latest
```
* Copy `certs/domain.crt` content in `myregistry` VM and paste it to `additional-ca` setting.

Case 1: Remove `harvester-containerd-registry` secret and change `containerd-registry` setting to our private registry
* Remove `cattle-system/harvester-containerd-registry` secret.
* Update `containerd-registry` setting as following:
```
...
value: '{"Mirrors":{"docker.io":{"Endpoints":["https://myregistry.local:5000/"]}},"Configs":{"myregistry.local:5000":{"Auth":{"Username":"testuser","Password":"testpassword"}}}}'
```
* A new `cattle-system/harvester-containerd-registry` secret is created.
* Check there are new jobs that automatically apply the change to the RKE2.
* Apply following yaml and nginx can be deployed.
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: myregistry-nginx
spec:
  selector:
    matchLabels:
      image: myregistry-nginx
  template:
    metadata:
      labels:
        image: myregistry-nginx
    spec:
      containers:
        - imagePullPolicy: Always
          image: myregistry.local:5000/nginx:latest
          name: nginx
```
