### PR TITLE
fix(backup-metadata): don't check vm in webhook

### DIFF
--- a/pkg/controller/master/backup/backup_target.go
+++ b/pkg/controller/master/backup/backup_target.go
@@ -71,7 +71,7 @@ type TargetHandler struct {
 // OnBackupTargetChange handles backupTarget setting object on change
 func (h *TargetHandler) OnBackupTargetChange(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
 	if setting == nil || setting.DeletionTimestamp != nil ||
-		setting.Name != settings.BackupTargetSettingName || setting.Value == "" {
+		setting.Name != settings.BackupTargetSettingName {
 		return setting, nil
 	}
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -211,8 +211,11 @@ func InitBackupTargetToString() string {
 
 func DecodeBackupTarget(value string) (*BackupTarget, error) {
 	target := &BackupTarget{}
-	if err := json.Unmarshal([]byte(value), target); err != nil {
-		return nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, value)
+
+	if value != "" {
+		if err := json.Unmarshal([]byte(value), target); err != nil {
+			return nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, value)
+		}
 	}
 
 	return target, nil

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -56,9 +56,15 @@ func (v *virtualMachineBackupValidator) Create(request *types.Request, newObj ru
 		return werror.NewInvalidError("source VM name is empty", fieldSourceName)
 	}
 
-	_, err := v.vms.Get(newVMBackup.Namespace, newVMBackup.Spec.Source.Name)
-	if err != nil {
-		return werror.NewInvalidError(err.Error(), fieldSourceName)
+	var err error
+
+	// If VMBackup is from metadata in backup target, we don't check whether the VM is existent,
+	// because the related VM may not exist in a new cluster.
+	if newVMBackup.Status == nil {
+		_, err = v.vms.Get(newVMBackup.Namespace, newVMBackup.Spec.Source.Name)
+		if err != nil {
+			return werror.NewInvalidError(err.Error(), fieldSourceName)
+		}
 	}
 
 	if newVMBackup.Spec.Type == v1beta1.Backup {


### PR DESCRIPTION
**Problem:**
Users can't import VMBackup in another cluster, because we check whether VM is existent in VMBackup webhook.

**Solution:**
Don't check the VM if the VMBackup is from backup-target metadata.

**Related Issue:**
https://github.com/harvester/harvester/issues/3095

**Test plan:**

1. Create a harvester cluster.
2. Create a `source-vm`.
3. Run `echo "123" > test.txt && sync` in `source-vm`.
4. Set up NFS/S3 backup target.
5. Take a backup for `source-vm`.
6. After the backup is finished, set `backup-target` setting to the default value.
7. Check `backup-target` in `longhorn.io/v1beta1/settings` is also reset.
8. Delete the backup and `source-vm`.
9. Set `backup-target` to original value again.
10. The backup should be imported in the cluster.
11. Restore the backup to `new-vm`.
12. Run `cat test.txt` in `new-vm`. It should return `123`.
