### PR TITLE
feat(vmimage): add retry

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6813,7 +6813,8 @@
       "type": "object",
       "required": [
         "displayName",
-        "sourceType"
+        "sourceType",
+        "retry"
       ],
       "properties": {
         "checksum": {
@@ -6834,6 +6835,11 @@
         "pvcNamespace": {
           "type": "string",
           "default": ""
+        },
+        "retry": {
+          "type": "integer",
+          "format": "int32",
+          "default": 0
         },
         "sourceType": {
           "type": "string",
@@ -6864,6 +6870,14 @@
             "default": {},
             "$ref": "#/definitions/harvesterhci.io.v1beta1.Condition"
           }
+        },
+        "failed": {
+          "type": "integer",
+          "format": "int32",
+          "default": 0
+        },
+        "lastFailedTime": {
+          "type": "string"
         },
         "progress": {
           "type": "integer",

--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachineimages.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachineimages.yaml
@@ -57,6 +57,11 @@ spec:
                 type: string
               pvcNamespace:
                 type: string
+              retry:
+                default: 3
+                maximum: 10
+                minimum: 0
+                type: integer
               sourceType:
                 enum:
                 - download
@@ -105,6 +110,12 @@ spec:
                   - type
                   type: object
                 type: array
+              failed:
+                default: 0
+                minimum: 0
+                type: integer
+              lastFailedTime:
+                type: string
               progress:
                 type: integer
               size:

--- a/pkg/apis/harvesterhci.io/v1beta1/image.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/image.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	ImageInitialized condition.Cond = "Initialized"
-	ImageImported    condition.Cond = "Imported"
+	ImageInitialized        condition.Cond = "Initialized"
+	ImageImported           condition.Cond = "Imported"
+	ImageRetryLimitExceeded condition.Cond = "RetryLimitExceeded"
 )
 
 const (
@@ -57,6 +58,13 @@ type VirtualMachineImageSpec struct {
 
 	// +optional
 	StorageClassParameters map[string]string `json:"storageClassParameters"`
+
+	// +optinoal
+	// +kubebuilder:default:=3
+	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Maximum:=10
+	// +kubebuilder:validation:Optional
+	Retry int `json:"retry" default:"3"`
 }
 
 type VirtualMachineImageStatus struct {
@@ -71,6 +79,15 @@ type VirtualMachineImageStatus struct {
 
 	// +optional
 	StorageClassName string `json:"storageClassName,omitempty"`
+
+	// +optional
+	// +kubebuilder:default:=0
+	// +kubebuilder:validation:Minimum:=0
+	Failed int `json:"failed"`
+
+	// +optinoal
+	// +kubebuilder:validation:Optional
+	LastFailedTime string `json:"lastFailedTime,omitempty"`
 
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -2930,8 +2930,15 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineImageSpec(ref common.R
 							},
 						},
 					},
+					"retry": {
+						SchemaProps: spec.SchemaProps{
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
+						},
+					},
 				},
-				Required: []string{"displayName", "sourceType"},
+				Required: []string{"displayName", "sourceType", "retry"},
 			},
 		},
 	}
@@ -2962,6 +2969,19 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineImageStatus(ref common
 						},
 					},
 					"storageClassName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"failed": {
+						SchemaProps: spec.SchemaProps{
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
+						},
+					},
+					"lastFailedTime": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/controller/master/image/register.go
+++ b/pkg/controller/master/image/register.go
@@ -19,9 +19,11 @@ func Register(ctx context.Context, management *config.Management, options config
 	storageClasses := management.StorageFactory.Storage().V1().StorageClass()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
 	vmImageHandler := &vmImageHandler{
-		backingImages:  backingImages,
-		storageClasses: storageClasses,
-		images:         images,
+		backingImages:     backingImages,
+		backingImageCache: backingImages.Cache(),
+		storageClasses:    storageClasses,
+		images:            images,
+		imageController:   images,
 		httpClient: http.Client{
 			Timeout: 15 * time.Second,
 		},

--- a/pkg/controller/master/image/vm_image_controller.go
+++ b/pkg/controller/master/image/vm_image_controller.go
@@ -3,13 +3,16 @@ package image
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	lhcontroller "github.com/longhorn/longhorn-manager/controller"
 	"github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	lhmanager "github.com/longhorn/longhorn-manager/manager"
 	"github.com/longhorn/longhorn-manager/types"
+	"github.com/rancher/norman/condition"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/pkg/generated/controllers/storage/v1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,35 +28,57 @@ import (
 
 // vmImageHandler syncs status on vm image changes, and manage a storageclass & a backingimage per vm image
 type vmImageHandler struct {
-	httpClient     http.Client
-	storageClasses ctlstoragev1.StorageClassClient
-	images         ctlharvesterv1.VirtualMachineImageClient
-	backingImages  lhv1beta1.BackingImageClient
-	pvcCache       ctlcorev1.PersistentVolumeClaimCache
+	httpClient        http.Client
+	storageClasses    ctlstoragev1.StorageClassClient
+	images            ctlharvesterv1.VirtualMachineImageClient
+	imageController   ctlharvesterv1.VirtualMachineImageController
+	backingImages     lhv1beta1.BackingImageClient
+	backingImageCache lhv1beta1.BackingImageCache
+	pvcCache          ctlcorev1.PersistentVolumeClaimCache
 }
 
 func (h *vmImageHandler) OnChanged(_ string, image *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
-	if image == nil || image.DeletionTimestamp != nil {
+	if image == nil || image.DeletionTimestamp != nil || harvesterv1.ImageRetryLimitExceeded.IsTrue(image) {
 		return image, nil
 	}
-	if harvesterv1.ImageInitialized.GetStatus(image) == "" {
-		return h.initialize(image)
-	} else if image.Spec.URL != image.Status.AppliedURL {
-		// URL is changed, recreate the storageclass and backingimage
-		if err := h.deleteBackingImageAndStorageClass(image); err != nil {
-			return image, err
+
+	if harvesterv1.ImageImported.IsTrue(image) {
+		// sync display_name to labels in order to list by labelSelector
+		if image.Spec.DisplayName != image.Labels[util.LabelImageDisplayName] {
+			toUpdate := image.DeepCopy()
+			if toUpdate.Labels == nil {
+				toUpdate.Labels = map[string]string{}
+			}
+			toUpdate.Labels[util.LabelImageDisplayName] = image.Spec.DisplayName
+			return h.images.Update(toUpdate)
 		}
-		return h.initialize(image)
+
+		return image, nil
 	}
 
-	// sync display_name to labels in order to list by labelSelector
-	if image.Spec.DisplayName != image.Labels[util.LabelImageDisplayName] {
-		toUpdate := image.DeepCopy()
-		if toUpdate.Labels == nil {
-			toUpdate.Labels = map[string]string{}
+	needRetry := false
+	backingImage, err := h.backingImageCache.Get(util.LonghornSystemNamespaceName, util.GetBackingImageName(image))
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			logrus.Errorf("failed to get backing image %s/%s, err: %v", util.LonghornSystemNamespaceName, util.GetBackingImageName(image), err)
+			return image, err
 		}
-		toUpdate.Labels[util.LabelImageDisplayName] = image.Spec.DisplayName
-		return h.images.Update(toUpdate)
+		needRetry = true
+	} else {
+		for _, status := range backingImage.Status.DiskFileStatusMap {
+			if status.State == v1beta1.BackingImageStateFailed {
+				needRetry = true
+				break
+			}
+		}
+	}
+
+	if needRetry {
+		if image.Status.LastFailedTime == "" {
+			return h.initialize(image)
+		}
+
+		return h.handleRetry(image)
 	}
 
 	return image, nil
@@ -63,18 +88,53 @@ func (h *vmImageHandler) OnRemove(_ string, image *harvesterv1.VirtualMachineIma
 	if image == nil {
 		return nil, nil
 	}
-	scName := util.GetImageStorageClassName(image.Name)
-	if err := h.storageClasses.Delete(scName, &metav1.DeleteOptions{}); !errors.IsNotFound(err) && err != nil {
-		return image, err
-	}
-	biName := util.GetBackingImageName(image)
-	if err := h.backingImages.Delete(util.LonghornSystemNamespaceName, biName, &metav1.DeleteOptions{}); !errors.IsNotFound(err) && err != nil {
+	if err := h.deleteBackingImageAndStorageClass(image); err != nil {
 		return image, err
 	}
 	return image, nil
 }
 
 func (h *vmImageHandler) initialize(image *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
+	if err := h.deleteBackingImageAndStorageClass(image); err != nil {
+		return image, err
+	}
+
+	image, err := h.checkImage(image)
+	if err != nil {
+		logrus.Errorf("failed to check image %s/%s, err: %v", image.Namespace, image.Name, err)
+		h.imageController.EnqueueAfter(image.Namespace, image.Name, 10*time.Second)
+		return h.images.Update(image)
+	}
+	return h.createBackingImageAndStorageClass(image)
+}
+
+func (h *vmImageHandler) checkImage(image *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
+	if image.Spec.SourceType != harvesterv1.VirtualMachineImageSourceTypeDownload {
+		return image, nil
+	}
+
+	toUpdate := image.DeepCopy()
+	toUpdate.Status.AppliedURL = image.Spec.URL
+	resp, err := h.httpClient.Head(image.Spec.URL)
+	if err != nil {
+		toUpdate = handleFail(toUpdate, condition.Cond(harvesterv1.ImageInitialized), err)
+		return toUpdate, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		err = fmt.Errorf("got %d status code from %s", resp.StatusCode, image.Spec.URL)
+		toUpdate = handleFail(toUpdate, condition.Cond(harvesterv1.ImageInitialized), err)
+		return toUpdate, err
+	}
+
+	if resp.ContentLength > 0 {
+		toUpdate.Status.Size = resp.ContentLength
+	}
+	return toUpdate, nil
+}
+
+func (h *vmImageHandler) createBackingImageAndStorageClass(image *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
 	if err := h.createBackingImage(image); err != nil && !errors.IsAlreadyExists(err) {
 		return nil, err
 	}
@@ -85,33 +145,15 @@ func (h *vmImageHandler) initialize(image *harvesterv1.VirtualMachineImage) (*ha
 	toUpdate := image.DeepCopy()
 	toUpdate.Status.AppliedURL = toUpdate.Spec.URL
 	toUpdate.Status.StorageClassName = util.GetImageStorageClassName(image.Name)
-
-	if image.Spec.SourceType == harvesterv1.VirtualMachineImageSourceTypeDownload {
-		resp, err := h.httpClient.Head(image.Spec.URL)
-		if err != nil {
-			harvesterv1.ImageInitialized.False(toUpdate)
-			harvesterv1.ImageInitialized.Message(toUpdate, err.Error())
-			return h.images.Update(toUpdate)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
-			harvesterv1.ImageInitialized.False(toUpdate)
-			harvesterv1.ImageInitialized.Message(toUpdate, fmt.Sprintf("got %d status code from %s", resp.StatusCode, image.Spec.URL))
-			return h.images.Update(toUpdate)
-		}
-
-		if resp.ContentLength > 0 {
-			toUpdate.Status.Size = resp.ContentLength
-		}
-	} else {
-		toUpdate.Status.Progress = 0
-	}
+	toUpdate.Status.Progress = 0
 
 	harvesterv1.ImageImported.Unknown(toUpdate)
 	harvesterv1.ImageImported.Reason(toUpdate, "Importing")
+	harvesterv1.ImageImported.LastUpdated(toUpdate, time.Now().Format(time.RFC3339))
 	harvesterv1.ImageInitialized.True(toUpdate)
+	harvesterv1.ImageInitialized.Message(toUpdate, "")
 	harvesterv1.ImageInitialized.Reason(toUpdate, "Initialized")
+	harvesterv1.ImageInitialized.LastUpdated(toUpdate, time.Now().Format(time.RFC3339))
 
 	return h.images.Update(toUpdate)
 }
@@ -183,4 +225,33 @@ func (h *vmImageHandler) deleteBackingImageAndStorageClass(image *harvesterv1.Vi
 		return err
 	}
 	return nil
+}
+
+func (h *vmImageHandler) handleRetry(image *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
+	ts, err := time.Parse(time.RFC3339, image.Status.LastFailedTime)
+	if err != nil {
+		logrus.Errorf("failed to parse lastFailedTime %s in image %s/%s, err: %v", image.Status.LastFailedTime, image.Namespace, image.Name, err)
+		toUpdate := image.DeepCopy()
+		toUpdate.Status.LastFailedTime = time.Now().Format(time.RFC3339)
+		return h.images.Update(toUpdate)
+	}
+
+	ts = ts.Add(10 * time.Second)
+	if time.Now().Before(ts) {
+		h.imageController.EnqueueAfter(image.Namespace, image.Name, 10*time.Second)
+		return image, nil
+	}
+	return h.initialize(image)
+}
+
+func handleFail(image *harvesterv1.VirtualMachineImage, cond condition.Cond, err error) *harvesterv1.VirtualMachineImage {
+	image.Status.Failed++
+	image.Status.LastFailedTime = time.Now().Format(time.RFC3339)
+	if image.Status.Failed > image.Spec.Retry {
+		harvesterv1.ImageRetryLimitExceeded.True(image)
+		harvesterv1.ImageRetryLimitExceeded.Message(image, "VMImage has reached the specified retry limit")
+		cond.False(image)
+		cond.Message(image, err.Error())
+	}
+	return image
 }

--- a/pkg/controller/master/upgrade/image_controller.go
+++ b/pkg/controller/master/upgrade/image_controller.go
@@ -40,6 +40,8 @@ func (h *vmImageHandler) OnChanged(key string, image *harvesterv1.VirtualMachine
 		setImageReadyCondition(toUpdate, corev1.ConditionTrue, "", "")
 	case harvesterv1.ImageImported.IsFalse(image):
 		setImageReadyCondition(toUpdate, corev1.ConditionFalse, harvesterv1.ImageImported.GetReason(image), harvesterv1.ImageImported.GetMessage(image))
+	case harvesterv1.ImageRetryLimitExceeded.IsTrue(image):
+		setImageReadyCondition(toUpdate, corev1.ConditionFalse, harvesterv1.ImageRetryLimitExceeded.GetReason(image), harvesterv1.ImageRetryLimitExceeded.GetMessage(image))
 	default:
 		return image, nil
 	}

--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -120,6 +120,7 @@ func (r *Repo) CreateImageFromISO(isoURL string, checksum string) (*harvesterv1.
 			SourceType:  v1beta1.VirtualMachineImageSourceTypeDownload,
 			URL:         isoURL,
 			Checksum:    checksum,
+			Retry:       3,
 		},
 	}
 

--- a/pkg/webhook/resources/virtualmachineimage/validator.go
+++ b/pkg/webhook/resources/virtualmachineimage/validator.go
@@ -161,6 +161,10 @@ func (v *virtualMachineImageValidator) Update(request *types.Request, oldObj run
 		}
 	}
 
+	if oldImage.Spec.URL != newImage.Spec.URL {
+		return werror.NewInvalidError("url cannot be modified", "spec.url")
+	}
+
 	return v.CheckImageDisplayNameAndURL(newImage)
 }
 

--- a/tests/integration/api/image_apis_test.go
+++ b/tests/integration/api/image_apis_test.go
@@ -198,7 +198,7 @@ var _ = Describe("verify image APIs", func() {
 						Description: "test description update",
 						DisplayName: imageDisplayName,
 						SourceType:  harvesterv1.VirtualMachineImageSourceTypeDownload,
-						URL:         "http://harvesterhci.io/test-update.img",
+						URL:         "http://harvesterhci.io/test.img",
 					},
 				}
 


### PR DESCRIPTION
**Problem:**
Creating VMImage from a URL may have network errors. We didn't have a retry mechanism to download it again.

**Solution:**
Add `retry` in VMImage.

**Related Issue:**
https://github.com/harvester/harvester/issues/3144
https://github.com/harvester/harvester/issues/3436

**Test plan:**

Setup:
* Create a harvester cluster.
* Download an image to your local. Make sure when we run `python3 -m http.server`, the harvester cluster can reach the URL. Don't start the python3 server at this moment.

Case 1: Don't retry unlimitedly for a failed URL.
1. Create `image-retry-1.yaml` file.
```yaml
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineImage
metadata:
  generateName: image-
  namespace: default
spec:
  checksum: ""
  displayName: focal-1.img
  pvcName: ""
  pvcNamespace: ""
  retry: 1
  sourceType: download
  storageClassParameters:
    migratable: "true"
    numberOfReplicas: "3"
    staleReplicaTimeout: "30"
  url: http://192.168.0.181:8000/focal-server-cloudimg-amd64.img
```
2. Run `kubectl create -f image-retry-1.yaml`.
3. Watch the VMImage and it will have `failed: 2` and `RetryLimitExceeded` condition in the status.

Case 2: Retry succeed.
1. Create `image-retry-3.yaml` file. (Remember to change the `url` field)
```yaml
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineImage
metadata:
  generateName: image-
  namespace: default
spec:
  checksum: ""
  displayName: focal-3.img
  pvcName: ""
  pvcNamespace: ""
  retry: 3
  sourceType: download
  storageClassParameters:
    migratable: "true"
    numberOfReplicas: "3"
    staleReplicaTimeout: "30"
  url: http://192.168.0.181:8000/focal-server-cloudimg-amd64.img
```
2. Run `kubectl create -f image-retry-3.yaml`.
3. Watch the VMImage. When `failed: 2` in the status, run `python3 -m http.server` in your image folder.
4. Check the image can be downloaded successfully.
5. Use the VMImage to create a VM and it should not have any error.

Case 3: Update from v1.1.0
1. Create a v1.1.0 cluster.
2. Create a VMImage on it and wait for it to finish.
3. Apply new CRD and upgrade harvester & harvester-webhook image to this branch.
4. The original VMImage should work.
5. Create a new VMImage and it should work.

Case 4: Users can't update URL for existent images
1. Create a VMImage with URL and wait for it to finish.
2. Update the URL and webhook should return an error.

Case 5: Upgrade controller can show `RetryLimitExceeded` error
1. Create a harvester cluster with version after `v1.1.2-rc1`.
2. Create a fake version with non-existent ISO URL.
```
cat > versions.yaml <<EOF
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: 1.1.2-test
  namespace: harvester-system
spec:
  isoChecksum: 2765d89e5e8024347c81d36cc84b7168bf358a3a2f4da0c63164ad834a94bcbbaa13af4900aad4caa0a27550e4b4db5bf2c4726daa88664378e0c581a79ad2cb
  isoURL: http://192.168.0.181:8000/harvester.iso
  minUpgradableVersion: 1.1.1
  releaseDate: "20211231"
  tags:
  - dev
  - test
EOF
```
3. Apply it and click `Upgrade` on the dashboard.
4. After 30 seconds, we can see error on the dashboard.
![Screenshot 2023-02-13 at 2 25 21 PM](https://user-images.githubusercontent.com/4927361/218386014-07131b3a-9188-429d-839d-cbc8af038eb5.png)
