### PR TITLE
feat(vm): add force stop

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -32,6 +32,7 @@ const (
 	addVolume           = "addVolume"
 	removeVolume        = "removeVolume"
 	cloneVM             = "clone"
+	forceStopVM         = "forceStop"
 )
 
 type vmformatter struct {
@@ -105,6 +106,10 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 
 	if vf.canCreateTemplate(vmi) {
 		resource.AddAction(request, createTemplate)
+	}
+
+	if vf.canForceStop(vm) {
+		resource.AddAction(request, forceStopVM)
 	}
 }
 
@@ -299,4 +304,15 @@ func (vf *vmformatter) getVMI(vm *kubevirtv1.VirtualMachine) *kubevirtv1.Virtual
 		return vmi
 	}
 	return nil
+}
+
+func (vf *vmformatter) canForceStop(vm *kubevirtv1.VirtualMachine) bool {
+	if vm == nil {
+		return false
+	}
+
+	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopping {
+		return false
+	}
+	return true
 }

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -200,6 +200,22 @@ func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) erro
 			return err
 		}
 		return nil
+	case forceStopVM:
+		var gracePeriod int64
+		stopOptions := &kubevirtv1.StopOptions{GracePeriod: &gracePeriod}
+		body, err := json.Marshal(stopOptions)
+		if err != nil {
+			return fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
+		}
+		// The request is equal to "virtctl stop my-vm --grace-period 0 --force"
+		if err := h.virtSubresourceRestClient.Put().Namespace(namespace).Resource(vmResource).SubResource(stopVM).Name(name).Body(body).Do(r.Context()).Error(); err != nil {
+			// Kubevirt returns "Halted does not support manual stop requests" error when VM runStrategy is Halted,
+			// but the request will still forcely stop the VM.
+			if strings.Contains(err.Error(), "Halted does not support manual stop requests") {
+				return nil
+			}
+			return err
+		}
 	default:
 		return apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
 	}

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -123,6 +123,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				addVolume:           &actionHandler,
 				removeVolume:        &actionHandler,
 				cloneVM:             &actionHandler,
+				forceStopVM:         &actionHandler,
 			}
 			apiSchema.ResourceActions = map[string]schemas.Action{
 				startVM:    {},
@@ -157,6 +158,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				cloneVM: {
 					Input: "cloneInput",
 				},
+				forceStopVM: {},
 			}
 		},
 		Formatter: vmformatter.formatter,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -18,65 +18,67 @@ var (
 	provider       Provider
 	InjectDefaults string
 
-	AdditionalCA            = NewSetting(AdditionalCASettingName, "")
-	APIUIVersion            = NewSetting("api-ui-version", "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
-	ClusterRegistrationURL  = NewSetting("cluster-registration-url", "")
-	ServerVersion           = NewSetting("server-version", "dev")
-	UIIndex                 = NewSetting(UIIndexSettingName, DefaultDashboardUIURL)
-	UIPath                  = NewSetting(UIPathSettingName, "/usr/share/harvester/harvester")
-	UISource                = NewSetting(UISourceSettingName, "auto") // Options are 'auto', 'external' or 'bundled'
-	UIPluginIndex           = NewSetting(UIPluginIndexSettingName, DefaultUIPluginURL)
-	VolumeSnapshotClass     = NewSetting(VolumeSnapshotClassSettingName, "longhorn")
-	BackupTargetSet         = NewSetting(BackupTargetSettingName, "")
-	UpgradableVersions      = NewSetting("upgradable-versions", "")
-	UpgradeCheckerEnabled   = NewSetting("upgrade-checker-enabled", "true")
-	UpgradeCheckerURL       = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
-	ReleaseDownloadURL      = NewSetting("release-download-url", "https://releases.rancher.com/harvester")
-	LogLevel                = NewSetting("log-level", "info") // options are info, debug and trace
-	SSLCertificates         = NewSetting(SSLCertificatesSettingName, "{}")
-	SSLParameters           = NewSetting(SSLParametersName, "{}")
-	SupportBundleImage      = NewSetting(SupportBundleImageName, "{}")
-	SupportBundleNamespaces = NewSetting("support-bundle-namespaces", "")
-	SupportBundleTimeout    = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
-	DefaultStorageClass     = NewSetting("default-storage-class", "longhorn")
-	HTTPProxy               = NewSetting(HTTPProxySettingName, "{}")
-	VMForceResetPolicySet   = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
-	OvercommitConfig        = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":150,"storage":200}`)
-	VipPools                = NewSetting(VipPoolsConfigSettingName, "")
-	AutoDiskProvisionPaths  = NewSetting("auto-disk-provision-paths", "")
-	CSIDriverConfig         = NewSetting(CSIDriverConfigSettingName, `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}`)
-	ContainerdRegistry      = NewSetting(ContainerdRegistrySettingName, "")
-	StorageNetwork          = NewSetting(StorageNetworkName, "")
-	RancherManagerSupport   = NewSetting(RancherManagerSupportSettingName, "false")
+	AdditionalCA                           = NewSetting(AdditionalCASettingName, "")
+	APIUIVersion                           = NewSetting("api-ui-version", "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
+	ClusterRegistrationURL                 = NewSetting("cluster-registration-url", "")
+	ServerVersion                          = NewSetting("server-version", "dev")
+	UIIndex                                = NewSetting(UIIndexSettingName, DefaultDashboardUIURL)
+	UIPath                                 = NewSetting(UIPathSettingName, "/usr/share/harvester/harvester")
+	UISource                               = NewSetting(UISourceSettingName, "auto") // Options are 'auto', 'external' or 'bundled'
+	UIPluginIndex                          = NewSetting(UIPluginIndexSettingName, DefaultUIPluginURL)
+	VolumeSnapshotClass                    = NewSetting(VolumeSnapshotClassSettingName, "longhorn")
+	BackupTargetSet                        = NewSetting(BackupTargetSettingName, "")
+	UpgradableVersions                     = NewSetting("upgradable-versions", "")
+	UpgradeCheckerEnabled                  = NewSetting("upgrade-checker-enabled", "true")
+	UpgradeCheckerURL                      = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
+	ReleaseDownloadURL                     = NewSetting("release-download-url", "https://releases.rancher.com/harvester")
+	LogLevel                               = NewSetting("log-level", "info") // options are info, debug and trace
+	SSLCertificates                        = NewSetting(SSLCertificatesSettingName, "{}")
+	SSLParameters                          = NewSetting(SSLParametersName, "{}")
+	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
+	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
+	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
+	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
+	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
+	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
+	OvercommitConfig                       = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":150,"storage":200}`)
+	VipPools                               = NewSetting(VipPoolsConfigSettingName, "")
+	AutoDiskProvisionPaths                 = NewSetting("auto-disk-provision-paths", "")
+	CSIDriverConfig                        = NewSetting(CSIDriverConfigSettingName, `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}`)
+	ContainerdRegistry                     = NewSetting(ContainerdRegistrySettingName, "")
+	StorageNetwork                         = NewSetting(StorageNetworkName, "")
+	DefaultVMTerminationGracePeriodSeconds = NewSetting(DefaultVMTerminationGracePeriodSecondsSettingName, "120")
+	RancherManagerSupport                  = NewSetting(RancherManagerSupportSettingName, "false")
 
 	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
 	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.2.0","harvester-csi-provider":">=0.0.1 <0.2.0"}`)
 )
 
 const (
-	AdditionalCASettingName           = "additional-ca"
-	BackupTargetSettingName           = "backup-target"
-	VMForceResetPolicySettingName     = "vm-force-reset-policy"
-	SupportBundleTimeoutSettingName   = "support-bundle-timeout"
-	HTTPProxySettingName              = "http-proxy"
-	OvercommitConfigSettingName       = "overcommit-config"
-	SSLCertificatesSettingName        = "ssl-certificates"
-	SSLParametersName                 = "ssl-parameters"
-	VipPoolsConfigSettingName         = "vip-pools"
-	VolumeSnapshotClassSettingName    = "volume-snapshot-class"
-	DefaultDashboardUIURL             = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
-	SupportBundleImageName            = "support-bundle-image"
-	CSIDriverConfigSettingName        = "csi-driver-config"
-	UIIndexSettingName                = "ui-index"
-	UIPathSettingName                 = "ui-path"
-	UISourceSettingName               = "ui-source"
-	UIPluginIndexSettingName          = "ui-plugin-index"
-	UIPluginBundledVersionSettingName = "ui-plugin-bundled-version"
-	DefaultUIPluginURL                = "https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js"
-	ContainerdRegistrySettingName     = "containerd-registry"
-	HarvesterCSICCMSettingName        = "harvester-csi-ccm-versions"
-	StorageNetworkName                = "storage-network"
-	RancherManagerSupportSettingName  = "rancher-manager-support"
+	AdditionalCASettingName                           = "additional-ca"
+	BackupTargetSettingName                           = "backup-target"
+	VMForceResetPolicySettingName                     = "vm-force-reset-policy"
+	SupportBundleTimeoutSettingName                   = "support-bundle-timeout"
+	HTTPProxySettingName                              = "http-proxy"
+	OvercommitConfigSettingName                       = "overcommit-config"
+	SSLCertificatesSettingName                        = "ssl-certificates"
+	SSLParametersName                                 = "ssl-parameters"
+	VipPoolsConfigSettingName                         = "vip-pools"
+	VolumeSnapshotClassSettingName                    = "volume-snapshot-class"
+	DefaultDashboardUIURL                             = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
+	SupportBundleImageName                            = "support-bundle-image"
+	CSIDriverConfigSettingName                        = "csi-driver-config"
+	UIIndexSettingName                                = "ui-index"
+	UIPathSettingName                                 = "ui-path"
+	UISourceSettingName                               = "ui-source"
+	UIPluginIndexSettingName                          = "ui-plugin-index"
+	UIPluginBundledVersionSettingName                 = "ui-plugin-bundled-version"
+	DefaultUIPluginURL                                = "https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js"
+	ContainerdRegistrySettingName                     = "containerd-registry"
+	HarvesterCSICCMSettingName                        = "harvester-csi-ccm-versions"
+	StorageNetworkName                                = "storage-network"
+	DefaultVMTerminationGracePeriodSecondsSettingName = "default-vm-termination-grace-period-seconds"
+	RancherManagerSupportSettingName                  = "rancher-manager-support"
 )
 
 func init() {

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -56,29 +56,31 @@ var supportedSSLProtocols = []string{"SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv
 type validateSettingFunc func(setting *v1beta1.Setting) error
 
 var validateSettingFuncs = map[string]validateSettingFunc{
-	settings.HTTPProxySettingName:            validateHTTPProxy,
-	settings.VMForceResetPolicySettingName:   validateVMForceResetPolicy,
-	settings.SupportBundleImageName:          validateSupportBundleImage,
-	settings.SupportBundleTimeoutSettingName: validateSupportBundleTimeout,
-	settings.OvercommitConfigSettingName:     validateOvercommitConfig,
-	settings.VipPoolsConfigSettingName:       validateVipPoolsConfig,
-	settings.SSLCertificatesSettingName:      validateSSLCertificates,
-	settings.SSLParametersName:               validateSSLParameters,
-	settings.ContainerdRegistrySettingName:   validateContainerdRegistry,
+	settings.HTTPProxySettingName:                              validateHTTPProxy,
+	settings.VMForceResetPolicySettingName:                     validateVMForceResetPolicy,
+	settings.SupportBundleImageName:                            validateSupportBundleImage,
+	settings.SupportBundleTimeoutSettingName:                   validateSupportBundleTimeout,
+	settings.OvercommitConfigSettingName:                       validateOvercommitConfig,
+	settings.VipPoolsConfigSettingName:                         validateVipPoolsConfig,
+	settings.SSLCertificatesSettingName:                        validateSSLCertificates,
+	settings.SSLParametersName:                                 validateSSLParameters,
+	settings.ContainerdRegistrySettingName:                     validateContainerdRegistry,
+	settings.DefaultVMTerminationGracePeriodSecondsSettingName: validateDefaultVMTerminationGracePeriodSeconds,
 }
 
 type validateSettingUpdateFunc func(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error
 
 var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
-	settings.HTTPProxySettingName:            validateUpdateHTTPProxy,
-	settings.VMForceResetPolicySettingName:   validateUpdateVMForceResetPolicy,
-	settings.SupportBundleImageName:          validateUpdateSupportBundleImage,
-	settings.SupportBundleTimeoutSettingName: validateUpdateSupportBundleTimeout,
-	settings.OvercommitConfigSettingName:     validateUpdateOvercommitConfig,
-	settings.VipPoolsConfigSettingName:       validateUpdateVipPoolsConfig,
-	settings.SSLCertificatesSettingName:      validateUpdateSSLCertificates,
-	settings.SSLParametersName:               validateUpdateSSLParameters,
-	settings.ContainerdRegistrySettingName:   validateUpdateContainerdRegistry,
+	settings.HTTPProxySettingName:                              validateUpdateHTTPProxy,
+	settings.VMForceResetPolicySettingName:                     validateUpdateVMForceResetPolicy,
+	settings.SupportBundleImageName:                            validateUpdateSupportBundleImage,
+	settings.SupportBundleTimeoutSettingName:                   validateUpdateSupportBundleTimeout,
+	settings.OvercommitConfigSettingName:                       validateUpdateOvercommitConfig,
+	settings.VipPoolsConfigSettingName:                         validateUpdateVipPoolsConfig,
+	settings.SSLCertificatesSettingName:                        validateUpdateSSLCertificates,
+	settings.SSLParametersName:                                 validateUpdateSSLParameters,
+	settings.ContainerdRegistrySettingName:                     validateUpdateContainerdRegistry,
+	settings.DefaultVMTerminationGracePeriodSecondsSettingName: validateUpdateDefaultVMTerminationGracePeriodSeconds,
 }
 
 type validateSettingDeleteFunc func(setting *v1beta1.Setting) error
@@ -701,4 +703,25 @@ func (v *settingValidator) validateUpdateRancherManagerSupport(oldSetting *v1bet
 	}
 
 	return nil
+}
+
+func validateDefaultVMTerminationGracePeriodSeconds(setting *v1beta1.Setting) error {
+	if setting.Value == "" {
+		return nil
+	}
+
+	num, err := strconv.ParseInt(setting.Value, 10, 64)
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), "value")
+	}
+
+	if num < 0 {
+		return werror.NewInvalidError("can't be negative", "value")
+	}
+
+	return nil
+}
+
+func validateUpdateDefaultVMTerminationGracePeriodSeconds(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	return validateDefaultVMTerminationGracePeriodSeconds(newSetting)
 }


### PR DESCRIPTION
**Feature:**
If users set `terminationGracePeriodSeconds`, we need provide a way to force stop the VM.

**Related Issue:**
https://github.com/harvester/harvester/issues/2466

**Test plan:**

Case 1: If users don't set `default-termination-grace-period-seconds` setting, `terminationGracePeriodSeconds` in a VM is 120 seconds

1. Create a VM.
2. Check whether `spec.template.spec.terminationGracePeriodSeconds` in the VM is `120`.

Case 2: `default-termination-grace-period-seconds` setting can't be negative.

1. Set value in `default-termination-grace-period-seconds` setting as `"-1"`. The webhook should return an error.

Case 3: `default-termination-grace-period-seconds` setting should be able to be parsed as an integer.

1. Set value in `default-termination-grace-period-seconds` setting as `"not an integer"`. The webhook should return an error.

Case 4: Set `default-termination-grace-period-seconds` setting and `terminationGracePeriodSeconds`in a new VM should follow the setting.

1. Set value in `default-termination-grace-period-seconds` setting as `"60"`.
2. Create a VM.
3. Check whether `spec.template.spec.terminationGracePeriodSeconds` in the VM is `60`.

Case 5: The controller should wait for `terminationGracePeriodSeconds`, before really removing the VM.

1. Follow Case 4.
2. SSH to the VM and run following commands.
```
# sudo vim /etc/systemd/system/set_gracefulshutdown.service
[Unit]
Description=Set flag for graceful shutdown
DefaultDependencies=no
RefuseManualStart=true
Before=shutdown.target

[Service]
Type=oneshot
TimeoutStartSec=50
ExecStart= /bin/bash -c 'sleep infinity'

[Install]
WantedBy=shutdown.target

# sudo systemctl daemon-reload
# sudo systemctl enable set_gracefulshutdown
```
3. On VM dashboard, stop the VM. We can see OS will wait for 170 seconds and eventually shutdown at 180 seconds:
<img width="865" alt="Screenshot 2023-05-18 at 3 45 46 PM" src="https://github.com/harvester/harvester/assets/1691518/8d4657e5-a930-4b25-82d4-1f52d596c97f">



Case 6: Users can force stop the VM if they don't wait for a graceful shutdown.

1. Follow Case 5.
2. Enable Developer Tools & Features.
3. Start the VM again.
4. Stop the VM again.
5. Click "View in API" on the VM.
6. Click "forceStop" and the controller will stop the VM immediately.