### PR TITLE
fix patchAffinity

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -330,13 +330,14 @@ func makeAffinityFromVMTemplate(template *kubevirtv1.VirtualMachineInstanceTempl
 	// clear node selector terms whose key contains the prefix "network.harvesterhci.io"
 	nodeSelectorTerms := make([]v1.NodeSelectorTerm, 0, len(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms))
 	for _, term := range affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
-		isNetworkAffinity := false
+		expressions := make([]v1.NodeSelectorRequirement, 0, len(term.MatchExpressions))
 		for _, expression := range term.MatchExpressions {
-			if strings.Contains(expression.String(), networkGroup) {
-				isNetworkAffinity = true
+			if !strings.HasPrefix(expression.Key, networkGroup) {
+				expressions = append(expressions, expression)
 			}
 		}
-		if !isNetworkAffinity {
+		if len(expressions) != 0 {
+			term.MatchExpressions = expressions
 			nodeSelectorTerms = append(nodeSelectorTerms, term)
 		}
 	}

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -294,6 +294,48 @@ func TestPatchAffinity(t *testing.T) {
 		},
 	}
 
+	vm5 := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      fmt.Sprintf("%s/%s", networkGroup, "mgmt"),
+												Operator: v1.NodeSelectorOpIn,
+												Values:   []string{"true"},
+											},
+											{
+												Key:      "just.for.testing",
+												Operator: v1.NodeSelectorOpIn,
+												Values:   []string{"true"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "default",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/net1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	net1 := &cniv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "net1",
@@ -393,6 +435,31 @@ func TestPatchAffinity(t *testing.T) {
 			name:     "emptyAffinity",
 			vm:       vm4,
 			affinity: &v1.Affinity{},
+		},
+		{
+			name: "supportMultiExpressions",
+			vm:   vm5,
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "just.for.testing",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								},
+								{
+									Key:      fmt.Sprintf("%s/%s", networkGroup, "mgmt"),
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								},
+							},
+						},
+					},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
user create a vm:
```go
	vm := &kubevirtv1.VirtualMachine{
		Spec: kubevirtv1.VirtualMachineSpec{
			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
				ObjectMeta: metav1.ObjectMeta{},
				Spec: kubevirtv1.VirtualMachineInstanceSpec{
					Affinity: &v1.Affinity{
						NodeAffinity: &v1.NodeAffinity{
							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
								NodeSelectorTerms: []v1.NodeSelectorTerm{
									{
										MatchExpressions: []v1.NodeSelectorRequirement{
											{
												Key:      "just.for.testing",
												Operator: v1.NodeSelectorOpIn,
												Values:   []string{"true"},
											},
										},
									},
								},
							},
						},
					},
					Networks: []kubevirtv1.Network{
						{
							Name: "default",
							NetworkSource: kubevirtv1.NetworkSource{
								Multus: &kubevirtv1.MultusNetwork{
									NetworkName: "default/net1",
								},
							},
						},
					},
				},
			},
		},
	}
```
after mutate, result:
```go
&v1.Affinity{
				NodeAffinity: &v1.NodeAffinity{
					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
						{
							MatchExpressions: []v1.NodeSelectorRequirement{
								{
									Key:      "just.for.testing",
									Operator: v1.NodeSelectorOpIn,
									Values:   []string{"true"},
								},
								{
									Key:      fmt.Sprintf("%s/%s", networkGroup, "mgmt"),
									Operator: v1.NodeSelectorOpIn,
									Values:   []string{"true"},
								},
							},
						},
					},
					},
				},
			}
```
This result in current logic will be mutated again, result:
```go
&v1.Affinity{
				NodeAffinity: &v1.NodeAffinity{
					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
						{
							MatchExpressions: []v1.NodeSelectorRequirement{
								{
									Key:      fmt.Sprintf("%s/%s", networkGroup, "mgmt"),
									Operator: v1.NodeSelectorOpIn,
									Values:   []string{"true"},
								},
							},
						},
					},
					},
				},
			}
```
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
fix the logic in patchAffinity

**Related Issue:**
https://github.com/harvester/harvester/issues/3816

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Create a vm with mgmt network and add a vm affinity rule `topology.kubernetes.io/zone` `In` `zone1`

![image](https://user-images.githubusercontent.com/15064560/233761317-e2d148e9-f17f-4fb3-bb7f-b10896024db6.png)
![1682136255386](https://user-images.githubusercontent.com/15064560/233761347-faaeab62-e37d-46a6-9b65-5cceeeb2effb.png)

- The created vm's yaml contains the vm affinity rule