### PR TITLE
feat(setting): add rancher-manager-support

### DIFF
--- a/pkg/data/crd.go
+++ b/pkg/data/crd.go
@@ -32,6 +32,7 @@ func createCRDs(ctx context.Context, restConfig *rest.Config) error {
 			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "GroupMember", rancherv3.GroupMember{}),
 			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "Token", rancherv3.Token{}),
 			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "NodeDriver", rancherv3.NodeDriver{}),
+			crd.NonNamespacedFromGV(rancherv3.SchemeGroupVersion, "Feature", rancherv3.Feature{}),
 			crd.NonNamespacedFromGV(upgradev1.SchemeGroupVersion, "Plan", upgradev1.Plan{}),
 			crd.NonNamespacedFromGV(loggingv1.GroupVersion, "Logging", loggingv1.Logging{}),
 		).

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -47,6 +47,7 @@ var (
 	CSIDriverConfig         = NewSetting(CSIDriverConfigSettingName, `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}`)
 	ContainerdRegistry      = NewSetting(ContainerdRegistrySettingName, "")
 	StorageNetwork          = NewSetting(StorageNetworkName, "")
+	RancherManagerSupport   = NewSetting(RancherManagerSupportSettingName, "false")
 
 	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
 	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.2.0","harvester-csi-provider":">=0.0.1 <0.2.0"}`)
@@ -75,6 +76,7 @@ const (
 	ContainerdRegistrySettingName     = "containerd-registry"
 	HarvesterCSICCMSettingName        = "harvester-csi-ccm-versions"
 	StorageNetworkName                = "storage-network"
+	RancherManagerSupportSettingName  = "rancher-manager-support"
 )
 
 func init() {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -64,6 +64,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.SnapshotFactory.Snapshot().V1beta1().VolumeSnapshotClass().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
+			clients.RancherManagementFactory.Management().V3().Feature().Cache(),
 		),
 		templateversion.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate().Cache(),


### PR DESCRIPTION
**Solution:**
Add a setting to show the rancher management page.

**Related Issue:**
https://github.com/harvester/harvester/issues/2679

**Test plan:**

### Setup

1. Create a harvester cluster.
2. Update `status.dynamic` in `multi-cluster-management` feature to `true`.

### Case 1: `rancher-manager-support` can't be enabled if `mcm-cluster-management` is disabled.

1. Change `rancher-manager-support` setting to `true`. We should get an error.

### Case 2: `rancher-manager-support` can be enabled/disabled if `mcm-cluster-management` is enabled.

1. Update `multi-cluster-management=true` in `cattle-system/rancher` deployment.
2. Change `rancher-manager-support` setting to `true`. We should not get any error.
3. Change `rancher-manager-support` setting to `false`. We should not get any error.

### Case 3: Only `true` and `false` are valid values

1. Change `rancher-manager-support` setting to `test`. We should get an error.