### PR TITLE
fix(upgrade): take prereleases into account

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -248,6 +248,66 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 	}
 }
 
+func Test_isVersionUpgradable(t *testing.T) {
+	var testCases = []struct {
+		name                 string
+		currentVersion       string
+		minUpgradableVersion string
+		isUpgradable         bool
+	}{
+		{
+			name:                 "upgrade from versions above the minimal requirement",
+			currentVersion:       "v1.1.1",
+			minUpgradableVersion: "v1.1.0",
+			isUpgradable:         true,
+		},
+		{
+			name:                 "upgrade from the exact version of the minimal requirement",
+			currentVersion:       "v1.1.0",
+			minUpgradableVersion: "v1.1.0",
+			isUpgradable:         true,
+		},
+		{
+			name:                 "upgrade from rc versions lower than the minimal requirement",
+			currentVersion:       "v1.1.0-rc1",
+			minUpgradableVersion: "v1.1.0",
+			isUpgradable:         false,
+		},
+		{
+			name:                 "upgrade from rc versions above the minimal requirement (rc minUpgradableVersion)",
+			currentVersion:       "v1.1.0-rc2",
+			minUpgradableVersion: "v1.1.0-rc1",
+			isUpgradable:         true,
+		},
+		{
+			name:                 "upgrade from rc versions lower than the minimal requirement (rc minUpgradableVersion)",
+			currentVersion:       "v1.1.0-rc1",
+			minUpgradableVersion: "v1.1.0-rc2",
+			isUpgradable:         false,
+		},
+		{
+			name:                 "upgrade from the exact rc version of the minimal requirement (rc minUpgradableVersion)",
+			currentVersion:       "v1.1.0-rc1",
+			minUpgradableVersion: "v1.1.0-rc1",
+			isUpgradable:         true,
+		},
+		{
+			name:                 "upgrade from versions lower than the minimal requirement",
+			currentVersion:       "v1.0.3",
+			minUpgradableVersion: "v1.1.0",
+			isUpgradable:         false,
+		},
+	}
+	for _, tc := range testCases {
+		err := isVersionUpgradable(tc.currentVersion, tc.minUpgradableVersion)
+		if tc.isUpgradable {
+			assert.Nil(t, err, "case %q", tc.name)
+		} else {
+			assert.NotNil(t, err, "case %q", tc.name)
+		}
+	}
+}
+
 func fakeImageExist(imageCache ctlharvesterv1.VirtualMachineImageCache, displayName string) (bool, error) {
 	vmis, err := imageCache.List(upgradeNamespace, labels.Everything())
 	if err != nil {


### PR DESCRIPTION
If users got a prerelease version installed and want to upgrade to the formal release version, the version checking should let them pass. For example, upgrading from v1.1.0-rc3 to v1.1.0 should not be blocked by the version-checking mechanism, though such behaviors are not recommended.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**

Users reported the upgrade from v1.1.0-rc3 to v1.1.0 will fail with the following message:

```
The current version v1.1.0-rc3 is less than the minimum upgradable version v1.0.3.
```

**Solution:**

This change contains two parts:
- the upgrade controller, will only take effect **after** the next upgrade
  - according to [the document](https://github.com/Masterminds/semver#working-with-prerelease-versions) of the library we leveraged, a suffix is essential to make the comparisons become prerelease-aware
- the upgrade script, takes effect in the next upgrade
  - the version sorting is good enough, just added some additional handling about rc versions

**Related Issue:**

#3040 
#3633

**Test plan:**

**Test case 1**

1. Prepare a v1.1.0-rc3 Harvester cluster with any number of nodes
2. Kickstart the upgrade to v1.1.0 (contain this PR)
3. The upgrade should continue til the end and not be blocked by the version checking

The following message should not show up in the condition of the upgrade CR:

```
The current version v1.1.0-rc3 is less than the minimum upgradable version v1.0.3.
```

The following line should not show up in the logs of any upgrade Jobs:

```
Current version is not supported. Abort the upgrade.
```

**Test case 2**

1. Prepare a v1.0.3-rc2 Harvester cluster with any number of nodes
2. Kickstart the upgrade to v1.1.0 (contain this PR)
3. The upgrade should be blocked by the version checking since v1.0.3-rc2 is older than v1.0.3, the required minimum upgradable version

The following line should show up in the logs of the apply-manifest Job:

```
Current version is not supported. Abort the upgrade.
```