### PR TITLE
Upgrade: set provisionGeneration when reset RKEConfig

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -273,9 +273,15 @@ func (h *upgradeHandler) cleanup(upgrade *harvesterv1.Upgrade, cleanJobs bool) e
 		return err
 	}
 	clusterToUpdate := cluster.DeepCopy()
-	clusterToUpdate.Spec.RKEConfig = &provisioningv1.RKEConfig{}
+	provisionGeneration := clusterToUpdate.Spec.RKEConfig.ProvisionGeneration
+	clusterToUpdate.Spec.RKEConfig = &provisioningv1.RKEConfig{
+		RKEClusterSpecCommon: rkev1.RKEClusterSpecCommon{
+			ProvisionGeneration: provisionGeneration,
+		},
+	}
+	logrus.Infof("Reset RKEConfig and set provisionGeneration to %d", provisionGeneration)
 	if !reflect.DeepEqual(clusterToUpdate, cluster) {
-		logrus.Debug("Update cluster fleet-local/local")
+		logrus.Info("Update cluster fleet-local/local")
 		if _, err := h.clusterClient.Update(clusterToUpdate); err != nil {
 			return err
 		}


### PR DESCRIPTION
To prevent another RKE2 server/agent restart on all nodes when an upgrade is done.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
We reset RKEConfig to default after an upgrade and this trigger RKE2 server/agent restarts.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Fill in the right provisionGeneration so the rancher agent doesn't restart RKE2 server or agents.

**Related Issue:**
https://github.com/harvester/harvester/issues/2984

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Upgrade from v1.0.3 to master ISO (with the change in the PR) (at least 2 nodes, better 3).
- After the upgrade, monitor pods should not be stuck in terminating (like those in https://user-images.githubusercontent.com/29251855/196623294-760be695-5a85-4130-a8d7-4e716168c305.png)

