### PR TITLE
additional logic to remove legacy wrangler finalizer on VM

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -15,6 +15,7 @@ const (
 	vmControllerSyncLabelsToVmi                        = "VMController.SyncLabelsToVmi"
 	vmControllerManagePVCOwnerControllerName           = "VMController.ManageOwnerOfPVCs"
 	harvesterUnsetOwnerOfPVCsFinalizer                 = "harvesterhci.io/VMController.UnsetOwnerOfPVCs"
+	oldWranglerFinalizer                               = "wrangler.cattle.io/VMController.UnsetOwnerOfPVCs"
 )
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/pkg/controller/master/virtualmachine/vm_controller.go
+++ b/pkg/controller/master/virtualmachine/vm_controller.go
@@ -248,6 +248,7 @@ func (h *VMController) OnVMRemove(vm *kubevirtv1.VirtualMachine) (*kubevirtv1.Vi
 	// remove harvester finalizers
 	vmObj := vm.DeepCopy()
 	util.RemoveFinalizer(vmObj, harvesterUnsetOwnerOfPVCsFinalizer)
+	util.RemoveFinalizer(vmObj, oldWranglerFinalizer) // post upgrade, these are not being cleaned by wrangler so need to be managed by us
 	return h.vmClient.Update(vmObj)
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR https://github.com/harvester/harvester/pull/3255 changed how we apply and remove custom finalizers on VM's to ensure PVC's are cleaned up.

Since we are no longer using wrangler OnRemove handler for the vm controller, on older installations, post upgrade this will not finalizer will not be removed, which will cause VM's to be stuck during deletion.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
This PR introduces an additional check to remove the old Wrangler finalizer if present on the VM.

**Related Issue:**
https://github.com/harvester/harvester/issues/2677

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
