### PR TITLE
CI: ignore Mergify backport branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -182,6 +182,11 @@ steps:
     event:
     - tag
 
+trigger:
+  ref:
+    exclude:
+    - mergify/**
+
 volumes:
 - name: docker
   host:
@@ -312,6 +317,11 @@ steps:
     - refs/tags/*
     event:
     - tag
+
+trigger:
+  ref:
+    exclude:
+    - mergify/**
 
 depends_on:
 - amd64


### PR DESCRIPTION
To ignore triggering on Mergify backport branches.

Fix triggering on PR: https://drone-publish.rancher.io/harvester/harvester/827
