### PR TITLE
A restored VM can't be cloned

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -721,12 +721,16 @@ func (h *vmActionHandler) cloneVolumes(newVM *kubevirtv1.VirtualMachine) ([]core
 					Name:        names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%s-", newVM.Name, volume.Name)),
 					Annotations: annotations,
 				},
-				Spec: *pvc.Spec.DeepCopy(),
-			}
-			newPVC.Spec.VolumeName = ""
-			newPVC.Spec.DataSource = &corev1.TypedLocalObjectReference{
-				Kind: "PersistentVolumeClaim",
-				Name: pvc.Name,
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: pvc.Spec.AccessModes,
+					DataSource: &corev1.TypedLocalObjectReference{
+						Kind: "PersistentVolumeClaim",
+						Name: pvc.Name,
+					},
+					Resources:        pvc.Spec.Resources,
+					StorageClassName: pvc.Spec.StorageClassName,
+					VolumeMode:       pvc.Spec.VolumeMode,
+				},
 			}
 			newPVCs = append(newPVCs, newPVC)
 			volume.PersistentVolumeClaim.ClaimName = newPVC.Name


### PR DESCRIPTION
**Problem:**
Follow reproduce steps in #2968, a restored VM can't be cloned, because we copy a field `dataSourceRef`. If `dataSource` and `dataSourceRef` is not matched, we can't provision a new PVC.

**Solution:**
Only copy useful fields.

**Related Issue:**
https://github.com/harvester/harvester/issues/2968

**Test plan:**

Setup:
* Create a Harvester cluster.
* Setup backup target (both NFS & S3 work).

Case 1: a new VM can be cloned
* Create a new VM `source-vm`.
* Run `echo "123" > test.txt && sync` in `source-vm`.
* Clone `source-vm` as a new VM `source-vm-c`.
* VM `source-vm-c` should not have any error. Also, we can get `123` when running `cat test.txt` in `source-vm-c`.

Case 2: a cloned VM can be cloned
* Follow case 1.
* Clone `source-vm-c` as a new VM `source-vm-c-c`.
* VM `source-vm-c-c` should not have any error. Also, we can get `123` when running `cat test.txt` in `source-vm-c-c`.
* Delete VM `source-vm-c` and `source-vm-c-c`.

Case 3: a restored VM can be cloned
* Follow case 2.
* Take a backup `source-vm-backup` for `source-vm`.
* Delete `source-vm`.
* Restore the backup `source-vm-backup` as VM `source-vm`.
* Clone `source-vm` as a new VM `source-vm-c`.
* VM `source-vm-c` should not have any error. Also, we can get `123` when running `cat test.txt` in `source-vm-c`.
* Delete `source-vm-backup`, `source-vm` and `source-vm-c`.

Case 4: a VM can be restored from a backup which is from a clond VM
* Create a new VM `source-vm`.
* Clone `source-vm` as a new VM `source-vm-c`.
* Take a backup `source-vm-c-backup` for `source-vm-c`.
* Restore a VM `restored-vm` from `source-vm-c-backup`.