### PR TITLE
fix(log-level): use default value if value is empty

### DIFF
--- a/pkg/controller/master/setting/log_level.go
+++ b/pkg/controller/master/setting/log_level.go
@@ -8,7 +8,11 @@ import (
 
 // setLogLevel updates the log level on setting changes
 func (h *Handler) setLogLevel(setting *harvesterv1.Setting) error {
-	level, err := logrus.ParseLevel(setting.Value)
+	value := setting.Value
+	if value == "" {
+		value = setting.Default
+	}
+	level, err := logrus.ParseLevel(value)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Problem:**
Update log-level value and then update it back to empty. We will get error message in status.

**Solution:**
Use default log-level value if the value is empty.

**Related Issue:**
https://github.com/harvester/harvester/issues/3340

**Test plan:**
1. Update `log-level` setting to debug
2. Update `log-level` setting to empty.
3. There should not have error in status.
