### PR TITLE
Sync harvester-system namespace uid as cluster uid to upgrade responder

### DIFF
--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -33,6 +33,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	vmImages := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage()
 	vms := management.VirtFactory.Kubevirt().V1().VirtualMachine()
 	services := management.CoreFactory.Core().V1().Service()
+	namespaces := management.CoreFactory.Core().V1().Namespace()
 	clusters := management.ProvisioningFactory.Provisioning().V1().Cluster()
 	machines := management.ClusterFactory.Cluster().V1alpha4().Machine()
 	secrets := management.CoreFactory.Core().V1().Secret()
@@ -125,7 +126,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 	nodes.OnChange(ctx, nodeControllerName, nodeHandler.OnChanged)
 
-	versionSyncer := newVersionSyncer(ctx, options.Namespace, versions, nodes)
+	versionSyncer := newVersionSyncer(ctx, options.Namespace, versions, nodes, namespaces)
 
 	settingHandler := settingHandler{
 		versionSyncer: versionSyncer,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

add clusterUID to extraInfo, example:

```json
{
    "appVersion": "v0.8.1",
    "extraInfo": {
        "nodeCount": "1",
        "cpuCount": "72",
        "memorySize": "32Gi",
        "clusterUID": "8ea1da9b-ba5c-4205-be64-f93b0797e81a"
    }
}
```

the clusterUID value is the UID of namespace harvester-system
```
# kubectl get ns harvester-system -ojson | jq -r '.metadata.uid'
a971571c-c1d4-48f4-a85d-52db94f48364
```
Refer to https://github.com/harvester/upgrade-responder#add-kubernetesversion-extra-field


**Related Issue:**
https://github.com/harvester/security/issues/26

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Run a fake upgrade responder locally
```bash
docker run -d --name fake-server -p 10000:8080 futuretea/server
```
2. Change the value of Harvester settings `upgrade-checker-url` to the fake server
```
http://<fake server ip>:10000
```
3. Tail the output of container fake-server 
```bash
docker logs -f fake-server 
```
4. Change the image of deployment/harvester in harvester-system to `futuretea/harvester:5c9ffd6d-amd64`
```bash
kubectl -n harvester-system edit deploy harvester
```

expected log:
```bash
{"level":"info","body":"{\"appVersion\":\"master-2ba017d4-head\",\"extraInfo\":{\"cpuCount\":\"32\",\"memorySize\":\"63Gi\",\"nodeCount\":\"2\"}}\n","method":"POST","path":"/","header":{"Accept-Encoding":["gzip"],"Content-Length":["104"],"Content-Type":["application/json"],"User-Agent":["Go-http-client/1.1"]},"time":1683735619,"message":"request"}
[GIN] 2023/05/10 - 16:20:19 | 200 |      49.929µs |      172.17.0.1 | POST     "/"
{"level":"info","body":"{\"appVersion\":\"master-2ba017d4-head\",\"extraInfo\":{\"cpuCount\":\"32\",\"memorySize\":\"63Gi\",\"nodeCount\":\"2\"}}\n","method":"POST","path":"/","header":{"Accept-Encoding":["gzip"],"Content-Length":["104"],"Content-Type":["application/json"],"User-Agent":["Go-http-client/1.1"]},"time":1683735619,"message":"request"}
[GIN] 2023/05/10 - 16:20:19 | 200 |      44.012µs |      172.17.0.1 | POST     "/"


{"level":"info","body":"{\"appVersion\":\"726ac1ce\",\"extraInfo\":{\"clusterUID\":\"a971571c-c1d4-48f4-a85d-52db94f48364\",\"cpuCount\":\"32\",\"memorySize\":\"63Gi\",\"nodeCount\":\"2\"}}\n","method":"POST","path":"/","header":{"Accept-Encoding":["gzip"],"Content-Length":["144"],"Content-Type":["application/json"],"User-Agent":["Go-http-client/1.1"]},"time":1683736346,"message":"request"}
[GIN] 2023/05/10 - 16:32:26 | 200 |     1.02023ms |      172.17.0.1 | POST     "/"
{"level":"info","body":"{\"appVersion\":\"726ac1ce\",\"extraInfo\":{\"clusterUID\":\"a971571c-c1d4-48f4-a85d-52db94f48364\",\"cpuCount\":\"32\",\"memorySize\":\"63Gi\",\"nodeCount\":\"2\"}}\n","method":"POST","path":"/","header":{"Accept-Encoding":["gzip"],"Content-Length":["144"],"Content-Type":["application/json"],"User-Agent":["Go-http-client/1.1"]},"time":1683736346,"message":"request"}
[GIN] 2023/05/10 - 16:32:26 | 200 |    2.319546ms |      172.17.0.1 | POST     "/"
```