### PR TITLE
Add storageclass validator and validate unique default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 api.test
 .docker
+.nocalhost

--- a/pkg/webhook/resources/storageclass/validator.go
+++ b/pkg/webhook/resources/storageclass/validator.go
@@ -1,0 +1,74 @@
+package storageclass
+
+import (
+	ctlstoragev1 "github.com/rancher/wrangler/pkg/generated/controllers/storage/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/harvester/harvester/pkg/util"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(storageClassCache ctlstoragev1.StorageClassCache) types.Validator {
+	return &storageClassValidator{
+		storageClassCache: storageClassCache,
+	}
+}
+
+type storageClassValidator struct {
+	types.DefaultValidator
+	storageClassCache ctlstoragev1.StorageClassCache
+}
+
+func (v *storageClassValidator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{"storageclasses"},
+		Scope:      admissionregv1.ClusterScope,
+		APIGroup:   storagev1.SchemeGroupVersion.Group,
+		APIVersion: storagev1.SchemeGroupVersion.Version,
+		ObjectType: &storagev1.StorageClass{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (v *storageClassValidator) Create(request *types.Request, newObj runtime.Object) error {
+	return v.validateSetUniqueDefault(newObj)
+}
+
+func (v *storageClassValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	return v.validateSetUniqueDefault(newObj)
+}
+
+func (v *storageClassValidator) validateSetUniqueDefault(newObj runtime.Object) error {
+	newSC := newObj.(*storagev1.StorageClass)
+
+	// if new storage class haven't storageclass.kubernetes.io/is-default-class annotation or the value is false.
+	if v, ok := newSC.Annotations[util.AnnotationIsDefaultStorageClassName]; !ok || v == "false" {
+		return nil
+	}
+
+	scList, err := v.storageClassCache.List(labels.Everything())
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), "")
+	}
+
+	for _, sc := range scList {
+		if sc.Name == newSC.Name {
+			continue
+		}
+
+		// return set default error
+		// when find another have storageclass.kubernetes.io/is-default-class annotation and value is true.
+		if v, ok := sc.Annotations[util.AnnotationIsDefaultStorageClassName]; ok && v == "true" {
+			return werror.NewInvalidError("default storage class %s already exists, please reset it first", sc.Name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/resources/node"
 	"github.com/harvester/harvester/pkg/webhook/resources/persistentvolumeclaim"
 	"github.com/harvester/harvester/pkg/webhook/resources/setting"
+	"github.com/harvester/harvester/pkg/webhook/resources/storageclass"
 	"github.com/harvester/harvester/pkg/webhook/resources/templateversion"
 	"github.com/harvester/harvester/pkg/webhook/resources/upgrade"
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachine"
@@ -68,6 +69,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		bundledeployment.NewValidator(
 			clients.FleetFactory.Fleet().V1alpha1().Cluster().Cache(),
 		),
+		storageclass.NewValidator(clients.StorageFactory.Storage().V1().StorageClass().Cache()),
 	}
 
 	router := webhook.NewRouter()


### PR DESCRIPTION
**Problem:**
Multiple StorageClass can be set as "default"

**Solution:**
Add a StorageClass validator to the harvester/webhook, if it is checked that a default sc already exists, it cannot be configured, need to reset the existing one.

**Related Issue:**
https://github.com/harvester/harvester/issues/2863

**Test plan:**
https://github.com/harvester/harvester/issues/2863
