### PR TITLE
Detach volumes when there is no workload or in-progress VMBackup/VMRestore

### DIFF
--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -8,14 +8,18 @@ import (
 
 	"github.com/gorilla/mux"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
+	lhv1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	"github.com/rancher/apiserver/pkg/apierror"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/pkg/generated/controllers/storage/v1"
 	"github.com/rancher/wrangler/pkg/schemas/validation"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta1"
 	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1beta1"
 	"github.com/harvester/harvester/pkg/util"
 )
@@ -23,6 +27,8 @@ import (
 type ActionHandler struct {
 	pvcs              ctlcorev1.PersistentVolumeClaimClient
 	pvcCache          ctlcorev1.PersistentVolumeClaimCache
+	volumes           ctllonghornv1.VolumeClient
+	volumeCache       ctllonghornv1.VolumeCache
 	snapshotCache     ctlsnapshotv1.VolumeSnapshotCache
 	storageClassCache ctlstoragev1.StorageClassCache
 }
@@ -124,5 +130,40 @@ func (h *ActionHandler) restore(ctx context.Context, snapshotNamespace, snapshot
 		return err
 	}
 
+	if sc.Provisioner == longhorntypes.LonghornDriverName {
+		if err = h.mountSourcePVC(volumeSnapshot); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *ActionHandler) mountSourcePVC(volumeSnapshot *snapshotv1.VolumeSnapshot) error {
+	if volumeSnapshot.Spec.Source.PersistentVolumeClaimName == nil {
+		return nil
+	}
+
+	pvc, err := h.pvcCache.Get(volumeSnapshot.Namespace, *volumeSnapshot.Spec.Source.PersistentVolumeClaimName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("can't find pvc %s/%s, err: %w", volumeSnapshot.Namespace, *volumeSnapshot.Spec.Source.PersistentVolumeClaimName, err)
+	}
+
+	volume, err := h.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
+	if err != nil {
+		return fmt.Errorf("failed to get volume %s/%s, error: %s", util.LonghornSystemNamespaceName, pvc.Spec.VolumeName, err.Error())
+	}
+
+	if volume.Status.State == lhv1beta1.VolumeStateDetached || volume.Status.State == lhv1beta1.VolumeStateDetaching {
+		volCpy := volume.DeepCopy()
+		volCpy.Spec.NodeID = volume.Status.OwnerID
+		logrus.Infof("mount detached volume %s to the node %s", volCpy.Name, volCpy.Spec.NodeID)
+		if _, err = h.volumes.Update(volCpy); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/api/volumesnapshot/schema.go
+++ b/pkg/api/volumesnapshot/schema.go
@@ -20,6 +20,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	actionHandler := ActionHandler{
 		pvcs:              scaled.CoreFactory.Core().V1().PersistentVolumeClaim(),
 		pvcCache:          scaled.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),
+		volumes:           scaled.LonghornFactory.Longhorn().V1beta1().Volume(),
+		volumeCache:       scaled.LonghornFactory.Longhorn().V1beta1().Volume().Cache(),
 		snapshotCache:     scaled.SnapshotFactory.Snapshot().V1beta1().VolumeSnapshot().Cache(),
 		storageClassCache: scaled.StorageFactory.Storage().V1().StorageClass().Cache(),
 	}

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -160,9 +160,6 @@ func (h *RestoreHandler) RestoreOnChanged(key string, restore *harvesterv1.Virtu
 	}
 
 	if isVMRestoreMissingVolumes(restore) {
-		if err := h.mountLonghornVolumes(backup); err != nil {
-			return nil, h.updateStatusError(restore, err, true)
-		}
 		return nil, h.initVolumesStatus(restore, backup)
 	}
 
@@ -345,6 +342,11 @@ func (h *RestoreHandler) reconcileResources(
 	// reconcile restoring volumes and create new PVC from CSI volumeSnapshot if not exist
 	isVolumesReady, err := h.reconcileVolumeRestores(vmRestore, backup)
 	if err != nil {
+		return nil, false, err
+	}
+
+	// mount volumes after creating PVCs, so detaching volumes controller doesn't detach the volumes
+	if err := h.mountLonghornVolumes(backup); err != nil {
 		return nil, false, err
 	}
 

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -22,6 +22,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/upgrade"
 	"github.com/harvester/harvester/pkg/controller/master/upgradelog"
 	"github.com/harvester/harvester/pkg/controller/master/virtualmachine"
+	"github.com/harvester/harvester/pkg/controller/master/volume"
 )
 
 type registerFunc func(context.Context, *config.Management, config.Options) error
@@ -47,6 +48,7 @@ var registerFuncs = []registerFunc{
 	addon.Register,
 	storagenetwork.Register,
 	nodedrain.Register,
+	volume.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/pkg/controller/master/volume/controller.go
+++ b/pkg/controller/master/volume/controller.go
@@ -1,0 +1,121 @@
+package volume
+
+import (
+	"fmt"
+	"time"
+
+	lhv1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
+	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta1"
+	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1beta1"
+	"github.com/harvester/harvester/pkg/indexeres"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	detachVolumeEnqueueInterval = 5 * time.Second
+)
+
+type Controller struct {
+	pvcCache         v1.PersistentVolumeClaimCache
+	volumes          ctllonghornv1.VolumeClient
+	volumeController ctllonghornv1.VolumeController
+	volumeCache      ctllonghornv1.VolumeCache
+	snapshotCache    ctlsnapshotv1.VolumeSnapshotCache
+}
+
+// Detach unused volumes, so attached volumes don't block node drain.
+func (c *Controller) DetachVolumesOnChange(_ string, volume *lhv1beta1.Volume) (*lhv1beta1.Volume, error) {
+	if volume == nil || volume.DeletionTimestamp != nil || volume.Status.KubernetesStatus.PVCName == "" {
+		return volume, nil
+	}
+
+	if isVolumeDetached(volume) {
+		return volume, nil
+	}
+
+	pvc, err := c.pvcCache.Get(volume.Status.KubernetesStatus.Namespace, volume.Status.KubernetesStatus.PVCName)
+	if err != nil {
+		return volume, fmt.Errorf("can't find pvc %s/%s, err: %w", volume.Status.KubernetesStatus.Namespace, volume.Status.KubernetesStatus.PVCName, err)
+	}
+	if pvc.Status.Phase == corev1.ClaimPending {
+		c.volumeController.EnqueueAfter(volume.Namespace, volume.Name, detachVolumeEnqueueInterval)
+		return volume, nil
+	}
+
+	canDetach, watchAgain, err := c.checkDetachVolume(pvc)
+	if err != nil {
+		return volume, err
+	}
+	logrus.Debugf("pvc: %s/%s, canDetach: %t, watchAgain: %t", pvc.Namespace, pvc.Name, canDetach, watchAgain)
+	if canDetach {
+		if err := c.detachVolume(pvc); err != nil {
+			return volume, err
+		}
+	}
+	if watchAgain {
+		c.volumeController.EnqueueAfter(volume.Namespace, volume.Name, detachVolumeEnqueueInterval)
+	}
+
+	return volume, nil
+}
+
+func (c *Controller) checkDetachVolume(pvc *corev1.PersistentVolumeClaim) (canDetach, watchAgain bool, err error) {
+	// 1. check whether any pod uses the PVC
+	volume, err := c.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
+	if err != nil {
+		return false, false, fmt.Errorf("can't find volume %s/%s, err: %w", util.LonghornSystemNamespaceName, pvc.Spec.VolumeName, err)
+	}
+	for _, workload := range volume.Status.KubernetesStatus.WorkloadsStatus {
+		// For running workload, we don't want to watch again
+		if workload.PodStatus == string(corev1.PodRunning) || workload.PodStatus == string(corev1.PodPending) {
+			logrus.Debugf("workload %s/%s is %s, don't detach pvc: %s/%s", volume.Status.KubernetesStatus.Namespace, workload.WorkloadName, workload.PodStatus, pvc.Namespace, pvc.Name)
+			return false, false, nil
+		}
+	}
+
+	// 2. check whether any in progress volume snapshot uses the PVC
+	volumeSnapshots, err := c.snapshotCache.GetByIndex(indexeres.VolumeSnapshotBySourcePVCIndex, fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name))
+	if err != nil {
+		return false, false, fmt.Errorf("can't get volume snapshots by index %s with pvc %s/%s, err: %w", indexeres.VolumeSnapshotBySourcePVCIndex, pvc.Namespace, pvc.Name, err)
+	}
+	for _, volumeSnapshot := range volumeSnapshots {
+		if volumeSnapshot.Status == nil || volumeSnapshot.Status.ReadyToUse == nil || !*volumeSnapshot.Status.ReadyToUse {
+			logrus.Debugf("volumeSnapshot %s/%s is in processing, don't detach pvc: %s/%s", volumeSnapshot.Namespace, volumeSnapshot.Name, pvc.Namespace, pvc.Name)
+			return false, true, nil
+		}
+
+		// 3. check whether any pending pvc's source pvc is it
+		childPVCs, err := c.pvcCache.GetByIndex(indexeres.PVCByDataSourceVolumeSnapshotIndex, fmt.Sprintf("%s/%s", volumeSnapshot.Namespace, volumeSnapshot.Name))
+		if err != nil {
+			return false, false, fmt.Errorf("can't get pvcs by index %s with volume snapshot %s/%s, err: %w", indexeres.PVCByDataSourceVolumeSnapshotIndex, volumeSnapshot.Namespace, volumeSnapshot.Name, err)
+		}
+		for _, childPVC := range childPVCs {
+			if childPVC.Status.Phase == corev1.ClaimPending {
+				logrus.Debugf("pvc %s/%s is not bound, don't detach pvc: %s/%s", childPVC.Namespace, childPVC.Name, pvc.Namespace, pvc.Name)
+				return false, true, nil
+			}
+		}
+	}
+	return true, false, nil
+}
+
+func (c *Controller) detachVolume(pvc *corev1.PersistentVolumeClaim) error {
+	volume, err := c.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
+	if err != nil {
+		return fmt.Errorf("can't find volume %s/%s, err: %w", util.LonghornSystemNamespaceName, pvc.Spec.VolumeName, err)
+	}
+
+	if volume.Status.State == lhv1beta1.VolumeStateAttached || volume.Status.State == lhv1beta1.VolumeStateAttaching {
+		volCpy := volume.DeepCopy()
+		volCpy.Spec.NodeID = ""
+		logrus.Infof("detach volume %s", volCpy.Name)
+		if _, err = c.volumes.Update(volCpy); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/master/volume/controller_test.go
+++ b/pkg/controller/master/volume/controller_test.go
@@ -1,0 +1,229 @@
+package volume
+
+import (
+	"fmt"
+	"testing"
+
+	lhv1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestHandler_DetachVolumesOnChange(t *testing.T) {
+	type input struct {
+		key    string
+		volume *lhv1beta1.Volume
+		pvcs   []*corev1.PersistentVolumeClaim
+	}
+	type output struct {
+		volume *lhv1beta1.Volume
+		err    error
+	}
+
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name:     "ignor nil resource",
+			given:    input{},
+			expected: output{},
+		},
+		{
+			name: "ignore deleted resource",
+			given: input{
+				key: "longhorn-system/test-with-deletion-timestamp",
+				volume: &lhv1beta1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: &metav1.Time{},
+					},
+				},
+			},
+			expected: output{
+				volume: &lhv1beta1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: &metav1.Time{},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "skip detached volume",
+			given: input{
+				key: "longhorn-system/test-skip-detached-volume",
+				volume: &lhv1beta1.Volume{
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateDetached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-missing-pvc",
+						},
+					},
+				},
+			},
+			expected: output{
+				volume: &lhv1beta1.Volume{
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateDetached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-missing-pvc",
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "skip detaching volume",
+			given: input{
+				key: "longhorn-system/test-skip-detaching-volume",
+				volume: &lhv1beta1.Volume{
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateDetaching,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-missing-pvc",
+						},
+					},
+				},
+			},
+			expected: output{
+				volume: &lhv1beta1.Volume{
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateDetaching,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-missing-pvc",
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "missing pvc",
+			given: input{
+				key: "longhorn-system/test-missing-pvc-volume",
+				volume: &lhv1beta1.Volume{
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateAttached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-missing-pvc",
+						},
+					},
+				},
+			},
+			expected: output{
+				volume: &lhv1beta1.Volume{
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateAttached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-missing-pvc",
+						},
+					},
+				},
+				err: fmt.Errorf("can't find pvc"),
+			},
+		},
+		{
+			name: "volume on a running pod",
+			given: input{
+				key: "longhorn-system/test-volume-on-a-running-pod",
+				volume: &lhv1beta1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "longhorn-system",
+						Name:      "test-volume-on-a-running-pod",
+					},
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateAttached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-pvc",
+							WorkloadsStatus: []lhv1beta1.WorkloadStatus{
+								{
+									PodName:   "test-pod",
+									PodStatus: "Running",
+								},
+							},
+						},
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "test-pvc",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "test-volume-on-a-running-pod",
+						},
+						Status: corev1.PersistentVolumeClaimStatus{
+							Phase: corev1.ClaimBound,
+						},
+					},
+				},
+			},
+			expected: output{
+				volume: &lhv1beta1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "longhorn-system",
+						Name:      "test-volume-on-a-running-pod",
+					},
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateAttached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-pvc",
+							WorkloadsStatus: []lhv1beta1.WorkloadStatus{
+								{
+									PodName:   "test-pod",
+									PodStatus: "Running",
+								},
+							},
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var pvcobjs []runtime.Object
+		for _, v := range tc.given.pvcs {
+			if tc.given.pvcs != nil {
+				pvcobjs = append(pvcobjs, v)
+			}
+		}
+		k8sclientset := k8sfake.NewSimpleClientset(pvcobjs...)
+
+		clientset := fake.NewSimpleClientset()
+		if tc.given.volume != nil {
+			var err = clientset.Tracker().Add(tc.given.volume)
+			assert.Nil(t, err, "mock resource should add into fake controller tracker")
+		}
+
+		var ctrl = &Controller{
+			pvcCache:    fakeclients.PersistentVolumeClaimCache(k8sclientset.CoreV1().PersistentVolumeClaims),
+			volumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta1().Volumes),
+		}
+		volume, err := ctrl.DetachVolumesOnChange(tc.given.key, tc.given.volume)
+		assert.Equal(t, tc.expected.volume, volume, "case %q", tc.name)
+		if tc.expected.err != nil {
+			assert.NotNil(t, err, "case %q", tc.name)
+		} else {
+			assert.Nil(t, err, "case %q", tc.name)
+		}
+	}
+}

--- a/pkg/controller/master/volume/register.go
+++ b/pkg/controller/master/volume/register.go
@@ -1,0 +1,32 @@
+package volume
+
+import (
+	"context"
+
+	"github.com/harvester/harvester/pkg/config"
+)
+
+const (
+	volumeControllerDetachVolume = "detach-volume-controller"
+)
+
+func Register(ctx context.Context, management *config.Management, options config.Options) error {
+	var (
+		pvcCache      = management.CoreFactory.Core().V1().PersistentVolumeClaim().Cache()
+		volumeClient  = management.LonghornFactory.Longhorn().V1beta1().Volume()
+		volumeCache   = volumeClient.Cache()
+		snapshotCache = management.SnapshotFactory.Snapshot().V1beta1().VolumeSnapshot().Cache()
+	)
+
+	// registers the volumecontroller
+	var volumeCtrl = &Controller{
+		pvcCache:         pvcCache,
+		volumes:          volumeClient,
+		volumeController: volumeClient,
+		volumeCache:      volumeCache,
+		snapshotCache:    snapshotCache,
+	}
+	volumeClient.OnChange(ctx, volumeControllerDetachVolume, volumeCtrl.DetachVolumesOnChange)
+
+	return nil
+}

--- a/pkg/controller/master/volume/util.go
+++ b/pkg/controller/master/volume/util.go
@@ -1,0 +1,9 @@
+package volume
+
+import (
+	lhv1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+)
+
+func isVolumeDetached(volume *lhv1beta1.Volume) bool {
+	return volume.Status.State == lhv1beta1.VolumeStateDetached || volume.Status.State == lhv1beta1.VolumeStateDetaching
+}


### PR DESCRIPTION
**Problem:**
When users created a backup on a shutdown VM, the upgrade controller cannot drain the node because the volume is attached on the node.

**Solution:**
If the VM is shutdown, detach volumes after taking a VM backup.

**Related Issue:**
- https://github.com/harvester/harvester/issues/3648
- https://github.com/harvester/harvester/issues/3681

**Test plan:**

### Setup: Mount volumes without a running workload or in-progress VMBackup/VMRestore.

1. Create the master-head Harvester.
2. Create `svm-backup` and `svm-snapshot` VMs.
3. Stop two VMs.
4. Take a backup on `svm-backup` and a snapshot on `svm-snapshot`.
5. VMs are not running, but their volumes are mounted.

### Case 1: Mounted volumes without a running workload or in-progress VMBackup/VMRestore will be detached.

1. Use this branch to build a new image and replace the image in `harvester/harvester` deployment.
2. Volumes from `svm-backup` and `svm-snapshot` VM will be detached.

### Case 2: The detaching volumes controller takes care of race conditions.

1. Follow Case 1.
2. Take a new backup for `svm-backup`.
3. Before the backup from the step 2 is finished. Take another backup for `svm-backup`.
4. All backups can be finished.
5. After backups are finished, volumes will be detached again because `svm-backup` is stopped.

### Case 3: Restore a new VM from a backup can work.

1. Follow Case 2.
2. Use any backup to restore the VM. Volumes from `svm-backup` will not be attached.
3. Restored VM has correct data and works fine.

### Case 4: VM snapshot and restore from the snapshot work fine

1. Create a new snapshot from `svm-snapshot`. Volumes from `svm-snapshot` will be attached.
2. After the snapshot is done, volumes from `svm-snapshot` will be detached.
3. Restore a new VM from the snapshot. Volumes from `svm-snapshot` will be attached again.
4. After the restored VM is done, volumes from `svm-snapshot` will be detached again.

### Case 5: Volume snapshot works fine

1. Create a new volume.
2. Take a snapshot for this volume. It will be attached.
3. After the snapshot is done, the volume will be detached.
4. Restore the snapshot to a new volume, the source volume will be attached again.
5. After the restored volume is done, the source volume will be detached again.