### PR TITLE
api/kubeconfig: Generate the clusterRoleBinding for harvester-csi-driver

### DIFF
--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -158,3 +158,21 @@ rules:
       - persistentvolumeclaims/status
     verbs:
       - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/component: apiserver
+  name: harvesterhci.io:csi-driver
+rules:
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/api/kubeconfig/generate_handler.go
+++ b/pkg/api/kubeconfig/generate_handler.go
@@ -102,7 +102,7 @@ func (h *GenerateHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := h.createRoleBindingIfNotExit(req.ClusterRoleName, sa); err != nil {
+	if _, err := h.createRoleBindingIfNotExists(sa); err != nil {
 		util.ResponseError(rw, http.StatusInternalServerError, errors.Wrap(err, "fail to create roleBinding"))
 		return
 	}
@@ -141,7 +141,7 @@ func (h *GenerateHandler) getServerURL() (string, error) {
 	return "https://" + vip + ":" + port, nil
 }
 
-func (h *GenerateHandler) createRoleBindingIfNotExit(clusterRoleName string, sa *corev1.ServiceAccount) (*rbacv1.RoleBinding, error) {
+func (h *GenerateHandler) createRoleBindingIfNotExists(sa *corev1.ServiceAccount) (*rbacv1.RoleBinding, error) {
 	namespace := sa.Namespace
 	name := sa.Namespace + "-" + sa.Name
 	roleBinding, err := h.roleBindingCache.Get(namespace, name)
@@ -175,7 +175,7 @@ func (h *GenerateHandler) createRoleBindingIfNotExit(clusterRoleName string, sa 
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     clusterRoleName,
+			Name:     "harvesterhci.io:cloudprovider",
 		},
 	})
 }


### PR DESCRIPTION
related issues: #3052, #3467

We need to add related work when we create the `HARVESTER` cloud provider.
That will make the harvester-CSI-driver can check with the `StorageClass` on the host cluster.

Also need the UI-related work to change the API payload like the following:
(refer to this https://github.com/rancher/dashboard/blob/master/shell/edit/provisioning.cattle.io.cluster/rke2.vue#L1215)
```yaml
    csiClusterRoleName: `harvesterhci.io:csi-driver`
    clusterRoleName:    'harvesterhci.io:cloudprovider',
    namespace: <namespace>,
    serviceAccountName: <name>
```

cc @guangbochen, @bk201 

**Test Plan**
1. create 3 node cluster using the ISO included this PR
2. create guest cluster
3. check the `ClusterRole` and `ClusterRoleBinding` with following contents:

**ClusterRole**
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    meta.helm.sh/release-name: harvester
    meta.helm.sh/release-namespace: harvester-system
    objectset.rio.cattle.io/id: default-mcc-harvester-cattle-fleet-local-system
  creationTimestamp: "2023-12-18T15:55:44Z"
  labels:
    app.kubernetes.io/component: apiserver
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: harvester
    app.kubernetes.io/part-of: harvester
    app.kubernetes.io/version: master-85038796-dirty
    helm.sh/chart: harvester-0.0.0-master-85038796-dirty
    helm.sh/release: harvester
    objectset.rio.cattle.io/hash: e852fa897f5eae59a44b4bfe186aad80b10b94b3
  name: harvesterhci.io:csi-driver
  resourceVersion: "3961"
  uid: 9e3a5b4f-97b9-43a6-a304-4b75b73a2b35
rules:
- apiGroups:
  - storage.k8s.io
  resources:
  - storageclasses
  verbs:
  - get
  - list
  - watch
```

**ClusterRoleBinding**
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  creationTimestamp: "2023-12-19T03:23:39Z"
  name: default-rke2-01
  ownerReferences:
  - apiVersion: v1
    kind: ServiceAccount
    name: rke2-01
    uid: 25f3858d-b865-46b4-b7b9-072ac35b554b
  resourceVersion: "633316"
  uid: 11ebd4d9-6d78-460e-8da5-f036f9d8052c
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: harvesterhci.io:csi-driver
subjects:
- kind: ServiceAccount
  name: rke2-01
  namespace: default
```
Also, make sure the `ServiceAccount` information should be correct.

