### PR TITLE
List VM's with cdrom and container disks during maintenance mode 

### DIFF
--- a/pkg/api/node/formatter_test.go
+++ b/pkg/api/node/formatter_test.go
@@ -345,8 +345,8 @@ func Test_listUnmigratableVM(t *testing.T) {
 	h := ActionHandler{
 		nodeCache:                   fakeclients.NodeCache(k8sclientset.CoreV1().Nodes),
 		nodeClient:                  fakeclients.NodeClient(k8sclientset.CoreV1().Nodes),
-		longhornVolumeCache:         fakeclients.LonghornVolumeCache(client.LonghornV1beta1().Volumes),
-		longhornReplicaCache:        fakeclients.LonghornReplicaCache(client.LonghornV1beta1().Replicas),
+		longhornVolumeCache:         fakeclients.LonghornVolumeCache(client.LonghornV1beta2().Volumes),
+		longhornReplicaCache:        fakeclients.LonghornReplicaCache(client.LonghornV1beta2().Replicas),
 		virtualMachineInstanceCache: fakeclients.VirtualMachineInstanceCache(client.KubevirtV1().VirtualMachineInstances),
 	}
 

--- a/pkg/api/node/formatter_test.go
+++ b/pkg/api/node/formatter_test.go
@@ -27,6 +27,9 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "healthy-vm",
 			Namespace: "default",
+			Labels: map[string]string{
+				kubevirtv1.NodeNameLabel: testNode.Name,
+			},
 		},
 	}
 	workingVolume = &lhv1beta2.Volume{
@@ -265,6 +268,48 @@ var (
 			},
 		},
 	}
+
+	vmWithCDROM = &kubevirtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cdrom-vm",
+			Namespace: "default",
+			Labels: map[string]string{
+				kubevirtv1.NodeNameLabel: testNode.Name,
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineInstanceSpec{
+			Domain: kubevirtv1.DomainSpec{
+				Devices: kubevirtv1.Devices{
+					Disks: []kubevirtv1.Disk{
+						{
+							DiskDevice: kubevirtv1.DiskDevice{
+								CDRom: &kubevirtv1.CDRomTarget{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vmWithContainerDisk = &kubevirtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "containerdisk-vm",
+			Namespace: "default",
+			Labels: map[string]string{
+				kubevirtv1.NodeNameLabel: testNode.Name,
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineInstanceSpec{
+			Volumes: []kubevirtv1.Volume{
+				{
+					VolumeSource: kubevirtv1.VolumeSource{
+						ContainerDisk: &kubevirtv1.ContainerDiskSource{},
+					},
+				},
+			},
+		},
+	}
 )
 
 func Test_listUnhealthyVM(t *testing.T) {
@@ -289,4 +334,27 @@ func Test_listUnhealthyVM(t *testing.T) {
 	err = json.NewDecoder(fakeHTTP.Body).Decode(resp)
 	assert.NoError(err, "expected no error parsing json response")
 	assert.Len(resp.VMs, 1, "expected to find one vm")
+}
+
+func Test_listUnmigratableVM(t *testing.T) {
+	assert := require.New(t)
+	typedObjects := []runtime.Object{workingVM, vmWithContainerDisk, vmWithCDROM}
+	client := fake.NewSimpleClientset(typedObjects...)
+	k8sclientset := k8sfake.NewSimpleClientset(testNode)
+
+	h := ActionHandler{
+		nodeCache:                   fakeclients.NodeCache(k8sclientset.CoreV1().Nodes),
+		nodeClient:                  fakeclients.NodeClient(k8sclientset.CoreV1().Nodes),
+		longhornVolumeCache:         fakeclients.LonghornVolumeCache(client.LonghornV1beta1().Volumes),
+		longhornReplicaCache:        fakeclients.LonghornReplicaCache(client.LonghornV1beta1().Replicas),
+		virtualMachineInstanceCache: fakeclients.VirtualMachineInstanceCache(client.KubevirtV1().VirtualMachineInstances),
+	}
+
+	fakeHTTP := httptest.NewRecorder()
+	err := h.listUnhealthyVM(fakeHTTP, testNode)
+	assert.NoError(err, "expected no error while listing unhealthy VM's")
+	resp := &ListUnhealthyVM{}
+	err = json.NewDecoder(fakeHTTP.Body).Decode(resp)
+	assert.NoError(err, "expected no error parsing json response")
+	assert.Len(resp.VMs, 2, "expected to find two vms")
 }

--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -249,19 +249,20 @@ func (ndc *ControllerHandler) FindAndListVM(node *corev1.Node) ([]string, error)
 // FindAndListNonMigratableVM is called by action handler to leverage caches to find VM's which may have a cdrom or container disk
 // attached to vmi
 func (ndc *ControllerHandler) FindAndListNonMigratableVM(node *corev1.Node) ([]string, error) {
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", kubevirtv1.NodeNameLabel, node.Name))
-	if err != nil {
-		return nil, err
+	labelsMap := map[string]string{
+		kubevirtv1.NodeNameLabel: node.Name,
 	}
-	vmiList, err := ndc.virtualMachineInstanceCache.List("", labelSelector)
+	labelSelector := labels.SelectorFromSet(labelsMap)
+
+	vmiList, err := ndc.virtualMachineInstanceCache.List(corev1.NamespaceAll, labelSelector)
 	if err != nil {
 		return nil, fmt.Errorf("error listing VMI: %v", err)
 	}
 
 	var impactedVMI []string
-	for _, v := range vmiList {
-		if vmContainsCDRomOrContainerDisk(v) {
-			impactedVMI = append(impactedVMI, fmt.Sprintf("%s/%s", v.Namespace, v.Name))
+	for _, vmi := range vmiList {
+		if vmContainsCDRomOrContainerDisk(vmi) {
+			impactedVMI = append(impactedVMI, fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name))
 		}
 	}
 	return impactedVMI, nil

--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -246,6 +246,27 @@ func (ndc *ControllerHandler) FindAndListVM(node *corev1.Node) ([]string, error)
 	return impactedVMDetails, nil
 }
 
+// FindAndListNonMigratableVM is called by action handler to leverage caches to find VM's which may have a cdrom or container disk
+// attached to vmi
+func (ndc *ControllerHandler) FindAndListNonMigratableVM(node *corev1.Node) ([]string, error) {
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", kubevirtv1.NodeNameLabel, node.Name))
+	if err != nil {
+		return nil, err
+	}
+	vmiList, err := ndc.virtualMachineInstanceCache.List("", labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error listing VMI: %v", err)
+	}
+
+	var impactedVMI []string
+	for _, v := range vmiList {
+		if vmContainsCDRomOrContainerDisk(v) {
+			impactedVMI = append(impactedVMI, fmt.Sprintf("%s/%s", v.Namespace, v.Name))
+		}
+	}
+	return impactedVMI, nil
+}
+
 func ActionHelper(nodeCache ctlcorev1.NodeCache, virtualMachineInstanceCache ctlkubevirtv1.VirtualMachineInstanceCache,
 	longhornVolumeCache ctllhv1.VolumeCache, longhornReplicaCache ctllhv1.ReplicaCache) *ControllerHandler {
 	return &ControllerHandler{
@@ -254,4 +275,19 @@ func ActionHelper(nodeCache ctlcorev1.NodeCache, virtualMachineInstanceCache ctl
 		longhornVolumeCache:         longhornVolumeCache,
 		longhornReplicaCache:        longhornReplicaCache,
 	}
+}
+
+func vmContainsCDRomOrContainerDisk(vmi *kubevirtv1.VirtualMachineInstance) bool {
+	for _, disk := range vmi.Spec.Domain.Devices.Disks {
+		if disk.CDRom != nil {
+			return true
+		}
+	}
+
+	for _, volume := range vmi.Spec.Volumes {
+		if volume.VolumeSource.ContainerDisk != nil {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION


**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Migration of VM's with cdrom or container disk is disabled when a VM specific migration is performed.

![image](https://github.com/harvester/harvester/assets/19664014/83af8be4-053b-42f0-9174-6fe452511eca)

New maintenance mode capability introduced in 1.1.2 attempts to migrate VM's to other nodes in the cluster.  This only checks for VM's with unhealthy volumes but ignores VM's with cdrom or container disk attachments.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The PR adds an additional check to the existing `listUnhealthyVM` to list VM's on node which may have a cdrom or container disk.

**Related Issue:**
https://github.com/harvester/harvester/issues/3600

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
To test:
* Create a VM with a cdrom or container disk.
* Once VM is running attempt to place the node VM is scheduled to in maintenance mode.
* This should error with a warning listing VM's which have a cdrom or container disk attached.
* Remove cdrom / container disk from listed VM's and try maintenance mode again.
* This should not be successful, unless the node is hosting last healthy replica for other VM's.
