### PR TITLE
fix: harvester-containerd-registry-script

### DIFF
--- a/deploy/charts/harvester/templates/cattle-system.yaml
+++ b/deploy/charts/harvester/templates/cattle-system.yaml
@@ -36,7 +36,7 @@ stringData:
     #!/bin/sh
     RESTART=true
     if [ -f "/etc/rancher/rke2/registries.yaml" ]; then
-      if [ cmp -s "/run/system-upgrade/secrets/registries/registries.yaml" "/etc/rancher/rke2/registries.yaml" ]; then
+      if cmp -s "/run/system-upgrade/secrets/registries/registries.yaml" "/etc/rancher/rke2/registries.yaml"; then
         RESTART=false
         echo "/etc/rancher/rke2/registries.yaml is not changed"
       fi


### PR DESCRIPTION
**Problem:**
The `harvester-containerd-registry-script` may show too many arguments error.
![image](https://user-images.githubusercontent.com/4927361/193495928-9b9e3de0-0441-40c8-8b11-a34b079f9f1e.png)


**Solution:**
Fix the script.

**Related Issue:**
https://github.com/harvester/harvester/issues/2176

**Test plan:**

Setup:
* Use vagrant-pxe-harvester to create a harvester cluster.
* Create another VM `myregistry` and set it in the same virtual network.
* In `myregistry` VM:
  * Install docker.
  * Run following commands:
```
mkdir auth
 docker run \
  --entrypoint htpasswd \
  httpd:2 -Bbn testuser testpassword > auth/htpasswd

mkdir -p certs

openssl req \
  -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
  -addext "subjectAltName = DNS:myregistry.local" \
  -x509 -days 365 -out certs/domain.crt

sudo mkdir -p /etc/docker/certs.d/myregistry.local:5000
sudo cp certs/domain.crt /etc/docker/certs.d/myregistry.local:5000/domain.crt

docker run -d \
  -p 5000:5000 \
  --restart=always \
  --name registry \
  -v "$(pwd)"/certs:/certs \
  -v "$(pwd)"/registry:/var/lib/registry \
  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
  -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
  -v "$(pwd)"/auth:/auth \
  -e "REGISTRY_AUTH=htpasswd" \
  -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
  -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
  registry:2
```
* Set IP and domain in `/etc/hosts` to all VM (harvester and `myregistry`). Remember to change the IP.
```
# vim /etc/hosts
192.168.0.50 myregistry.local
```
* Login, pull, and push nginx image in `myregsitry` VM:
```
# username: testuser, password: testpassword
docker login myregistry.local:5000
docker pull nginx:latest
docker tag nginx:latest myregistry.local:5000:/nginx:latest
docker push myregistry.local:5000/nginx:latest
docker pull nginx:1.22
docker tag nginx:latest myregistry.local:5000:/nginx:1.22
docker push myregistry.local:5000/nginx:1.22
```
* Copy `certs/domain.crt` content in `myregistry` VM and paste it to `additional-ca` setting.

Test:
1. Login the harvester node and write the following content to `/etc/rancher/rke2/registries.yaml`.
```
mirrors:
  docker.io:
    endpoint:
    - https://myregistry.local:5000/
    rewrite: {}
configs:
  myregistry.local:5000:
    auth:
      username: testuser
      password: testpassword
      auth: ""
      identity_token: ""
    tls:
      ca_file: ""
      cert_file: ""
      key_file: ""
      insecure_skip_verify: false
auths: {}
```
2. On the setting page, setup the `containerd-registry` setting.

![Screen Shot 2022-10-03 at 11 25 38 AM](https://user-images.githubusercontent.com/4927361/193496269-9758c92f-6f6b-437e-b434-6ae68185a5c9.png)

3. Check `cattle-system/apply-sync-containerd-registry-on-harvester-node-0-with-xxx` job result. It should not have any error.