### PR TITLE
feat(vmtemplate): add with data

### DIFF
--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -48,6 +48,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	secrets := scaled.CoreFactory.Core().V1().Secret()
 	vmt := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate()
 	vmtv := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion()
+	vmImages := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage()
+	storageClasses := scaled.StorageFactory.Storage().V1().StorageClass()
 
 	copyConfig := rest.CopyConfig(server.RESTConfig)
 	copyConfig.GroupVersion = &kubevirtSubResouceGroupVersion
@@ -81,6 +83,9 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		secretCache:               secrets.Cache(),
 		virtSubresourceRestClient: virtSubresourceClient,
 		virtRestClient:            virtv1Client.RESTClient(),
+		vmImages:                  vmImages,
+		vmImageCache:              vmImages.Cache(),
+		storageClassCache:         storageClasses.Cache(),
 	}
 
 	vmformatter := vmformatter{

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -27,6 +27,7 @@ type MigrateInput struct {
 type CreateTemplateInput struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	WithData    bool   `json:"withData"`
 }
 
 type AddVolumeInput struct {

--- a/pkg/apis/harvesterhci.io/v1beta1/template.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/template.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	VersionAssigned condition.Cond = "assigned" // version number was assigned to templateVersion object's status.Version
+	VersionAssigned      condition.Cond = "assigned" // version number was assigned to templateVersion object's status.Version
+	TemplateVersionReady condition.Cond = "ready"    // all images in the template are ready
 )
 
 // +genclient

--- a/pkg/controller/master/template/register.go
+++ b/pkg/controller/master/template/register.go
@@ -9,11 +9,13 @@ import (
 const (
 	templateControllerAgentName        = "template-controller"
 	templateVersionControllerAgentName = "template-version-controller"
+	vmImageControllerAgentName         = "vm-image-in-template-controller"
 )
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
 	templates := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate()
 	templateVersions := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion()
+	vmImages := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage()
 
 	templateController := &templateHandler{
 		templates:            templates,
@@ -26,9 +28,16 @@ func Register(ctx context.Context, management *config.Management, options config
 		templateCache:      templates.Cache(),
 		templateVersions:   templateVersions,
 		templateController: templates,
+		vmImageCache:       vmImages.Cache(),
+	}
+
+	vmImageController := &vmImageHandler{
+		templateVersionCache:      templateVersions.Cache(),
+		templateVersionController: templateVersions,
 	}
 
 	templates.OnChange(ctx, templateControllerAgentName, templateController.OnChanged)
 	templateVersions.OnChange(ctx, templateVersionControllerAgentName, templateVersionController.OnChanged)
+	vmImages.OnChange(ctx, vmImageControllerAgentName, vmImageController.OnChanged)
 	return nil
 }

--- a/pkg/controller/master/template/vm_image_controller.go
+++ b/pkg/controller/master/template/vm_image_controller.go
@@ -1,0 +1,39 @@
+package template
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/indexeres"
+)
+
+// vmImageHandler watch vm image and enqueue related vm template versions.
+type vmImageHandler struct {
+	templateVersionCache      ctlharvesterv1.VirtualMachineTemplateVersionCache
+	templateVersionController ctlharvesterv1.VirtualMachineTemplateVersionController
+}
+
+func (h *vmImageHandler) OnChanged(key string, vmImage *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
+	if vmImage == nil || vmImage.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	vmTemplateVersions, err := h.templateVersionCache.GetByIndex(indexeres.VMTemplateVersionByImageIDIndex, fmt.Sprintf("%s/%s", vmImage.Namespace, vmImage.Name))
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return vmImage, nil
+		}
+		return vmImage, err
+	}
+
+	for _, vmTemplateVersion := range vmTemplateVersions {
+		if harvesterv1.TemplateVersionReady.IsTrue(vmTemplateVersion) {
+			continue
+		}
+		h.templateVersionController.Enqueue(vmTemplateVersion.Namespace, vmTemplateVersion.Name)
+	}
+	return vmImage, nil
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -36,7 +36,8 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		virtualmachineimage.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
 			clients.Core.PersistentVolumeClaim().Cache(),
-			clients.K8s.AuthorizationV1().SelfSubjectAccessReviews()),
+			clients.K8s.AuthorizationV1().SelfSubjectAccessReviews(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion().Cache()),
 		upgrade.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),
 			clients.Core.Node().Cache(),


### PR DESCRIPTION
**Enhancement:**
Add the `withData` field when users create a template from a VM, so system will automatically create new images from source VM volumes.

**Related Issue:**
https://github.com/harvester/harvester/issues/571

**Test plan:**

1. Create a harvester cluster and set up an image.
2. Create a `source-vm` with 2 volumes.
3. After `source-vm` provisioned, run `echo "123" > test.txt && sync`.
4. Enable developer feature on the dashboard.
5. Create a `vm-template` with data form the `source-vm`.
![Screenshot 2022-11-03 at 2 12 14 PM](https://user-images.githubusercontent.com/4927361/199657512-9ce32c1e-08da-43af-be9f-64aa5f973b04.png)
6. Before new images are ready, check `vm-template` ready condition is false.
7. After new images are ready, check `vm-template` ready condition is true.
8. Delete `source-vm`.
9. Create a `new-vm` from `vm-template`.
![Screenshot 2022-11-03 at 2 14 58 PM](https://user-images.githubusercontent.com/4927361/199657829-5abff36c-1f77-4937-a056-2a91496172c4.png)
10. After `new-vm` provisioned, run `cat test.txt` and check the result is `123`.

