### PR TITLE
new generate target

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -72,7 +72,7 @@ ENV DAPPER_RUN_ARGS --privileged --network host -v /run/containerd/containerd.so
 ENV GO111MODULE off
 ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS GOPROXY PUSH RKE2_IMAGE_REPO USE_LOCAL_IMAGES CODECOV_TOKEN
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester/
-ENV DAPPER_OUTPUT ./bin ./dist ./package
+ENV DAPPER_OUTPUT ./bin ./dist ./package ./pkg
 ENV DAPPER_DOCKER_SOCKET true
 ENV HOME ${DAPPER_SOURCE}
 # -- for dapper

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -72,7 +72,7 @@ ENV DAPPER_RUN_ARGS --privileged --network host -v /run/containerd/containerd.so
 ENV GO111MODULE off
 ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS GOPROXY PUSH RKE2_IMAGE_REPO USE_LOCAL_IMAGES CODECOV_TOKEN
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester/
-ENV DAPPER_OUTPUT ./bin ./dist ./package ./pkg
+ENV DAPPER_OUTPUT ./api ./bin ./deploy ./dist ./package ./pkg
 ENV DAPPER_DOCKER_SOCKET true
 ENV HOME ${DAPPER_SOURCE}
 # -- for dapper

--- a/scripts/generate
+++ b/scripts/generate
@@ -4,4 +4,3 @@ set -e
 cd $(dirname $0)/..
 
 go generate
-./scripts/generate-openapi

--- a/scripts/generate
+++ b/scripts/generate
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+go generate
+./scripts/generate-openapi


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR introduces a new `generate` target for Make which allows `go generate` and `openapi-gen` to be executed via Dapper in a consistent build environment.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**
https://github.com/harvester/harvester/issues/3375
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
