### PR TITLE
Bump kubevip to v0.5.10

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -456,7 +456,7 @@ kube-vip:
   enabled: false
   image:
     repository: ghcr.io/kube-vip/kube-vip
-    tag: v0.4.4
+    tag: v0.5.10
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
There are some CVEs in the old version. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Bump to the latest version.

We won't bump kube-vip-cloud-provider because 
- The kube-vip-cloud-provider latest version is incompatible with the version we use currently.
- We will disable the kube-vip-cloud-provider in the Harvester v1.2.0. 

**Related Issue:**
https://github.com/harvester/security/issues/19

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Regress the LB test cases of Harvester including the DHCP and IPAM modes. Detailly,
- Set up a Harvester cluster and create an RKE2 downstream cluster with the Harvester cloud provider.
- Set the VIP pool where IPs can be reachable.
- Deploy an Nginx and create the related laodbalancer type services including both DHCP and IPAM mode.
- Ping LB address.
