### PR TITLE
upgrade: convert logging from managedchart to addon

### DIFF
--- a/package/upgrade/addons/logging_addon.yaml
+++ b/package/upgrade/addons/logging_addon.yaml
@@ -1,0 +1,66 @@
+apiVersion: harvesterhci.io/v1beta1
+kind: Addon
+metadata:
+  name: rancher-logging
+  namespace: cattle-logging-system
+spec:
+  repo: http://harvester-cluster-repo.cattle-system.svc/charts
+  version: "102.0.0+up3.17.10"
+  chart: rancher-logging
+  enabled: false
+  valuesContent: |
+    images:
+      fluentbit:
+        tag: 1.9.5 # replace the default 1.9.3, which has bug in systemd log
+      fluentbit_debug:
+        tag: 1.9.5-debug
+    systemdLogPath: /var/log/journal
+    disablePvc: true
+    additionalLoggingSources:
+      rke2:
+        enabled: true
+      kubeAudit:
+        enabled: true
+        auditFilename: "audit.log"
+        pathPrefix: "/var/lib/rancher/rke2/server/logs/"
+        loggingRef: "harvester-kube-audit-log-ref"
+        fluentbit:
+          logTag: kube-audit
+          tolerations:
+          - key: node-role.kubernetes.io/controlplane
+            value: "true"
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/etcd
+            value: "true"
+            effect: NoExecute
+    fluentd:
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 800Mi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    fluentbit:
+      resources:
+        limits:
+          cpu: 200m
+          memory: 200Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+    eventTailer:
+      name: harvester-default
+      namespace: cattle-logging-system
+      controlNamespace: cattle-logging-system
+      workloadOverrides:
+        containers:
+        - image: banzaicloud/eventrouter:v0.1.0
+          name: event-tailer
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 20m
+              memory: 20Mi

--- a/package/upgrade/addons/monitoring_addon.yaml
+++ b/package/upgrade/addons/monitoring_addon.yaml
@@ -1,0 +1,86 @@
+apiVersion: harvesterhci.io/v1beta1
+kind: Addon
+metadata:
+  name: rancher-monitoring
+  namespace: cattle-monitoring-system
+spec:
+  repo: http://harvester-cluster-repo.cattle-system.svc/charts
+  version: "100.1.0+up19.0.3"
+  chart: rancher-monitoring
+  enabled: false
+  valuesContent: |
+    alertmanager:
+      enabled: true
+      config:
+        global:
+          resolve_timeout: 5m
+      service:
+        port: 9093
+      alertmanagerSpec:
+        externalUrl: "https://replace_with_vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/"
+        retention: 120h
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: harvester-longhorn
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 5Gi
+        resources:
+          limits:
+            memory: 600Mi
+            cpu: 1000m
+          requests:
+            memory: 100Mi
+            cpu: 100m
+    grafana:
+      persistence:
+        enabled: true
+        size: 2Gi
+        storageClassName: harvester-longhorn
+        type: pvc
+        accessModes:
+        - ReadWriteOnce
+      resources:
+        limits:
+          cpu: 200m
+          memory: 500Mi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    prometheus:
+      service:
+        port: 9090
+      prometheusSpec:
+        evaluationInterval: 1m
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 2500Mi
+          requests:
+            cpu: 750m
+            memory: 1750Mi
+        retention: 5d
+        retentionSize: 50GiB
+        scrapeInterval: 1m
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 50Gi
+              storageClassName: harvester-longhorn
+              volumeMode: Filesystem
+        externalUrl: "https://replace_with_vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/"
+    prometheus-node-exporter:
+      resources:
+        limits:
+          cpu: 200m
+          memory: 180Mi
+        requests:
+          cpu: 100m
+          memory: 30Mi

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -413,7 +413,8 @@ EOF
   wait_kubevirt harvester-system kubevirt $REPO_KUBEVIRT_VERSION
 }
 
-upgrade_monitoring() {
+#upgrade both monitoring and monitoring_crd
+upgrade_managedchart_monitoring_and_crd() {
   echo "Upgrading Monitoring"
 
   pre_generation_monitoring=$(kubectl get managedcharts.management.cattle.io rancher-monitoring -n fleet-local -o=jsonpath='{.status.observedGeneration}')
@@ -449,6 +450,76 @@ EOF
 
   wait_rollout cattle-monitoring-system daemonset rancher-monitoring-prometheus-node-exporter
   wait_rollout cattle-monitoring-system deployment rancher-monitoring-operator
+}
+
+#upgrade only monitoring_crd
+upgrade_managedchart_monitoring_crd() {
+  local nm=rancher-monitoring-crd
+  echo "Upgrading Managedchart $nm to $REPO_MONITORING_CHART_VERSION"
+
+  local pre_version=$(kubectl get managedcharts.management.cattle.io "$nm" -n fleet-local -o=jsonpath='{.spec.version}')
+  if [ "$pre_version" = "$REPO_MONITORING_CHART_VERSION" ]; then
+    echo "the $nm has already been target version $REPO_MONITORING_CHART_VERSION, nothing to upgrade"
+    pause_managed_chart "$nm" "false"
+    return 0
+  fi
+
+  local pre_generation=$(kubectl get managedcharts.management.cattle.io "$nm" -n fleet-local -o=jsonpath='{.status.observedGeneration}')
+
+  mkdir -p $UPGRADE_TMP_DIR/monitoring
+  cd $UPGRADE_TMP_DIR/monitoring
+
+  cat >"$nm".yaml <<EOF
+spec:
+  version: $REPO_MONITORING_CHART_VERSION
+EOF
+
+  kubectl patch managedcharts.management.cattle.io "$nm" -n fleet-local --patch-file ./"$nm".yaml --type merge
+
+  pause_managed_chart "$nm" "false"
+
+  wait_managed_chart fleet-local "$nm" $REPO_MONITORING_CHART_VERSION $pre_generation ready
+}
+
+upgrade_monitoring() {
+  if [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.1.1" ]] && [[ "$UPGRADE_PREVIOUS_VERSION" < "v1.2.0" ]]; then
+    upgrade_managedchart_monitoring_crd
+    convert_monitoring_to_addon
+  elif [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
+    # from v1.2.0, only crd here, rancher-monitoring is upgraded in addons
+    upgrade_managedchart_monitoring_crd
+  else
+    # legacy, upgrade both
+    upgrade_managedchart_monitoring_and_crd
+  fi
+}
+
+upgrade_managedchart_logging_crd() {
+  nm=rancher-logging-crd
+  echo "Upgrading Managedchart $nm to $REPO_LOGGING_CHART_VERSION"
+
+  pre_version=$(kubectl get managedcharts.management.cattle.io "$nm" -n fleet-local -o=jsonpath='{.spec.version}')
+  if [ "$pre_version" = "$REPO_LOGGING_CHART_VERSION" ]; then
+    echo "the $nm has already been target version $REPO_LOGGING_CHART_VERSION, nothing to upgrade"
+    pause_managed_chart "$nm" "false"
+    return 0
+  fi
+
+  pre_generation_logging_crd=$(kubectl get managedcharts.management.cattle.io "$nm" -n fleet-local -o=jsonpath='{.status.observedGeneration}')
+
+  mkdir -p $UPGRADE_TMP_DIR/logging
+  cd $UPGRADE_TMP_DIR/logging
+
+  cat >"$nm".yaml <<EOF
+spec:
+  version: $REPO_LOGGING_CHART_VERSION
+EOF
+
+  kubectl patch managedcharts.management.cattle.io "$nm" -n fleet-local --patch-file ./"$nm".yaml --type merge
+
+  pause_managed_chart "$nm" "false"
+
+  wait_managed_chart fleet-local "$nm" $REPO_LOGGING_CHART_VERSION $pre_generation_logging_crd ready
 }
 
 loop_wait_rollout_logging_audit() {
@@ -528,54 +599,356 @@ loop_wait_rollout_event() {
   return 0
 }
 
+loop_wait_rollout_monitoring() {
+  local NS=cattle-monitoring-system
+
+  for i in $(seq 1 $1)
+  do
+    local EXIT_CODE=0 # reset each loop
+    sleep 10
+
+    local nm=rancher-monitoring-operator
+    wait_rollout $NS deployment $nm || EXIT_CODE=$?
+    if [ $EXIT_CODE != 0 ]; then
+      echo "continue waiting rollout deployment $nm, $i"
+      continue
+    fi
+
+    local nm=rancher-monitoring-prometheus-adapter
+    wait_rollout $NS deployment $nm || EXIT_CODE=$?
+    if [ $EXIT_CODE != 0 ]; then
+      echo "continue waiting rollout deployment $nm, $i"
+      continue
+    fi
+
+    local nm=rancher-monitoring-kube-state-metrics
+    wait_rollout $NS deployment $nm || EXIT_CODE=$?
+    if [ $EXIT_CODE != 0 ]; then
+      echo "continue waiting rollout deployment $nm, $i"
+      continue
+    fi
+
+    local nm=rancher-monitoring-grafana
+    wait_rollout $NS deployment $nm || EXIT_CODE=$?
+    if [ $EXIT_CODE != 0 ]; then
+      echo "continue waiting rollout deployment $nm, $i"
+      continue
+    fi
+
+    local nm=prometheus-rancher-monitoring-prometheus
+    wait_rollout $NS statefulset $nm || EXIT_CODE=$?
+    if [ $EXIT_CODE != 0 ]; then
+      echo "continue waiting rollout statefulset $nm, $i"
+      continue
+    fi
+
+    # alertmanager may be disabled, do not wait
+    #local nm=alertmanager-rancher-monitoring-alertmanager
+    #wait_rollout $NS statefulset $nm || EXIT_CODE=$?
+    #if [ $EXIT_CODE != 0 ]; then
+    #  echo "continue waiting rollout statefulset $nm, $i"
+    #  continue
+    #fi
+
+    local nm=rancher-monitoring-prometheus-node-exporter
+    wait_rollout $NS daemonset $nm || EXIT_CODE=$?
+    if [ $EXIT_CODE != 0 ]; then
+      echo "continue waiting rollout daemonset $nm, $i"
+      continue
+    fi
+
+    break
+  done
+
+  if [ $EXIT_CODE != 0 ]; then
+    echo "fail to wait rollout monitoring"
+    return $EXIT_CODE
+  fi
+
+  echo "success to wait rollout monitoring"
+  return 0
+}
+
+convert_logging_audit_to_addon() {
+  echo "Logging Event Audit: start to convert logging from managedchart to addon"
+  local chart_name="rancher-logging"
+  local namespace="cattle-logging-system"
+  local cnt=0
+
+  # check if logging addon is there
+  cnt=$(kubectl get addon.harvesterhci.io -n "$namespace" "$chart_name" --no-headers | wc -l)
+  if [ "$cnt" -gt 0 ]; then
+    echo "logging has already been addon"
+    return 0
+  fi
+
+  local src_file=/usr/local/share/addons/logging_addon.yaml
+  if [ ! -f $src_file ]; then
+    echo "there is no $src_file, cannot convert"
+    return 0
+  fi
+
+  # check if logging managedchart is there
+  cnt=$(kubectl get managedchart -n fleet-local $chart_name --no-headers | wc -l)
+
+  mkdir -p $UPGRADE_TMP_DIR/logging
+  local saved_config_file=$UPGRADE_TMP_DIR/logging/saved_config.yaml
+
+  # save config
+  local enabled=false
+  local pod_cnt=0
+
+  if [ "$cnt" -gt 0 ]; then
+    enabled=true
+    kubectl get managedchart -n fleet-local "$chart_name" -o yaml | yq -e ".spec.values" > "$saved_config_file"
+    echo "saved managedchart config:"
+    cat "$saved_config_file"
+
+    # eventTailer needs to be deleted separately, as it is not part of the managedchart in v1.1.2
+    local et_cnt=$(kubectl get eventtailers.logging-extensions.banzaicloud.io harvester-default --no-headers | wc -l)
+    if [ "$et_cnt" -gt 0 ]; then
+      local et_spec=$(kubectl get eventtailers.logging-extensions.banzaicloud.io harvester-default -oyaml | yq -e ".spec")
+      echo "saved eventTailer config:"
+      echo "$et_spec"
+      # merge eventTailer config into saved_config_file
+      values="$et_spec" yq -i e '.eventTailer=env(values)' "$saved_config_file"
+      echo "delete eventtailer harvester-default"
+      kubectl delete eventtailers.logging-extensions.banzaicloud.io harvester-default
+    else
+      echo "eventTailer harvester-default is not found"
+    fi
+
+    pod_cnt=$(kubectl get pods -n "$namespace" --no-headers | wc -l)
+    echo "there are $pod_cnt pods in $namespace will be replaced"
+    echo "delete managedchart $chart_name"
+    kubectl delete managedchart -n fleet-local "$chart_name"
+    sleep 20
+
+    # check until all pods are deleted
+    while [ true ]; do
+      pod_cnt=$(kubectl get pods -n "$namespace" --no-headers | wc -l)
+      if [ "$pod_cnt" -gt 0 ]; then
+        date; echo "there are still $pod_cnt pods in $namespace to be deleted"
+        sleep 5
+      else
+        echo "all pods in $namespace are deleted"
+        break
+      fi
+    done
+  fi
+
+  # create tmp addon yaml file
+  local target_file="$UPGRADE_TMP_DIR/logging/logging_addon_tmp.yaml"
+  rm -f $target_file
+  cp $src_file $target_file
+
+  # replace with saved&merged config
+  if [ -f "$saved_config_file" ]; then
+    echo "replace addon valuesContent with saved config"
+    values=$(cat "$saved_config_file") yq -i e '.spec.valuesContent=strenv(values)' $target_file
+  fi
+
+  if [ $enabled = true ]; then
+    echo "enable logging addon"
+    yq -i e '.spec.enabled = true' $target_file
+  else
+    echo "disable logging addon"
+    yq -i e '.spec.enabled = false' $target_file
+  fi
+
+  # make sure the version is aligned with harvester-installer
+  if [ ! -z $REPO_LOGGING_CHART_VERSION ]; then
+    echo "replace addon chart version to target: $REPO_LOGGING_CHART_VERSION"
+    values="$REPO_LOGGING_CHART_VERSION" yq -i e '.spec.version=strenv(values)' $target_file
+  fi
+
+  echo "final logging addon yaml file"
+  cat $target_file
+
+  kubectl apply -f $target_file
+  rm -f $target_file
+  rm -f $saved_config_file
+  kubectl get addon.harvesterhci.io -A || echo "fail to get addon"
+
+  if [ $enabled = true ]; then
+    # wait for addon to be applied
+    echo "wait for rollout of logging and audit"
+    sleep 30
+    # loop wait for at most 6 minutes (36 * 10s)
+    loop_wait_rollout_logging_audit 36
+
+    pod_cnt=$(kubectl get pods -n "$namespace" --no-headers | wc -l) || echo "fail to get pods in $namespace"
+    echo "there are $pod_cnt pods in $namespace after upgrade"
+  fi
+
+  echo "Logging Event Audit: finish converting"
+}
+
+convert_monitoring_to_addon() {
+  echo "Monitoring: start to convert monitoring from managedchart to addon"
+  local chart_name="rancher-monitoring"
+  local namespace="cattle-monitoring-system"
+  local cnt=0
+
+  # check if monitoring addon is there
+  cnt=$(kubectl get addon.harvesterhci.io -n "$namespace" "$chart_name" --no-headers | wc -l)
+  if [ "$cnt" -gt 0 ]; then
+    echo "monitoring has already been addon"
+    return 0
+  fi
+
+  local src_file=/usr/local/share/addons/monitoring_addon.yaml
+  if [ ! -f $src_file ]; then
+    echo "there is no $src_file, cannot convert"
+    return 0
+  fi
+
+  # check if monitoring managedchart is there
+  cnt=$(kubectl get managedchart -n fleet-local "$chart_name" --no-headers | wc -l)
+
+  # save config
+  local saved_config="null"
+  local enabled=false
+  local pod_cnt=0
+
+  if [ "$cnt" -gt 0 ]; then
+    # in v1.1.2, the monitoring is enabled
+    enabled=true
+    saved_config=$(kubectl get managedchart -n fleet-local "$chart_name" -o yaml | yq -e ".spec.values")
+    echo "saved managedchart config:"
+    echo "$saved_config"
+    pod_cnt=$(kubectl get pods -n "$namespace" --no-headers | wc -l)
+    echo "there are $pod_cnt pods in $namespace will be replaced"
+    echo "delete managedchart $chart_name"
+    kubectl delete managedchart -n fleet-local "$chart_name"
+
+    # check until all pods are deleted
+    while [ true ]; do
+      pod_cnt=$(kubectl get pods -n "$namespace" --no-headers | wc -l)
+      if [ "$pod_cnt" -gt 0 ]; then
+        date; echo "there are still $pod_cnt pods in $namespace to be deleted"
+        sleep 5
+      else
+        echo "all pods in $namespace are deleted"
+        break
+      fi
+    done
+  fi
+
+  # create tmp addon yaml file
+  mkdir -p $UPGRADE_TMP_DIR/monitoring
+  target_file="$UPGRADE_TMP_DIR/monitoring/monitoring_addon_tmp.yaml"
+  rm -f $target_file
+  cp $src_file $target_file
+
+  # replace with saved config
+  if [ "$saved_config" != "null" ]; then
+    echo "replace addon valuesContent with saved config"
+    values="$saved_config" yq -i e '.spec.valuesContent=strenv(values)' $target_file
+  else
+    # replace the replace_with_vip field in add yaml file
+    # use sed to replace sub-string in the valuesContent, it is not easily done in yq
+    detect_harvester_vip
+    if [ -n "$HARVESTER_VIP" ]; then
+      echo "replace the 'replace_with_vip' with $HARVESTER_VIP in $target_file"
+      sed -i "s/replace_with_vip/$HARVESTER_VIP/" $target_file
+    else
+      echo "detect vip fail, does not replace the 'replace_with_vip' in $target_file"
+    fi
+  fi
+
+  if [ $enabled = true ]; then
+    echo "enable monitoring addon"
+    yq -i e '.spec.enabled = true' $target_file
+  else
+    echo "disable monitoring addon"
+    yq -i e '.spec.enabled = false' $target_file
+  fi
+
+  # make sure the version is aligned with harvester-installer
+  if [ ! -z $REPO_MONITORING_CHART_VERSION ]; then
+    echo "replace addon chart version to target: $REPO_MONITORING_CHART_VERSION"
+    values="$REPO_MONITORING_CHART_VERSION" yq -i e '.spec.version=strenv(values)' $target_file
+  fi
+
+  echo "final monitoring addon yaml file"
+  cat $target_file
+
+  kubectl apply -f $target_file
+  rm -f $target_file
+  kubectl get addon.harvesterhci.io -A || echo "fail to get addon"
+
+  if [ $enabled = true ]; then
+    echo "wait for rollout of monitoring"
+    sleep 30
+    # loop wait for at most 6 minutes (36 * 10s)
+    loop_wait_rollout_monitoring 36
+
+    pod_cnt=$(kubectl get pods -n "$namespace" --no-headers | wc -l)
+    echo "there are $pod_cnt pods in $namespace after upgrade"
+  fi
+
+  echo "Monitoring: finish converting"
+}
+
+upgrade_logging_event_audit_new_feature() {
+  # from v1.0.3 to v1.1.0, logging, event, audit are enabled by default
+  echo "Logging Event Audit: start to upgrade manifest"
+
+  # prepare a malformed yaml file, make sure it is effectively replaced
+  echo "to-be-replaced-file" > rancher-logging.yaml
+
+  # reuse framework to generate yaml file
+  upgrade_managed_chart_from_version $UPGRADE_PREVIOUS_VERSION rancher-logging rancher-logging.yaml
+
+  echo "Apply resource file of logging and audit"
+
+  kubectl apply -f ./rancher-logging.yaml
+
+  # wait for managedchart to be applied
+  sleep 50
+
+  echo "Wait for rollout of logging and audit"
+  # loop wait for at most 6 minutes (36 * 10s)
+  loop_wait_rollout_logging_audit 36
+
+  # due to error: unable to recognize "./rancher-logging.yaml": no matches for kind "EventTailer" in version "logging-extensions.banzaicloud.io/v1alpha1"
+  # the eventtailer needs to be deployed after the managedcharts are deployed
+
+  # prepare a malformed yaml file, make sure it is effectively replaced
+  echo "to-be-replaced-file" > rancher-logging.yaml
+
+  # reuse frame work to generate yaml file
+  # rancher-logging_event-extension is reusing chart rancher-logging, but as an extension for event
+  upgrade_managed_chart_from_version $UPGRADE_PREVIOUS_VERSION rancher-logging_event-extension rancher-logging.yaml
+
+  echo "Apply resource file of event"
+
+  kubectl apply -f ./rancher-logging.yaml
+
+  # wait few seconds
+  sleep 20
+
+  echo "Wait for rollout of event"
+  # loop wait for at most 3 minutes (18 * 10s)
+  loop_wait_rollout_event 18
+
+  echo "Logging Event Audit: finish upgrading manifest"
+}
 
 upgrade_logging_event_audit() {
   # from v1.0.3, logging, event, audit are enabled by default
   echo "The current version is $UPGRADE_PREVIOUS_VERSION, will check Logging Event Audit upgrade manifest option"
 
-  if test "$UPGRADE_PREVIOUS_VERSION" = "v1.0.3"; then
-    echo "Logging Event Audit: start to upgrade manifest"
-
-    # prepare a malformed yaml file, make sure it is effectively replaced
-    echo "to-be-replaced-file" > rancher-logging.yaml
-
-    # reuse frame work to generate yaml file
-    upgrade_managed_chart_from_version $UPGRADE_PREVIOUS_VERSION rancher-logging rancher-logging.yaml
-
-    echo "Apply resource file of logging and audit"
-
-    kubectl apply -f ./rancher-logging.yaml
-
-    # wait for managedchart to be applied
-    sleep 50
-
-    echo "Wait for rollout of logging and audit"
-    # loop wait for at most 6 minutes (36 * 10s)
-    loop_wait_rollout_logging_audit 36
-
-    # due to error: unable to recognize "./rancher-logging.yaml": no matches for kind "EventTailer" in version "logging-extensions.banzaicloud.io/v1alpha1"
-    # the eventtailer needs to be deployed after the managedcharts are deployed
-
-    # prepare a malformed yaml file, make sure it is effectively replaced
-    echo "to-be-replaced-file" > rancher-logging.yaml
-
-    # reuse frame work to generate yaml file
-    # rancher-logging_event-extension is reusing chart rancher-logging, but as an extension for event
-    upgrade_managed_chart_from_version $UPGRADE_PREVIOUS_VERSION rancher-logging_event-extension rancher-logging.yaml
-
-    echo "Apply resource file of event"
-
-    kubectl apply -f ./rancher-logging.yaml
-
-    # wait few seconds
-    sleep 20
-
-    echo "Wait for rollout of event"
-    # loop wait for at most 3 minutes (18 * 10s)
-    loop_wait_rollout_event 18
-
-    echo "Logging Event Audit: finish upgrading manifest"
-
+  if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.0.3" ]]; then
+    upgrade_logging_event_audit_new_feature
+  elif [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.1.1" ]] && [[ "$UPGRADE_PREVIOUS_VERSION" < "v1.2.0" ]]; then
+    # from v1.1.2 to potential v1.1.3,v1.1.4 ...
+    upgrade_managedchart_logging_crd
+    convert_logging_audit_to_addon
+  elif [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
+    # from v1.2.0, only crd here, rancher-logging is upgraded in addons
+    upgrade_managedchart_logging_crd
   else
     echo "Logging Event Audit: nothing to do in $UPGRADE_PREVIOUS_VERSION"
   fi
@@ -616,10 +989,33 @@ EOF
 }
 
 pause_all_charts() {
-  charts="harvester harvester-crd rancher-monitoring rancher-monitoring-crd"
+  local charts="harvester harvester-crd rancher-monitoring-crd rancher-logging-crd"
   for chart in $charts; do
     pause_managed_chart $chart "true"
   done
+
+  # those charts may have been converted to addon, check if they are there first
+  charts="rancher-monitoring rancher-logging"
+  for chart in $charts; do
+    local cnt=$(kubectl get managedchart -n fleet-local "$chart" --no-headers | wc -l)
+    if [ "$cnt" -gt 0 ]; then
+      pause_managed_chart $chart "true"
+    fi
+  done
+}
+
+# NOTE: review in each release, add corresponding process
+upgrade_addon_rancher_monitoring()
+{
+  echo "upgrade of addon rancher_monitoring"
+  echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
+}
+
+# NOTE: review in each release, add corresponding process
+upgrade_addon_rancher_logging()
+{
+  echo "upgrade of addon rancher_logging"
+  echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
 }
 
 upgrade_addons()
@@ -629,6 +1025,13 @@ upgrade_addons()
   for addon in $addons; do
     upgrade_addon $addon "harvester-system"
   done
+
+  # those 2 addons are not simply installed, they are converted from managedchart, above code is no reused
+  # from v1.2.0, they are upgraded per following
+  if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
+    upgrade_addon_rancher_monitoring
+    upgrade_addon_rancher_logging
+  fi
 }
 
 reuse_vlan_cn() {

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -482,15 +482,21 @@ EOF
 }
 
 upgrade_monitoring() {
-  if [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.1.1" ]] && [[ "$UPGRADE_PREVIOUS_VERSION" < "v1.2.0" ]]; then
+  if [[ $(is_formal_release $UPGRADE_PREVIOUS_VERSION) = "true" ]]; then
+    if [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.1.1" ]] && [[ "$UPGRADE_PREVIOUS_VERSION" < "v1.2.0" ]]; then
+      upgrade_managedchart_monitoring_crd
+      convert_monitoring_to_addon
+    elif [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
+      # from v1.2.0, only crd here, rancher-monitoring is upgraded in addons
+      upgrade_managedchart_monitoring_crd
+    else
+      # legacy, upgrade both
+      upgrade_managedchart_monitoring_and_crd
+    fi
+  else
+   # for version like v1.2.0/v1.1.2 master-head to master-head/rc/formal release, try convert anyway
     upgrade_managedchart_monitoring_crd
     convert_monitoring_to_addon
-  elif [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
-    # from v1.2.0, only crd here, rancher-monitoring is upgraded in addons
-    upgrade_managedchart_monitoring_crd
-  else
-    # legacy, upgrade both
-    upgrade_managedchart_monitoring_and_crd
   fi
 }
 
@@ -940,17 +946,23 @@ upgrade_logging_event_audit() {
   # from v1.0.3, logging, event, audit are enabled by default
   echo "The current version is $UPGRADE_PREVIOUS_VERSION, will check Logging Event Audit upgrade manifest option"
 
-  if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.0.3" ]]; then
-    upgrade_logging_event_audit_new_feature
-  elif [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.1.1" ]] && [[ "$UPGRADE_PREVIOUS_VERSION" < "v1.2.0" ]]; then
-    # from v1.1.2 to potential v1.1.3,v1.1.4 ...
+  if [[ $(is_formal_release $UPGRADE_PREVIOUS_VERSION) = "true" ]]; then
+    if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.0.3" ]]; then
+      upgrade_logging_event_audit_new_feature
+    elif [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.1.1" ]] && [[ "$UPGRADE_PREVIOUS_VERSION" < "v1.2.0" ]]; then
+      # from v1.1.2 to potential v1.1.3,v1.1.4 ...
+      upgrade_managedchart_logging_crd
+      convert_logging_audit_to_addon
+    elif [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
+      # from v1.2.0, only crd here, rancher-logging is upgraded in addons
+      upgrade_managedchart_logging_crd
+    else
+      echo "Logging Event Audit: nothing to do in $UPGRADE_PREVIOUS_VERSION"
+    fi
+  else
+    # for version like v1.2.0/v1.1.2 master-head to master-head/rc/formal release, try convert anyway
     upgrade_managedchart_logging_crd
     convert_logging_audit_to_addon
-  elif [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
-    # from v1.2.0, only crd here, rancher-logging is upgraded in addons
-    upgrade_managedchart_logging_crd
-  else
-    echo "Logging Event Audit: nothing to do in $UPGRADE_PREVIOUS_VERSION"
   fi
 }
 
@@ -1007,15 +1019,29 @@ pause_all_charts() {
 # NOTE: review in each release, add corresponding process
 upgrade_addon_rancher_monitoring()
 {
-  echo "upgrade of addon rancher_monitoring"
-  echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
+  echo "upgrade addon rancher_monitoring"
+  if [[ $(is_formal_release $UPGRADE_PREVIOUS_VERSION) = "true" ]]; then
+    if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
+      echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
+    fi
+  else
+    # the addon may be existing in v1.2.0 master-head release and the chart version is bumped, then the addon is upgraded to new version
+    upgrade_addon_try_patch_version_only "rancher-monitoring" "cattle-monitoring-system" $REPO_MONITORING_CHART_VERSION
+  fi
 }
 
 # NOTE: review in each release, add corresponding process
 upgrade_addon_rancher_logging()
 {
-  echo "upgrade of addon rancher_logging"
-  echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
+  echo "upgrade addon rancher_logging"
+  if [[ $(is_formal_release $UPGRADE_PREVIOUS_VERSION) = "true" ]]; then
+    if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
+      echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
+    fi
+  else
+    # the addon may be existing in v1.2.0 master-head release and the chart version is bumped, then the addon is upgraded to new version
+    upgrade_addon_try_patch_version_only "rancher-logging" "cattle-logging-system" $REPO_LOGGING_CHART_VERSION
+  fi
 }
 
 upgrade_addons()
@@ -1028,10 +1054,8 @@ upgrade_addons()
 
   # those 2 addons are not simply installed, they are converted from managedchart, above code is no reused
   # from v1.2.0, they are upgraded per following
-  if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
-    upgrade_addon_rancher_monitoring
-    upgrade_addon_rancher_logging
-  fi
+  upgrade_addon_rancher_monitoring
+  upgrade_addon_rancher_logging
 }
 
 reuse_vlan_cn() {


### PR DESCRIPTION
```
When upgrade
If monitoring, logging are managedchart:
  copy monitoring, logging existing config.
  delete monitoring, logging managedchart.
Add new addons, reuse existing config if possible.
Replace VIP in monitoring addon for newly added addons
Wait for rollout of addons if they are enabled
Update addon version dynamically
```

Signed-off-by: Jian Wang <w13915984028@gmail.com>

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Upgrade path:
v1.1.2 -> v1.2.0

As v1.1.2 is not released, the current code also allows v1.1.1 to v1.2.0 upgrade, for test.


**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Reduce Harvester footprint.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Convert some features to addon.

**Related Issue:**
https://github.com/harvester/harvester/issues/2992

Epic: https://github.com/harvester/harvester/issues/3262

rancher-monitoring chart version bump is in: https://github.com/harvester/harvester-installer/pull/492, the upgrade test is included in this PR https://github.com/harvester/harvester/pull/3380, as addon version is fetched dynamically.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Upgrade from v1.1.1 or v1.1.2 to v1.2.0,  after v1.1.2 is released, the final upgrade path is v1.1.2 to v1.2.0

Tested in single-node cluster, the upgrade is successful, the monitoring and logging are converted from managedchart to addons successfully.

Tested in 2-node cluster, the upgrade is successful, the monitoring and logging are converted from managedchart to addons successfully.