### PR TITLE
[backport v1.1] fix(setting): add harvester-system as additional noProxy value

### DIFF
--- a/pkg/util/proxy.go
+++ b/pkg/util/proxy.go
@@ -14,6 +14,7 @@ var builtInNoProxy = []string{
 	"longhorn-system",
 	"cattle-system",
 	"cattle-system.svc",
+	"harvester-system",
 	".svc",
 	".cluster.local",
 }

--- a/pkg/util/proxy_test.go
+++ b/pkg/util/proxy_test.go
@@ -15,17 +15,17 @@ func Test_AddBuiltInNoProxy(t *testing.T) {
 		{
 			name:   "single item",
 			input:  "192.168.1.0/24",
-			output: "192.168.1.0/24,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
+			output: "192.168.1.0/24,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
 		},
 		{
 			name:   "multiple items",
 			input:  "192.168.1.0/24,example.com",
-			output: "192.168.1.0/24,example.com,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
+			output: "192.168.1.0/24,example.com,localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
 		},
 		{
 			name:   "overlapped items",
 			input:  "10.0.0.0/8,127.0.0.1",
-			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,longhorn-system,cattle-system,cattle-system.svc,.svc,.cluster.local",
+			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
 		},
 	}
 


### PR DESCRIPTION
This makes sure the internal traffic of Kubernetes like readiness probes of repo VM is not proxied.

Signed-off-by: Zespre Chang <zespre.chang@suse.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Backport of #2782 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

#3282 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
