### PR TITLE
Add node base info to upgrade responder

### DIFF
--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -116,7 +116,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 	nodes.OnChange(ctx, nodeControllerName, nodeHandler.OnChanged)
 
-	versionSyncer := newVersionSyncer(ctx, options.Namespace, versions, versions.Cache())
+	versionSyncer := newVersionSyncer(ctx, options.Namespace, versions, nodes)
 
 	settingHandler := settingHandler{
 		versionSyncer: versionSyncer,


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

add nodeCount, cpuCount, memorySize to extraInfo, example:

```json
{
    "appVersion": "v0.8.1",
    "extraInfo": {
        "nodeCount": "1",
        "cpuCount": "72",
        "memorySize": "131869232Ki"
    }
}
```

Refer to https://github.com/harvester/upgrade-responder#add-kubernetesversion-extra-field

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
