### PR TITLE
CI: fix excluding target from ref to branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -183,7 +183,7 @@ steps:
     - tag
 
 trigger:
-  ref:
+  branch:
     exclude:
     - mergify/**
 
@@ -319,7 +319,7 @@ steps:
     - tag
 
 trigger:
-  ref:
+  branch:
     exclude:
     - mergify/**
 


### PR DESCRIPTION
`branch` should be used while specifying branch names.

https://docs.drone.io/pipeline/docker/syntax/trigger/#by-branch
