### PR TITLE
fix(upgrade): remove rkeConfig

### DIFF
--- a/package/upgrade/migrations/upgrade_manifests/v1.0.3/pre-hook.sh
+++ b/package/upgrade/migrations/upgrade_manifests/v1.0.3/pre-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+echo "Remove rke.cattle.io/init-node-machine-id label in fleet-local/local cluster"
+kubectl -n fleet-local label clusters.provisioning.cattle.io local rke.cattle.io/init-node-machine-id-

--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -338,7 +338,8 @@ func (r *UpgradeRepo) deleteVM() error {
 func (r *UpgradeRepo) deleteImage(pvcName string) error {
 	imageID := r.upgrade.Status.ImageID
 	if imageID == "" {
-		return errors.New("Upgrade repo image is not provided")
+		logrus.Error("Upgrade repo image is not provided")
+		return nil
 	}
 
 	image, err := r.GetImage(imageID)


### PR DESCRIPTION
**Problem:**
We kept `rkeConfig` in cluster CR after the upgrade, so when we tried to add a new management node in an upgraded cluster, it triggered pre/post drain again on each node.

**Solution:**
Remove `rkeConfig` after an upgrade.

**Related Issue:**
https://github.com/harvester/harvester/issues/2470
https://github.com/harvester/harvester/issues/2665
https://github.com/harvester/harvester/issues/2892

**Test plan:**
1. Create a 3-node v1.0.3 cluster.
2. Upgrade the cluster to this branch.
3. Remove 1 node.
4. After the node is removed, provision a new node.
5. Check the node can join the cluster.
