### PR TITLE
feat(upgrade): add v1.1.2 pre-hook

### DIFF
--- a/package/upgrade/migrations/upgrade_manifests/v1.1.2/pre-hook.sh
+++ b/package/upgrade/migrations/upgrade_manifests/v1.1.2/pre-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+echo "Set multi-cluster-management feature as dynamic"
+kubectl patch feature multi-cluster-management --type merge --patch  '{"status": {"dynamic": true}}'


### PR DESCRIPTION
**Problem:**
In old clusters, the `status.dynamic` of the `multi-cluster-management` feature is `false`, so we can't change the feature's value.

**Solution:**
Set `status.dynamic` to `true`, so we can update the value of the `multi-cluster-management` feature to `true` in the new version.

**Related Issue:**
https://github.com/harvester/harvester/issues/2679

**Test plan:**

1. Install a v1.1.2 cluster.
2. Upgrade the cluster to the version of this branch.
3. Check whether the `status.dynamic` of the `multi-cluster-management` feature is `true`.
