### PR TITLE
Upgrade: add logs when waiting CAPI cluster to be provisioned

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -100,10 +100,12 @@ wait_capi_cluster() {
 
     if [ "$current_generation" -gt "$generation" ]; then
       if [ "$current_phase" = "Provisioned" ]; then
+        echo "CAPI cluster $namespace/$name is provisioned (current generation: $current_generation)."
         break
       fi
     fi
 
+    echo "Waiting for CAPI cluster $namespace/$name to be provisioned (current phase: $current_phase, current generation: $current_generation)..."
     sleep 5
   done
 }


### PR DESCRIPTION
**Problem:**
No logs when waiting for CAPI cluster.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add some logs.

**Related Issue:**
https://github.com/harvester/harvester/issues/3104

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Perform an upgrade and you could see this in apply-manifests job:
```
CAPI cluster fleet-local/local is provisioned (current generation: 54).
```
If the cluster is somehow under provisioning, you can see logs like:
```
Waiting for CAPI cluster fleet-local/local to be provisioned (current phase: Provisioning, current generation: 55)...
```
