### PR TITLE
Check volume's real state before adding it to running VM

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -18,6 +18,7 @@ import (
 	wranglername "github.com/rancher/wrangler/pkg/name"
 	"github.com/rancher/wrangler/pkg/schemas/validation"
 	"github.com/rancher/wrangler/pkg/slice"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -857,7 +858,8 @@ func (h *vmActionHandler) checkAttachable(pvc *corev1.PersistentVolumeClaim) err
 	}
 
 	if sc.VolumeBindingMode == nil {
-		return fmt.Errorf("volme %v not specify VolumeBindingMode is not permitted", pvc.Name)
+		logrus.Infof("volme %v not specify VolumeBindingMode", pvc.Name)
+		return nil
 	}
 
 	if *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -45,6 +45,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	settings := scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	nodes := scaled.CoreFactory.Core().V1().Node()
 	pvcs := scaled.CoreFactory.Core().V1().PersistentVolumeClaim()
+	pvs := scaled.CoreFactory.Core().V1().PersistentVolume()
 	secrets := scaled.CoreFactory.Core().V1().Secret()
 	vmt := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate()
 	vmtv := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion()
@@ -81,6 +82,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		nadCache:                  nads.Cache(),
 		nodeCache:                 nodes.Cache(),
 		pvcCache:                  pvcs.Cache(),
+		pvCache:                   pvs.Cache(),
 		secretClient:              secrets,
 		secretCache:               secrets.Cache(),
 		virtSubresourceRestClient: virtSubresourceClient,


### PR DESCRIPTION
**Problem:**
Since LH volume creation and replica scheduling are asynchronous. Even if CreateVolume CSI call success, the replica scheduling still may fail. In such a circumstance, the volume is impossible to be mounted.

**Solution:**
Up-to-date Longhorn supports **[updating PV annotation according to volume schedule condition](https://github.com/longhorn/longhorn-manager/pull/1307)**, we could check if there is replica scheduling error for an LH volume, and prohibit it from being added to the running VM if need

**Related Issue:**
#1931 

**Test plan:**
1. Creating an oversize volume
2. Checking the volume has "insufficient storage" condition ![Screenshot_oversize_vol](https://user-images.githubusercontent.com/19387129/236768581-1ef048a6-7de9-489a-a409-ba6d158ea642.png)
3. Creating a running VM
4. Adding the oversize volume to the running VM
5. The oversize volume should be prohibited to be added ![Screenshot_insufficient_storage](https://user-images.githubusercontent.com/19387129/236769070-7024e4c0-55ee-4e3e-bd5d-5a9a166bba1c.png)

