### PR TITLE
fix(upgrade): shutdown VMs as few as possible

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -186,14 +186,42 @@ shutdown_non_migrate_able_vms()
     done
 
   # VMs with nodeAffinity
+  # Skip only when the VMs have other places to go
+  local node_labels=""
+  local node_count=0
   kubectl get vmi -A -l kubevirt.io/nodeName=$HARVESTER_UPGRADE_NODE_NAME -o json |
     jq -r '.items[] | select(.spec.affinity.nodeAffinity != null) | [.metadata.name, .metadata.namespace] | @tsv' |
     while IFS=$'\t' read -r name namespace; do
       if [ -z "$name" ]; then
         break
       fi
-      echo "Stop ${namespace}/${name}"
-      virtctl stop $name -n $namespace
+      node_labels=$(kubectl -n "$namespace" get vmi "$name" -o yaml |
+        yq '.spec.affinity.nodeAffinity.*.nodeSelectorTerms[].matchExpressions[] | select(.operator=="In" and .values[] == "true") | .key')
+      for nl in $node_labels; do
+        # For nodes considered "candidates" for the VM to live-migrate to, they should
+        # 1. match the same labels as nodeAffinity described
+        # 2. not be the node that the VM currently runs on
+        # 3. be schedulable at the time
+        node_count=$(kubectl get nodes -o yaml |
+                nl="$nl" n="$HARVESTER_UPGRADE_NODE_NAME" yq '.items[] | select(.metadata.labels.[env(nl)] == "true" and .metadata.name != env(n) and .spec.unschedulable == null) | .metadata.name' | wc -l)
+
+        if [ "$node_count" -gt 0 ]; then
+          # If such nodes exist, continue to check for the next label
+          echo "$namespace/$name still has $node_count place(s) to go for label $nl"
+          continue
+        else
+          # If there is no candidates for any of the labels, just break the loop and shut the VM down
+          echo "$namespace/$name has no other places to go for label $nl"
+          break
+        fi
+      done
+
+      if [ $node_count -gt 0 ]; then
+        echo "$namespace/$name is considered live-migratable"
+      else
+        echo "$namespace/$name is non-migratable, shutdown immediately"
+        virtctl stop "$name" -n "$namespace"
+      fi
     done
 }
 


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Currently, we will shut down all the VMs that have `nodeAffinity` set during pre-drain stage of an upgrade. This is not desirable for a cluster that consists of 3 nodes and above.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Take `nodeAffinity` into account, especially for the network-related ones, and try not to shut down those VMs if they still got places to go.

**Related Issue:**

#3206 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Create a 3-node (assume node-1, node-2, and node-3) cluster in v1.1.0 (each node should have 3 NICs)
2. Create a `ClusterNetwork` "small-cn" and a `VlanConfig` "n1-nc" which selects only node-1
<img width="1337" alt="Screen Shot 2022-11-28 at 13 54 53" src="https://user-images.githubusercontent.com/1827717/204204755-7a3a9dcc-37bc-40bc-8a93-6542615f134b.png">
<img width="1334" alt="Screen Shot 2022-11-28 at 13 55 22" src="https://user-images.githubusercontent.com/1827717/204204773-c037d4b8-52f7-43e3-affd-285f8598c658.png">
<img width="1335" alt="Screen Shot 2022-11-28 at 13 56 26" src="https://user-images.githubusercontent.com/1827717/204204783-1cf24aad-b6f6-49f0-9235-55ae1d5613bc.png">

3. Create a `ClusterNetwork` "medium-cn" and two `VlanConfig` "n2-nc" and "n3-nc" which select node-2 and node-3 respectively
<img width="1337" alt="Screen Shot 2022-11-28 at 13 56 46" src="https://user-images.githubusercontent.com/1827717/204204834-0b8c1e39-ce4a-4815-8ea4-9df106c6aa29.png">
<img width="1334" alt="Screen Shot 2022-11-28 at 13 57 18" src="https://user-images.githubusercontent.com/1827717/204204858-326a25b8-2eec-4689-bede-c7fdc017e4de.png">
<img width="1332" alt="Screen Shot 2022-11-28 at 13 57 28" src="https://user-images.githubusercontent.com/1827717/204204874-fe057351-58ea-4564-abd9-1ce5918b7866.png">
<img width="1332" alt="Screen Shot 2022-11-28 at 13 57 46" src="https://user-images.githubusercontent.com/1827717/204204908-036cdbfb-a20c-455d-b4de-b361a64ae3f7.png">
<img width="1334" alt="Screen Shot 2022-11-28 at 13 57 55" src="https://user-images.githubusercontent.com/1827717/204204923-049420a3-691b-48fe-ab21-1a4a49e26273.png">

4. Create a `ClusterNetwork` "big-cn" and a `VlanConfig` "all-nc" which selects all the nodes
<img width="1336" alt="Screen Shot 2022-11-28 at 13 58 08" src="https://user-images.githubusercontent.com/1827717/204204944-4aaebe8b-d1a7-46ca-82d9-2844f407d1b0.png">
<img width="1335" alt="Screen Shot 2022-11-28 at 13 58 28" src="https://user-images.githubusercontent.com/1827717/204204957-7ea8e60f-b1cf-4147-aeac-68c287b961e0.png">
<img width="1335" alt="Screen Shot 2022-11-28 at 13 58 46" src="https://user-images.githubusercontent.com/1827717/204205025-609fa48f-98fc-4186-92df-ed3b6da8cd17.png">
<img width="1339" alt="Screen Shot 2022-11-28 at 14 03 52" src="https://user-images.githubusercontent.com/1827717/204205395-df283df2-32a1-40cb-8939-1f62c9073155.png">

5. Create a `NetworkAttachmentDefinition` "small-net" which associates with "small-cn"
<img width="1336" alt="Screen Shot 2022-11-28 at 11 22 24" src="https://user-images.githubusercontent.com/1827717/204185287-fd6c4663-313f-458b-94cf-0667b3d32f55.png">

6. Create a `NetworkAttachmentDefinition` "medium-net" which associates with "medium-cn"
<img width="1334" alt="Screen Shot 2022-11-28 at 11 23 03" src="https://user-images.githubusercontent.com/1827717/204185343-9886e7bd-8d01-43dc-ad37-3419b4999dcf.png">

7. Create a `NetworkAttachmentDefinition` "big-net" which associates with "big-cn"
<img width="1334" alt="Screen Shot 2022-11-28 at 11 23 28" src="https://user-images.githubusercontent.com/1827717/204185428-bee866f4-5e5f-48ee-b25c-585721f63959.png">
<img width="1342" alt="Screen Shot 2022-11-28 at 11 23 52" src="https://user-images.githubusercontent.com/1827717/204185472-cde02179-0299-4420-8561-40d59f4211a4.png">

8. Create a VM "non-migratable-vm-1" attached to "small-net"
9. Create a VM "non-migratable-vm-2" attached to "small-net" and "big-net"
10. Create a VM "migratable-vm-1" attached to "medium-net"
11. Create a VM "migratable-vm-2" attached to "medium-net" and "big-net"
12. Upgrade the cluster (the ISO image should include this fix)
13. The VMs "non-migratable-vm-1" and "non-migratable-vm-2" should be shut down during the upgrade but "migratable-vm-1" and "migratable-vm-2" should be live-migrated among nodes
