### PR TITLE
Added elemental base image and rsync.

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,5 @@
 FROM quay.io/costoolkit/releases-green:luet-toolchain-0.21.2 as luet
-FROM quay.io/costoolkit/releases-green:luet-makeiso-toolchain-0.4.0 as makeiso
+FROM quay.io/costoolkit/elemental-cli:v0.2.5 as elemental
 
 FROM golang:1.18.3-buster
 
@@ -34,6 +34,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         gnupg \
+        rsync \
     && rm -rf /var/lib/apt/lists/*; \
     \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - >/dev/null; \
@@ -63,9 +64,9 @@ RUN curl -Lo /usr/bin/kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64 
 # install codecov
 RUN curl -Lo /usr/bin/codecov https://uploader.codecov.io/latest/linux/codecov && chmod +x /usr/bin/codecov
 
-# luet & makeiso
+# luet & elemental
 COPY --from=luet /usr/bin/luet /usr/bin/luet
-COPY --from=makeiso /usr/bin/luet-makeiso /usr/bin/luet-makeiso
+COPY --from=elemental /usr/bin/elemental /usr/bin/elemental
 
 # -- for make rules
 

--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -211,6 +212,13 @@ func (r *Repo) createVM(image *harvesterv1.VirtualMachineImage) (*kubevirtv1.Vir
 							Cores:   1,
 							Sockets: 1,
 							Threads: 1,
+						},
+						Firmware: &kubevirtv1.Firmware{
+							Bootloader: &kubevirtv1.Bootloader{
+								EFI: &kubevirtv1.EFI{
+									SecureBoot: pointer.Bool(false),
+								},
+							},
 						},
 						Devices: kubevirtv1.Devices{
 							Disks: []kubevirtv1.Disk{


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
We need to migrate from `luet-makeiso` to `elemental build-iso`.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add `elemental` base image for elemental binary and `rsync` package for elemental `build-iso` command execution.

**Related Issue:**
https://github.com/harvester/harvester/issues/2204

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Boot:
1. Build an ISO from `elemental-build` branch (both `harvester` and `harvester-installer` repo);
2. Try to boot up using this ISO in UEFI environment, it should boot up without problem;
3. Try to boot up using this ISO in legacy BIOS environment too.

Upgrade:
1. Build an ISO from `elemental-build` branch (both `harvester` and `harvester-installer` repo);
2. Install a clean environment using v1.1.2;
3. Create a http server to serve the ISO file;
4. Create a version object in Harvester and let Harvester upgrade to the ISO just built;
5. Check if Harvester upgraded successfully.

**Additional Information:**
We might need to create another issue to add legacy BIOS boot capability if it's necessary.
