### PR TITLE
feat(feature): add lockedValue

### DIFF
--- a/pkg/controller/master/rancher/feature.go
+++ b/pkg/controller/master/rancher/feature.go
@@ -1,0 +1,42 @@
+package rancher
+
+import (
+	"reflect"
+
+	rancherv3api "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+)
+
+var lockedFeatures = map[string]bool{
+	"harvester":                true,
+	"rke2":                     true,
+	"multi-cluster-management": true,
+}
+
+// RancherFeatureOnChange updates the lockedValue of some required features to prevent users from changing them.
+func (h *Handler) RancherFeatureOnChange(key string, feature *rancherv3api.Feature) (*rancherv3api.Feature, error) {
+	if feature == nil || feature.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	if lockedValue, ok := lockedFeatures[feature.Name]; ok {
+		var featureValue bool
+		if feature.Spec.Value == nil {
+			featureValue = feature.Status.Default
+		} else {
+			featureValue = *feature.Spec.Value
+		}
+
+		// Don't change lockedValue when it's not equal to current value.
+		if featureValue != lockedValue {
+			return feature, nil
+		}
+
+		featureCopy := feature.DeepCopy()
+		featureCopy.Status.LockedValue = &lockedValue
+		if !reflect.DeepEqual(feature, featureCopy) {
+			return h.RancherFeatures.Update(featureCopy)
+		}
+	}
+
+	return feature, nil
+}

--- a/pkg/controller/master/rancher/register.go
+++ b/pkg/controller/master/rancher/register.go
@@ -40,6 +40,8 @@ type Handler struct {
 	RancherSettingCache      rancherv3.SettingCache
 	RancherSettingController rancherv3.SettingController
 	RancherUserCache         rancherv3.UserCache
+	RancherFeatures          rancherv3.FeatureClient
+	RancherFeatureCache      rancherv3.FeatureCache
 	ingresses                networkingv1.IngressClient
 	Services                 ctlcorev1.ServiceClient
 	Configmaps               ctlcorev1.ConfigMapClient
@@ -63,6 +65,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	if options.RancherEmbedded {
 		rancherSettings := management.RancherManagementFactory.Management().V3().Setting()
 		rancherUsers := management.RancherManagementFactory.Management().V3().User()
+		rancherFeatures := management.RancherManagementFactory.Management().V3().Feature()
 		ingresses := management.NetworkingFactory.Networking().V1().Ingress()
 		secrets := management.CoreFactory.Core().V1().Secret()
 		services := management.CoreFactory.Core().V1().Service()
@@ -74,6 +77,8 @@ func Register(ctx context.Context, management *config.Management, options config
 			RancherSettingController: rancherSettings,
 			RancherSettingCache:      rancherSettings.Cache(),
 			RancherUserCache:         rancherUsers.Cache(),
+			RancherFeatures:          rancherFeatures,
+			RancherFeatureCache:      rancherFeatures.Cache(),
 			ingresses:                ingresses,
 			Services:                 services,
 			Configmaps:               configmaps,
@@ -86,6 +91,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		nodes.OnChange(ctx, controllerRancherName, h.PodResourcesOnChanged)
 		rancherSettings.OnChange(ctx, controllerRancherName, h.RancherSettingOnChange)
 		secrets.OnChange(ctx, controllerRancherName, h.TLSSecretOnChange)
+		rancherFeatures.OnChange(ctx, controllerRancherName, h.RancherFeatureOnChange)
 		if err := h.registerExposeService(); err != nil {
 			return err
 		}


### PR DESCRIPTION
**Solution:**
Add `lockedValue` to prevent users from changing Rancher features.

**Related Issue:**
https://github.com/harvester/harvester/issues/2679

**Test plan:**

1. Install a new harvester cluster.
2. Check whether the `status.lockedValue` of `harvester`, `rke2`, and `multi-cluster-management` features is `true`.
