### PR TITLE
fix(build): fix to 8-char commit hash

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -8,7 +8,7 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"
 fi
 
-COMMIT=$(git rev-parse --short HEAD)
+COMMIT=$(git rev-parse --short=8 HEAD)
 COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 COMMIT_BRANCH_FORMATTED=$(echo "${COMMIT_BRANCH}" | sed -E 's/[^a-zA-Z0-9]+/-/g')
 GIT_TAG=$(git tag -l --contains HEAD | head -n 1)


### PR DESCRIPTION
This can prevent the potential version and image tag inconsistency in the built artifacts

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

ISO images downloaded from `https://releases.rancher.com/harvester/master/harvester-master-amd64.iso` which was built by Drone CI `https://drone-publish.rancher.io/harvester/harvester-installer` have shorter image tag (consists of 7-char commit hash), especially for the `rancher/harvester-upgrade` image. However, Drone CI will pass a `VERSION` argument consisting of an 8-character commit hash while building container images. This causes a future upgrade to fail due to the mismatch version string and image tag.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Specify an "at least" length for the commit hash to 8-character long. Might need to bump to 12 characters in the future if there are object collisions.

**Related Issue:**

#3621

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. `git clone --branch=fix-3621 --single-branch --depth=1 https://github.com/starbops/harvester.git`
2. `make && make build-iso`
3. `isoinfo -J -i dist/artifacts/harvester-master-amd64.iso -x /bundle/harvester/images-lists/harvester-extra-master.txt`
4. The listed tags should consist of an 8-char commit hash