### PR TITLE
Make LH reuse data

### DIFF
--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -38,6 +38,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	secrets := management.CoreFactory.Core().V1().Secret()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
 	deployments := management.AppsFactory.Apps().V1().Deployment()
+	lhSettings := management.LonghornFactory.Longhorn().V1beta1().Setting()
 
 	controller := &upgradeHandler{
 		ctx:               ctx,
@@ -62,6 +63,8 @@ func Register(ctx context.Context, management *config.Management, options config
 		clusterClient:     clusters,
 		clusterCache:      clusters.Cache(),
 		deploymentClient:  deployments,
+		lhSettingClient:   lhSettings,
+		lhSettingCache:    lhSettings.Cache(),
 	}
 	upgrades.OnChange(ctx, upgradeControllerName, controller.OnChanged)
 	upgrades.OnRemove(ctx, upgradeControllerName, controller.OnRemove)


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The upgrade controller will extend the `replica-replenishment-wait-interval` setting to 30 mins and will revert back to the original value after the upgrade ends. By extending the value to 30 mins, the probability of reusing data of a failed replica is increased in the node upgrade scenario, thus improving the entire upgrade speed.

**Related Issue:**

#3671 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Provision a multi-node Harvester cluster using the ISO image containing the PR
2. Upgrade the cluster with the same ISO image
3. There should be a `longhorn.io/replica-replenishment-wait-interval` annotation set in the upgrade CR after the upgrade progress is entering NodeUpgrade
4. Check the Longhorn setting `replica-replenishment-wait-interval` is changed to 1800 (30 mins)
5. Wait for the upgrade ends
6. After the upgrade ends, check the Longhorn setting `replica-replenishment-wait-interval`, it should be reverted back to the original value (normally 600, the default value)