### PR TITLE
fix(setting): rerun when there is error

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -82,11 +82,13 @@ func (h *Handler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*har
 	if toUpdate.Annotations == nil {
 		toUpdate.Annotations = make(map[string]string)
 	}
-	toUpdate.Annotations[util.AnnotationHash] = currentHash
 
 	var err error
 	if syncer, ok := syncers[setting.Name]; ok {
 		err = syncer(setting)
+		if err == nil {
+			toUpdate.Annotations[util.AnnotationHash] = currentHash
+		}
 		if updateErr := h.setConfiguredCondition(toUpdate, err); updateErr != nil {
 			return setting, updateErr
 		}


### PR DESCRIPTION
**Problem:**
When there is an error in the setting controller, it doesn't retry.

**Solution:**
Don't set the hash in the annotation if there is an error in syner.

**Related Issue:**
https://github.com/harvester/harvester/issues/3519

**Test plan:**
1. Give a wrong value to `log-level` setting, like `test`.
2. The setting controller should keep generating error logs.
