### PR TITLE
upgrade: cleanup the static pod yaml

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -31,7 +31,7 @@ if [ "$container_state" = "CONTAINER_EXITED" ]; then
 
     # workaround for https://github.com/harvester/harvester/issues/2865
     # kubelet could start from old manifest first and generate a new manifest later.
-    rm -f /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
+    rm -f /var/lib/rancher/rke2/agent/pod-manifests/*
 
     reboot
     exit 0


### PR DESCRIPTION

**Problem:**
Because `kube-controller-manager` need to authorize with `kube-apiserver`, `kube-controller-manager` will fail if starting before `kube-apiserver`.

**Solution:**
ensure the static pods bootup sequence

**Related Issue:**
#2893 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
