### PR TITLE
Fix code scanning alert - Log entries created from user input and incorrect conversion

### DIFF
--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -63,7 +63,7 @@ func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h Handler) do(rw http.ResponseWriter, req *http.Request) error {
-	vars := mux.Vars(req)
+	vars := util.EncodeVars(mux.Vars(req))
 	if req.Method == http.MethodGet {
 		return h.doGet(vars["link"], rw, req)
 	} else if req.Method == http.MethodPost {
@@ -92,7 +92,7 @@ func (h Handler) doPost(action string, rw http.ResponseWriter, req *http.Request
 }
 
 func (h Handler) downloadImage(rw http.ResponseWriter, req *http.Request) error {
-	vars := mux.Vars(req)
+	vars := util.EncodeVars(mux.Vars(req))
 	namespace := vars["namespace"]
 	name := vars["name"]
 	vmImage, err := h.Images.Get(namespace, name, metav1.GetOptions{})
@@ -132,7 +132,7 @@ func (h Handler) downloadImage(rw http.ResponseWriter, req *http.Request) error 
 }
 
 func (h Handler) uploadImage(rw http.ResponseWriter, req *http.Request) error {
-	vars := mux.Vars(req)
+	vars := util.EncodeVars(mux.Vars(req))
 	namespace := vars["namespace"]
 	name := vars["name"]
 	image, err := h.Images.Get(namespace, name, metav1.GetOptions{})

--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/nodedrain"
 	kubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	longhornv1beta1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/drainhelper"
 )
 
@@ -77,7 +78,7 @@ func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h ActionHandler) do(rw http.ResponseWriter, req *http.Request) error {
-	vars := mux.Vars(req)
+	vars := util.EncodeVars(mux.Vars(req))
 	action := vars["action"]
 	name := vars["name"]
 	node, err := h.nodeCache.Get(name)

--- a/pkg/api/supportbundle/download_handler.go
+++ b/pkg/api/supportbundle/download_handler.go
@@ -48,7 +48,7 @@ func NewDownloadHandler(scaled *config.Scaled, namespace string) *DownloadHandle
 }
 
 func (h *DownloadHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	bundleName := mux.Vars(r)["bundleName"]
+	bundleName := util.EncodeVars(mux.Vars(r))["bundleName"]
 
 	retainSb := false
 	if retain, err := strconv.ParseBool(r.URL.Query().Get("retain")); err == nil {

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -75,7 +75,7 @@ func (h vmActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) error {
-	vars := mux.Vars(r)
+	vars := util.EncodeVars(mux.Vars(r))
 	action := vars["action"]
 	namespace := vars["namespace"]
 	name := vars["name"]

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -59,7 +59,7 @@ func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
-	vars := mux.Vars(r)
+	vars := util.EncodeVars(mux.Vars(r))
 	action := vars["action"]
 	pvcName := vars["name"]
 	pvcNamespace := vars["namespace"]
@@ -265,7 +265,7 @@ func (h *ActionHandler) clone(ctx context.Context, pvcNamespace, pvcName, newPVC
 	}
 
 	if _, err = h.pvcs.Create(newPVC); err != nil {
-		logrus.Errorf("failed to clone volume %s/%s to new pvc %s", pvcNamespace, pvcName, newPVCName)
+		logrus.Errorf("failed to clone volume %s/%s", pvcNamespace, pvcName)
 		return err
 	}
 
@@ -334,7 +334,7 @@ func (h *ActionHandler) snapshot(ctx context.Context, pvcNamespace, pvcName, sna
 	}
 
 	if _, err = h.snapshots.Create(snapshot); err != nil {
-		logrus.Errorf("failed to create volume snapshot %s from volume %s/%s", snapshotName, pvcNamespace, pvcName)
+		logrus.Errorf("failed to create volume snapshot from volume %s/%s", pvcNamespace, pvcName)
 		return err
 	}
 

--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -41,7 +41,7 @@ func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
-	vars := mux.Vars(r)
+	vars := util.EncodeVars(mux.Vars(r))
 	action := vars["action"]
 	snapshotName := vars["name"]
 	snapshotNamespace := vars["namespace"]
@@ -120,7 +120,7 @@ func (h *ActionHandler) restore(ctx context.Context, snapshotNamespace, snapshot
 	}
 
 	if _, err = h.pvcs.Create(newPVC); err != nil {
-		logrus.Errorf("failed to restore volume snapshot %s/%s to new pvc %s", snapshotNamespace, snapshotName, newPVCName)
+		logrus.Errorf("failed to restore volume snapshot %s/%s", snapshotNamespace, snapshotName)
 		return err
 	}
 

--- a/pkg/controller/master/storagenetwork/storage_network.go
+++ b/pkg/controller/master/storagenetwork/storage_network.go
@@ -438,9 +438,9 @@ func (h *Handler) checkPrometheusStatusAndStart() error {
 		logrus.Infof("current prometheus replicas: %v", *prometheus.Spec.Replicas)
 		logrus.Infof("start prometheus")
 		prometheusCopy := prometheus.DeepCopy()
-		replicas, err := strconv.Atoi(replicasStr)
+		replicas, err := strconv.ParseInt(replicasStr, 10, 32)
 		if err != nil {
-			return fmt.Errorf("strconv atoi error %v", err)
+			return fmt.Errorf("strconv ParseInt error %v", err)
 		}
 		*prometheusCopy.Spec.Replicas = int32(replicas)
 		delete(prometheusCopy.Annotations, ReplicaStorageNetworkAnnotation)
@@ -470,9 +470,9 @@ func (h *Handler) checkAlertmanagerStatusAndStart() error {
 		logrus.Infof("current alertmanager replicas: %v", *alertmanager.Spec.Replicas)
 		logrus.Infof("start alertmanager")
 		alertmanagerCopy := alertmanager.DeepCopy()
-		replicas, err := strconv.Atoi(replicasStr)
+		replicas, err := strconv.ParseInt(replicasStr, 10, 32)
 		if err != nil {
-			return fmt.Errorf("strconv atoi error %v", err)
+			return fmt.Errorf("strconv ParseInt error %v", err)
 		}
 		*alertmanagerCopy.Spec.Replicas = int32(replicas)
 		delete(alertmanagerCopy.Annotations, ReplicaStorageNetworkAnnotation)
@@ -502,9 +502,9 @@ func (h *Handler) checkGrafanaStatusAndStart() error {
 		logrus.Infof("current Grafana replicas: %v", *grafana.Spec.Replicas)
 		logrus.Infof("start grafana")
 		grafanaCopy := grafana.DeepCopy()
-		replicas, err := strconv.Atoi(replicasStr)
+		replicas, err := strconv.ParseInt(replicasStr, 10, 32)
 		if err != nil {
-			return fmt.Errorf("strconv atoi error %v", err)
+			return fmt.Errorf("strconv ParseInt error %v", err)
 		}
 		*grafanaCopy.Spec.Replicas = int32(replicas)
 		delete(grafanaCopy.Annotations, ReplicaStorageNetworkAnnotation)
@@ -562,9 +562,9 @@ func (h *Handler) checkVMImportControllerStatusAndStart() error {
 	if replicasStr, ok := vmImportControllerDeploy.Annotations[ReplicaStorageNetworkAnnotation]; ok {
 		logrus.Infof("start vm import controller")
 		vmImportControllerDeployCopy := vmImportControllerDeploy.DeepCopy()
-		replicas, err := strconv.Atoi(replicasStr)
+		replicas, err := strconv.ParseInt(replicasStr, 10, 32)
 		if err != nil {
-			return fmt.Errorf("strconv atoi error %v", err)
+			return fmt.Errorf("strconv ParseInt error %v", err)
 		}
 		*vmImportControllerDeployCopy.Spec.Replicas = int32(replicas)
 		delete(vmImportControllerDeployCopy.Annotations, ReplicaStorageNetworkAnnotation)

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 )
@@ -32,4 +33,18 @@ func ResponseError(rw http.ResponseWriter, statusCode int, err error) {
 func ResponseErrorMsg(rw http.ResponseWriter, statusCode int, errMsg string) {
 	rw.WriteHeader(statusCode)
 	_, _ = rw.Write(ResponseBody(v1beta1.ErrorResponse{Errors: []string{errMsg}}))
+}
+
+func removeNewLineInString(v string) string {
+	escaped := strings.Replace(v, "\n", "", -1)
+	escaped = strings.Replace(escaped, "\r", "", -1)
+	return escaped
+}
+
+func EncodeVars(vars map[string]string) map[string]string {
+	escapedVars := make(map[string]string)
+	for k, v := range vars {
+		escapedVars[k] = removeNewLineInString(v)
+	}
+	return escapedVars
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
- https://github.com/harvester/harvester/security/code-scanning/15
- https://github.com/harvester/harvester/security/code-scanning/22

**Solution:**
- use strconv.ParseInt instead of strconv.Atoi
- remove `\n` and '\r' from user input

**Related Issue:**
https://github.com/harvester/security/issues/20

**Test plan:**
- build the latest Harvester API server.
- replace with the custom image in any v1.1.2.x cluster.
- make sure it runs correctly and contains no extra error logs.
