### PR TITLE
fix(backup-target): init value

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -28,7 +28,7 @@ var (
 	UISource                = NewSetting(UISourceSettingName, "auto") // Options are 'auto', 'external' or 'bundled'
 	UIPluginIndex           = NewSetting(UIPluginIndexSettingName, DefaultUIPluginURL)
 	VolumeSnapshotClass     = NewSetting(VolumeSnapshotClassSettingName, "longhorn")
-	BackupTargetSet         = NewSetting(BackupTargetSettingName, InitBackupTargetToString())
+	BackupTargetSet         = NewSetting(BackupTargetSettingName, "")
 	UpgradableVersions      = NewSetting("upgradable-versions", "")
 	UpgradeCheckerEnabled   = NewSetting("upgrade-checker-enabled", "true")
 	UpgradeCheckerURL       = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")


### PR DESCRIPTION
**Problem:**
When users setup `systemSettings` with `backup-target` and the backup-target is broken, the system can't be started.

**Solution:**
Update the default value of the `backup-target` setting to prevent the server try to update the setting during initialization.

**Related Issue:**
https://github.com/harvester/harvester/issues/2986

**Test plan:**

**Start server**
* Download https://github.com/harvester/ipxe-examples.
* `cd vagrant-pxe-harvester`
* Add following content in https://github.com/harvester/ipxe-examples/blob/main/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2.
```
systemSettings:
  backup-target: '{"type": "nfs", "endpoint": "nfs://longhorn-test-nfs-svc.default:/opt/backupstore", "accessKeyId": "", "secretAccessKey": "", "bucketName": "","bucketRegion": "", "cert": "", "virtualHostedStyle": false}'
```
* Start servers. `./setup_harvester.sh`
* Check harvester server can start successfully.

**Create VM and backup**
* Create NFS.
```
kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.3.0/deploy/backupstores/nfs-backupstore.yaml
```
* Create VM and take a backup. It should not have any error.
* Use the backup to restore a VM. It should not have any error.
