### PR TITLE
refactored how to check if maintenance mode is possible

### DIFF
--- a/pkg/api/node/schema.go
+++ b/pkg/api/node/schema.go
@@ -43,6 +43,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				cordonAction:                 {},
 				uncordonAction:               {},
 				listUnhealthyVM:              {},
+				maintenancePossible:          {},
 			}
 			s.ActionHandlers = map[string]http.Handler{
 				enableMaintenanceModeAction:  nodeHandler,
@@ -50,6 +51,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				cordonAction:                 nodeHandler,
 				uncordonAction:               nodeHandler,
 				listUnhealthyVM:              nodeHandler,
+				maintenancePossible:          nodeHandler,
 			}
 		},
 	}

--- a/pkg/controller/master/nodedrain/nodedrain_controller_test.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller_test.go
@@ -12,7 +12,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
@@ -258,36 +257,6 @@ var (
 			},
 		},
 	}
-
-	cpNode1 = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "harvester-cp-1",
-			Labels: map[string]string{
-				"node-role.kubernetes.io/control-plane": "true",
-			},
-			Annotations: make(map[string]string),
-		},
-	}
-
-	cpNode2 = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "harvester-cp-2",
-			Labels: map[string]string{
-				"node-role.kubernetes.io/control-plane": "true",
-			},
-			Annotations: make(map[string]string),
-		},
-	}
-
-	cpNode3 = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "harvester-cp-3",
-			Labels: map[string]string{
-				"node-role.kubernetes.io/control-plane": "true",
-			},
-			Annotations: make(map[string]string),
-		},
-	}
 )
 
 func Test_listVMI(t *testing.T) {
@@ -314,91 +283,4 @@ func Test_listVMI(t *testing.T) {
 	assert.NoError(err, "expected no error")
 	assert.Len(vmiList, 1, "expected to find only 1 vmi")
 	assert.Contains(vmiList, failingVM, "expected to find failingVM only")
-}
-
-func Test_meetsControlPlaneRequirementsHA(t *testing.T) {
-	assert := require.New(t)
-	typedObjects := []runtime.Object{workingVolume, workingVM, workingReplica1, workingReplica2, workingReplica3, failingVolume, failingVM,
-		failingReplica1, failingReplica2, failingReplica3, failingVM2, failingVolume2, failingReplica12, failingReplica22, failingReplica32}
-	client := fake.NewSimpleClientset(typedObjects...)
-	k8sclientset := k8sfake.NewSimpleClientset(testNode, cpNode1, cpNode2, cpNode3)
-
-	ndc := &ControllerHandler{
-		nodes:                        fakeclients.NodeClient(k8sclientset.CoreV1().Nodes),
-		nodeCache:                    fakeclients.NodeCache(k8sclientset.CoreV1().Nodes),
-		virtualMachineInstanceClient: fakeclients.VirtualMachineInstanceClient(client.KubevirtV1().VirtualMachineInstances),
-		virtualMachineInstanceCache:  fakeclients.VirtualMachineInstanceCache(client.KubevirtV1().VirtualMachineInstances),
-		virtualMachineClient:         fakeclients.VirtualMachineClient(client.KubevirtV1().VirtualMachines),
-		virtualMachineCache:          fakeclients.VirtualMachineCache(client.KubevirtV1().VirtualMachines),
-		longhornVolumeCache:          fakeclients.LonghornVolumeCache(client.LonghornV1beta1().Volumes),
-		longhornReplicaCache:         fakeclients.LonghornReplicaCache(client.LonghornV1beta1().Replicas),
-		restConfig:                   nil,
-		context:                      context.TODO(),
-	}
-
-	ok, err := ndc.meetsControlPlaneRequirements(testNode)
-	assert.NoError(err, "expected no error while checking testNode")
-	assert.True(ok, "testNode is not a controlplane node, so expected it to meet requirements")
-
-	ok, err = ndc.meetsControlPlaneRequirements(cpNode2)
-	assert.NoError(err, "expected no error while checking cpNode2")
-	assert.True(ok, "cpNode2 is a controlplane node, expect it to meet requirements")
-}
-
-func Test_failsControlPlaneRequirementsHA(t *testing.T) {
-	assert := require.New(t)
-	typedObjects := []runtime.Object{workingVolume, workingVM, workingReplica1, workingReplica2, workingReplica3, failingVolume, failingVM,
-		failingReplica1, failingReplica2, failingReplica3, failingVM2, failingVolume2, failingReplica12, failingReplica22, failingReplica32}
-	client := fake.NewSimpleClientset(typedObjects...)
-	cpNode1.Annotations = map[string]string{
-		ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
-	}
-
-	nodeObjects := []runtime.Object{testNode, cpNode1, cpNode2, cpNode3}
-
-	k8sclientset := k8sfake.NewSimpleClientset(nodeObjects...)
-
-	ndc := &ControllerHandler{
-		nodes:                        fakeclients.NodeClient(k8sclientset.CoreV1().Nodes),
-		nodeCache:                    fakeclients.NodeCache(k8sclientset.CoreV1().Nodes),
-		virtualMachineInstanceClient: fakeclients.VirtualMachineInstanceClient(client.KubevirtV1().VirtualMachineInstances),
-		virtualMachineInstanceCache:  fakeclients.VirtualMachineInstanceCache(client.KubevirtV1().VirtualMachineInstances),
-		virtualMachineClient:         fakeclients.VirtualMachineClient(client.KubevirtV1().VirtualMachines),
-		virtualMachineCache:          fakeclients.VirtualMachineCache(client.KubevirtV1().VirtualMachines),
-		longhornVolumeCache:          fakeclients.LonghornVolumeCache(client.LonghornV1beta1().Volumes),
-		longhornReplicaCache:         fakeclients.LonghornReplicaCache(client.LonghornV1beta1().Replicas),
-		restConfig:                   nil,
-		context:                      context.TODO(),
-	}
-
-	ok, err := ndc.meetsControlPlaneRequirements(cpNode2)
-	assert.NoError(err, "expected no error while checking cpNode2")
-	assert.False(ok, "cpNode2 is a controlplane node, expect it to not meet requirements a cpNode1 is already in maintenance mode")
-}
-
-func Test_failsControlPlaneRequirementsSingleNode(t *testing.T) {
-	assert := require.New(t)
-	typedObjects := []runtime.Object{workingVolume, workingVM, workingReplica1, workingReplica2, workingReplica3, failingVolume, failingVM,
-		failingReplica1, failingReplica2, failingReplica3, failingVM2, failingVolume2, failingReplica12, failingReplica22, failingReplica32}
-	client := fake.NewSimpleClientset(typedObjects...)
-	nodeObjects := []runtime.Object{testNode, cpNode1}
-
-	k8sclientset := k8sfake.NewSimpleClientset(nodeObjects...)
-
-	ndc := &ControllerHandler{
-		nodes:                        fakeclients.NodeClient(k8sclientset.CoreV1().Nodes),
-		nodeCache:                    fakeclients.NodeCache(k8sclientset.CoreV1().Nodes),
-		virtualMachineInstanceClient: fakeclients.VirtualMachineInstanceClient(client.KubevirtV1().VirtualMachineInstances),
-		virtualMachineInstanceCache:  fakeclients.VirtualMachineInstanceCache(client.KubevirtV1().VirtualMachineInstances),
-		virtualMachineClient:         fakeclients.VirtualMachineClient(client.KubevirtV1().VirtualMachines),
-		virtualMachineCache:          fakeclients.VirtualMachineCache(client.KubevirtV1().VirtualMachines),
-		longhornVolumeCache:          fakeclients.LonghornVolumeCache(client.LonghornV1beta1().Volumes),
-		longhornReplicaCache:         fakeclients.LonghornReplicaCache(client.LonghornV1beta1().Replicas),
-		restConfig:                   nil,
-		context:                      context.TODO(),
-	}
-
-	ok, err := ndc.meetsControlPlaneRequirements(cpNode1)
-	assert.NoError(err, "expected no error while checking cpNode1")
-	assert.False(ok, "single controlplane cluster. expected to not meet requirements")
 }

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -2,14 +2,20 @@ package drainhelper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/drain"
+
+	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 )
 
 // drain helper leverages k8s.io/kubectl/pkg/drain to evict pods while following longhorn
@@ -24,6 +30,13 @@ const (
 	defaultTimeOut            = 240 * time.Second
 	DrainAnnotation           = "harvesterhci.io/drain-requested"
 	ForcedDrain               = "harvesterhci.io/drain-forced"
+	defaultSingleCPCount      = 1
+	defaultHACPCount          = 3
+)
+
+var (
+	errSingleControlPlaneNode = errors.New("single controlplane cluster, cannot plance controlplane in maintenance mode")
+	errHAControlPlaneNode     = errors.New("another controlplane is already in maintenance mode, cannot place current node in maintenance mode")
 )
 
 func defaultDrainHelper(ctx context.Context, cfg *rest.Config) (*drain.Helper, error) {
@@ -58,4 +71,46 @@ func DrainNode(ctx context.Context, cfg *rest.Config, node *corev1.Node) error {
 	}
 
 	return drain.RunNodeDrain(d, node.Name)
+}
+
+// DrainPossible is a helper method to check node object and query remaining nodes in cluster
+// to identify if it is possible to place the current mode in maintenance mode
+func DrainPossible(nodeCache ctlcorev1.NodeCache, node *corev1.Node) error {
+	_, cpLabelOK := node.Labels["node-role.kubernetes.io/control-plane"]
+	if !cpLabelOK { // not a controlplane node. no further action needed
+		return nil
+	}
+
+	req, err := labels.NewRequirement("node-role.kubernetes.io/control-plane", selection.Exists, nil)
+	if err != nil {
+		return fmt.Errorf("error creating requirement: %v", err)
+	}
+
+	cpSelector := labels.NewSelector()
+	cpSelector = cpSelector.Add(*req)
+
+	nodeList, err := nodeCache.List(cpSelector)
+	if err != nil {
+		return fmt.Errorf("error listing nodes matching selector %s: %v", cpSelector.String(), err)
+	}
+
+	// only controlplane node which we are trying to place into maintenance
+	if len(nodeList) == defaultSingleCPCount {
+		return errSingleControlPlaneNode
+	}
+
+	var availableNodes int
+	for _, v := range nodeList {
+		_, ok := v.Annotations[ctlnode.MaintainStatusAnnotationKey]
+		logrus.Debugf("nodeName: %s,  annotation present: %v", v.Name, ok)
+		if !ok {
+			availableNodes++
+		}
+	}
+
+	if availableNodes != defaultHACPCount {
+		return errHAControlPlaneNode
+	}
+
+	return nil
 }

--- a/pkg/util/drainhelper/helper_test.go
+++ b/pkg/util/drainhelper/helper_test.go
@@ -2,10 +2,56 @@ package drainhelper
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+
+	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+var (
+	cpNode1 = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-cp-1",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/control-plane": "true",
+			},
+			Annotations: make(map[string]string),
+		},
+	}
+
+	cpNode2 = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-cp-2",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/control-plane": "true",
+			},
+			Annotations: make(map[string]string),
+		},
+	}
+
+	cpNode3 = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-cp-3",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/control-plane": "true",
+			},
+			Annotations: make(map[string]string),
+		},
+	}
+
+	testNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-58rk8",
+		},
+	}
 )
 
 func Test_defaultDrainHelper(t *testing.T) {
@@ -21,4 +67,47 @@ func Test_defaultDrainHelper(t *testing.T) {
 	assert.True(dh.DeleteEmptyDirData, "expected to skip deletion of empty data directory")
 	assert.True(dh.Force, "expected force to be set")
 	assert.Equal(defaultSkipPodLabels, dh.PodSelector, "expected drain handler pod labels to match const")
+}
+
+func Test_meetsControlPlaneRequirementsHA(t *testing.T) {
+	assert := require.New(t)
+	k8sclientset := k8sfake.NewSimpleClientset(testNode, cpNode1, cpNode2, cpNode3)
+
+	nodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
+	err := DrainPossible(nodeCache, testNode)
+	assert.NoError(err, "expected no error while checking testNode")
+
+	err = DrainPossible(nodeCache, cpNode2)
+	assert.NoError(err, "expected no error while checking cpNode2")
+}
+
+func Test_failsControlPlaneRequirementsHA(t *testing.T) {
+	assert := require.New(t)
+	k8sclientset := k8sfake.NewSimpleClientset(testNode, cpNode1, cpNode2, cpNode3)
+
+	cpNode1.Annotations = map[string]string{
+		ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+	}
+
+	nodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
+	nodeClient := fakeclients.NodeClient(k8sclientset.CoreV1().Nodes)
+
+	_, err := nodeClient.Update(cpNode1)
+	assert.NoError(err, "expected no error while updating cpNode1")
+
+	err = DrainPossible(nodeCache, cpNode2)
+	assert.True(errors.Is(err, errHAControlPlaneNode), "expected error while checking cpNode2")
+}
+
+func Test_failsControlPlaneRequirementsSingleNode(t *testing.T) {
+	assert := require.New(t)
+	nodeObjects := []runtime.Object{testNode, cpNode2}
+
+	k8sclientset := k8sfake.NewSimpleClientset(nodeObjects...)
+
+	nodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
+
+	err := DrainPossible(nodeCache, cpNode1)
+	assert.Error(err, "expected error while trying to place cpNode1 in maintenance mode")
+	assert.True(errors.Is(err, errSingleControlPlaneNode), "expected error singleControlPlaneNodeError")
 }

--- a/tests/integration/api/host_apis_test.go
+++ b/tests/integration/api/host_apis_test.go
@@ -40,6 +40,34 @@ var _ = Describe("verify host APIs", func() {
 
 		})
 
+		Specify("verify maintenance possible for worker nodes", func() {
+			nodes, respCode, respBody, err := helper.GetCollection(nodesAPI)
+			MustRespCodeIs(http.StatusOK, "get host", err, respCode, respBody)
+			nodeName := nodes.Data[1].ID
+			nodeObjectAPI := fmt.Sprintf("%s/%s", nodesAPI, nodeName)
+
+			By("enable maintenance mode of the host", func() {
+				MustFinallyBeTrue(func() bool {
+					respCode, respBody, err = helper.PostAction(nodeObjectAPI, "maintenancePossible")
+					return CheckRespCodeIs(http.StatusNoContent, "maintenancePossible action", err, respCode, respBody)
+				}, 30*time.Second, 5*time.Second)
+			})
+		})
+
+		Specify("verify maintenance possible for controlplane nodes", func() {
+			nodes, respCode, respBody, err := helper.GetCollection(nodesAPI)
+			MustRespCodeIs(http.StatusOK, "get host", err, respCode, respBody)
+			nodeName := nodes.Data[0].ID
+			nodeObjectAPI := fmt.Sprintf("%s/%s", nodesAPI, nodeName)
+
+			By("enable maintenance mode of the host", func() {
+				MustFinallyBeTrue(func() bool {
+					respCode, respBody, err = helper.PostAction(nodeObjectAPI, "maintenancePossible")
+					return CheckRespCodeIs(http.StatusInternalServerError, "maintenancePossible action", err, respCode, respBody)
+				}, 30*time.Second, 5*time.Second)
+			})
+		})
+
 		Specify("verify host maintenance mode for worker nodes", func() {
 
 			nodes, respCode, respBody, err := helper.GetCollection(nodesAPI)


### PR DESCRIPTION
register handler for maintenancePossible

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Related to issue: https://github.com/harvester/harvester/issues/2723

An earlier PR: https://github.com/harvester/harvester/pull/3271 introduced the drain helper.

QA identified an issue in the UX for how nodes are placed into drain: https://github.com/harvester/harvester/issues/2723#issuecomment-1432868440

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Changes have been made to expose an additional api call `maintenancePossible` which can identify if a specific controlplane node can be placed into maintenance.
The UI can leverage this api call to query the status of clusters to ensure in a HA setup only one controlplane node can be in maintenance mode at any given time.

For a single controlplane cluster, ie, cluster with 2 nodes, the controlplane cannot be placed into maintenance mode.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
