### PR TITLE
Update node manager image repo to rancher/harvester-node-manager

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -475,5 +475,6 @@ harvester-pcidevices-controller:
 harvester-node-manager:
   image:
     imagePullPolicy: IfNotPresent
-    repository: ghcr.io/harvester/node-manager
+    repository: rancher/harvester-node-manager
     tag: v0.1.1
+


### PR DESCRIPTION
We move back to dockerhub. 

Fix fail to build ISO. https://drone-publish.rancher.io/harvester/harvester/728/3/2