### PR TITLE
bump golangci-lint and fix lint errors

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -2,23 +2,17 @@
 	"linters": {
 		"disable-all": true,
 		"enable": [
-			"govet",
 			"goimports",
-			"misspell",
-			"ineffassign",
 			"gofmt",
-			"staticcheck",
-			"bodyclose",
-			"gosimple",
-			"prealloc",
-			"deadcode",
-			"errcheck"
+			"misspell",
+			"revive",
+			"prealloc"
 		]
 	},
 	"run": {
 		"skip-files": [
 			"/zz_generated_",
-                        "_generated"
+			"_generated"
 		],
 		"skip-dirs": [
 			"generated"
@@ -29,9 +23,9 @@
 			"test"
 		]
 	},
-        "linters-settings": {
-                "goimports": {
-                        "local-prefixes": "github.com/harvester/harvester"
-                }
-        }
+	"linters-settings": {
+		"goimports": {
+			"local-prefixes": "github.com/harvester/harvester"
+		}
+	}
 }

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -44,7 +44,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 ## install golangci
 RUN if [ "${ARCH}" = "amd64" ]; then \
-        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.41.1; \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0; \
     fi
 ## install controller-gen
 RUN if [ "${ARCH}" = "amd64" ]; then \

--- a/pkg/api/image/schema.go
+++ b/pkg/api/image/schema.go
@@ -12,7 +12,7 @@ import (
 )
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
-	imgHandler := ImageHandler{
+	imgHandler := Handler{
 		httpClient:                  http.Client{},
 		Images:                      scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage(),
 		ImageCache:                  scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),

--- a/pkg/api/kubeconfig/generate_handler.go
+++ b/pkg/api/kubeconfig/generate_handler.go
@@ -107,13 +107,13 @@ func (h *GenerateHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	serverUrl, err := h.getServerUrl()
+	serverURL, err := h.getServerURL()
 	if err != nil {
 		util.ResponseError(rw, http.StatusInternalServerError, errors.Wrap(err, "failed to get server url"))
 		return
 	}
 
-	kubeConfig, err := h.generateKubeConfig(secret, serverUrl)
+	kubeConfig, err := h.generateKubeConfig(secret, serverURL)
 	if err != nil {
 		util.ResponseError(rw, http.StatusInternalServerError, errors.Wrap(err, "fail to generate kubeconfig"))
 		return
@@ -122,7 +122,7 @@ func (h *GenerateHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	util.ResponseOKWithBody(rw, kubeConfig)
 }
 
-func (h *GenerateHandler) getServerUrl() (string, error) {
+func (h *GenerateHandler) getServerURL() (string, error) {
 	vipCm, err := h.configMapCache.Get(h.namespace, rancher.VipConfigmapName)
 	if err != nil {
 		return "", err

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -268,7 +268,7 @@ func ejectCdRomFromVM(vm *kubevirtv1.VirtualMachine, diskNames []string) error {
 		volumes = append(volumes, vol)
 	}
 
-	if err := removeVolumeClaimTemplatesFromVmAnnotation(vm, toRemoveClaimNames); err != nil {
+	if err := removeVolumeClaimTemplatesFromVMAnnotation(vm, toRemoveClaimNames); err != nil {
 		return err
 	}
 	vm.Spec.Template.Spec.Volumes = volumes
@@ -276,7 +276,7 @@ func ejectCdRomFromVM(vm *kubevirtv1.VirtualMachine, diskNames []string) error {
 	return nil
 }
 
-func removeVolumeClaimTemplatesFromVmAnnotation(vm *kubevirtv1.VirtualMachine, toRemoveDiskNames []string) error {
+func removeVolumeClaimTemplatesFromVMAnnotation(vm *kubevirtv1.VirtualMachine, toRemoveDiskNames []string) error {
 	volumeClaimTemplatesStr, ok := vm.Annotations[util.AnnotationVolumeClaimTemplates]
 	if !ok {
 		return nil
@@ -712,8 +712,8 @@ func (h *vmActionHandler) cloneVolumes(newVM *kubevirtv1.VirtualMachine) ([]core
 			}
 
 			annotations := map[string]string{}
-			if imageId, ok := pvc.Annotations[util.AnnotationImageID]; ok {
-				annotations[util.AnnotationImageID] = imageId
+			if imageID, ok := pvc.Annotations[util.AnnotationImageID]; ok {
+				annotations[util.AnnotationImageID] = imageID
 			}
 			newPVC := corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
@@ -758,47 +758,47 @@ func (h *vmActionHandler) cloneVolumes(newVM *kubevirtv1.VirtualMachine) ([]core
 }
 
 func sanitizeVirtualMachineForTemplateVersion(templateVersionName string, vm *kubevirtv1.VirtualMachine) harvesterv1.VirtualMachineSourceSpec {
-	sanitizedVm := removeMacAddresses(vm)
-	sanitizedVm = replaceSecrets(templateVersionName, sanitizedVm)
+	sanitizedVM := removeMacAddresses(vm)
+	sanitizedVM = replaceSecrets(templateVersionName, sanitizedVM)
 
 	return harvesterv1.VirtualMachineSourceSpec{
-		ObjectMeta: sanitizedVm.ObjectMeta,
-		Spec:       sanitizedVm.Spec,
+		ObjectMeta: sanitizedVM.ObjectMeta,
+		Spec:       sanitizedVM.Spec,
 	}
 }
 
 func replaceSecrets(templateVersionName string, vm *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine {
-	sanitizedVm := vm.DeepCopy()
-	for index, credential := range sanitizedVm.Spec.Template.Spec.AccessCredentials {
+	sanitizedVM := vm.DeepCopy()
+	for index, credential := range sanitizedVM.Spec.Template.Spec.AccessCredentials {
 		if sshPublicKey := credential.SSHPublicKey; sshPublicKey != nil && sshPublicKey.Source.Secret != nil {
-			sanitizedVm.Spec.Template.Spec.AccessCredentials[index].SSHPublicKey.Source.Secret.SecretName = getTemplateVersionSSHPublicKeySecretName(templateVersionName, index)
+			sanitizedVM.Spec.Template.Spec.AccessCredentials[index].SSHPublicKey.Source.Secret.SecretName = getTemplateVersionSSHPublicKeySecretName(templateVersionName, index)
 		}
 		if userPassword := credential.UserPassword; userPassword != nil && userPassword.Source.Secret != nil {
-			sanitizedVm.Spec.Template.Spec.AccessCredentials[index].UserPassword.Source.Secret.SecretName = getTemplateVersionUserPasswordSecretName(templateVersionName, index)
+			sanitizedVM.Spec.Template.Spec.AccessCredentials[index].UserPassword.Source.Secret.SecretName = getTemplateVersionUserPasswordSecretName(templateVersionName, index)
 		}
 	}
-	for index, volume := range sanitizedVm.Spec.Template.Spec.Volumes {
+	for index, volume := range sanitizedVM.Spec.Template.Spec.Volumes {
 		if volume.CloudInitNoCloud == nil {
 			continue
 		}
 		if volume.CloudInitNoCloud.UserDataSecretRef != nil {
-			sanitizedVm.Spec.Template.Spec.Volumes[index].CloudInitNoCloud.UserDataSecretRef.Name = getTemplateVersionUserDataSecretName(templateVersionName, volume.Name)
+			sanitizedVM.Spec.Template.Spec.Volumes[index].CloudInitNoCloud.UserDataSecretRef.Name = getTemplateVersionUserDataSecretName(templateVersionName, volume.Name)
 		}
 		if volume.CloudInitNoCloud.NetworkDataSecretRef != nil {
-			sanitizedVm.Spec.Template.Spec.Volumes[index].CloudInitNoCloud.NetworkDataSecretRef.Name = getTemplateVersionNetworkDataSecretName(templateVersionName, volume.Name)
+			sanitizedVM.Spec.Template.Spec.Volumes[index].CloudInitNoCloud.NetworkDataSecretRef.Name = getTemplateVersionNetworkDataSecretName(templateVersionName, volume.Name)
 		}
 	}
-	return sanitizedVm
+	return sanitizedVM
 }
 
 // removeMacAddresses replaces the mac address of each device interface with an empty string.
 // This is because macAddresses are unique, and should not reuse the original's.
 func removeMacAddresses(vm *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine {
-	sanitizedVm := vm.DeepCopy()
-	for index := range sanitizedVm.Spec.Template.Spec.Domain.Devices.Interfaces {
-		sanitizedVm.Spec.Template.Spec.Domain.Devices.Interfaces[index].MacAddress = ""
+	sanitizedVM := vm.DeepCopy()
+	for index := range sanitizedVM.Spec.Template.Spec.Domain.Devices.Interfaces {
+		sanitizedVM.Spec.Template.Spec.Domain.Devices.Interfaces[index].MacAddress = ""
 	}
-	return sanitizedVm
+	return sanitizedVM
 }
 
 // getSSHKeysFromVMITemplateSpec first checks the given VirtualMachineInstanceTemplateSpec

--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -69,7 +69,7 @@ func (h *ActionHandler) restore(ctx context.Context, snapshotNamespace, snapshot
 
 	sourceStorageClassName := volumeSnapshot.Annotations[util.AnnotationStorageClassName]
 	sourceStorageProvisioner := volumeSnapshot.Annotations[util.AnnotationStorageProvisioner]
-	sourceImageId := volumeSnapshot.Annotations[util.AnnotationImageID]
+	sourceImageID := volumeSnapshot.Annotations[util.AnnotationImageID]
 	// default to using source storageClass
 	if storageClassName == "" {
 		storageClassName = sourceStorageClassName
@@ -81,7 +81,7 @@ func (h *ActionHandler) restore(ctx context.Context, snapshotNamespace, snapshot
 	if sourceStorageProvisioner != "" && sc.Provisioner != sourceStorageProvisioner {
 		return apierror.NewAPIError(validation.InvalidBodyContent, "Can not use different provisioner for restoring volume snapshot")
 	}
-	if sourceImageId != "" && storageClassName != sourceStorageClassName {
+	if sourceImageID != "" && storageClassName != sourceStorageClassName {
 		return apierror.NewAPIError(validation.InvalidBodyContent, "Can not use different storageClass for restoring image volume snapshot")
 	}
 
@@ -115,8 +115,8 @@ func (h *ActionHandler) restore(ctx context.Context, snapshotNamespace, snapshot
 		},
 	}
 
-	if sourceImageId != "" {
-		newPVC.Annotations[util.AnnotationImageID] = sourceImageId
+	if sourceImageID != "" {
+		newPVC.Annotations[util.AnnotationImageID] = sourceImageID
 	}
 
 	if _, err = h.pvcs.Create(newPVC); err != nil {

--- a/pkg/controller/master/addon/addon.go
+++ b/pkg/controller/master/addon/addon.go
@@ -159,9 +159,8 @@ func (h *Handler) checkHelmChartExists(a *harvesterv1.Addon) (bool, error) {
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
-		} else {
-			return false, err
 		}
+		return false, err
 	}
 
 	return true, nil
@@ -210,9 +209,8 @@ func (h *Handler) checkAndDeleteChart(a *harvesterv1.Addon) error {
 		if apierrors.IsNotFound(err) {
 			// chart doesn't exist. Nothing to do
 			return nil
-		} else {
-			return fmt.Errorf("error looking up chart in checkAndDeleteChart: %v", err)
 		}
+		return fmt.Errorf("error looking up chart in checkAndDeleteChart: %v", err)
 	}
 
 	var addonOwned bool

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -274,23 +274,23 @@ func (h *Handler) getCSIDriverMap(backup *harvesterv1.VirtualMachineBackup) (map
 			continue
 		}
 
-		if driverInfo, ok := csiDriverConfig[csiDriverName]; !ok {
+		driverInfo, ok := csiDriverConfig[csiDriverName]
+		if !ok {
 			return nil, nil, fmt.Errorf("can't find CSI driver %s in setting CSIDriverInfo", csiDriverName)
-		} else {
-			volumeSnapshotClassName := ""
-			switch backup.Spec.Type {
-			case harvesterv1.Backup:
-				volumeSnapshotClassName = driverInfo.BackupVolumeSnapshotClassName
-			case harvesterv1.Snapshot:
-				volumeSnapshotClassName = driverInfo.VolumeSnapshotClassName
-			}
-			volumeSnapshotClass, err := h.snapshotClassCache.Get(volumeSnapshotClassName)
-			if err != nil {
-				return nil, nil, fmt.Errorf("can't find volumeSnapshotClass %s for CSI driver %s", volumeSnapshotClassName, csiDriverName)
-			}
-			csiDriverVolumeSnapshotClassNameMap[csiDriverName] = volumeSnapshotClassName
-			csiDriverVolumeSnapshotClassMap[csiDriverName] = *volumeSnapshotClass
 		}
+		volumeSnapshotClassName := ""
+		switch backup.Spec.Type {
+		case harvesterv1.Backup:
+			volumeSnapshotClassName = driverInfo.BackupVolumeSnapshotClassName
+		case harvesterv1.Snapshot:
+			volumeSnapshotClassName = driverInfo.VolumeSnapshotClassName
+		}
+		volumeSnapshotClass, err := h.snapshotClassCache.Get(volumeSnapshotClassName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("can't find volumeSnapshotClass %s for CSI driver %s", volumeSnapshotClassName, csiDriverName)
+		}
+		csiDriverVolumeSnapshotClassNameMap[csiDriverName] = volumeSnapshotClassName
+		csiDriverVolumeSnapshotClassMap[csiDriverName] = *volumeSnapshotClass
 	}
 
 	return csiDriverVolumeSnapshotClassNameMap, csiDriverVolumeSnapshotClassMap, nil

--- a/pkg/controller/master/backup/backup_metadata.go
+++ b/pkg/controller/master/backup/backup_metadata.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/longhorn/backupstore"
-	_ "github.com/longhorn/backupstore/nfs"
-	_ "github.com/longhorn/backupstore/s3"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/master/node/node_down_controller.go
+++ b/pkg/controller/master/node/node_down_controller.go
@@ -30,8 +30,8 @@ type nodeDownHandler struct {
 	virtualMachineInstanceCache v1.VirtualMachineInstanceCache
 }
 
-// NodeDownRegister registers a controller to delete VMI when node is down
-func NodeDownRegister(ctx context.Context, management *config.Management, options config.Options) error {
+// DownRegister registers a controller to delete VMI when node is down
+func DownRegister(ctx context.Context, management *config.Management, options config.Options) error {
 	nodes := management.CoreFactory.Core().V1().Node()
 	pods := management.CoreFactory.Core().V1().Pod()
 	setting := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()

--- a/pkg/controller/master/rancher/pod_resources.go
+++ b/pkg/controller/master/rancher/pod_resources.go
@@ -51,7 +51,7 @@ func (h *Handler) PodResourcesOnChanged(key string, node *corev1.Node) (*corev1.
 }
 
 func (h *Handler) getNonTerminatedPods(node *corev1.Node) ([]*corev1.Pod, error) {
-	var pods []*corev1.Pod
+	var pods = make([]*corev1.Pod, 0)
 
 	fromCache, err := h.podCache.GetByIndex(indexeres.PodByNodeNameIndex, node.Name)
 	if err != nil {

--- a/pkg/controller/master/setting/containerd_registry.go
+++ b/pkg/controller/master/setting/containerd_registry.go
@@ -113,13 +113,13 @@ func (h *Handler) removeCredentialInSetting(setting *harvesterv1.Setting, regist
 		registry.Configs[configName] = config
 	}
 
-	registryJson, err := json.Marshal(registry)
+	registryJSON, err := json.Marshal(registry)
 	if err != nil {
 		return err
 	}
 
 	toUpdate := setting.DeepCopy()
-	toUpdate.Value = string(registryJson)
+	toUpdate.Value = string(registryJSON)
 	if !reflect.DeepEqual(setting, toUpdate) {
 		if _, err = h.settings.Update(toUpdate); err != nil {
 			return err

--- a/pkg/controller/master/setting/overcommit_config_test.go
+++ b/pkg/controller/master/setting/overcommit_config_test.go
@@ -51,7 +51,7 @@ func TestHandler_syncOvercommitConfig(t *testing.T) {
 			Value:      `{"cpu":1300,"memory":1200,"storage":1100}`,
 		}
 		expected := settings.Overcommit{
-			Cpu:     1300,
+			CPU:     1300,
 			Memory:  1200,
 			Storage: 1100,
 		}

--- a/pkg/controller/master/setting/ssl_certificate.go
+++ b/pkg/controller/master/setting/ssl_certificate.go
@@ -65,7 +65,7 @@ func (h *Handler) updateTLSSecret(publicCertificate, privateKey string) error {
 	return err
 }
 
-//updateIngressDefaultCertificate updates default ssl certificate of nginx ingress controller
+// updateIngressDefaultCertificate updates default ssl certificate of nginx ingress controller
 func (h *Handler) updateIngressDefaultCertificate(namespace, secretName string) error {
 	secretRef := fmt.Sprintf("%s/%s", namespace, secretName)
 	helmChartConfig, err := h.helmChartConfigCache.Get(util.KubeSystemNamespace, util.Rke2IngressNginxAppName)

--- a/pkg/controller/master/setting/support_bundle_image.go
+++ b/pkg/controller/master/setting/support_bundle_image.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	SupportBundleRespository = "support-bundle-kit"
+	SupportBundleRepository = "support-bundle-kit"
 )
 
 func UpdateSupportBundleImage(settingClient v1beta1.SettingClient, settingCache v1beta1.SettingCache, app *catalogv1api.App) error {
@@ -34,14 +34,14 @@ func UpdateSupportBundleImage(settingClient v1beta1.SettingClient, settingCache 
 	}
 
 	var supportBundleYaml map[string]interface{}
-	if v, ok := values[SupportBundleRespository]; !ok {
-		logrus.Warningf("cant't find %s in apps %s/%s", SupportBundleRespository, app.Namespace, app.Name)
+	v, ok := values[SupportBundleRepository]
+	if !ok {
+		logrus.Warningf("cant't find %s in apps %s/%s", SupportBundleRepository, app.Namespace, app.Name)
 		return nil
-	} else {
-		if supportBundleYaml, ok = v.(map[string]interface{}); !ok {
-			logrus.Warningf("unknown %s yaml struct %+v in apps %s/%s", SupportBundleRespository, v, app.Namespace, app.Name)
-			return nil
-		}
+	}
+	if supportBundleYaml, ok = v.(map[string]interface{}); !ok {
+		logrus.Warningf("unknown %s yaml struct %+v in apps %s/%s", SupportBundleRepository, v, app.Namespace, app.Name)
+		return nil
 	}
 
 	var supportBundle struct {

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -31,7 +31,7 @@ var registerFuncs = []registerFunc{
 	migration.Register,
 	node.PromoteRegister,
 	node.MaintainRegister,
-	node.NodeDownRegister,
+	node.DownRegister,
 	setting.Register,
 	template.Register,
 	virtualmachine.Register,

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -191,7 +191,7 @@ func preparePlan(upgrade *harvesterv1.Upgrade) *upgradev1.Plan {
 	}
 }
 
-func applyNodeJob(upgrade *harvesterv1.Upgrade, repoInfo *UpgradeRepoInfo, nodeName string, jobType string) *batchv1.Job {
+func applyNodeJob(upgrade *harvesterv1.Upgrade, repoInfo *RepoInfo, nodeName string, jobType string) *batchv1.Job {
 	// Use the image tag in the upgrade repo because it's already preloaded and might contain updated codes.
 	imageVersion := repoInfo.Release.Harvester
 	hostPathDirectory := corev1.HostPathDirectory
@@ -296,7 +296,7 @@ func applyNodeJob(upgrade *harvesterv1.Upgrade, repoInfo *UpgradeRepoInfo, nodeN
 	}
 }
 
-func applyManifestsJob(upgrade *harvesterv1.Upgrade, repoInfo *UpgradeRepoInfo) *batchv1.Job {
+func applyManifestsJob(upgrade *harvesterv1.Upgrade, repoInfo *RepoInfo) *batchv1.Job {
 	// Use the image tag in the upgrade repo because it's already preloaded and might contain updated codes.
 	imageVersion := repoInfo.Release.Harvester
 	return &batchv1.Job{

--- a/pkg/controller/master/upgrade/job_controller.go
+++ b/pkg/controller/master/upgrade/job_controller.go
@@ -269,7 +269,7 @@ func (h *jobHandler) syncManifestJob(job *batchv1.Job) (*batchv1.Job, error) {
 	return job, nil
 }
 
-func (h *jobHandler) setNodeWaitRebootLabel(node *v1.Node, repoInfo *UpgradeRepoInfo) error {
+func (h *jobHandler) setNodeWaitRebootLabel(node *v1.Node, repoInfo *RepoInfo) error {
 	nodeUpdate := node.DeepCopy()
 	nodeUpdate.Annotations[harvesterNodePendingOSImage] = repoInfo.Release.OS
 	_, err := h.nodeClient.Update(nodeUpdate)

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	upgradeControllerLock sync.Mutex
-	rke2DrainNodes        bool = true
+	rke2DrainNodes        = true
 )
 
 const (
@@ -386,7 +386,7 @@ func (h *upgradeHandler) upgradeKubernetes(kubernetesVersion string) error {
 		toUpdate.Spec.RKEConfig = &provisioningv1.RKEConfig{}
 	}
 
-	toUpdate.Spec.RKEConfig.ProvisionGeneration += 1
+	toUpdate.Spec.RKEConfig.ProvisionGeneration++
 	toUpdate.Spec.RKEConfig.UpgradeStrategy.ControlPlaneConcurrency = "1"
 	toUpdate.Spec.RKEConfig.UpgradeStrategy.WorkerConcurrency = "1"
 	toUpdate.Spec.RKEConfig.UpgradeStrategy.ControlPlaneDrainOptions.DeleteEmptyDirData = rke2DrainNodes
@@ -436,8 +436,8 @@ func ensureSingleUpgrade(namespace string, upgradeCache ctlharvesterv1.UpgradeCa
 	return onGoingUpgrades[0], nil
 }
 
-func getCachedRepoInfo(upgrade *harvesterv1.Upgrade) (*UpgradeRepoInfo, error) {
-	repoInfo := &UpgradeRepoInfo{}
+func getCachedRepoInfo(upgrade *harvesterv1.Upgrade) (*RepoInfo, error) {
+	repoInfo := &RepoInfo{}
 	if err := repoInfo.Load(upgrade.Status.RepoInfo); err != nil {
 		return nil, err
 	}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -33,7 +33,7 @@ func NewRouter(scaled *config.Scaled, restConfig *rest.Config, options config.Op
 	}, nil
 }
 
-//Routes adds some customize routes to the default router
+// Routes adds some customize routes to the default router
 func (r *Router) Routes(h router.Handlers) http.Handler {
 	m := mux.NewRouter()
 	m.UseEncodedPath()

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -39,7 +39,7 @@ var (
 	SupportBundleNamespaces = NewSetting("support-bundle-namespaces", "")
 	SupportBundleTimeout    = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
 	DefaultStorageClass     = NewSetting("default-storage-class", "longhorn")
-	HTTPProxy               = NewSetting(HttpProxySettingName, "{}")
+	HTTPProxy               = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet   = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
 	OvercommitConfig        = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":150,"storage":200}`)
 	VipPools                = NewSetting(VipPoolsConfigSettingName, "")
@@ -57,7 +57,7 @@ const (
 	BackupTargetSettingName           = "backup-target"
 	VMForceResetPolicySettingName     = "vm-force-reset-policy"
 	SupportBundleTimeoutSettingName   = "support-bundle-timeout"
-	HttpProxySettingName              = "http-proxy"
+	HTTPProxySettingName              = "http-proxy"
 	OvercommitConfigSettingName       = "overcommit-config"
 	SSLCertificatesSettingName        = "ssl-certificates"
 	SSLParametersName                 = "ssl-parameters"
@@ -251,7 +251,7 @@ func DecodeVMForceResetPolicy(value string) (*VMForceResetPolicy, error) {
 }
 
 type Overcommit struct {
-	Cpu     int `json:"cpu"`
+	CPU     int `json:"cpu"`
 	Memory  int `json:"memory"`
 	Storage int `json:"storage"`
 }

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 
 	"github.com/longhorn/backupstore"
-	_ "github.com/longhorn/backupstore/nfs"
-	_ "github.com/longhorn/backupstore/s3"
 	"github.com/rancher/wharfie/pkg/registries"
 	"github.com/rancher/wrangler/pkg/slice"
 	"github.com/sirupsen/logrus"
@@ -48,7 +46,7 @@ var supportedSSLProtocols = []string{"SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv
 type validateSettingFunc func(setting *v1beta1.Setting) error
 
 var validateSettingFuncs = map[string]validateSettingFunc{
-	settings.HttpProxySettingName:            validateHTTPProxy,
+	settings.HTTPProxySettingName:            validateHTTPProxy,
 	settings.VMForceResetPolicySettingName:   validateVMForceResetPolicy,
 	settings.SupportBundleImageName:          validateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName: validateSupportBundleTimeout,
@@ -62,7 +60,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 type validateSettingUpdateFunc func(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error
 
 var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
-	settings.HttpProxySettingName:            validateUpdateHTTPProxy,
+	settings.HTTPProxySettingName:            validateUpdateHTTPProxy,
 	settings.VMForceResetPolicySettingName:   validateUpdateVMForceResetPolicy,
 	settings.SupportBundleImageName:          validateUpdateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName: validateUpdateSupportBundleTimeout,
@@ -197,8 +195,8 @@ func validateOvercommitConfig(setting *v1beta1.Setting) error {
 		msg := fmt.Sprintf("Cannot undercommit. Should be greater than or equal to 100 but got %d", percentage)
 		return werror.NewInvalidError(msg, field)
 	}
-	if overcommit.Cpu < 100 {
-		return emit(overcommit.Cpu, "cpu")
+	if overcommit.CPU < 100 {
+		return emit(overcommit.CPU, "cpu")
 	}
 	if overcommit.Memory < 100 {
 		return emit(overcommit.Memory, "memory")
@@ -352,7 +350,7 @@ func (v *settingValidator) validateBackupTarget(setting *v1beta1.Setting) error 
 // customizeTransport sets HTTP proxy and trusted CAs in the default HTTP transport.
 // The transport used in the library is a one-time cache. Overwrite to update dynamically.
 func (v *settingValidator) customizeTransport() error {
-	httpProxySetting, err := v.settingCache.Get(settings.HttpProxySettingName)
+	httpProxySetting, err := v.settingCache.Get(settings.HTTPProxySettingName)
 	if err != nil {
 		return fmt.Errorf("failed to get HTTP proxy setting: %v", err)
 	}

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -73,7 +73,7 @@ func (v *restoreValidator) Create(request *types.Request, newObj runtime.Object)
 		return werror.NewInvalidError("Target VM name is empty", fieldTargetName)
 	}
 
-	vmBackup, err := v.getVmBackup(newRestore)
+	vmBackup, err := v.getVMBackup(newRestore)
 	if err != nil {
 		return werror.NewInvalidError(err.Error(), fieldVirtualMachineBackupName)
 	}
@@ -118,7 +118,7 @@ func (v *restoreValidator) Create(request *types.Request, newObj runtime.Object)
 	return nil
 }
 
-func (v *restoreValidator) getVmBackup(vmRestore *v1beta1.VirtualMachineRestore) (*v1beta1.VirtualMachineBackup, error) {
+func (v *restoreValidator) getVMBackup(vmRestore *v1beta1.VirtualMachineRestore) (*v1beta1.VirtualMachineBackup, error) {
 	vmBackup, err := v.vmBackup.Get(vmRestore.Spec.VirtualMachineBackupNamespace, vmRestore.Spec.VirtualMachineBackupName)
 	if err != nil {
 		return nil, fmt.Errorf("can't get vmbackup %s/%s, err: %w", vmRestore.Spec.VirtualMachineBackupNamespace, vmRestore.Spec.VirtualMachineBackupName, err)

--- a/tests/integration/api/suite_test.go
+++ b/tests/integration/api/suite_test.go
@@ -92,7 +92,7 @@ var _ = BeforeSuite(func() {
 	select {
 	case <-time.After(harvesterStartTimeOut * time.Second):
 		MustFinallyBeTrue(func() bool {
-			return validateApiIsReady()
+			return validateAPIIsReady()
 		})
 	case err := <-testSuiteStartErrChan:
 		MustNotError(err)
@@ -116,7 +116,7 @@ var _ = AfterSuite(func() {
 })
 
 // validate the v1 api server is ready
-func validateApiIsReady() bool {
+func validateAPIIsReady() bool {
 	apiURL := helper.BuildAPIURL("v1", "", options.HTTPSListenPort)
 	code, _, err := helper.GetResponse(apiURL)
 	if err != nil || code != http.StatusOK {

--- a/tests/integration/controllers/addons_test.go
+++ b/tests/integration/controllers/addons_test.go
@@ -217,9 +217,8 @@ var _ = Describe("addon and helm chart deletion", func() {
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						return nil
-					} else {
-						return err
 					}
+					return err
 				}
 
 				// default scenario when hc is found
@@ -596,9 +595,8 @@ var _ = Describe("enable and disable successful addon", func() {
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						return nil
-					} else {
-						return fmt.Errorf("error getting hemChart: %v", err)
 					}
+					return fmt.Errorf("error getting hemChart: %v", err)
 				}
 
 				return fmt.Errorf("waiting for helm chart to be removed")
@@ -687,9 +685,8 @@ var _ = Describe("enable and disable failed addon", func() {
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						return nil
-					} else {
-						return fmt.Errorf("error getting hemChart: %v", err)
 					}
+					return fmt.Errorf("error getting hemChart: %v", err)
 				}
 
 				return fmt.Errorf("waiting for helm chart to be removed")


### PR DESCRIPTION
**Problem:**
`golang-ci` lint is not installed properly and was out-of-date.

**Solution:**
Bump `golangci-lint` and fix existing lint errors.

**Related Issue:**
N/A

**Test plan:**
- Pass the CI build.
