### PR TITLE
Release v1.1.1-rc2

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -26,29 +26,29 @@ kubevirt-operator:
   containers:
     operator:
       image:
-        repository: registry.suse.com/suse/sles/15.4/virt-operator
-        tag: &kubevirtVersion 0.54.0-150400.3.3.2
+        repository: registry.suse.com/harvester-beta/virt-operator
+        tag: &kubevirtVersion 0.54.0-150400.3.7.1
     ## The following images are placeholder for images in use.
     ## They are not used by the kubevirt-operator chart.
     controller:
       image:
-        repository: registry.suse.com/suse/sles/15.4/virt-controller
+        repository: registry.suse.com/harvester-beta/virt-controller
         tag: *kubevirtVersion
     handler:
       image:
-        repository: registry.suse.com/suse/sles/15.4/virt-handler
+        repository: registry.suse.com/harvester-beta/virt-handler
         tag: *kubevirtVersion
     api:
       image:
-        repository: registry.suse.com/suse/sles/15.4/virt-api
+        repository: registry.suse.com/harvester-beta/virt-api
         tag: *kubevirtVersion
     launcher:
       image:
-        repository: registry.suse.com/suse/sles/15.4/virt-launcher
+        repository: registry.suse.com/harvester-beta/virt-launcher
         tag: *kubevirtVersion
     libguestfs: # introduced from kubevirt v0.44.0
       image:
-        repository: registry.suse.com/suse/sles/15.4/libguestfs-tools
+        repository: registry.suse.com/harvester-beta/libguestfs-tools
         tag: *kubevirtVersion
 
 ## Specify the parameters to override the sub-chart.

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -445,7 +445,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.11
+    tag: v0.0.12
 
 generalJob:
   image:

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,12 +10,12 @@ RUN zypper -n rm container-suseconnect && \
 
 WORKDIR /var/lib/harvester/harvester
 
-ENV HARVESTER_UI_VERSION v1.1.1-rc1
+ENV HARVESTER_UI_VERSION v1.1.1-rc2
 ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9
 
-ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION 1.1.1
+ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION v1.1.1-rc2
 
 ARG ARCH=amd64
 ARG VERSION=dev

--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,5 +1,5 @@
 versions:
-- name: v1.1.1-rc1
+- name: v1.1.1-rc2
   minUpgradableVersion: v1.0.3
 - name: v1.1.0
   minUpgradableVersion: v1.0.3

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -17,8 +17,14 @@ clean_up_tmp_files()
     umount $target_elemental_cli || echo "Umount $target_elemental_cli failed with return code: $?"
   fi
   echo "Clean up tmp files..."
-  [[ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]] && \rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
-  [[ -n "$tmp_rootfs_squashfs" ]] && \rm -vf "$tmp_rootfs_squashfs"
+  if [ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]; then
+    echo "Try to remove $NEW_OS_SQUASHFS_IMAGE_FILE..."
+    rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
+  fi
+  if [ -n "$tmp_rootfs_squashfs" ]; then
+    echo "Try to remove $tmp_rootfs_squashfs..."
+    rm -vf "$tmp_rootfs_squashfs"
+  fi
 }
 
 # Create a systemd service on host to reboot the host if this running pod succeeds.

--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -115,6 +115,10 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string, pullPolicy
 									Name:  "SUPPORT_BUNDLE_EXCLUDE_RESOURCES",
 									Value: m.getExcludeResources(),
 								},
+								{
+									Name:  "SUPPORT_BUNDLE_EXTRA_COLLECTORS",
+									Value: m.getExtraCollectors(),
+								},
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -166,6 +170,11 @@ func (m *Manager) getExcludeResources() string {
 	resources = append(resources, rancherv3.Resource(rancherv3.UserResourceName).String())
 
 	return strings.Join(resources, ",")
+}
+
+func (m *Manager) getExtraCollectors() string {
+	extraCollectors := []string{"harvester"}
+	return strings.Join(extraCollectors, ",")
 }
 
 func (m *Manager) GetStatus(sb *harvesterv1.SupportBundle) (*types.ManagerStatus, error) {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -8,9 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=v1.1.1-rc1
+HARVESTER_INSTALLER_VERSION=v1.1.1-rc2
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
Version changes:
- UI: v1.1.1-rc2
- Installer: v1.1.1-rc2
- Deps
  - kubevirt: 0.54.0-150400.3.7.1 (patched version)
  - support-bundle-kit image: [v0.0.12](https://github.com/rancher/support-bundle-kit/releases/tag/v0.0.12)
- Upgrade matrix: minimum v1.0.3