### PR TITLE
add validator webhook for harvester addon

### DIFF
--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -1,0 +1,79 @@
+package addon
+
+import (
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(addons ctlharvesterv1.AddonCache) types.Validator {
+	return &addonValidator{
+		addons: addons,
+	}
+}
+
+type addonValidator struct {
+	types.DefaultValidator
+
+	addons ctlharvesterv1.AddonCache
+}
+
+func (v *addonValidator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{v1beta1.AddonResourceName},
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   v1beta1.SchemeGroupVersion.Group,
+		APIVersion: v1beta1.SchemeGroupVersion.Version,
+		ObjectType: &v1beta1.Addon{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+// Do not allow one addon to be created twice
+func (v *addonValidator) Create(request *types.Request, newObj runtime.Object) error {
+	newAddon := newObj.(*v1beta1.Addon)
+
+	addons, err := v.addons.List(metav1.NamespaceAll, labels.Everything())
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("cannot list addons, err: %+v", err))
+	}
+
+	return validateNewAddon(newAddon, addons)
+}
+
+// Do not allow some fields to be changed, or set to non-existing values
+func (v *addonValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	newAddon := newObj.(*v1beta1.Addon)
+	oldAddon := oldObj.(*v1beta1.Addon)
+
+	return validateUpdatedAddon(newAddon, oldAddon)
+}
+
+func validateNewAddon(newAddon *v1beta1.Addon, addonList []*v1beta1.Addon) error {
+	for _, addon := range addonList {
+		if addon.Spec.Chart == newAddon.Spec.Chart {
+			return werror.NewConflict(fmt.Sprintf("addon with Chart %q has been created, cannot create a new one", addon.Spec.Chart))
+		}
+	}
+
+	return nil
+}
+
+func validateUpdatedAddon(newAddon *v1beta1.Addon, oldAddon *v1beta1.Addon) error {
+	if newAddon.Spec.Chart != oldAddon.Spec.Chart {
+		return werror.NewBadRequest("chart field cannot be changed.")
+	}
+
+	return nil
+}

--- a/pkg/webhook/resources/addon/validator_test.go
+++ b/pkg/webhook/resources/addon/validator_test.go
@@ -1,0 +1,180 @@
+package addon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	// corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+)
+
+func Test_validateUpdatedAddon(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		oldAddon      *harvesterv1.Addon
+		newAddon      *harvesterv1.Addon
+		expectedError bool
+	}{
+		{
+			name: "user can enable addon",
+			oldAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       false,
+					ValuesContent: "sample",
+				},
+			},
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "user can disable addon",
+			oldAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+			},
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       false,
+					ValuesContent: "sample",
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "user cannot change chart field",
+			oldAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+			},
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1-changed",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validateUpdatedAddon(tc.oldAddon, tc.newAddon)
+		if tc.expectedError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}
+
+func Test_validateNewAddon(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		newAddon      *harvesterv1.Addon
+		addonList     []*harvesterv1.Addon
+		expectedError bool
+	}{
+		{
+			name: "user can add new addon",
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+			},
+			addonList:     []*harvesterv1.Addon{},
+			expectedError: false,
+		},
+		{
+			name: "user cannot add same addon, no matter differences in version and repo fields",
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+			},
+			addonList: []*harvesterv1.Addon{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "addon1",
+					},
+					Spec: harvesterv1.AddonSpec{
+						Repo:          "repo1",
+						Chart:         "chart1",
+						Version:       "version1",
+						Enabled:       true,
+						ValuesContent: "sample",
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validateNewAddon(tc.newAddon, tc.addonList)
+		if tc.expectedError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/harvester/harvester/pkg/webhook/clients"
 	"github.com/harvester/harvester/pkg/webhook/config"
+	"github.com/harvester/harvester/pkg/webhook/resources/addon"
 	"github.com/harvester/harvester/pkg/webhook/resources/bundle"
 	"github.com/harvester/harvester/pkg/webhook/resources/bundledeployment"
 	"github.com/harvester/harvester/pkg/webhook/resources/keypair"
@@ -87,6 +88,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		),
 		storageclass.NewValidator(clients.StorageFactory.Storage().V1().StorageClass().Cache()),
 		namespace.NewValidator(clients.HarvesterCoreFactory.Core().V1().ResourceQuota().Cache()),
+		addon.NewValidator(clients.HarvesterFactory.Harvesterhci().V1beta1().Addon().Cache()),
 	}
 
 	router := webhook.NewRouter()


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

With the wide usage of `harvester addon`, webook is required for following scenarios.
(1) cannot create more than one instance for one addon
(2) cannot change addon field `chart`

We did not find feasible solution for below 2 checks, leave them blank now.
<del>
(3) check the existing of given chart (chart + repo + version)  (TBD)
(4) check the valuesContent is an valid yaml/json format (TBD)
</del>

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add webhook to validate addon.

**Related Issue:**
https://github.com/harvester/harvester/issues/3660

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

(1) cannot create more than one instance for one addon
```
harv31:/home/rancher # kk create -f new_addon.yam 

Error from server (Conflict): error when creating "new_addon.yam": admission webhook "validator.harvesterhci.io" denied the request: addon with Chart "harvester-vm-import-controller" has been created, cannot create a new one
```

(2) cannot change addon field `chart`
```
kk edit addons.harvesterhci.io -n harvester-system pcidevices-controller

error: addons.harvesterhci.io "pcidevices-controller" could not be patched: admission webhook "validator.harvesterhci.io" denied the request: chart field cannot be changed.
You can run `kubectl replace -f /tmp/kubectl-edit-2576031672.yaml` to try this update again.
```