### PR TITLE
Upgrade: do not fail pre-drain/post-drain jobs

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v0.49.0/vir
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/latest/download/wharfie-amd64  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 
+COPY do_upgrade_node.sh /usr/local/bin/
 COPY upgrade_node.sh /usr/local/bin/
 COPY upgrade_manifests.sh /usr/local/bin/
 COPY lib.sh /usr/local/bin

--- a/package/upgrade/do_upgrade_node.sh
+++ b/package/upgrade/do_upgrade_node.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+retries=0
+
+until $SCRIPT_DIR/upgrade_node.sh $@; do
+  # Do not fail pre-drain/post-drain jobs
+  case $1 in
+  "pre-drain"|"post-drain")
+    ;;
+  *)
+    echo "[Error] Running \"upgrade_node.sh $*\""
+    exit 1
+    ;;
+  esac
+
+  # A fallback to exit if seeing some files
+  # This could be useful to modify a running job container and resume an upgrade.
+  if [ -e "/tmp/skip-retry-with-fail" ]; then
+    echo "Exit 1 manually."
+    exit 1
+  fi
+
+  if [ -e "/tmp/skip-retry-with-succeed" ]; then
+    echo "Exit 0 manually."
+    exit 0
+  fi
+
+  echo "[$(date)] Running \"upgrade_node.sh $*\" errors, will retry ($retries retries)..."
+  sleep 60
+  retries=$((retries+1))
+done

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -178,7 +178,7 @@ func preparePlan(upgrade *harvesterv1.Upgrade) *upgradev1.Plan {
 			},
 			Upgrade: &upgradev1.ContainerSpec{
 				Image:   fmt.Sprintf("%s:%s", upgradeImageRepository, imageVersion),
-				Command: []string{"upgrade_node.sh"},
+				Command: []string{"do_upgrade_node.sh"},
 				Args:    []string{"prepare"},
 				Env: []corev1.EnvVar{
 					{
@@ -230,7 +230,7 @@ func applyNodeJob(upgrade *harvesterv1.Upgrade, repoInfo *UpgradeRepoInfo, nodeN
 						{
 							Name:    "apply",
 							Image:   fmt.Sprintf("%s:%s", upgradeImageRepository, imageVersion),
-							Command: []string{"upgrade_node.sh"},
+							Command: []string{"do_upgrade_node.sh"},
 							Args:    []string{jobType},
 							Env: []corev1.EnvVar{
 								{


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
There are two reasons we don't want to fail a pre-drain or post-drain jobs:
- It's hard to debug. Some pods' logs can't retain. (This should not be an issue after https://github.com/harvester/harvester/issues/1926)
- Users can't resume an upgrade if jobs fail. Rancher is in its provisioning state. Thus I feel it's better to wait there for trouble shooting and then continue.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Wrap the original upgrade_node.sh with retry loop. I once consider using a huge backoff limit value in jobs, but this might create flooding pods and make it even harder to debug (old logs vanish).

**Related Issue:**
https://github.com/harvester/harvester/issues/3073

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

- There are some way to simulate a failing pre-drain or post-drain job.
  - Insert the `exit 1` statement to upgrade_node.sh.
  - make the `elemental` command fail (will fail the post-drain job).
    ```
    touch /tmp/fake
    mount --bind /tmp/fake /usr/bin/elemental
    ```
