### PR TITLE
Add unreachable toleration to node promotion

### DIFF
--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -457,6 +457,11 @@ func buildPromoteJob(namespace string, node *corev1.Node) *batchv1.Job {
 							Operator: corev1.TolerationOpExists,
 							Effect:   corev1.TaintEffectNoSchedule,
 						},
+						{
+							Key:      corev1.TaintNodeUnreachable,
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
 					},
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes: []corev1.Volume{{


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
find error in https://github.com/harvester/harvester/issues/3039:
```
  status:
    conditions:
    - lastProbeTime: "null"
      lastTransitionTime: "2022-10-25T22:47:24Z"
      message: '0/3 nodes are available: 1 node(s) didn''t match pod anti-affinity
        rules, 1 node(s) had untolerated taint {node.kubernetes.io/unreachable: },
        2 node(s) didn''t match Pod''s node affinity/selector. preemption: 0/3 nodes
        are available: 3 Preemption is not helpful for scheduling.'
      reason: Unschedulable
      status: "False"
      type: PodScheduled
    phase: Pending
    qosClass: BestEffort
```

promotion pod tolerations:
```
    tolerations:
    - effect: NoSchedule
      key: node.kubernetes.io/unschedulable
      operator: Exists
    - effect: NoExecute
      key: node.kubernetes.io/not-ready
      operator: Exists
      tolerationSeconds: 300
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
      tolerationSeconds: 300
```

the failed node taints:
```yaml
  spec:
    podCIDR: 10.52.1.0/24
    podCIDRs:
    - 10.52.1.0/24
    providerID: rke2://harvester-2
    taints:
    - effect: NoSchedule
      key: node.kubernetes.io/unschedulable
      timeAdded: "2022-10-25T22:39:11Z"
    - effect: NoSchedule
      key: node.kubernetes.io/unreachable
      timeAdded: "2022-10-25T22:42:10Z"
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      timeAdded: "2022-10-25T22:42:20Z"
    unschedulable: true
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add unreachable toleration to node promotion

**Related Issue:**
https://github.com/harvester/harvester/issues/3039

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
