### PR TITLE
CI: fix excluding target from ref to branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -183,7 +183,7 @@ steps:
     - tag
 
 trigger:
-  ref:
+  branch:
     exclude:
     - mergify/**
 
@@ -319,7 +319,7 @@ steps:
     - tag
 
 trigger:
-  ref:
+  branch:
     exclude:
     - mergify/**
 


### PR DESCRIPTION
A forward port of https://github.com/harvester/harvester/pull/3370 to the master branch.