### PR TITLE
feat(upgrade): add enhancement around elemental upgrade

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -5,8 +5,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/lib.sh
 UPGRADE_TMP_DIR=$HOST_DIR/usr/local/upgrade_tmp
 
-trap clean_up_tmp_files EXIT
-
 clean_up_tmp_files()
 {
   if [ -n "$tmp_rootfs_mount" ]; then
@@ -14,8 +12,8 @@ clean_up_tmp_files()
     umount $tmp_rootfs_mount || echo "Umount $tmp_rootfs_mount failed with return code: $?"
   fi
   echo "Clean up tmp files..."
-  \rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
-  \rm -vf "$tmp_rootfs_squashfs"
+  [[ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]] && \rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
+  [[ -n "$tmp_rootfs_squashfs" ]] && \rm -vf "$tmp_rootfs_squashfs"
 }
 
 # Create a systemd service on host to reboot the host if this running pod succeeds.
@@ -421,6 +419,9 @@ EOF
 }
 
 upgrade_os() {
+  # The trap will be only effective from this point to the end of the execution
+  trap clean_up_tmp_files EXIT
+
   CURRENT_OS_VERSION=$(source $HOST_DIR/etc/os-release && echo $PRETTY_NAME)
 
   if [ "$REPO_OS_PRETTY_NAME" = "$CURRENT_OS_VERSION" ]; then

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -5,6 +5,15 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/lib.sh
 UPGRADE_TMP_DIR=$HOST_DIR/usr/local/upgrade_tmp
 
+trap clean_up_tmp_files EXIT
+
+clean_up_tmp_files()
+{
+  echo "Clean up large tmp files..."
+  \rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
+  \rm -vf "$tmp_rootfs_squashfs"
+}
+
 # Create a systemd service on host to reboot the host if this running pod succeeds.
 # This prevents job become from entering `Error`.
 reboot_if_job_succeed()
@@ -429,7 +438,7 @@ upgrade_os() {
   tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
   mount $tmp_rootfs_squashfs $tmp_rootfs_mount
 
-  chroot $HOST_DIR elemental upgrade --directory ${tmp_rootfs_mount#"$HOST_DIR"}
+  chroot $HOST_DIR elemental upgrade --logfile "${UPGRADE_TMP_DIR#"$HOST_DIR"}/elemental-upgrade-$(date +%Y%m%d%H%M%S).log" --directory ${tmp_rootfs_mount#"$HOST_DIR"}
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

We need more information about the execution of `elemental upgrade`.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- Set up log file for `elemental upgrade`, the log file will be put under `/usr/local/upgrade_tmp/` on each node.
- Clean up downloaded large files (squashfs) before exit

**Related Issue:**

#3069

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a v1.0.3 Harvester cluster with any number of nodes
2. Kickstart the upgrade to v1.1.0 (contains the changes in this PR)
3. After the upgrade succeeded, check the log file under `/usr/local/upgrade_tmp/elemental-upgrade-*.log`, and there shouldn't be any squashfs file

```
node-0:~ # ls -ltrh /usr/local/upgrade_tmp/
total 12K
-rw------- 1 root root   58 Nov  3 09:27 tmp.Gxer603C2T
-rw------- 1 root root   58 Nov  3 09:33 tmp.7ho2PcdZH2
-rwxr-xr-x 1 root root 1.4K Nov  3 09:34 elemental-upgrade-20221103093405.log
```

```
node-0:~ # cat /usr/local/upgrade_tmp/elemental-upgrade-20221103093405.log
INFO[2022-11-03T09:34:05Z] Starting elemental version v0.0.14
INFO[2022-11-03T09:34:05Z] Upgrading active partition
INFO[2022-11-03T09:34:05Z] Creating file system image /run/initramfs/cos-state/cOS/transition.img
INFO[2022-11-03T09:34:05Z] Running before-upgrade hook
INFO[2022-11-03T09:34:05Z] Copying COS_ACTIVE image...
INFO[2022-11-03T09:34:36Z] Finished copying COS_ACTIVE...
INFO[2022-11-03T09:34:38Z] Running after-upgrade-chroot hook
INFO[2022-11-03T09:34:38Z] Running after-upgrade hook
INFO[2022-11-03T09:34:39Z] Backing up current active image
INFO[2022-11-03T09:34:39Z] Moving /run/initramfs/cos-state/cOS/active.img to /run/initramfs/cos-state/cOS/passive.img
INFO[2022-11-03T09:34:39Z] Finished moving /run/initramfs/cos-state/cOS/active.img to /run/initramfs/cos-state/cOS/passive.img
INFO[2022-11-03T09:34:39Z] Moving /run/initramfs/cos-state/cOS/transition.img to /run/initramfs/cos-state/cOS/active.img
INFO[2022-11-03T09:34:39Z] Finished moving /run/initramfs/cos-state/cOS/transition.img to /run/initramfs/cos-state/cOS/active.img
INFO[2022-11-03T09:34:39Z] Upgrade completed
```