### PR TITLE
Fix volume detach

### DIFF
--- a/pkg/controller/master/volume/controller_test.go
+++ b/pkg/controller/master/volume/controller_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
@@ -19,6 +20,7 @@ func TestHandler_DetachVolumesOnChange(t *testing.T) {
 	type input struct {
 		key    string
 		volume *lhv1beta1.Volume
+		vm     *kubevirtv1.VirtualMachine
 		pvcs   []*corev1.PersistentVolumeClaim
 	}
 	type output struct {
@@ -197,6 +199,83 @@ func TestHandler_DetachVolumesOnChange(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "volume on a restarting vm",
+			given: input{
+				key: "longhorn-system/test-volume-on-a-restarting-vm",
+				volume: &lhv1beta1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "longhorn-system",
+						Name:      "test-volume-on-a-restarting-vm",
+					},
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateAttached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-pvc",
+							WorkloadsStatus: []lhv1beta1.WorkloadStatus{
+								{
+									PodName:      "test-pod",
+									PodStatus:    "Succeeded",
+									WorkloadName: "test-vm",
+									WorkloadType: "VirtualMachineInstance",
+								},
+							},
+						},
+					},
+				},
+				vm: &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-vm",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						RunStrategy: &[]kubevirtv1.VirtualMachineRunStrategy{kubevirtv1.RunStrategyRerunOnFailure}[0],
+					},
+					Status: kubevirtv1.VirtualMachineStatus{
+						PrintableStatus: kubevirtv1.VirtualMachineStatusStopped,
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "test-pvc",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "test-volume-on-a-restarting-vm",
+						},
+						Status: corev1.PersistentVolumeClaimStatus{
+							Phase: corev1.ClaimBound,
+						},
+					},
+				},
+			},
+			expected: output{
+				volume: &lhv1beta1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "longhorn-system",
+						Name:      "test-volume-on-a-restarting-vm",
+					},
+					Status: lhv1beta1.VolumeStatus{
+						State: lhv1beta1.VolumeStateAttached,
+						KubernetesStatus: lhv1beta1.KubernetesStatus{
+							Namespace: "default",
+							PVCName:   "test-pvc",
+							WorkloadsStatus: []lhv1beta1.WorkloadStatus{
+								{
+									PodName:      "test-pod",
+									PodStatus:    "Succeeded",
+									WorkloadName: "test-vm",
+									WorkloadType: "VirtualMachineInstance",
+								},
+							},
+						},
+					},
+				},
+				err: nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -211,12 +290,16 @@ func TestHandler_DetachVolumesOnChange(t *testing.T) {
 		clientset := fake.NewSimpleClientset()
 		if tc.given.volume != nil {
 			var err = clientset.Tracker().Add(tc.given.volume)
-			assert.Nil(t, err, "mock resource should add into fake controller tracker")
+			assert.Nil(t, err, "mock volume should add into fake controller tracker")
 		}
-
+		if tc.given.vm != nil {
+			var err = clientset.Tracker().Add(tc.given.vm)
+			assert.Nil(t, err, "mock vm should add into fake controller tracker")
+		}
 		var ctrl = &Controller{
 			pvcCache:    fakeclients.PersistentVolumeClaimCache(k8sclientset.CoreV1().PersistentVolumeClaims),
 			volumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta1().Volumes),
+			vmCache:     fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines),
 		}
 		volume, err := ctrl.DetachVolumesOnChange(tc.given.key, tc.given.volume)
 		assert.Equal(t, tc.expected.volume, volume, "case %q", tc.name)

--- a/pkg/controller/master/volume/register.go
+++ b/pkg/controller/master/volume/register.go
@@ -16,6 +16,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		volumeClient  = management.LonghornFactory.Longhorn().V1beta1().Volume()
 		volumeCache   = volumeClient.Cache()
 		snapshotCache = management.SnapshotFactory.Snapshot().V1beta1().VolumeSnapshot().Cache()
+		vmCache       = management.VirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	)
 
 	// registers the volumecontroller
@@ -25,6 +26,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		volumeController: volumeClient,
 		volumeCache:      volumeCache,
 		snapshotCache:    snapshotCache,
+		vmCache:          vmCache,
 	}
 	volumeClient.OnChange(ctx, volumeControllerDetachVolume, volumeCtrl.DetachVolumesOnChange)
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The pod  status of the restarted VM is `Succeeded` for a moment, causing the volume controller to detach volumes attached by longhorn, resulting  volumes cannot be mounted in the NodeStageVolume stage

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
if volume's workload.WorkloadType is `VirtualMachineInstance`, add more check

**Related Issue:**
- https://github.com/harvester/harvester/issues/3648
- https://github.com/harvester/harvester/issues/3681
- https://github.com/harvester/harvester/issues/3739
- https://github.com/harvester/harvester/issues/3727
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
VMs can be restarted normally

More test refer to the test plan in https://github.com/harvester/harvester/pull/3670#issue-1628642961