### PR TITLE
feat(setting): sync harvester rancher setting

### DIFF
--- a/pkg/controller/master/setting/harvester_rancher_sync.go
+++ b/pkg/controller/master/setting/harvester_rancher_sync.go
@@ -1,0 +1,58 @@
+package setting
+
+import (
+	"reflect"
+
+	ranchersettings "github.com/rancher/rancher/pkg/settings"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+)
+
+func (h *Handler) syncHarvesterToRancher(setting *harvesterv1.Setting) error {
+	switch setting.Name {
+	case settings.UIIndexSettingName:
+		return h.copyHarvesterToRancher(setting, ranchersettings.UIIndex.Name)
+	case settings.UISourceSettingName:
+		return h.copyUISourceToRancher(setting)
+	}
+	return nil
+}
+
+func (h *Handler) copyHarvesterToRancher(setting *harvesterv1.Setting, rancherSettingName string) error {
+	rancherSetting, err := h.rancherSettingCache.Get(rancherSettingName)
+	if err != nil {
+		return err
+	}
+
+	rancherSettingCopy := rancherSetting.DeepCopy()
+	rancherSettingCopy.Value = setting.Value
+	if !reflect.DeepEqual(rancherSetting, rancherSettingCopy) {
+		_, err = h.rancherSettings.Update(rancherSettingCopy)
+	}
+	return err
+}
+
+func (h *Handler) copyUISourceToRancher(setting *harvesterv1.Setting) error {
+	rancherSetting, err := h.rancherSettingCache.Get(ranchersettings.UIOfflinePreferred.Name)
+	if err != nil {
+		return err
+	}
+
+	rancherSettingCopy := rancherSetting.DeepCopy()
+	switch setting.Value {
+	case "external":
+		rancherSettingCopy.Value = "false"
+	case "bundled":
+		rancherSettingCopy.Value = "true"
+	case "auto":
+		rancherSettingCopy.Value = "dynamic"
+	case "":
+		rancherSettingCopy.Value = ""
+	}
+
+	if !reflect.DeepEqual(rancherSetting, rancherSettingCopy) {
+		_, err = h.rancherSettings.Update(rancherSettingCopy)
+	}
+	return err
+}

--- a/pkg/controller/master/setting/harvester_rancher_sync.go
+++ b/pkg/controller/master/setting/harvester_rancher_sync.go
@@ -12,7 +12,7 @@ import (
 func (h *Handler) syncHarvesterToRancher(setting *harvesterv1.Setting) error {
 	switch setting.Name {
 	case settings.UIIndexSettingName:
-		return h.copyHarvesterToRancher(setting, ranchersettings.UIIndex.Name)
+		return h.copyHarvesterToRancher(setting, ranchersettings.UIDashboardIndex.Name)
 	case settings.UISourceSettingName:
 		return h.copyUISourceToRancher(setting)
 	}

--- a/pkg/controller/master/setting/rancher_harvester_sync.go
+++ b/pkg/controller/master/setting/rancher_harvester_sync.go
@@ -16,7 +16,7 @@ func (h *Handler) rancherSettingOnChange(_ string, rancherSetting *mgmtv3.Settin
 
 	var err error
 	switch rancherSetting.Name {
-	case ranchersettings.UIIndex.Name:
+	case ranchersettings.UIDashboardIndex.Name:
 		err = h.copyRancherToHarvester(rancherSetting, settings.UIIndexSettingName)
 	case ranchersettings.UIOfflinePreferred.Name:
 		err = h.copyUIOfflinePreferredToHarvester(rancherSetting)

--- a/pkg/controller/master/setting/rancher_harvester_sync.go
+++ b/pkg/controller/master/setting/rancher_harvester_sync.go
@@ -1,0 +1,63 @@
+package setting
+
+import (
+	"reflect"
+
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	ranchersettings "github.com/rancher/rancher/pkg/settings"
+
+	"github.com/harvester/harvester/pkg/settings"
+)
+
+func (h *Handler) rancherSettingOnChange(_ string, rancherSetting *mgmtv3.Setting) (*mgmtv3.Setting, error) {
+	if rancherSetting == nil || rancherSetting.DeletionTimestamp != nil {
+		return rancherSetting, nil
+	}
+
+	var err error
+	switch rancherSetting.Name {
+	case ranchersettings.UIIndex.Name:
+		err = h.copyRancherToHarvester(rancherSetting, settings.UIIndexSettingName)
+	case ranchersettings.UIOfflinePreferred.Name:
+		err = h.copyUIOfflinePreferredToHarvester(rancherSetting)
+	}
+	return rancherSetting, err
+}
+
+func (h *Handler) copyRancherToHarvester(rancherSetting *mgmtv3.Setting, harvesterSettingName string) error {
+	harvesterSetting, err := h.settingCache.Get(harvesterSettingName)
+	if err != nil {
+		return err
+	}
+
+	harvesterSettingCopy := harvesterSetting.DeepCopy()
+	harvesterSettingCopy.Value = rancherSetting.Value
+	if !reflect.DeepEqual(harvesterSetting, harvesterSettingCopy) {
+		_, err = h.settings.Update(harvesterSettingCopy)
+	}
+	return err
+}
+
+func (h *Handler) copyUIOfflinePreferredToHarvester(rancherSetting *mgmtv3.Setting) error {
+	harvesterSetting, err := h.settingCache.Get(settings.UISourceSettingName)
+	if err != nil {
+		return err
+	}
+
+	harvesterSettingCopy := harvesterSetting.DeepCopy()
+	switch rancherSetting.Value {
+	case "dynamic":
+		harvesterSettingCopy.Value = "auto"
+	case "false":
+		harvesterSettingCopy.Value = "external"
+	case "true":
+		harvesterSettingCopy.Value = "bundled"
+	case "":
+		harvesterSettingCopy.Value = ""
+	}
+
+	if !reflect.DeepEqual(harvesterSetting, harvesterSettingCopy) {
+		_, err = h.settings.Update(harvesterSettingCopy)
+	}
+	return err
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -24,6 +24,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	managedCharts := management.RancherManagementFactory.Management().V3().ManagedChart()
 	ingresses := management.NetworkingFactory.Networking().V1().Ingress()
 	helmChartConfigs := management.HelmFactory.Helm().V1().HelmChartConfig()
+	rancherSettings := management.RancherManagementFactory.Management().V3().Setting()
 	controller := &Handler{
 		namespace:            options.Namespace,
 		apply:                management.Apply,
@@ -46,6 +47,8 @@ func Register(ctx context.Context, management *config.Management, options config
 		managedChartCache:    managedCharts.Cache(),
 		helmChartConfigs:     helmChartConfigs,
 		helmChartConfigCache: helmChartConfigs.Cache(),
+		rancherSettings:      rancherSettings,
+		rancherSettingCache:  rancherSettings.Cache(),
 		httpClient: http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -74,5 +77,6 @@ func Register(ctx context.Context, management *config.Management, options config
 
 	settings.OnChange(ctx, controllerName, controller.settingOnChanged)
 	apps.OnChange(ctx, controllerName, controller.appOnChanged)
+	rancherSettings.OnChange(ctx, controllerName, controller.rancherSettingOnChange)
 	return nil
 }


### PR DESCRIPTION
**Problem:**
Users can modify some settings on both Rancher and Harvester sides. We would like to sync this kind of setting between the two systems.

**Solution:**
Add a sync controller for it.

**Related Issue:**
https://github.com/harvester/harvester/issues/2679

**Test plan:**

### Case 1: Harvester `ui-index` maps to Rancher `ui-dashboard-index`

1. Change Harvester `ui-index`. Rancher `ui-dashboard-index` should also be changed.
2. Set default to Rancher `ui-dashboard-index`. Harvester `ui-index` should also be set to the default value.

### Case 2: Harvester `ui-source` maps to Rancher `ui-offline-preferred`

1. Update values on both sides and we can see the mapping between them.

Auto -> Dynamic
External -> Remote
Bundled -> Local