### PR TITLE
Upgrade: remove kube-apiserver static pod manifest before rebooting

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -28,6 +28,11 @@ if [ "$container_state" = "CONTAINER_EXITED" ]; then
 
   if [ "$container_exit_code" = "0" ]; then
     sleep 10
+
+    # workaround for https://github.com/harvester/harvester/issues/2865
+    # kubelet could start from old manifest first and generate a new manifest later.
+    rm -f /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
+
     reboot
     exit 0
   fi


### PR DESCRIPTION


**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
RKE2 keeps displaying the log after a node is upgraded and rebooted.

```
Sep 29 10:23:39 node4 rke2[2050]: time="2022-09-29T10:23:39Z" level=info msg="Latest etcd manifest deployed"
Sep 29 10:23:39 node4 rke2[2050]: time="2022-09-29T10:23:39Z" level=info msg="kube-apiserver pod not found, retrying"
Sep 29 10:23:40 node4 rke2[2050]: time="2022-09-29T10:23:40Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:45 node4 rke2[2050]: time="2022-09-29T10:23:45Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:50 node4 rke2[2050]: time="2022-09-29T10:23:50Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:55 node4 rke2[2050]: time="2022-09-29T10:23:55Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:59 node4 rke2[2050]: time="2022-09-29T10:23:59Z" level=info msg="Latest etcd manifest deployed"
```
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The kube-apiserver uid changes but kubelet could load the old pod manifest. Removing the old manifest ensures kubelet always load the new generated one.

**Related Issue:**
https://github.com/harvester/harvester/issues/2865

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
The upgrade, once the node is rebooted, we should not see flooding of these messages:

```
Sep 29 10:23:39 node4 rke2[2050]: time="2022-09-29T10:23:39Z" level=info msg="Latest etcd manifest deployed"
Sep 29 10:23:39 node4 rke2[2050]: time="2022-09-29T10:23:39Z" level=info msg="kube-apiserver pod not found, retrying"
Sep 29 10:23:40 node4 rke2[2050]: time="2022-09-29T10:23:40Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:45 node4 rke2[2050]: time="2022-09-29T10:23:45Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:50 node4 rke2[2050]: time="2022-09-29T10:23:50Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:55 node4 rke2[2050]: time="2022-09-29T10:23:55Z" level=info msg="Waiting to retrieve kube-proxy configuration; server is not ready: https://127.0.0.1:9345/v1-rke2/readyz: 500 Internal Server Error"
Sep 29 10:23:59 node4 rke2[2050]: time="2022-09-29T10:23:59Z" level=info msg="Latest etcd manifest deployed"
```
