### PR TITLE
publish kernel/initrd artifacts to GH releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -381,6 +381,23 @@ steps:
     event:
       - push
 
+- name: upload_kernel_initrd_releases
+  image: plugins/github-release
+  settings:
+    prerelease: true
+    checksum:
+      - sha256
+    files:
+    - "dist/artifacts/harvester*initrd-amd64"
+    - "dist/artifacts/harvester*vmlinuz-amd64"
+    api_key:
+      from_secret: gh_token
+  when:
+    instance:
+      - drone-publish.rancher.io
+    event:
+      - tag
+
 trigger:
   event:
     - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -385,6 +385,7 @@ steps:
   image: plugins/github-release
   settings:
     prerelease: true
+    draft: true
     checksum:
       - sha256
     files:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
IPXE boot using releases.rancher.com cert chain currently fails due to the length of the cert chain.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
We should publish the kernel and initrd artifacts to GH releases.
As tested the certchain on GH releases endpoints allows us PXE boot devices successfully.

We only need the kernel / initrd as once the kernel is booted, the rootfs can be successfully pulled from releases.rancher.com and harvester installer can also download the iso from releases.rancher.com

**Related Issue:**
https://github.com/harvester/harvester/issues/2226

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
