### PR TITLE
Format memory Quantity to Gi in version_syncer

### DIFF
--- a/pkg/controller/master/upgrade/version_syncer.go
+++ b/pkg/controller/master/upgrade/version_syncer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -138,7 +139,7 @@ func (s *versionSyncer) getExtraInfo() (map[string]string, error) {
 		memory.Add(*node.Status.Capacity.Memory())
 	}
 	extraInfo[extraInfoCPUCount] = cpu.String()
-	extraInfo[extraInfoMemorySize] = memory.String()
+	extraInfo[extraInfoMemorySize] = formatQuantityToGi(memory)
 	extraInfo[extraInfoNodeCount] = strconv.Itoa(len(nodes.Items))
 	return extraInfo, nil
 }
@@ -231,4 +232,13 @@ func canUpgrade(currentVersion string, newVersion *harvesterv1.Version) bool {
 	default:
 		return false
 	}
+}
+
+func formatQuantityToGi(q *resource.Quantity) string {
+	// 32920204Ki,
+	// q.Value(): 32920204*1024=33710288896
+	// math.Pow(1024, 3): 1024*1024*1024=1073741824
+	// float64(q.Value())/math.Pow(1024, 3): 33710288896/1073741824=31.3951530456543
+	// math.Ceil(31.3951530456543)=32
+	return fmt.Sprintf("%dGi", int64(math.Ceil(float64(q.Value())/math.Pow(1024, 3))))
 }

--- a/pkg/controller/master/upgrade/version_syncer_test.go
+++ b/pkg/controller/master/upgrade/version_syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -229,5 +230,31 @@ func TestGetUpgradableVersions(t *testing.T) {
 		}
 
 		assert.Equal(t, tc.expected, actual, "case %q", tc.name)
+	}
+}
+
+func Test_formatQuantityToGi(t *testing.T) {
+	type args struct {
+		qs string
+	}
+	testCases := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test1",
+			args: args{
+				qs: "32920204Ki",
+			},
+			want: "32Gi",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := resource.ParseQuantity(tc.args.qs)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, formatQuantityToGi(&q))
+		})
 	}
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Format memory Quantity to Gi in version_syncer

**Related Issue:**
https://github.com/harvester/security/issues/17

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
```bash
make test
```
