### PR TITLE
Cut v1.1.2-rc2

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -365,16 +365,16 @@ harvester-network-controller:
     repository: rancher/harvester-network-controller
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.3.2-rc1
+    tag: v0.3.2-rc2
   helper:
     image:
       repository: rancher/harvester-network-helper
-      tag: v0.3.2-rc1
+      tag: v0.3.2-rc2
   webhook:
     image:
       repository: rancher/harvester-network-webhook
       pullPolicy: IfNotPresent
-      tag: v0.3.2-rc1
+      tag: v0.3.2-rc2
 
 harvester-node-disk-manager:
   ## Specify to install harvester node disk manager,
@@ -388,7 +388,7 @@ harvester-node-disk-manager:
     repository: rancher/harvester-node-disk-manager
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.4.9
+    tag: v0.4.10
 
 csi-snapshotter:
   ## Specify whether to install the csi-snapshotter
@@ -452,7 +452,7 @@ harvester-load-balancer:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/harvester-load-balancer
-    tag: v0.1.3
+    tag: v0.1.4
 
 kube-vip:
   enabled: false
@@ -472,7 +472,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.18
+    tag: v0.0.19
 
 generalJob:
   image:

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,12 +10,12 @@ RUN zypper -n rm container-suseconnect && \
 
 WORKDIR /var/lib/harvester/harvester
 
-ENV HARVESTER_UI_VERSION v1.1.2-rc1
+ENV HARVESTER_UI_VERSION v1.1.2-rc2
 ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9
 
-ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION v1.1.2-rc1
+ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION v1.1.2-rc2
 
 ARG ARCH=amd64
 ARG VERSION=dev

--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,6 +1,6 @@
 versions:
-- name: v1.1.2-rc1
-  minUpgradableVersion: v1.1.0
+- name: v1.1.2-rc2
+  minUpgradableVersion: v1.1.0-0
 - name: v1.1.1
   minUpgradableVersion: v1.0.3
 - name: v1.1.0

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=v1.1
+HARVESTER_INSTALLER_VERSION=v1.1.2-rc2
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
Deps:
- harvester-network-controller: `v0.3.2-rc2`
- harvester-node-disk-manager: `v0.4.10`
- harvester-load-balancer: `v0.1.4`
- support-bundle-kit: `v0.0.19`
- GUI: v1.1.2-rc2
- Installer:v1.1.2-rc2

Upgrade matrix: support upgrade from v1.1.0 (including release candidates).