### PR TITLE
fix(upgradelog): unset log-processing return value

### DIFF
--- a/pkg/api/upgradelog/handler.go
+++ b/pkg/api/upgradelog/handler.go
@@ -46,6 +46,7 @@ do
 		echo "Failed to process the file $f with ret=$ret"
 		echo "Copy the original file to the destination"
 		cp $f $tmpdir/logs/$f
+		unset ret
 	fi
 done
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

When there's an error happened to process the log lines, every log file after the problematic log file (lexical order) will be mistakenly skipped.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Reset the return value variable at the end of each run.

**Related Issue:**

#3705

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Provision a single-node Harvester cluster with an ISO image including the fix
2. Trigger an upgrade to the same version using the same ISO image
3. `kubectl exec` into the fluentd Pod and mess up a random log file, for example, `echo "AA AA AA" >> /archive/logs/harvester-system.harvester-86bfd6897c-gjqtr.apiserver.20230323.log`
4. Click "Download Log" on the UI
5. Check the downloaded log archive, the only file in JSON format should be the file you messed up with, other files should be normal