### PR TITLE
fix(upgrade): use loop to do the download retry

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -14,7 +14,13 @@ download_file()
   local output=$2
 
   echo "Downloading the file from \"$url\" to \"$output\"..."
-  curl -sSfL --retry 10 --retry-connrefused "$url" -o "$output"
+  local i=0
+  while [[ "$i" -lt 100 ]]; do
+    curl -sSfL "$url" -o "$output" && break
+    echo "Failed to download the requested file from \"$url\" to \"$output\" with error code: $?, retrying ($i)..."
+    sleep 10
+    i=$((i + 1))
+  done
 }
 
 detect_repo()


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The behavior of curl's retry is not as expected in the pod. The reason might be the version (7.66).

Previous PR: #3094 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fall back to the traditional while loop.

**Related Issue:**

#3079 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Same as PR #3094
