### PR TITLE
fix version-based patches to work with re-run upgrade_node job

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -216,6 +216,20 @@ detect_upgrade()
   UPGRADE_PREVIOUS_VERSION=$(echo "$upgrade_obj" | yq e .status.previousVersion -)
 }
 
+# refer https://github.com/harvester/harvester/issues/3098
+detect_node_current_harvester_version()
+{
+  NODE_CURRENT_HARVESTER_VERSION=""
+  local harvester_release_file=/host/etc/harvester-release.yaml
+
+  if [ -f "$harvester_release_file" ]; then
+    NODE_CURRENT_HARVESTER_VERSION=$(yq e '.harvester' $harvester_release_file)
+    echo "NODE_CURRENT_HARVESTER_VERSION is: $NODE_CURRENT_HARVESTER_VERSION"
+  else
+    echo "$harvester_release_file is not existing, NODE_CURRENT_HARVESTER_VERSION is set as empty"
+  fi
+}
+
 upgrade_addon()
 {
   local name=$1

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -245,11 +245,12 @@ patch_logging_event_audit()
   # should happen before RKE2 is patched
   # note: the host '/' is mapped to pod '/host/', refer: pkg/controller/master/upgrade/common.go applyNodeJob
 
-  # get UPGRADE_PREVIOUS_VERSION
+  # get UPGRADE_PREVIOUS_VERSION and NODE_CURRENT_HARVESTER_VERSION
   detect_upgrade
-  echo "The current version is $UPGRADE_PREVIOUS_VERSION, will check Logging Event Audit upgrade node option"
+  detect_node_current_harvester_version
+  echo "The UPGRADE_PREVIOUS_VERSION is $UPGRADE_PREVIOUS_VERSION, NODE_CURRENT_HARVESTER_VERSION is $NODE_CURRENT_HARVESTER_VERSION, will check Logging Event Audit upgrade node option"
 
-  if test "$UPGRADE_PREVIOUS_VERSION" = "v1.0.3"; then
+  if test "$UPGRADE_PREVIOUS_VERSION" = "v1.0.3" || test "$NODE_CURRENT_HARVESTER_VERSION" = "v1.0.3"; then
     echo "Patch kube-audit policy file"
     # this file should be there in each NODE
     # keep syncing with harvester/harvester-installer/pkg/config/templates/rke2-92-harvester-kube-audit-policy.yaml
@@ -258,9 +259,11 @@ patch_logging_event_audit()
 
     KUBE_AUDIT_POLICY_FILE_IN_CONTAINER=/host/etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
     KUBE_AUDIT_POLICY_FILE_IN_HOST=/etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
-    echo "Create new file $KUBE_AUDIT_POLICY_FILE_IN_CONTAINER"
 
-    cat > $KUBE_AUDIT_POLICY_FILE_IN_CONTAINER << 'EOF'
+    if [ ! -f $KUBE_AUDIT_POLICY_FILE_IN_CONTAINER ]; then
+      echo "Create new policy file $KUBE_AUDIT_POLICY_FILE_IN_CONTAINER"
+
+      cat > $KUBE_AUDIT_POLICY_FILE_IN_CONTAINER << 'EOF'
 apiVersion: audit.k8s.io/v1
 kind: Policy
 omitStages:
@@ -277,15 +280,32 @@ rules:
       - "ResponseComplete"
 EOF
 
+    else
+      echo "Reuse the existing policy file $KUBE_AUDIT_POLICY_FILE_IN_CONTAINER, the file content is:"
+      cat $KUBE_AUDIT_POLICY_FILE_IN_CONTAINER
+    fi
+
     # it means the NODE role is rke2-server when 90-harvester-server.yaml exists, patch it
     RKE2_SERVER_CONFIG_FILE_IN_CONTAINER=/host/etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml
     PATCH_SERVER_IN_CUSTOM=1
+    local param=audit-policy-file
+
     if [ -f "$RKE2_SERVER_CONFIG_FILE_IN_CONTAINER" ]; then
-      echo "Patch rke2 server config file with audit-policy-file parameter"
-      echo "audit-policy-file: $KUBE_AUDIT_POLICY_FILE_IN_HOST" >> $RKE2_SERVER_CONFIG_FILE_IN_CONTAINER
+      local audit_policy_file_param=$(yq e '.'$param $RKE2_SERVER_CONFIG_FILE_IN_CONTAINER)
+
+      if [ "$audit_policy_file_param" == "null" ]; then
+        echo "$param parameter is not in $RKE2_SERVER_CONFIG_FILE_IN_CONTAINER"
+        echo "Patch rke2 server config file with $param parameter"
+        echo "$param: $KUBE_AUDIT_POLICY_FILE_IN_HOST" >> $RKE2_SERVER_CONFIG_FILE_IN_CONTAINER
+        echo "After patch, the file content is"
+        cat $RKE2_SERVER_CONFIG_FILE_IN_CONTAINER
+      else
+        echo "$param parameter is in $RKE2_SERVER_CONFIG_FILE_IN_CONTAINER, value: $audit_policy_file_param, skip patch"
+      fi
+
     else
       # for rke2-agent node, do nothing now, this file will be patched when the node is promoted to server
-      echo "There is no rke2 server file, this node should be rke2 agent, audit-policy-file parameter is not patched"
+      echo "There is no file $RKE2_SERVER_CONFIG_FILE_IN_CONTAINER, $param parameter is not patched"
       PATCH_SERVER_IN_CUSTOM=0
     fi
 
@@ -360,19 +380,31 @@ remove_rke2_canal_config() {
 
 convert_nodenetwork_to_vlanconfig() {
   detect_upgrade
+  detect_node_current_harvester_version
+  echo "The UPGRADE_PREVIOUS_VERSION is $UPGRADE_PREVIOUS_VERSION, NODE_CURRENT_HARVESTER_VERSION is $NODE_CURRENT_HARVESTER_VERSION, will check nodenetwork upgrade node option"
 
-  [[ $UPGRADE_PREVIOUS_VERSION != "v1.0.3" ]] && return
+  if test "$UPGRADE_PREVIOUS_VERSION" != "v1.0.3" && test "$NODE_CURRENT_HARVESTER_VERSION" != "v1.0.3"; then
+    echo "There is nothing to do in nodenetwork"
+    return
+  fi
 
   # Don't need to convert nodenetwork if harvester-mgmt is used as vlan interface in any nodenetwork
   [[ $(kubectl get nodenetwork -o yaml | yq '.items[].spec.nic | select(. == "harvester-mgmt")') ]] &&
   echo "Don't need to convert nodenetwork because harvester-mgmt is used as VLAN interface in not less than one nodenetwork" && return
 
   local name=${HARVESTER_UPGRADE_NODE_NAME}-vlan
+  local EXIT_CODE=$?
+  # when object is not existing, kubectl will return 1
+  nn=$(kubectl get nodenetwork "$name" -o yaml) || EXIT_CODE=$?
+  if [ $EXIT_CODE != 0 ]; then
+    echo "Cannot find nodenetwork $name, skip patch"
+    return
+  fi
 
-  nn=$(kubectl get nn "$name" -o yaml)
   vlan_interface=$(echo "$nn" | yq '.spec.nic')
 
-  [[ "$vlan_interface" == "null" ]] && echo "Invalid nodenetwork $name" && return
+  # the default ${HARVESTER_UPGRADE_NODE_NAME}-vlan has no nics
+  [[ "$vlan_interface" == "null" ]] && echo "Default/invalid nodenetwork $name without any nics, skip patch" && return
 
   type=$(echo "$nn" | yq e '.spec.nic as $nic | .status.networkLinkStatus.[$nic].type')
   if [ "$type" == "bond" ]; then
@@ -387,6 +419,8 @@ convert_nodenetwork_to_vlanconfig() {
     mode="active-backup"
     miimon=0
   fi
+
+  # below code is idempotent
 
   kubectl apply -f - <<EOF
 apiVersion: network.harvesterhci.io/v1beta1


### PR DESCRIPTION
Signed-off-by: Jian Wang <w13915984028@gmail.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

A re-run upgrade_node job might miss some version-based patches

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

(1) check NODE level harvester version, run script again in `v1.0.3`
(2) update code to be re-entrancable


**Related Issue:**
https://github.com/harvester/harvester/issues/3098

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

local test:
```
harv41:/home/rancher # ./a2.sh 
NODE_CURRENT_HARVESTER_VERSION is: v1.0.3
The current version is , NODE_CURRENT_HARVESTER_VERSION is v1.0.3, will check Logging Event Audit upgrade node option
Patch kube-audit policy file
Create new policy file ./92-harvester-kube-audit-policy.yaml
audit-policy-file parameter is not in ./90-harvester-server.yaml
Patch rke2 server config file with audit-policy-file parameter
cni: multus,canal
cluster-cidr: 10.52.0.0/16
service-cidr: 10.53.0.0/16
cluster-dns: 10.53.0.10
tls-san:
  - 192.168.122.144
audit-policy-file: ./92-harvester-kube-audit-policy.yaml

```

re-run the script,  re-use existing values

```
harv41:/home/rancher # ./a2.sh 
NODE_CURRENT_HARVESTER_VERSION is: v1.0.3
The current version is , NODE_CURRENT_HARVESTER_VERSION is v1.0.3, will check Logging Event Audit upgrade node option
Patch kube-audit policy file
Reuse the existing policy file ./92-harvester-kube-audit-policy.yaml, the file content is
apiVersion: audit.k8s.io/v1
kind: Policy
omitStages:
  - "ResponseStarted"
  - "ResponseComplete"
rules:
  # Any include/exclude rules are added here

  # A catch-all rule to log all other (create/delete/patch) requests at the Metadata level
  - level: Metadata
    verbs: ["create", "delete", "patch"]
    omitStages:
      - "ResponseStarted"
      - "ResponseComplete"
audit-policy-file parameter is in ./90-harvester-server.yaml, value: ./92-harvester-kube-audit-policy.yaml, skip patch

```

Network part:

```
NODE_CURRENT_HARVESTER_VERSION is: v1.0.3
The UPGRADE_PREVIOUS_VERSION is , NODE_CURRENT_HARVESTER_VERSION is v1.0.3, will check nodenetwork upgrade node option
Default/invalid nodenetwork harv41-vlan without any nics, skip patch
```