### PR TITLE
Handle log archive generation error cases

### DIFF
--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_upgradelogs.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_upgradelogs.yaml
@@ -50,6 +50,8 @@ spec:
                       type: string
                     ready:
                       type: boolean
+                    reason:
+                      type: string
                     size:
                       format: int64
                       type: integer

--- a/pkg/api/upgradelog/handler.go
+++ b/pkg/api/upgradelog/handler.go
@@ -203,7 +203,7 @@ func (h Handler) generateArchive(rw http.ResponseWriter, req *http.Request) erro
 		return fmt.Errorf("failed to create log packager job for the upgradelog resource (%s/%s): %w", upgradeLogNamespace, upgradeLogName, err)
 	}
 	toUpdate := upgradeLog.DeepCopy()
-	ctlupgradelog.SetUpgradeLogArchive(toUpdate, archiveName, archiveSize, generatedTime, false)
+	ctlupgradelog.SetUpgradeLogArchive(toUpdate, archiveName, archiveSize, generatedTime)
 	if _, err := h.upgradeLogClient.Update(toUpdate); err != nil {
 		return fmt.Errorf("failed to update the upgradelog resource (%s/%s): %w", upgradeLogNamespace, upgradeLogName, err)
 	}

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -1424,7 +1424,14 @@ func schema_pkg_apis_harvesterhciio_v1beta1_Archive(ref common.ReferenceCallback
 					},
 					"ready": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
 							Format: "",
 						},
 					},

--- a/pkg/apis/harvesterhci.io/v1beta1/upgradelog.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/upgradelog.go
@@ -44,5 +44,7 @@ type Archive struct {
 	// +optional
 	GeneratedTime string `json:"generatedTime,omitempty"`
 	// +optional
-	Ready bool `json:"ready,omitempty"`
+	Ready bool `json:"ready"`
+	// +optional
+	Reason string `json:"reason,omitempty"`
 }

--- a/pkg/controller/master/upgradelog/controller.go
+++ b/pkg/controller/master/upgradelog/controller.go
@@ -474,7 +474,17 @@ func (h *handler) OnJobChange(_ string, job *batchv1.Job) (*batchv1.Job, error) 
 		if !ok {
 			return job, nil
 		}
-		if err := setUpgradeLogArchiveReady(toUpdate, archiveName, true); err != nil {
+		if err := setUpgradeLogArchiveReady(toUpdate, archiveName, true, ""); err != nil {
+			return job, err
+		}
+	}
+
+	if job.Status.Failed > 0 {
+		archiveName, ok := job.Annotations[util.AnnotationArchiveName]
+		if !ok {
+			return job, nil
+		}
+		if err := setUpgradeLogArchiveReady(toUpdate, archiveName, false, "failed to package the logs"); err != nil {
 			return job, err
 		}
 	}

--- a/pkg/controller/master/upgradelog/controller_test.go
+++ b/pkg/controller/master/upgradelog/controller_test.go
@@ -293,10 +293,10 @@ func TestHandler_OnJobChange(t *testing.T) {
 			given: input{
 				key:        testJobName,
 				job:        newTestJobBuilder().WithLabel(util.LabelUpgradeLog, testUpgradeLogName).WithAnnotation(util.AnnotationArchiveName, testArchiveName).Build(),
-				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "", false).Build(),
+				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "").Build(),
 			},
 			expected: output{
-				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "", false).Build(),
+				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "").Build(),
 			},
 		},
 		{
@@ -304,10 +304,10 @@ func TestHandler_OnJobChange(t *testing.T) {
 			given: input{
 				key:        testJobName,
 				job:        newTestJobBuilder().WithLabel(util.LabelUpgradeLog, testUpgradeLogName).WithAnnotation(util.AnnotationArchiveName, testArchiveName).Done().Build(),
-				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "", false).Build(),
+				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "").Build(),
 			},
 			expected: output{
-				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "", true).Build(),
+				upgradeLog: newTestUpgradeLogBuilder().Archive(testArchiveName, 0, "").ArchiveReady(testArchiveName, true, "").Build(),
 			},
 		},
 	}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

In the previous implementation, the `status.archives.<archive-name>.ready` will become `true` only when the log packager Job ends successfully. Sometimes things go wrong, and the Job could fail, but the upgradelog controller does not reflect the failure of generating a log archive.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The upgradelog controller will keep an eye on the log packager Job. If the Job fails eventually, it will mark the log archive as "not ready" (`status.archives.<archive-name>.ready: false`) and note down the reason (`status.archives.<archive-name>.reason`) for further reference.

**Related Issue:**

#3655 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Provision a single-node Harvester cluster with the ISO image containing this fix
2. Trigger an upgrade with the same ISO image (make sure to select the "enable logging" checkbox on the UI or create the upgrade CR with `logEnable: true`)
3. Intentionally sabotage the logging environment to make the log packager Job fail (need to take this action before the upgrade ends):

```
$ kubectl -n harvester-system exec -it hvst-upgrade-7hp7l-upgradelog-infra-fluentd-0 -c fluentd -- sh
/ $ cd /archive
/archive $ mv logs logs.bak && touch logs
```

4. Click the "Download Log" button on the upgrade dialog or execute the following command to manually generate a log archive via Harvester API

```
curl -k -X POST -u "${CATTLE_ACCESS_KEY}:${CATTLE_SECRET_KEY}" https://<harvester-vip>/v1/harvester/harvesterhci.io.upgradelogs/harvester-system/<upgradelog-name>?action=generate
```

5. After the log packager Job failed, check the UpgradeLog CR, it should record the failed log archive with a reason:

```
...
status:
  archives:
    hvst-upgrade-7hp7l-upgradelog-archive-2023-03-23T08-01-42Z:
      generatedTime: 2023-03-23T08-01-42Z
      ready: true
    hvst-upgrade-7hp7l-upgradelog-archive-2023-03-23T08-02-47Z:
      generatedTime: 2023-03-23T08-02-47Z
      ready: false
      reason: failed to package the logs
  conditions:
  - lastUpdateTime: "2023-03-23T08:01:29Z"
    status: "True"
    type: Started
  - lastUpdateTime: "2023-03-23T08:01:14Z"
    message: rancher-logging ManagedChart is ready
    reason: Skipped
    status: "True"
    type: LoggingOperatorReady
  - lastUpdateTime: "2023-03-23T08:01:29Z"
    status: "True"
    type: InfraReady
  - status: Unknown
    type: Stopped
  - lastUpdateTime: "2023-03-23T08:01:35Z"
    status: "True"
    type: DownloadReady
```