### PR TITLE
fix(upgradelog): direct copy truncated log files

### DIFF
--- a/pkg/api/upgradelog/handler.go
+++ b/pkg/api/upgradelog/handler.go
@@ -41,10 +41,11 @@ cd /archive/logs
 
 for f in *.log
 do
-    cat $f | awk '{$1=$2=""; print $0}' | jq -r .message > $tmpdir/logs/$f
-	if [ $? -eq 4 ]; then
-	    echo "Incomplete JSON format log line, abort processing the file $f."
-	    continue
+	awk '{$1=$2=""; print $0}' $f | jq -r .message > $tmpdir/logs/$f || ret=$?
+	if [ -n "$ret" ]; then
+		echo "Failed to process the file $f with ret=$ret"
+		echo "Copy the original file to the destination"
+		cp $f $tmpdir/logs/$f
 	fi
 done
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

It is possible that the following happened when users want to download the upgrade log archive after the upgrade has finished. The download button keeps greying out and there's no file returned.

<img width="573" alt="image" src="https://user-images.githubusercontent.com/1827717/224903760-54b4bc68-1d0c-41d8-a737-6d8bae80c02c.png">

And from the packager's logs we can discover the packaging has some problems

![image](https://user-images.githubusercontent.com/1827717/224903471-29e45ae3-ef60-4a04-bea0-0208ccaedb43.png)

This is due to the incomplete log line at the end of that specific file, and that prevents the packager from processing the file using `jq` since it's not in a valid JSON format (truncated).

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Keep the log in its original format (JSON) and let the packaging continue when processing those kinds of files.

**Related Issue:**

#1926

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Provision a v1.1.2-rc3 single-node cluster
2. Upgrade to master-head
3. After the upgrade ended, try to download the upgrade log archive, it should succeed