### PR TITLE
fix(embedded_rancher): trim spaces

### DIFF
--- a/pkg/controller/master/rancher/embedded_rancher.go
+++ b/pkg/controller/master/rancher/embedded_rancher.go
@@ -91,6 +91,9 @@ func (h *Handler) syncCACert(setting *rancherv3api.Setting) error {
 		}
 		cacert = internalCACerts.Value
 	}
+	// Trim spaces to avoid checksum error in rancher.
+	// Ref: https://github.com/rancher/rancher/blob/a841a9e101ae601a033fa8b39342ad4800c91d85/package/run.sh#L243
+	cacert = strings.TrimSpace(cacert)
 
 	caCertsCopy := setting.DeepCopy()
 	caCertsCopy.Default = cacert


### PR DESCRIPTION
**Problem:**
There are remaining spaces which may make `CA_CHECKSUM` error.

**Solution:**
Trim the remaining spaces.

**Related Issue:**
https://github.com/harvester/harvester/issues/2679

**Test plan:**
1. Create a harvester cluster.
2. Run `curl --insecure -sfL https://<vip>/v3/settings/cacerts | jq -r '.value | select(length > 0)'`. There should not have `\n` in the end of line.
