### PR TITLE
fix: set proper ccm & csi maximum version

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -49,7 +49,7 @@ var (
 	StorageNetwork          = NewSetting(StorageNetworkName, "")
 
 	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
-	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.1.14","harvester-csi-provider":">=0.0.1 <0.1.15"}`)
+	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.2.0","harvester-csi-provider":">=0.0.1 <0.2.0"}`)
 )
 
 const (


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The current default value is invalid, as it will prevent users from successfully selecting the Harvester cloud provider when creating or modifying the RKE2 Kubernetes cluster.

**Solution:**
Update the CSI & CCM maximum supported versions (We will bump the chart minor release version if it contains a significant design change). e.g.,

| Harvester version | RKE2 with old CCM design | RKE2 with new CCM design( v0.2 - https://github.com/harvester/harvester/issues/2134) |
| -- | -- | -- |
| `>= v1.2` | Supported | Supported |
| `< v1.2` | Supported | Not Supported |


**Related Issue:**
https://github.com/harvester/harvester/issues/3404

**Test plan:**
- import an existing Harvester cluster(e.g., v1.1.2-rc3) into a Rancher server (>= v2.6.9 or v2.7)
- spin up a guest RKE2 k8s cluster(>= v1.24.10); its built-in Harvester CCM chart version is v0.1.14, and users can still select the Harvester cloud provider, but its configured `harvester-csi-ccm-versions` setting value is `"harvester-cloud-provider":">=0.0.1 <0.1.14"`.
- replace the `ui-dashboard-index` value in the Rancher global setting page - request it from @n313893254 
- you should not be able to select the `Harvester` cloud provider as the UI validation is enabled with the above modification.
- update the Harvester management chart, and patch the Harvester API server with a custom image(or patch the Harvester default setting value manually to `{"harvester-cloud-provider":">=0.0.1 <0.2.0","harvester-csi-provider":">=0.0.1 <0.2.0"}`)
- now, you should be able to select the Harvester cloud provider correctly.