### PR TITLE
Remove generated rke2-config in previous versions

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -344,6 +344,7 @@ get_all_running_vm_count() {
 
 delete_canal_flannel_iface() {
   kubectl delete helmchartconfig rke2-canal -n kube-system || true
+  kubectl patch configmap rke2-canal-config -n kube-system -p '{"data":{"canal_iface": ""}}' --type merge
 }
 
 modify_nad_bridge() {

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -315,6 +315,8 @@ command_pre_drain() {
 
   # Add logging related kube-audit policy file
   patch_logging_event_audit
+
+  remove_rke2_canal_config
 }
 
 get_node_rke2_version() {
@@ -350,6 +352,10 @@ clean_rke2_archives() {
       rm -f "$HOST_DIR/var/lib/rancher/rke2/agent/images/$(basename $archive)"
       rm -f "$HOST_DIR/var/lib/rancher/rke2/agent/images/$(basename $list)"
     done
+}
+
+remove_rke2_canal_config() {
+  rm -f "$HOST_DIR/var/lib/rancher/rke2/server/manifests/rke2-canal-config.yaml"
 }
 
 convert_nodenetwork_to_vlanconfig() {
@@ -463,6 +469,8 @@ command_single_node_upgrade() {
 
   wait_repo
   detect_repo
+
+  remove_rke2_canal_config
 
   # Copy OS things, we need to shutdown repo VMs.
   NEW_OS_SQUASHFS_IMAGE_FILE=$(mktemp -p $UPGRADE_TMP_DIR)


### PR DESCRIPTION
A forward port of the [last-minute upgrade fix](https://github.com/harvester/harvester/pull/2959) on v1.1.0-rc3.