### PR TITLE
fix(vmbackup): prevent users from deleting vmbackup when there is vmrestore in progress

### DIFF
--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	VMBackupBySourceUIDIndex          = "harvesterhci.io/vmbackup-by-source-uid"
-	VMRestoreByTargetNamespaceAndName = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
+	VMBackupBySourceUIDIndex            = "harvesterhci.io/vmbackup-by-source-uid"
+	VMRestoreByTargetNamespaceAndName   = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
+	VMRestoreByVMBackupNamespaceAndName = "harvesterhci.io/vmrestore-by-vmbackup-namespace-and-name"
 )
 
 func RegisterIndexers(clients *clients.Clients) {
@@ -17,6 +18,7 @@ func RegisterIndexers(clients *clients.Clients) {
 	vmRestoreCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache()
 	vmBackupCache.AddIndexer(VMBackupBySourceUIDIndex, vmBackupBySourceUID)
 	vmRestoreCache.AddIndexer(VMRestoreByTargetNamespaceAndName, vmRestoreByTargetNamespaceAndName)
+	vmRestoreCache.AddIndexer(VMRestoreByVMBackupNamespaceAndName, vmRestoreByVMBackupNamespaceAndName)
 }
 
 func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
@@ -31,4 +33,11 @@ func vmRestoreByTargetNamespaceAndName(obj *harvesterv1.VirtualMachineRestore) (
 		return []string{}, nil
 	}
 	return []string{fmt.Sprintf("%s-%s", obj.Namespace, obj.Spec.Target.Name)}, nil
+}
+
+func vmRestoreByVMBackupNamespaceAndName(obj *harvesterv1.VirtualMachineRestore) ([]string, error) {
+	if obj == nil {
+		return []string{}, nil
+	}
+	return []string{fmt.Sprintf("%s-%s", obj.Spec.VirtualMachineBackupNamespace, obj.Spec.VirtualMachineBackupName)}, nil
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -49,6 +49,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		virtualmachinebackup.NewValidator(
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 		),
 		virtualmachinerestore.NewValidator(
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),


### PR DESCRIPTION
**Problem:**
Users may delete VMBackup when there is VMRestore in progress. This makes VMRestore controller fail.

**Solution:**
Prevent users from doing it.

**Related Issue:**
https://github.com/harvester/harvester/issues/3597

**Test plan:**
1. Create a VM.
2. Take a backup.
3. Restote the backup to a new VM.
4. Beofer the new VM is done, delete the backup. Webhook should deny the request.
