### PR TITLE
fix project-member cannot list volumesnapshot

### DIFF
--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -47,6 +47,13 @@ rules:
       - network-attachment-definitions
     verbs:
       - '*'
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+      - volumesnapshotcontents
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -83,6 +90,15 @@ rules:
       - ""
     resources:
       - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+      - volumesnapshotcontents
     verbs:
       - get
       - list


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
When a project member accesses the resources in a namespace under a project, the permissions are from `ClusterRole/project-member` and `ClusterRole/edit`.

Neither has permission to volumesnapshots.

**Solution:**
Add volumesnapshots permissions to `ClusterRole/harvesterhci.io:edit`
The `ClusterRole/harvesterhci.io:edit` will be aggregated to `ClusterRole/edit`

```bash
# kubectl get ClusterRole edit -ojson | jq -r '.aggregationRule'
{
  "clusterRoleSelectors": [
    {
      "matchLabels": {
        "rbac.authorization.k8s.io/aggregate-to-edit": "true"
      }
    }
  ]
}
# kubectl get ClusterRole -l rbac.authorization.k8s.io/aggregate-to-edit=true
NAME                                           CREATED AT
harvesterhci.io:edit                           2023-05-05T13:58:36Z
kubevirt.io:edit                               2023-05-05T13:59:44Z
system:aggregate-to-edit                       2023-05-05T13:55:10Z
system:rke2-metrics-server-aggregated-reader   2023-05-05T13:55:43Z
view
```

**Related Issue:**
https://github.com/harvester/harvester/issues/3023

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

- Install Rancher
- Import Harvester
- Go to the Harvester cluster from `Virtualization Management`
- Create a project `test`, and add a project member for the project `test`
- Log in as the project member, create a namespace `test`
- Go to the Volume page and create a volume
- Volume created successfully
- ~Click the right menu "Take Snapshot"~ (There seems to be a bug in the UI, we can not see the created volume)
- Take a snapshot by `snapshot` action from `View API`
- Go to the volume snapshot page and check