### PR TITLE
Mark network unreachable as retriable error

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -176,7 +176,7 @@ func (h *upgradeHandler) OnChanged(key string, upgrade *harvesterv1.Upgrade) (*h
 			Jitter:   0.1,
 		}
 		var repoInfo *RepoInfo
-		if err := retry.OnError(backoff, util.IsConnectionRefusedOrTimeout, func() error {
+		if err := retry.OnError(backoff, util.IsRetriableNetworkError, func() error {
 			repoInfo, err = repo.getInfo()
 			if err != nil {
 				logrus.Warnf("Repo info retrieval failed with: %s", err)


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The upgrade will fail at retrieving repo info with "no route to host" error occasionally.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

In the previous fix, we only retry on "timed out" and "connection refused" errors. The "network unreachable" error should also be included.

**Related Issue:**

#3444
#3550

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Deploy a Harvester cluster (single node is okay) with the fix
2. Upgrade with the same ISO image that used to install the cluster
3. The upgrade should succeed