### PR TITLE
Add ignore harvester patch diff of default sc

### DIFF
--- a/package/upgrade/migrations/managed_charts/v1.1.0.sh
+++ b/package/upgrade/migrations/managed_charts/v1.1.0.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_harvester_ignore_default_sc()
+{
+	# add ignoring resources when upgrading to match the pr (https://github.com/harvester/harvester-installer/pull/481)
+	yq e '.spec.diff.comparePatches += [{"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass", "name": "harvester-longhorn", "jsonPointers":["/metadata/annotations"]}]' $CHART_MANIFEST -i
+}
+
+case $CHART_NAME in
+  harvester)
+    patch_harvester_ignore_default_sc
+    ;;
+esac

--- a/package/upgrade/migrations/managed_charts/v1.1.1.sh
+++ b/package/upgrade/migrations/managed_charts/v1.1.1.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_harvester_ignore_default_sc()
+{
+	# add ignoring resources when upgrading to match the pr (https://github.com/harvester/harvester-installer/pull/481)
+	yq e '.spec.diff.comparePatches += [{"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass", "name": "harvester-longhorn", "jsonPointers":["/metadata/annotations"]}]' $CHART_MANIFEST -i
+}
+
+case $CHART_NAME in
+  harvester)
+    patch_harvester_ignore_default_sc
+    ;;
+esac


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The `mcc-harvester` bundle CR will contain an errApplied status after setting a different default storageClass.

**Solution:**
Ignore the patch diff since Harvester is allowing users to config different default storageClass.

**Related Issue:**
https://github.com/harvester/harvester/issues/3802

**Test plan(upgrade):**
- config a new default storage class other than `harvester-longhorn`
- upgrade harvester from the previous version like v1.1.1 to the latest `v1.1.2-head` ISO
- check the bundle status of the `mcc-harvester` later, it should not contain any errors like below:
- config another new storage class and set it as the default one, check the bundle status again.
```
ks get bundles -n fleet-local
NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
fleet-agent-local                             1/1
local-managed-system-agent                    1/1
mcc-harvester                                 0/1                       ErrApplied(1) [Cluster fleet-local/local: cannot patch "harvester-longhorn" with kind StorageClass: admission webhook "validator.harvesterhci.io" denied the request: default storage class %!s(MISSING) already exists, please reset it first]; storageclass.storage.k8s.io harvester-longhorn modified {"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}
mcc-harvester-crd                             1/1
mcc-local-managed-system-upgrade-controller   1/1
mcc-rancher-logging                           1/1
mcc-rancher-logging-crd                       1/1
mcc-rancher-monitoring                        1/1
mcc-rancher-monitoring-crd                    1/1
```

