### PR TITLE
Support Multi CSI driver

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -14,6 +14,7 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	lhv1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
@@ -909,6 +910,10 @@ func (h *RestoreHandler) mountLonghornVolumes(backup *harvesterv1.VirtualMachine
 		pvc, err := h.pvcCache.Get(pvcNamespace, pvcName)
 		if err != nil {
 			return fmt.Errorf("failed to get pvc %s/%s, error: %s", pvcNamespace, pvcName, err.Error())
+		}
+
+		if provisioner := util.GetProvisionedPVCProvisioner(pvc); provisioner != longhorntypes.LonghornDriverName {
+			continue
 		}
 
 		volume, err := h.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)

--- a/pkg/util/volume.go
+++ b/pkg/util/volume.go
@@ -1,8 +1,14 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
 )
 
 const (
@@ -21,4 +27,21 @@ func GetProvisionedPVCProvisioner(pvc *corev1.PersistentVolumeClaim) string {
 		provisioner = pvc.Annotations[AnnStorageProvisioner]
 	}
 	return provisioner
+}
+
+// LoadCSIDriverConfig loads the CSI driver configuration from settings.
+func LoadCSIDriverConfig(settingCache ctlharvesterv1.SettingCache) (map[string]settings.CSIDriverInfo, error) {
+	csiDriverConfigSetting, err := settingCache.Get(settings.CSIDriverConfigSettingName)
+	if err != nil {
+		return nil, fmt.Errorf("can't get %s setting, err: %w", settings.CSIDriverConfigSettingName, err)
+	}
+	csiDriverConfigSettingValue := csiDriverConfigSetting.Default
+	if csiDriverConfigSetting.Value != "" {
+		csiDriverConfigSettingValue = csiDriverConfigSetting.Value
+	}
+	csiDriverConfig := make(map[string]settings.CSIDriverInfo)
+	if err := json.Unmarshal([]byte(csiDriverConfigSettingValue), &csiDriverConfig); err != nil {
+		return nil, fmt.Errorf("can't parse %s setting, err: %w", settings.CSIDriverConfigSettingName, err)
+	}
+	return csiDriverConfig, nil
 }

--- a/pkg/webhook/clients/clients.go
+++ b/pkg/webhook/clients/clients.go
@@ -6,6 +6,7 @@ import (
 	ctlfleetv1 "github.com/rancher/rancher/pkg/generated/controllers/fleet.cattle.io"
 	rancherv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io"
 	"github.com/rancher/wrangler/pkg/clients"
+	corev1 "github.com/rancher/wrangler/pkg/generated/controllers/core"
 	storagev1 "github.com/rancher/wrangler/pkg/generated/controllers/storage"
 	"github.com/rancher/wrangler/pkg/schemes"
 	v1 "k8s.io/api/admissionregistration/v1"
@@ -31,6 +32,7 @@ type Clients struct {
 	LonghornFactory          *ctllonghornv1.Factory
 	ClusterFactory           *ctlclusterv1.Factory
 	RancherManagementFactory *rancherv3.Factory
+	CoreFactory              *corev1.Factory
 }
 
 func New(ctx context.Context, rest *rest.Config, threadiness int) (*Clients, error) {
@@ -112,6 +114,11 @@ func New(ctx context.Context, rest *rest.Config, threadiness int) (*Clients, err
 		return nil, err
 	}
 
+	coreFactory, err := corev1.NewFactoryFromConfigWithOptions(rest, clients.FactoryOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Clients{
 		Clients:                  *clients,
 		HarvesterFactory:         harvesterFactory,
@@ -123,5 +130,6 @@ func New(ctx context.Context, rest *rest.Config, threadiness int) (*Clients, err
 		LonghornFactory:          longhornFactory,
 		ClusterFactory:           clusterFactory,
 		RancherManagementFactory: rancherFactory,
+		CoreFactory:              coreFactory,
 	}, nil
 }

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -1,16 +1,20 @@
 package virtualmachinebackup
 
 import (
+	"encoding/json"
 	"fmt"
 
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/indexeres"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -25,11 +29,13 @@ func NewValidator(
 	vms ctlkubevirtv1.VirtualMachineCache,
 	setting ctlharvesterv1.SettingCache,
 	vmrestores ctlharvesterv1.VirtualMachineRestoreCache,
+	pvcCache ctlcorev1.PersistentVolumeClaimCache,
 ) types.Validator {
 	return &virtualMachineBackupValidator{
 		vms:        vms,
 		setting:    setting,
 		vmrestores: vmrestores,
+		pvcCache:   pvcCache,
 	}
 }
 
@@ -39,6 +45,7 @@ type virtualMachineBackupValidator struct {
 	vms        ctlkubevirtv1.VirtualMachineCache
 	setting    ctlharvesterv1.SettingCache
 	vmrestores ctlharvesterv1.VirtualMachineRestoreCache
+	pvcCache   ctlcorev1.PersistentVolumeClaimCache
 }
 
 func (v *virtualMachineBackupValidator) Resource() types.Resource {
@@ -67,8 +74,11 @@ func (v *virtualMachineBackupValidator) Create(request *types.Request, newObj ru
 	// If VMBackup is from metadata in backup target, we don't check whether the VM is existent,
 	// because the related VM may not exist in a new cluster.
 	if newVMBackup.Status == nil {
-		_, err = v.vms.Get(newVMBackup.Namespace, newVMBackup.Spec.Source.Name)
+		vm, err := v.vms.Get(newVMBackup.Namespace, newVMBackup.Spec.Source.Name)
 		if err != nil {
+			return werror.NewInvalidError(err.Error(), fieldSourceName)
+		}
+		if err = v.checkBackupVolumeSnapshotClass(vm, newVMBackup); err != nil {
 			return werror.NewInvalidError(err.Error(), fieldSourceName)
 		}
 	}
@@ -78,6 +88,61 @@ func (v *virtualMachineBackupValidator) Create(request *types.Request, newObj ru
 	}
 	if err != nil {
 		return werror.NewInvalidError(err.Error(), fieldTypeName)
+	}
+
+	return nil
+}
+
+// checkBackupVolumeSnapshotClass checks if the volumeSnapshotClassName is configured for the provisioner used by the PVCs in the VirtualMachine.
+func (v *virtualMachineBackupValidator) checkBackupVolumeSnapshotClass(vm *kubevirtv1.VirtualMachine, newVMBackup *v1beta1.VirtualMachineBackup) error {
+	// Load CSI driver configuration from settings.
+	csiDriverConfigSetting, err := v.setting.Get(settings.CSIDriverConfigSettingName)
+	if err != nil {
+		return fmt.Errorf("can't get %s setting, err: %w", settings.CSIDriverConfigSettingName, err)
+	}
+	csiDriverConfigSettingValue := csiDriverConfigSetting.Default
+	if csiDriverConfigSetting.Value != "" {
+		csiDriverConfigSettingValue = csiDriverConfigSetting.Value
+	}
+	csiDriverConfig := make(map[string]settings.CSIDriverInfo)
+	if err := json.Unmarshal([]byte(csiDriverConfigSettingValue), &csiDriverConfig); err != nil {
+		return fmt.Errorf("can't parse %s setting, err: %w", settings.CSIDriverConfigSettingName, err)
+	}
+
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvcNamespace := vm.Namespace
+		pvcName := volume.PersistentVolumeClaim.ClaimName
+
+		pvc, err := v.pvcCache.Get(pvcNamespace, pvcName)
+		if err != nil {
+			return fmt.Errorf("can't get pvc %s/%s, err: %w", pvcNamespace, pvcName, err)
+		}
+
+		// Get the provisioner used by the PVC and find its configuration in the CSI driver configuration.
+		provisioner := util.GetProvisionedPVCProvisioner(pvc)
+		c, ok := csiDriverConfig[provisioner]
+		if !ok {
+			return fmt.Errorf("provisioner %s is not configured in the csi-driver-config setting", provisioner)
+		}
+
+		// Determine which configuration value is required based on the type of backup.
+		var requiredValue string
+		switch newVMBackup.Spec.Type {
+		case v1beta1.Backup:
+			requiredValue = c.BackupVolumeSnapshotClassName
+		case v1beta1.Snapshot:
+			requiredValue = c.VolumeSnapshotClassName
+		}
+
+		// If the required value is missing, return an error.
+		if requiredValue == "" {
+			return fmt.Errorf("%s's %s is not configured for provisioner %s in the csi-driver-config setting",
+				newVMBackup.Spec.Type, "VolumeSnapshotClassName", provisioner)
+		}
 	}
 
 	return nil

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -50,6 +50,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
+			clients.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),
 		),
 		virtualmachinerestore.NewValidator(
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

1. fix bug
- If the user uses non-Longhorn storageclass to create volumes, an error will be reported during snapshot/restore of volumes. the operation here needs to determine if it is the volume of longhorn, if not, it should be skipped

2. add validation
- Add csi-driver-config setting validation when vmBackup create

**Related Issue:**
https://github.com/harvester/harvester/issues/2405

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
**Setup Base Cluster**  (You can skip this step and contact me on slack, and I can provide a clean environment for testing)

1. build a Harvester iso based include the harvester PR and the harvester-installer PR https://github.com/harvester/harvester-installer/pull/459

2. Prepare a custom Harvester config
```yaml
os:
  persistentStatePaths:
    - /var/lib/rook
  modules:
    - rbd
    - nbd
```
ceph needs the rbd module, rook will `modprobe rbd` in pod, but will fail in 1.11, it is safer to run modprobe from the host

3. Create a Harvester cluster
- use the custom iso
- use the custom Harvester config
- the cluster has two nodes
- each Harvester node has two disks

You can also try the [harvester-auto](https://github.com/futuretea/harvester-auto) project, just only send one message to slack bot:
```text
pr2c 3566 459 https://tinyurl.com/harvester-rook-config
```

**Setup Rook Ceph**

4. Install rook-ceph operator to the Harvester cluster
```bash
helm repo add rook-release https://charts.rook.io/release
helm repo update
helm upgrade --install --create-namespace --namespace rook-ceph rook-ceph rook-release/rook-ceph --version v1.11.1
kubectl -n rook-ceph wait --for=condition=Available deploy rook-ceph-operator
```

5. create rook-ceph cluster,storageclass,snapshotclass
```bash
git clone -b v1.11.1 https://github.com/rook/rook.git && cd rook/deploy/examples
kubectl apply -f ./cluster-test.yaml
kubectl apply -f ./csi/rbd/storageclass-test.yaml
kubectl apply -f ./csi/rbd/snapshotclass.yaml
watch 'kubectl --namespace rook-ceph get pods'
```
**Test**

6. Configure the Harvester `csi-driver-config` settings 
- Option 1:  use UI
change  `ui-index` settings to `https://harvester-dev.oss-cn-hangzhou.aliyuncs.com/dashboard/external-storage-class/index.html` which include the UI PR https://github.com/harvester/dashboard/pull/655 and configure the `csi-driver-config` from UI
- Option 2:  use kubectl
```bash
cat > /tmp/fix.yaml <<EOF
value: '{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"},"rook-ceph.rbd.csi.ceph.com":{"volumeSnapshotClassName":"csi-rbdplugin-snapclass","backupVolumeSnapshotClassName":"csi-rbdplugin-snapclass"}}'
EOF
kubectl -n harvester-system patch setting csi-driver-config --patch-file=/tmp/fix.yaml --type merge
```
7. Test all volume-related functions
- vm create
- vm clone
- vm backup & restore
- vm snapshot & restore
- vm live migration
- volume create
- volume clone
- volume snapshot & restore
- volume resize

8. Reboot Harvester node, All functions still work