### PR TITLE
feat(lh): add priority-class

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -420,6 +420,7 @@ longhorn:
   defaultSettings:
     ## Specify the concurrent automatic engine upgrade per node limit
     concurrentAutomaticEngineUpgradePerNodeLimit: 3
+    priorityClass: system-cluster-critical
 
 rancherEmbedded: false
 


### PR DESCRIPTION
**Solution:**
Add priority-class to LH workload.

**Related Issue:**
https://github.com/harvester/harvester/issues/3756

**Test plan:**

**Case 1: New cluster**
1. Create a cluster from this branch.
2. Check whether LH workloads have priority-class.

**Case 2: Old cluster**
1. Create a cluster with an older version like `v1.1.2`.
2. Upgrade the cluster to this branch.
3. LH workloads don't have priority-class if there is any attached volume.
4. Stop workloads that use volumes.
5. All LH pods restart.
6. Recheck LH workloads. They have priority-class now.
