### PR TITLE
fix(upgrade): make sure trap will throw no errors

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -17,8 +17,14 @@ clean_up_tmp_files()
     umount $target_elemental_cli || echo "Umount $target_elemental_cli failed with return code: $?"
   fi
   echo "Clean up tmp files..."
-  [[ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]] && \rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
-  [[ -n "$tmp_rootfs_squashfs" ]] && \rm -vf "$tmp_rootfs_squashfs"
+  if [ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]; then
+    echo "Try to remove $NEW_OS_SQUASHFS_IMAGE_FILE..."
+    rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
+  fi
+  if [ -n "$tmp_rootfs_squashfs" ]; then
+    echo "Try to remove $tmp_rootfs_squashfs..."
+    rm -vf "$tmp_rootfs_squashfs"
+  fi
 }
 
 # Create a systemd service on host to reboot the host if this running pod succeeds.


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

When upgrading with the same ISO, the cleanup trap in the upgrade_os will throw out an error that triggers the post-drain to retry again. This is because the line:

```
[[ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]] && \rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
```

will short-circuit with a non-zero return code if the variable is not set.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

A trap should never exit with a non-zero return code, all cases should be handled carefully.

**Related Issue:**

#3175

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Create a cluster with master ISO after v1.1.1-rc1
2. Upgrade to the same ISO again
3. Check if the post-drain job ended successfully