### PR TITLE
Upgrade rancher/dapper version to avoid CI errors.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,7 +32,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: stage-binaries
-  image: rancher/dapper:v0.5.2
+  image: rancher/dapper:v0.5.8
   commands:
   - "cp -r ./bin/* ./package/"
   when:
@@ -349,7 +349,7 @@ steps:
       - tag
 
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.5.8
   commands:
   - dapper build-iso
   volumes:


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Drone CI often runs into error when running build jobs for PRs.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Upgrade `rancher/dapper` to v0.5.8 to try to avoid error.