### PR TITLE
update harvester-longhorn sc with different chart config

### DIFF
--- a/deploy/charts/harvester/templates/harvester-storageclass.yaml
+++ b/deploy/charts/harvester/templates/harvester-storageclass.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.longhorn.enabled -}}
-apiVersion: v1
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:

--- a/deploy/charts/harvester/templates/harvester-storageclass.yaml
+++ b/deploy/charts/harvester/templates/harvester-storageclass.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.longhorn.enabled -}}
+{{- if .Values.longhorn.enabled -}}
 apiVersion: v1
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -10,10 +10,10 @@ metadata:
 {{- end }}
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
-reclaimPolicy: "{{ .Values.longhorn.persistence.reclaimPolicy }}"
+reclaimPolicy: "{{ .Values.storageClass.reclaimPolicy }}"
 volumeBindingMode: Immediate
 parameters:
-  numberOfReplicas: "{{ .Values.longhorn.persistence.defaultClassReplicaCount }}"
+  numberOfReplicas: "{{ .Values.storageClass.replicaCount }}"
   staleReplicaTimeout: "30"
   fromBackup: ""
   baseImage: ""

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -354,6 +354,8 @@ storageClass:
   ## Will be set "false" when upgrading for existing default Storage Class.
   ## defaults to "true".
   defaultStorageClass: true
+  reclaimPolicy: Delete
+  replicaCount: 3
 
 harvester-network-controller:
   ## Specify to install harvester network controller,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
From Harvester v1.1.1 we have introduced the custom default storage class `harvester-longhorn`, it uses the default configurations from the longhorn dependency chart, this will cause a problem if user want to modify the `longhorn` sc configuration. Additionally, the storageClass is immutable in k8s so it should only allow configuration during the release install.
e.g.,
```
- bundleState: ErrApplied
  message: 'cannot patch "harvester-longhorn" with kind StorageClass: StorageClass.storage.k8s.io
     "harvester-longhorn" is invalid: parameters: Forbidden: updates to parameters are forbidden.'
```

**Solution:**
- `harvester-longhorn` storage class should not use the same configuration from the longhorn dependency chart.

**Related Issue:**
https://github.com/harvester/harvester/issues/2659

**Test plan:**
1. before this change, if u modify the `longhorn` sc configuration via the harvester managedChart: 
```
$kubectl edit managedchart -n fleet-local harvester 
# add the persistence and defaultClassReplicaCount to the managedchart spec
spec:
  longhorn:
    defaultSettings:
      defaultDataPath: /var/lib/harvester/defaultdisk
      taintToleration: kubevirt.io/drain:NoSchedule
    enabled: true
    persistence: # add the persistence and defaultClassReplicaCount as below
      defaultClassReplicaCount: 2
```
its status will contain an error of:
```
 message: 'cannot patch "harvester-longhorn" with kind StorageClass: StorageClass.storage.k8s.io
 "harvester-longhorn" is invalid: parameters: Forbidden: updates to parameters
 are forbidden.'
```
2. build a new ISO including this change, and upgrade to the newer version, e.g., v1.1.2-head, then users can modify the `longhorn` storageClass replicas to custom values like 2, and the managedChart will not contain any of the above errors.
3. You can check the harvester `managedChart` via `$kubectl get managedchart -n fleet-local harvester | less`.

Note: single node upgrade will encounter another issue https://github.com/harvester/harvester/issues/3616