### PR TITLE
pvc cleanup fixes

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -8,13 +8,13 @@ import (
 
 const (
 	vmControllerCreatePVCsFromAnnotationControllerName = "VMController.CreatePVCsFromAnnotation"
-	vmControllerSetOwnerOfPVCsControllerName           = "VMController.SetOwnerOfPVCs"
-	vmControllerUnsetOwnerOfPVCsControllerName         = "VMController.UnsetOwnerOfPVCs"
 	vmiControllerUnsetOwnerOfPVCsControllerName        = "VMIController.UnsetOwnerOfPVCs"
 	vmiControllerReconcileFromHostLabelsControllerName = "VMIController.ReconcileFromHostLabels"
 	vmControllerSetDefaultManagementNetworkMac         = "VMController.SetDefaultManagementNetworkMacAddress"
 	vmControllerStoreRunStrategyControllerName         = "VMController.StoreRunStrategyToAnnotation"
 	vmControllerSyncLabelsToVmi                        = "VMController.SyncLabelsToVmi"
+	vmControllerManagePVCOwnerControllerName           = "VMController.ManageOwnerOfPVCs"
+	harvesterUnsetOwnerOfPVCsFinalizer                 = "harvesterhci.io/VMController.UnsetOwnerOfPVCs"
 )
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
@@ -48,10 +48,9 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 	var virtualMachineClient = management.VirtFactory.Kubevirt().V1().VirtualMachine()
 	virtualMachineClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)
-	virtualMachineClient.OnChange(ctx, vmControllerSetOwnerOfPVCsControllerName, vmCtrl.SetOwnerOfPVCs)
+	virtualMachineClient.OnChange(ctx, vmControllerManagePVCOwnerControllerName, vmCtrl.ManageOwnerOfPVCs)
 	virtualMachineClient.OnChange(ctx, vmControllerStoreRunStrategyControllerName, vmCtrl.StoreRunStrategy)
 	virtualMachineClient.OnChange(ctx, vmControllerSyncLabelsToVmi, vmCtrl.SyncLabelsToVmi)
-	virtualMachineClient.OnRemove(ctx, vmControllerUnsetOwnerOfPVCsControllerName, vmCtrl.OnVMRemove)
 
 	// registers the vmi controller
 	var virtualMachineCache = virtualMachineClient.Cache()

--- a/pkg/controller/master/virtualmachine/vm_controller_test.go
+++ b/pkg/controller/master/virtualmachine/vm_controller_test.go
@@ -8,11 +8,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
+	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
@@ -30,6 +32,7 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 		pvcs []*corev1.PersistentVolumeClaim
 	}
 
+	var testFinalizers = []string{harvesterUnsetOwnerOfPVCsFinalizer}
 	var testCases = []struct {
 		name     string
 		given    input
@@ -58,6 +61,7 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 						Name:              "test",
 						UID:               "fake-vm-uid",
 						DeletionTimestamp: &metav1.Time{},
+						Finalizers:        testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{},
@@ -118,9 +122,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 				key: "default/test",
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -175,9 +180,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 			expected: output{
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -237,9 +243,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 				key: "default/test",
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 						Annotations: map[string]string{
 							util.AnnotationVolumeClaimTemplates: MustPVCTemplatesToString([]corev1.PersistentVolumeClaim{
 								{
@@ -336,9 +343,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 			expected: output{
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 						Annotations: map[string]string{
 							util.AnnotationVolumeClaimTemplates: MustPVCTemplatesToString([]corev1.PersistentVolumeClaim{
 								{
@@ -503,9 +511,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 			expected: output{
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -568,9 +577,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 				key: "default/test",
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -647,9 +657,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 			expected: output{
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -734,9 +745,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 				key: "default/test",
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -816,9 +828,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 			expected: output{
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -903,9 +916,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 				key: "default/test",
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -1004,9 +1018,10 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 			expected: output{
 				vm: &kubevirtv1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "test",
-						UID:       "fake-vm-uid",
+						Namespace:  "default",
+						Name:       "test",
+						UID:        "fake-vm-uid",
+						Finalizers: testFinalizers,
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
@@ -1106,20 +1121,31 @@ func TestVMController_SetOwnerOfPVCs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		var clientset = fake.NewSimpleClientset()
-		if tc.given.pvcs != nil {
-			for _, dv := range tc.given.pvcs {
-				var err = clientset.Tracker().Add(dv)
-				assert.Nil(t, err, "mock resource should add into fake controller tracker")
+		var pvcobjs, harvobjs []runtime.Object
+		for _, v := range tc.given.pvcs {
+			if tc.given.pvcs != nil {
+				pvcobjs = append(pvcobjs, v)
 			}
 		}
 
-		var ctrl = &VMController{
-			pvcClient: fakeclients.PersistentVolumeClaimClient(clientset.CoreV1().PersistentVolumeClaims),
-			pvcCache:  fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+		clientset := fake.NewSimpleClientset(pvcobjs...)
+
+		if tc.given.vm != nil {
+			harvobjs = append(harvobjs, tc.given.vm)
 		}
+
+		harvFakeClient := fakegenerated.NewSimpleClientset(harvobjs...)
+
+		var ctrl = &VMController{
+			pvcClient:      fakeclients.PersistentVolumeClaimClient(clientset.CoreV1().PersistentVolumeClaims),
+			pvcCache:       fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+			vmClient:       fakeclients.VirtualMachineClient(harvFakeClient.KubevirtV1().VirtualMachines),
+			vmBackupCache:  fakeclients.VMBackupCache(harvFakeClient.HarvesterhciV1beta1().VirtualMachineBackups),
+			vmBackupClient: fakeclients.VMBackupClient(harvFakeClient.HarvesterhciV1beta1().VirtualMachineBackups),
+		}
+
 		var actual output
-		actual.vm, actual.err = ctrl.SetOwnerOfPVCs(tc.given.key, tc.given.vm)
+		actual.vm, actual.err = ctrl.ManageOwnerOfPVCs(tc.given.key, tc.given.vm)
 		if tc.expected.pvcs != nil {
 			for _, pvc := range tc.expected.pvcs {
 				var pvcStored, err = clientset.Tracker().Get(corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"), pvc.Namespace, pvc.Name)
@@ -1143,7 +1169,7 @@ func TestVMController_UnsetOwnerOfPVCs(t *testing.T) {
 		err error
 		pvc *corev1.PersistentVolumeClaim
 	}
-	var testFinalizers = []string{"wrangler.cattle.io/VMController.UnsetOwnerOfPVCs"}
+	var testFinalizers = []string{harvesterUnsetOwnerOfPVCsFinalizer}
 
 	var testCases = []struct {
 		name     string
@@ -1957,7 +1983,7 @@ func TestVMController_UnsetOwnerOfPVCs(t *testing.T) {
 			pvcCache:  fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
 		}
 		if tc.given.vm != nil {
-			var hasFinalizer = sets.NewString(tc.given.vm.Finalizers...).Has("wrangler.cattle.io/VMController.UnsetOwnerOfPVCs")
+			var hasFinalizer = sets.NewString(tc.given.vm.Finalizers...).Has(harvesterUnsetOwnerOfPVCsFinalizer)
 			assert.True(t, hasFinalizer, "case %q's input is not a process target", tc.name)
 		}
 		var actual output

--- a/pkg/util/fakeclients/vmbackup.go
+++ b/pkg/util/fakeclients/vmbackup.go
@@ -1,0 +1,84 @@
+package fakeclients
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	harvesterv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harvestertype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/harvesterhci.io/v1beta1"
+	harvesterv1ctl "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/indexeres"
+	"github.com/harvester/harvester/pkg/ref"
+)
+
+type VMBackupClient func(string) harvestertype.VirtualMachineBackupInterface
+
+func (c VMBackupClient) Create(vmBackup *harvesterv1beta1.VirtualMachineBackup) (*harvesterv1beta1.VirtualMachineBackup, error) {
+	return c(vmBackup.Namespace).Create(context.TODO(), vmBackup, metav1.CreateOptions{})
+}
+
+func (c VMBackupClient) Update(volume *harvesterv1beta1.VirtualMachineBackup) (*harvesterv1beta1.VirtualMachineBackup, error) {
+	return c(volume.Namespace).Update(context.TODO(), volume, metav1.UpdateOptions{})
+}
+
+func (c VMBackupClient) UpdateStatus(volume *harvesterv1beta1.VirtualMachineBackup) (*harvesterv1beta1.VirtualMachineBackup, error) {
+	panic("implement me")
+}
+
+func (c VMBackupClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return c(namespace).Delete(context.TODO(), name, *options)
+}
+
+func (c VMBackupClient) Get(namespace, name string, options metav1.GetOptions) (*harvesterv1beta1.VirtualMachineBackup, error) {
+	return c(namespace).Get(context.TODO(), name, options)
+}
+
+func (c VMBackupClient) List(namespace string, opts metav1.ListOptions) (*harvesterv1beta1.VirtualMachineBackupList, error) {
+	return c(namespace).List(context.TODO(), opts)
+}
+
+func (c VMBackupClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	return c(namespace).Watch(context.TODO(), opts)
+}
+
+func (c VMBackupClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *harvesterv1beta1.VirtualMachineBackup, err error) {
+	return c(namespace).Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}
+
+type VMBackupCache func(string) harvestertype.VirtualMachineBackupInterface
+
+func (c VMBackupCache) Get(namespace, name string) (*harvesterv1beta1.VirtualMachineBackup, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c VMBackupCache) List(namespace string, selector labels.Selector) ([]*harvesterv1beta1.VirtualMachineBackup, error) {
+	panic("implement me")
+}
+
+func (c VMBackupCache) AddIndexer(indexName string, indexer harvesterv1ctl.VirtualMachineBackupIndexer) {
+	panic("implement me")
+}
+
+func (c VMBackupCache) GetByIndex(indexName, key string) ([]*harvesterv1beta1.VirtualMachineBackup, error) {
+	switch indexName {
+	case indexeres.VMBackupBySourceVMNameIndex:
+		vmNamespace, _ := ref.Parse(key)
+		backupList, err := c(vmNamespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		var backups []*harvesterv1beta1.VirtualMachineBackup
+		for _, b := range backupList.Items {
+			if b.Spec.Source.Name == key {
+				backups = append(backups, &b)
+			}
+		}
+		return backups, nil
+	default:
+		return nil, nil
+	}
+}

--- a/pkg/util/finalizer.go
+++ b/pkg/util/finalizer.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ContainsFinalizer(obj metav1.Object, finalizer string) bool {
+	finalizers := obj.GetFinalizers()
+	for _, v := range finalizers {
+		if v == finalizer {
+			return true
+		}
+	}
+
+	return false
+}
+
+func AddFinalizer(obj metav1.Object, finalizer string) {
+	if !ContainsFinalizer(obj, finalizer) {
+		finalizers := obj.GetFinalizers()
+		finalizers = append(finalizers, finalizer)
+		obj.SetFinalizers(finalizers)
+	}
+}
+
+func RemoveFinalizer(obj metav1.Object, finalizer string) {
+	if ContainsFinalizer(obj, finalizer) {
+		finalizers := obj.GetFinalizers()
+		var newFinalizers []string
+		for _, v := range finalizers {
+			if v != finalizer {
+				newFinalizers = append(newFinalizers, v)
+			}
+		}
+		obj.SetFinalizers(newFinalizers)
+	}
+}

--- a/pkg/util/finalizer_test.go
+++ b/pkg/util/finalizer_test.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+const (
+	testFinalizer = "harvesterhci.io/test-finalizer"
+)
+
+func Test_AddFinalizer(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Finalizers: []string{
+				"some-finalizer",
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{},
+	}
+
+	AddFinalizer(vm, testFinalizer)
+	assert := require.New(t)
+	assert.True(ContainsFinalizer(vm, testFinalizer), "expected to find finalizer")
+}
+
+func Test_RemoveFinalizer(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Finalizers: []string{
+				"some-finalizer",
+				testFinalizer,
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{},
+	}
+
+	RemoveFinalizer(vm, testFinalizer)
+	assert := require.New(t)
+	assert.False(ContainsFinalizer(vm, testFinalizer), "expected to find finalizer")
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
In certain cases when the VM is created and deleted immediately the ownership references may not be cleaned up from the PVC. 
The harvester validation webhook, prevents deletion of such PVCs. The only options in such a scenario are to edit the PVC to drop the ownership annotation or remove the same from longhorn console.

The problem is likely caused by a race condition in the virtualmachine controller, which has an OnChange method and OnRemove method to SetOwnerReferences and RemovedOwnerReferences from the PVC's making up the VM.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces a possible fix, by merging the OnChange and OnRemove handlers into a single OnChange handler, along with custom finalizers to ensure resource cleanup.

**Related Issue:**
https://github.com/harvester/harvester/issues/2677

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
To replicate the issue, I used the following VM json and shell script to trigger the VM creation and deletion.

```json
{
    "apiVersion": "kubevirt.io/v1",
    "kind": "VirtualMachine",
    "metadata": {
        "annotations": {
            "harvesterhci.io/vmRunStrategy": "RerunOnFailure",
            "harvesterhci.io/volumeClaimTemplates": "[{\"metadata\":{\"name\":\"workload-1-disk-0-8p4bi\",\"annotations\":{\"harvesterhci.io/imageId\":\"default/image-98xqv\"}},\"spec\":{\"accessModes\":[\"ReadWriteMany\"],\"resources\":{\"requests\":{\"storage\":\"10Gi\"}},\"volumeMode\":\"Block\",\"storageClassName\":\"longhorn-image-98xqv\"}}]",
            "kubevirt.io/latest-observed-api-version": "v1",
            "kubevirt.io/storage-observed-api-version": "v1alpha3",
            "network.harvesterhci.io/ips": "[]"
        },
        "labels": {
            "harvesterhci.io/creator": "harvester",
            "harvesterhci.io/os": "ubuntu"
        },
        "name": "workload-1",
        "namespace": "default"
    },
    "spec": {
        "runStrategy": "RerunOnFailure",
        "template": {
            "metadata": {
                "annotations": {
                    "harvesterhci.io/sshNames": "[]"
                },
                "creationTimestamp": null,
                "labels": {
                    "harvesterhci.io/vmName": "workload-1"
                }
            },
            "spec": {
                "domain": {
                    "cpu": {
                        "cores": 2,
                        "sockets": 1,
                        "threads": 1
                    },
                    "devices": {
                        "disks": [
                            {
                                "bootOrder": 1,
                                "disk": {
                                    "bus": "virtio"
                                },
                                "name": "disk-0"
                            },
                            {
                                "disk": {
                                    "bus": "virtio"
                                },
                                "name": "cloudinitdisk"
                            }
                        ],
                        "inputs": [
                            {
                                "bus": "usb",
                                "name": "tablet",
                                "type": "tablet"
                            }
                        ],
                        "interfaces": [
                            {
                                "masquerade": {},
                                "model": "virtio",
                                "name": "default"
                            }
                        ]
                    },
                    "features": {
                        "acpi": {
                            "enabled": true
                        }
                    },
                    "machine": {
                        "type": "q35"
                    },
                    "memory": {
                        "guest": "3996Mi"
                    },
                    "resources": {
                        "limits": {
                            "cpu": "2",
                            "memory": "4Gi"
                        },
                        "requests": {
                            "cpu": "125m",
                            "memory": "2730Mi"
                        }
                    }
                },
                "evictionStrategy": "LiveMigrate",
                "hostname": "workload-1",
                "networks": [
                    {
                        "name": "default",
                        "pod": {}
                    }
                ],
                "volumes": [
                    {
                        "name": "disk-0",
                        "persistentVolumeClaim": {
                            "claimName": "workload-1-disk-0-8p4bi"
                        }
                    },
                    {
                        "cloudInitNoCloud": {
                            "networkDataSecretRef": {
                                "name": "workload-1-sg8ma"
                            },
                            "secretRef": {
                                "name": "workload-1-sg8ma"
                            }
                        },
                        "name": "cloudinitdisk"
                    }
                ]
            }
        }
    }
}
```

```sh
#!/bin/sh
TOKEN="token"
ENDPOINT="endpoint"

curl -k -u "${TOKEN}" -H "Content-Type: application/json" -X POST --data @workload.json ${ENDPOINT}/v1/kubevirt.io.virtualmachines &
sleep 1
curl -k -u "${TOKEN}" -H "Content-Type: application/json" -X DELETE ${ENDPOINT}/v1/kubevirt.io.virtualmachines/default/workload-1 &
sleep 10
curl -k -u "${TOKEN}" -H "Content-Type: application/json" -X DELETE ${ENDPOINT}/v1/persistentvolumeclaims/default/workload-1-disk-0-8p4bi
```

The script will create a workload-1 VM along with PVC claim workload-1-disk-0-8p4bi

**NOTE**: Before using the script please ensure that image and storageclass details are updated in the VM json.