### PR TITLE
Bump harvester-upgrade dependencies

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -6,7 +6,8 @@ RUN zypper rm -y container-suseconnect && \
     zypper in -y curl tar gzip && zypper clean -a
 
 RUN mkdir -p /tmp/elemental_cli && \
-    curl -sfL https://github.com/rancher/elemental-cli/releases/download/v0.0.14-harvester1/elemental-v0.0.14-harvester1-Linux-x86_64.tar.gz |tar -xz -C /tmp/elemental_cli
+    curl -sfL https://github.com/rancher/elemental-cli/releases/download/v0.1.1/elemental-v0.1.1-Linux-x86_64.tar.gz | tar -xz -C /tmp/elemental_cli
+
 
 FROM registry.suse.com/bci/bci-base:15.4
 
@@ -17,11 +18,11 @@ RUN zypper rm -y container-suseconnect && \
     zypper --no-gpg-checks ref && \
     zypper in -y curl e2fsprogs rsync awk zstd jq helm && zypper clean -a
 
-ENV KUBECTL_VERSION v1.22.12
+ENV KUBECTL_VERSION v1.24.11
 RUN curl -sfL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
-RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v0.49.0/virtctl-v0.49.0-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
+RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v0.55.2/virtctl-v0.55.2-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/latest/download/wharfie-amd64  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 


### PR DESCRIPTION
**Problem:**
Bump harvester-upgrade dependencies.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- `elemental`: v0.1.1 (same as the one in the OS).
- `kubectl`: v1.24.11
- `virtctl`: v0.55.2
- `yq` should be bumped to the latest version with a new build too.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
