### PR TITLE
Add Client.Timeout exceeded to retriable list

### DIFF
--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"syscall"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +37,9 @@ func NewStillExists(qualifiedResource schema.GroupResource, name string) *apierr
 }
 
 func IsRetriableNetworkError(err error) bool {
-	if errors.Is(err, syscall.ENETDOWN) {
+	if os.IsTimeout(err) {
+		return true
+	} else if errors.Is(err, syscall.ENETDOWN) {
 		return true
 	} else if errors.Is(err, syscall.ENETUNREACH) {
 		return true


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

It's possible to encounter the following error while the controller tries to get the `harvester-release.yaml` from the repo VM.

```
Get "http://upgrade-repo-hvst-upgrade-p47zw.harvester-system/harvester-iso/harvester-release.yaml": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

`Client.Timeout` should be included in the retriable error list.

**Related Issue:**

#3550 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a single-node Harvester environment
2. Do upgrade with the same ISO image as the installed one (master build includes this PR)
3. The upgrade should succeed