### PR TITLE
fix(upgrade): add retries for curl downloads

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -13,12 +13,12 @@ download_file()
   local url=$1
   local output=$2
 
-  local i=0
-  until curl -sfL "$url" -o "$output"
+  local i=1
+  until curl -sSfL "$url" -o "$output"
   do
-    i=$((i + 1))
-    echo "Cannot download the requested file \"$output\" from \"$url\", retrying ($i)..."
+    echo "Failed to download the requested file \"$output\" from \"$url\" with error code: $?, retrying ($i)..."
     sleep 10
+    i=$((i + 1))
   done
 }
 

--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -13,14 +13,8 @@ download_file()
   local url=$1
   local output=$2
 
-  local i=1
   echo "Downloading the file from \"$url\" to \"$output\"..."
-  until curl -sSfL "$url" -o "$output"
-  do
-    echo "Failed to download the requested file from \"$url\" to \"$output\" with error code: $?, retrying ($i)..."
-    sleep 10
-    i=$((i + 1))
-  done
+  curl -sSfL --retry 10 --retry-connrefused "$url" -o "$output"
 }
 
 detect_repo()

--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -14,9 +14,10 @@ download_file()
   local output=$2
 
   local i=1
+  echo "Downloading the file from \"$url\" to \"$output\"..."
   until curl -sSfL "$url" -o "$output"
   do
-    echo "Failed to download the requested file \"$output\" from \"$url\" with error code: $?, retrying ($i)..."
+    echo "Failed to download the requested file from \"$url\" to \"$output\" with error code: $?, retrying ($i)..."
     sleep 10
     i=$((i + 1))
   done

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -423,7 +423,7 @@ upgrade_os() {
     tmp_rootfs_squashfs="$NEW_OS_SQUASHFS_IMAGE_FILE"
   else
     tmp_rootfs_squashfs=$(mktemp -p $UPGRADE_TMP_DIR)
-    curl -fL $UPGRADE_REPO_SQUASHFS_IMAGE -o $tmp_rootfs_squashfs
+    download_file "$UPGRADE_REPO_SQUASHFS_IMAGE" "$tmp_rootfs_squashfs"
   fi
 
   tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
@@ -474,7 +474,7 @@ command_single_node_upgrade() {
 
   # Copy OS things, we need to shutdown repo VMs.
   NEW_OS_SQUASHFS_IMAGE_FILE=$(mktemp -p $UPGRADE_TMP_DIR)
-  curl -fL $UPGRADE_REPO_SQUASHFS_IMAGE -o $NEW_OS_SQUASHFS_IMAGE_FILE
+  download_file "$UPGRADE_REPO_SQUASHFS_IMAGE" "$NEW_OS_SQUASHFS_IMAGE_FILE"
 
   # Stop all VMs
   shutdown_all_vms


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Failures might occur around curl commands in `detect_repo` and many other places in the upgrade scripts during node upgrades due to network issues. This leads to a total failure of the node upgrade Pod because we have `set -e` in the upgrade scripts.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add retry for file downloading using curl.

**Related Issue:**

#3079 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a v1.0.3 Harvester cluster with any number of nodes
2. Kickstart the upgrade to v1.1.0 which contains the changes in this PR
3. Wait until the upgrade entering phase 4: node upgrade
4. Copy the output of the upgrade repo VM's Service resource with `kubectl -n harvester-system get svc upgrade-repo-hvst-upgrade-lbwg6 -o yaml > upgrade-repo-svc.yaml` for example
5. Remove the Service resource with `kubectl -n harvester-system delete svc upgrade-repo-hvst-upgrade-lbwg6` for example
6. Check the logs of the running post-drain Pod, there should be some `curl` retrying logs
7. Resume the upgrade by putting back the Service resource with `kubectl apply -f upgrade-repo-svc.yaml`
8. Check the logs of the running post-drain Pod, the retry should end, and the upgrade proceeds
