### PR TITLE
Add full CIDR/IP Range format support in vip-pools settings

### DIFF
--- a/pkg/util/fakeclients/networkattachmentdefinition.go
+++ b/pkg/util/fakeclients/networkattachmentdefinition.go
@@ -23,10 +23,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 
-	cnitype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/k8s.cni.cncf.io/v1"
-	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cnitype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 )
 
 type NetworkAttachmentDefinitionCache func(namespace string) cnitype.NetworkAttachmentDefinitionInterface


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Add full CIDR/IP Range format support in vip-pools settings
refer to https://github.com/kube-vip/kube-vip-cloud-provider/blob/main/README.md#multiple-pools-or-ranges

**Related Issue:**
https://github.com/harvester/harvester/issues/3100

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
run `make` to check the unit test result