### PR TITLE
feat(upgrade): add checks

### DIFF
--- a/pkg/data/crd.go
+++ b/pkg/data/crd.go
@@ -54,6 +54,7 @@ func createCRDs(ctx context.Context, restConfig *rest.Config) error {
 			crd.FromGV(provisioningv1.SchemeGroupVersion, "Cluster", provisioningv1.Cluster{}),
 			crd.FromGV(fleetv1alpha1.SchemeGroupVersion, "Cluster", fleetv1alpha1.Cluster{}),
 			crd.FromGV(clusterv1.GroupVersion, "Cluster", clusterv1.Cluster{}),
+			crd.FromGV(clusterv1.GroupVersion, "Machine", clusterv1.Machine{}),
 			crd.FromGV(harvesterv1.SchemeGroupVersion, "Addon", harvesterv1.Addon{}).WithStatus(),
 			crd.FromGV(monitoringv1.SchemeGroupVersion, "Prometheus", monitoringv1.Prometheus{}),
 			crd.FromGV(monitoringv1.SchemeGroupVersion, "Alertmanager", monitoringv1.Alertmanager{}),

--- a/pkg/webhook/clients/clients.go
+++ b/pkg/webhook/clients/clients.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ctlfleetv1 "github.com/rancher/rancher/pkg/generated/controllers/fleet.cattle.io"
+	rancherv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
 	"github.com/rancher/wrangler/pkg/clients"
 	storagev1 "github.com/rancher/wrangler/pkg/generated/controllers/storage"
 	"github.com/rancher/wrangler/pkg/schemes"
@@ -21,14 +22,15 @@ import (
 type Clients struct {
 	clients.Clients
 
-	HarvesterFactory *ctlharvesterv1.Factory
-	KubevirtFactory  *ctlkubevirtv1.Factory
-	CNIFactory       *ctlcniv1.Factory
-	SnapshotFactory  *ctlsnapshotv1.Factory
-	FleetFactory     *ctlfleetv1.Factory
-	StorageFactory   *storagev1.Factory
-	LonghornFactory  *ctllonghornv1.Factory
-	ClusterFactory   *ctlclusterv1.Factory
+	HarvesterFactory         *ctlharvesterv1.Factory
+	KubevirtFactory          *ctlkubevirtv1.Factory
+	CNIFactory               *ctlcniv1.Factory
+	SnapshotFactory          *ctlsnapshotv1.Factory
+	FleetFactory             *ctlfleetv1.Factory
+	StorageFactory           *storagev1.Factory
+	LonghornFactory          *ctllonghornv1.Factory
+	ClusterFactory           *ctlclusterv1.Factory
+	RancherManagementFactory *rancherv3.Factory
 }
 
 func New(ctx context.Context, rest *rest.Config, threadiness int) (*Clients, error) {
@@ -105,15 +107,21 @@ func New(ctx context.Context, rest *rest.Config, threadiness int) (*Clients, err
 		return nil, err
 	}
 
+	rancherFactory, err := rancherv3.NewFactoryFromConfigWithOptions(rest, clients.FactoryOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Clients{
-		Clients:          *clients,
-		HarvesterFactory: harvesterFactory,
-		KubevirtFactory:  kubevirtFactory,
-		CNIFactory:       cniFactory,
-		SnapshotFactory:  snapshotFactory,
-		FleetFactory:     fleetFactory,
-		StorageFactory:   storageFactory,
-		LonghornFactory:  longhornFactory,
-		ClusterFactory:   clusterFactory,
+		Clients:                  *clients,
+		HarvesterFactory:         harvesterFactory,
+		KubevirtFactory:          kubevirtFactory,
+		CNIFactory:               cniFactory,
+		SnapshotFactory:          snapshotFactory,
+		FleetFactory:             fleetFactory,
+		StorageFactory:           storageFactory,
+		LonghornFactory:          longhornFactory,
+		ClusterFactory:           clusterFactory,
+		RancherManagementFactory: rancherFactory,
 	}, nil
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -42,6 +42,8 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.Core.Node().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta1().Volume().Cache(),
 			clients.ClusterFactory.Cluster().V1alpha4().Cluster().Cache(),
+			clients.ClusterFactory.Cluster().V1alpha4().Machine().Cache(),
+			clients.RancherManagementFactory.Management().V3().ManagedChart().Cache(),
 		),
 		virtualmachinebackup.NewValidator(
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),


### PR DESCRIPTION
**Enhancement:**
Add node and cluster checks before starting the upgrade.

**Related Issue:**
https://github.com/harvester/harvester/issues/3067
https://github.com/harvester/harvester/issues/3298
https://github.com/harvester/harvester/issues/3391

**Test plan:**

Case 1: A cluster with any non-ready node can't be upgraded.
1. Create a 2-node harvester cluster.
2. Stop the agent node.
3. Apply a new version.
```
cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master-head
  namespace: harvester-system
spec:
  isoURL: "http://192.168.0.181:8000/harvester-master-amd64.iso"
EOF
```
4. Click the upgrade on the dashboard.
5. Webhook should stop the upgrade because a node is not ready.

Case 2: A cluster with any maintenance node can't be upgraded.
1. Create a 3-node harvester cluster.
2. Enable maintenance mode on any node.
3. Click the upgrade on the dashboard.
4. Webhook should stop the upgrade because a node is in maintenance mode.

Case 3: A cluster with any non-ready managed chart can't be upgraded.
1. Create a 3-node harvester cluster.
2. Create another harvester-webhook image with a different name.
3. Change the harvester-webhook image in the cluster.
4. Check the harvester ManagedChart is not ready.
5. Click the upgrade on the dashboard.
6. Webhook should stop the upgrade because the harvester ManagedChart is not ready.