### PR TITLE
Upgrade: gracefully shutdown fleet-agent in the single node case

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -586,6 +586,13 @@ command_single_node_upgrade() {
   # Add logging related kube-audit policy file
   patch_logging_event_audit
 
+  # During the RKE2 upgrade, the kube-api server will be restarted and fleet-agent will restart.
+  # The fleet agent might not clear applying charts state in this case.
+  # We stop the agent and let it gracefully handle the clearn up.
+  echo "Scale down the fleet agent..."
+  kubectl scale --replicas=0 deployment/fleet-agent -n cattle-fleet-local-system
+  kubectl rollout status deployment fleet-agent -n cattle-fleet-local-system
+
   # Upgarde RKE2
   upgrade_rke2
   wait_rke2_upgrade

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -37,6 +37,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	machines := management.ClusterFactory.Cluster().V1alpha4().Machine()
 	secrets := management.CoreFactory.Core().V1().Secret()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
+	deployments := management.AppsFactory.Apps().V1().Deployment()
 
 	controller := &upgradeHandler{
 		ctx:               ctx,
@@ -60,6 +61,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		pvcClient:         pvcs,
 		clusterClient:     clusters,
 		clusterCache:      clusters.Cache(),
+		deploymentClient:  deployments,
 	}
 	upgrades.OnChange(ctx, upgradeControllerName, controller.OnChanged)
 	upgrades.OnRemove(ctx, upgradeControllerName, controller.OnRemove)


### PR DESCRIPTION
**Problem:**
In a single node upgrade case, fleet agent could be terminated unexpectedly due to the upgrade of kube-api server. 
This leaves managed charts (bundles) in the pending status.

**Solution:**
Bring down fleet-agent before upgrading RKE2 and enable it again when the upgrade is done.

**Related Issue:**
https://github.com/harvester/harvester/issues/3616


**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
