### PR TITLE
[upgrade] fix 3616 another operation is in progress

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -655,3 +655,5 @@ upgrade_monitoring
 upgrade_logging_event_audit
 apply_extra_manifests
 upgrade_addons
+# wait fleet bundles upto 90 seconds
+wait_for_fleet_bundles 9

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -37,6 +37,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	machines := management.ClusterFactory.Cluster().V1alpha4().Machine()
 	secrets := management.CoreFactory.Core().V1().Secret()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
+	deployments := management.AppsFactory.Apps().V1().Deployment()
 
 	controller := &upgradeHandler{
 		ctx:               ctx,
@@ -60,6 +61,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		pvcClient:         pvcs,
 		clusterClient:     clusters,
 		clusterCache:      clusters.Cache(),
+		deploymentClient:  deployments,
 	}
 	upgrades.OnChange(ctx, upgradeControllerName, controller.OnChanged)
 	upgrades.OnRemove(ctx, upgradeControllerName, controller.OnRemove)


### PR DESCRIPTION
      the fleet-agent takes time to apply changes to downstream objects
      restart of fleet-agent may cause data inconsistency
      wait certain time for all fleet bundles in upgrade manifest and node
      decrease the chance of hitting issue, but not fully solve it
      when issue 3616 is still there, users may helm rollback manually

     PR https://github.com/harvester/harvester/pull/3641 is merged into here, thanks @bk201 
    

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
      the `fleet-agent` takes time to apply changes to downstream objects
      in the upgrade, following issue is encountered, add this workaround to decrease the hitting chance

Harvester issue: https://github.com/harvester/harvester/issues/3616
Upstream issue: https://github.com/rancher/fleet/issues/637

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**workaround**: try to wait all bundles to be ready; scale down fleet-agent

**formal solution**: wait upstream https://github.com/rancher/fleet/issues/637

**Related Issue:**
https://github.com/harvester/harvester/issues/3616

candidate PR: https://github.com/harvester/harvester/pull/3641

**Test plan:**

<del>
manual test:
(1) `kubectl edit managedchart -n fleet-local rancher-monitoring` to set a new resource limit for grafana POD
(2) check, when the `bundle` is in `WaitApplied(1) [Cluster fleet-local/local]`, and after 10 seconds, kill the `fleet-agent` process 
(3) easily, the `bundle` is in status `ErrApplied(1) [Cluster fleet-local/local: another operation (install/upgrade/rollback) is in progress]`
![image](https://user-images.githubusercontent.com/31133476/225452794-b726895f-f76f-465d-9dcc-25129aeeec05.png)

(4) run test shell script in one machine, with kubeconfig file and helm
[gh-issue-3616-independent-run-script.txt](https://github.com/harvester/harvester/files/10984832/gh-issue-3616-independent-run-script.txt)

the log looks like:
[gh-issue-3616-helm-rollback-test-result.log](https://github.com/harvester/harvester/files/10984792/gh-issue-3616-helm-rollback-test-result.log)

(5) the bunlde is rolled-back

</del>

system test:
build-iso, run single-node upgrade from v1.1.1 to master-head, observe the upgrade log (upgrade manifest and node)

<!-- Make sure tests pass on the Circle CI. -->
single-node harvester cluster, upgrade from v1.1.1 to master-head

reference validation: https://github.com/harvester/harvester/issues/3616#issuecomment-1466104172
