### PR TITLE
Set overcommit-config mem to 100 FIXES #3135

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -41,7 +41,7 @@ var (
 	DefaultStorageClass     = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy               = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet   = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
-	OvercommitConfig        = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":150,"storage":200}`)
+	OvercommitConfig        = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":100,"storage":200}`)
 	VipPools                = NewSetting(VipPoolsConfigSettingName, "")
 	AutoDiskProvisionPaths  = NewSetting("auto-disk-provision-paths", "")
 	CSIDriverConfig         = NewSetting(CSIDriverConfigSettingName, `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}`)


### PR DESCRIPTION
**Problem:**
Creating a VM with memory >= 4GiB, the VM won't start, with error HostDeviceNotLiveMigratable

**Solution:**
[Set overcommit-config mem to 100](https://github.com/harvester/harvester/issues/3135#issuecomment-1312979703)

**Related Issue:**
- https://github.com/harvester/harvester/issues/3135

**Test plan:**
- Create Harvester ISO with this setting, install ISO, create VM with memory >= 4GiB, then verify that it starts