### PR TITLE
Bump kubevirt image to official v0.54.0 from SLEs

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -26,29 +26,29 @@ kubevirt-operator:
   containers:
     operator:
       image:
-        repository: registry.suse.com/harvester-beta/virt-operator
-        tag: &kubevirtVersion 0.54.0
+        repository: registry.suse.com/suse/sles/15.4/virt-operator
+        tag: &kubevirtVersion 0.54.0-150400.3.3.2
     ## The following images are placeholder for images in use.
     ## They are not used by the kubevirt-operator chart.
     controller:
       image:
-        repository: registry.suse.com/harvester-beta/virt-controller
+        repository: registry.suse.com/suse/sles/15.4/virt-controller
         tag: *kubevirtVersion
     handler:
       image:
-        repository: registry.suse.com/harvester-beta/virt-handler
+        repository: registry.suse.com/suse/sles/15.4/virt-handler
         tag: *kubevirtVersion
     api:
       image:
-        repository: registry.suse.com/harvester-beta/virt-api
+        repository: registry.suse.com/suse/sles/15.4/virt-api
         tag: *kubevirtVersion
     launcher:
       image:
-        repository: registry.suse.com/harvester-beta/virt-launcher
+        repository: registry.suse.com/suse/sles/15.4/virt-launcher
         tag: *kubevirtVersion
     libguestfs: # introduced from kubevirt v0.44.0
       image:
-        repository: registry.suse.com/harvester-beta/libguestfs-tools
+        repository: registry.suse.com/suse/sles/15.4/libguestfs-tools
         tag: *kubevirtVersion
 
 ## Specify the parameters to override the sub-chart.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Need to bump kubevirt image to the official v0.54.0 from SLEs.


**Solution:**
Bump kubevirt image to the official v0.54.0 from SLEs.

**Related Issue:**
https://github.com/harvester/harvester/issues/2315

**Test plan:**
All the kubevirt components and basic VM operations work as expected.
```
harvester-system            kube-vip-n8tcp                                              1/1     Running     2 (62m ago)   87m
harvester-system            virt-api-559d997756-gj9hz                                   1/1     Running     1 (62m ago)   82m
harvester-system            virt-controller-8595bb9985-gv925                            1/1     Running     1 (62m ago)   81m
harvester-system            virt-controller-8595bb9985-xvrqq                            1/1     Running     1 (62m ago)   81m
harvester-system            virt-handler-gwvhr                                          1/1     Running     1 (62m ago)   81m
harvester-system            virt-operator-568765879f-d2mrj                              1/1     Running     2 (62m ago)   87m
```
and the images are up-to-the-date, e.g.,
```
    Image:         registry.suse.com/suse/sles/15.4/virt-controller:0.54.0-150400.3.3.2
```