### PR TITLE
fix: detach and attach volumes

### DIFF
--- a/pkg/controller/master/volume/controller_test.go
+++ b/pkg/controller/master/volume/controller_test.go
@@ -136,67 +136,6 @@ func TestHandler_DetachVolumesOnChange(t *testing.T) {
 				err: fmt.Errorf("can't find pvc"),
 			},
 		},
-		{
-			name: "volume on a running pod",
-			given: input{
-				key: "longhorn-system/test-volume-on-a-running-pod",
-				volume: &lhv1beta1.Volume{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "longhorn-system",
-						Name:      "test-volume-on-a-running-pod",
-					},
-					Status: lhv1beta1.VolumeStatus{
-						State: lhv1beta1.VolumeStateAttached,
-						KubernetesStatus: lhv1beta1.KubernetesStatus{
-							Namespace: "default",
-							PVCName:   "test-pvc",
-							WorkloadsStatus: []lhv1beta1.WorkloadStatus{
-								{
-									PodName:   "test-pod",
-									PodStatus: "Running",
-								},
-							},
-						},
-					},
-				},
-				pvcs: []*corev1.PersistentVolumeClaim{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "test-pvc",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{
-							VolumeName: "test-volume-on-a-running-pod",
-						},
-						Status: corev1.PersistentVolumeClaimStatus{
-							Phase: corev1.ClaimBound,
-						},
-					},
-				},
-			},
-			expected: output{
-				volume: &lhv1beta1.Volume{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "longhorn-system",
-						Name:      "test-volume-on-a-running-pod",
-					},
-					Status: lhv1beta1.VolumeStatus{
-						State: lhv1beta1.VolumeStateAttached,
-						KubernetesStatus: lhv1beta1.KubernetesStatus{
-							Namespace: "default",
-							PVCName:   "test-pvc",
-							WorkloadsStatus: []lhv1beta1.WorkloadStatus{
-								{
-									PodName:   "test-pod",
-									PodStatus: "Running",
-								},
-							},
-						},
-					},
-				},
-				err: nil,
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/controller/master/volume/pod_controller.go
+++ b/pkg/controller/master/volume/pod_controller.go
@@ -1,0 +1,78 @@
+package volume
+
+import (
+	"fmt"
+	"time"
+
+	lhv1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	longhorntypes "github.com/longhorn/longhorn-manager/types"
+	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
+	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	attachVolumeEnqueueInterval = 1 * time.Second
+)
+
+type PodController struct {
+	podController v1.PodController
+	pvcCache      v1.PersistentVolumeClaimCache
+	volumes       ctllonghornv1.VolumeClient
+	volumeCache   ctllonghornv1.VolumeCache
+}
+
+// Detach unused volumes, so attached volumes don't block node drain.
+func (c *PodController) AttachVolumesOnChange(_ string, pod *corev1.Pod) (*corev1.Pod, error) {
+	if pod == nil || pod.DeletionTimestamp != nil {
+		return pod, nil
+	}
+
+	// only attach volumes for pending pod
+	if pod.Status.Phase != corev1.PodPending {
+		return pod, nil
+	}
+
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvc, err := c.pvcCache.Get(pod.Namespace, volume.PersistentVolumeClaim.ClaimName)
+		if err != nil {
+			return pod, fmt.Errorf("can't find pvc %s/%s, err: %w", pod.Namespace, volume.PersistentVolumeClaim.ClaimName, err)
+		}
+		if util.GetProvisionedPVCProvisioner(pvc) != longhorntypes.LonghornDriverName {
+			continue
+		}
+		if pvc.Spec.VolumeName == "" {
+			c.podController.EnqueueAfter(pod.Namespace, pod.Name, attachVolumeEnqueueInterval)
+			break
+		}
+
+		volume, err := c.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
+		if err != nil {
+			return pod, fmt.Errorf("can't find volume %s, err: %w", pvc.Spec.VolumeName, err)
+		}
+		if isVolumeAttached(volume) {
+			continue
+		}
+		if volume.Status.State == lhv1beta1.VolumeStateDetaching {
+			c.podController.EnqueueAfter(pod.Namespace, pod.Name, attachVolumeEnqueueInterval)
+			break
+		}
+		if volume.Status.State == lhv1beta1.VolumeStateDetached && volume.Spec.NodeID != volume.Status.OwnerID {
+			logrus.Infof("Attach volume %s to node %s", volume.Name, volume.Status.OwnerID)
+			volCpy := volume.DeepCopy()
+			volCpy.Spec.NodeID = volCpy.Status.OwnerID
+			if _, err = c.volumes.Update(volCpy); err != nil {
+				return pod, fmt.Errorf("can't update volume %s, err: %w", pvc.Spec.VolumeName, err)
+			}
+		}
+	}
+
+	return pod, nil
+}

--- a/pkg/controller/master/volume/pod_controller_test.go
+++ b/pkg/controller/master/volume/pod_controller_test.go
@@ -1,0 +1,551 @@
+package volume
+
+import (
+	"fmt"
+	"testing"
+
+	lhv1beta1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestHandler_AttachVolumesOnChange(t *testing.T) {
+	type input struct {
+		key     string
+		pod     *corev1.Pod
+		pvcs    []*corev1.PersistentVolumeClaim
+		volumes []*lhv1beta1.Volume
+	}
+	type output struct {
+		pod *corev1.Pod
+		err error
+	}
+
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name:     "ignor nil resource",
+			given:    input{},
+			expected: output{},
+		},
+		{
+			name: "ignore deleted resource",
+			given: input{
+				key: "default/test-deleted-pod",
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: &metav1.Time{},
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: &metav1.Time{},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "skip running pod",
+			given: input{
+				key: "default/test-running-pod",
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "skip succeeded pod",
+			given: input{
+				key: "default/test-succeeded-pod",
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "skip failed pod",
+			given: input{
+				key: "default/test-failed-pod",
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "skip unknown pod",
+			given: input{
+				key: "default/test-unknown-pod",
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodUnknown,
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodUnknown,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "missing pvc",
+			given: input{
+				key: "default/test-missing-pvc-pod",
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-missing-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-missing-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				err: fmt.Errorf("can't get pvc"),
+			},
+		},
+		{
+			name: "non longhorn pvc",
+			given: input{
+				key: "default/test-non-longhorn-pvc-pod",
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-non-longhorn-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "test-non-longhorn-pvc",
+							Annotations: map[string]string{
+								"volume.kubernetes.io/storage-provisioner": "not-longhorn-driver",
+							},
+						},
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-non-longhorn-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "missing volume",
+			given: input{
+				key: "default/test-missing-volume-pod",
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-missing-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "test-missing-volume-pvc",
+							Annotations: map[string]string{
+								"volume.kubernetes.io/storage-provisioner": "driver.longhorn.io",
+							},
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "test-missing-volume",
+						},
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-missing-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				err: fmt.Errorf("can't find volume"),
+			},
+		},
+		{
+			name: "attaching volume",
+			given: input{
+				key: "default/test-attaching-volume-pod",
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-attaching-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "test-attaching-volume-pvc",
+							Annotations: map[string]string{
+								"volume.kubernetes.io/storage-provisioner": "driver.longhorn.io",
+							},
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "test-attaching-volume",
+						},
+					},
+				},
+				volumes: []*lhv1beta1.Volume{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "longhorn-system",
+							Name:      "test-attaching-volume",
+						},
+						Status: lhv1beta1.VolumeStatus{
+							State: lhv1beta1.VolumeStateAttaching,
+						},
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-attaching-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "attached volume",
+			given: input{
+				key: "default/test-attached-volume-pod",
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-attached-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "test-attached-volume-pvc",
+							Annotations: map[string]string{
+								"volume.kubernetes.io/storage-provisioner": "driver.longhorn.io",
+							},
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "test-attached-volume",
+						},
+					},
+				},
+				volumes: []*lhv1beta1.Volume{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "longhorn-system",
+							Name:      "test-attached-volume",
+						},
+						Status: lhv1beta1.VolumeStatus{
+							State: lhv1beta1.VolumeStateAttached,
+						},
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-attached-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "detached volume",
+			given: input{
+				key: "default/test-detached-volume-pod",
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-detached-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "test-detached-volume-pvc",
+							Annotations: map[string]string{
+								"volume.kubernetes.io/storage-provisioner": "driver.longhorn.io",
+							},
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "test-detached-volume",
+						},
+					},
+				},
+				volumes: []*lhv1beta1.Volume{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "longhorn-system",
+							Name:      "test-detached-volume",
+						},
+						Spec: lhv1beta1.VolumeSpec{
+							NodeID: "",
+						},
+						Status: lhv1beta1.VolumeStatus{
+							State:   lhv1beta1.VolumeStateDetached,
+							OwnerID: "node-1",
+						},
+					},
+				},
+			},
+			expected: output{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-detached-volume-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var objs, lhObjs []runtime.Object
+		for _, p := range tc.given.pvcs {
+			if p != nil {
+				objs = append(objs, p)
+			}
+		}
+		for _, v := range tc.given.volumes {
+			if v != nil {
+				lhObjs = append(lhObjs, v)
+			}
+		}
+		k8sclientset := k8sfake.NewSimpleClientset(objs...)
+		clientset := fake.NewSimpleClientset(lhObjs...)
+
+		var ctrl = &PodController{
+			pvcCache:    fakeclients.PersistentVolumeClaimCache(k8sclientset.CoreV1().PersistentVolumeClaims),
+			volumes:     fakeclients.LonghornVolumeClient(clientset.LonghornV1beta1().Volumes),
+			volumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta1().Volumes),
+		}
+		pod, err := ctrl.AttachVolumesOnChange(tc.given.key, tc.given.pod)
+		assert.Equal(t, tc.expected.pod, pod, "case %q", tc.name)
+		if tc.expected.err != nil {
+			assert.NotNil(t, err, "case %q", tc.name)
+		} else {
+			assert.Nil(t, err, "case %q", tc.name)
+		}
+	}
+}

--- a/pkg/controller/master/volume/util.go
+++ b/pkg/controller/master/volume/util.go
@@ -7,3 +7,7 @@ import (
 func isVolumeDetached(volume *lhv1beta1.Volume) bool {
 	return volume.Status.State == lhv1beta1.VolumeStateDetached || volume.Status.State == lhv1beta1.VolumeStateDetaching
 }
+
+func isVolumeAttached(volume *lhv1beta1.Volume) bool {
+	return volume.Status.State == lhv1beta1.VolumeStateAttached || volume.Status.State == lhv1beta1.VolumeStateAttaching
+}

--- a/pkg/util/fakeclients/longhornvolume.go
+++ b/pkg/util/fakeclients/longhornvolume.go
@@ -23,7 +23,7 @@ func (c LonghornVolumeClient) Update(volume *longhornv1.Volume) (*longhornv1.Vol
 	return c(volume.Namespace).Update(context.TODO(), volume, metav1.UpdateOptions{})
 }
 
-func (c LonghornVolumeClient) UpdateStatus(setting *longhornv1.Setting) (*longhornv1.Volume, error) {
+func (c LonghornVolumeClient) UpdateStatus(volume *longhornv1.Volume) (*longhornv1.Volume, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
**Problem:**
When a previous pod is terminated and the volume is in detaching state, starting a new pod with the volume may have error, because the volume can't be attached.  

**Solution:**
Add a controller to watch pods. If there is a pending pod, the controller tries to attach volumes.

**Related Issue:**
https://github.com/harvester/harvester/issues/3727

**Test plan:**

### Case 1: hotplug volumes

1. Create a new VM.
2. Attach a hotplug volume 1.
3. Attach another hotplug volume 2.
4. Remove the hotplug volume 1. (need to restart VM)
5. Remove the hotplug volume 2. (need to restart VM)
6. All steps work fine, and the VM can be restarted.

### Case 2: Stop and restart VM

1. Create a new VM.
2. Use CLI to watch VM's volumes.
3. Stop the VM.
4. Once VM's volumes get into detaching state, start the VM again.
5. All steps work fine, and the VM can be restarted.

All test cases in https://github.com/harvester/harvester/pull/3670

**Additional context**
Thanks @futuretea's another PR https://github.com/harvester/harvester/pull/3741 to fix #3727. We learned some experience from it and knew that if the volume is in detaching state and another new pod uses it, LH may not attach the volume correctly. This is why we add `attach-volume-controller` in this PR.