### PR TITLE
SupportBundle: add extra collectors

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -115,6 +115,10 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string, pullPolicy
 									Name:  "SUPPORT_BUNDLE_EXCLUDE_RESOURCES",
 									Value: m.getExcludeResources(),
 								},
+								{
+									Name:  "SUPPORT_BUNDLE_EXTRA_COLLECTORS",
+									Value: m.getExtraCollectors(),
+								},
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -166,6 +170,11 @@ func (m *Manager) getExcludeResources() string {
 	resources = append(resources, rancherv3.Resource(rancherv3.UserResourceName).String())
 
 	return strings.Join(resources, ",")
+}
+
+func (m *Manager) getExtraCollectors() string {
+	extraCollectors := []string{"harvester"}
+	return strings.Join(extraCollectors, ",")
 }
 
 func (m *Manager) GetStatus(sb *harvesterv1.SupportBundle) (*types.ManagerStatus, error) {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -8,9 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (


### PR DESCRIPTION
related issues: #3064 
blocked by: https://github.com/rancher/support-bundle-kit/pull/47

After support-bundle-kit PR reviewed, this change need to bump the newer support-bundle-kit.
Also, I thought maybe we need UI to implement that what extra collectors for the support bundle? cc @bk201 @guangbochen 