### PR TITLE
Clean up containerDisk(cd-rom type) volumes after enjectCDROM

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -276,11 +276,13 @@ func ejectCdRomFromVM(vm *kubevirtv1.VirtualMachine, diskNames []string) error {
 	volumes := make([]kubevirtv1.Volume, 0, len(vm.Spec.Template.Spec.Volumes))
 	toRemoveClaimNames := make([]string, 0, len(vm.Spec.Template.Spec.Volumes))
 	for _, vol := range vm.Spec.Template.Spec.Volumes {
-		if vol.VolumeSource.PersistentVolumeClaim != nil && slice.ContainsString(diskNames, vol.Name) {
-			toRemoveClaimNames = append(toRemoveClaimNames, vol.VolumeSource.PersistentVolumeClaim.ClaimName)
+		if !slice.ContainsString(diskNames, vol.Name) {
+			volumes = append(volumes, vol)
 			continue
 		}
-		volumes = append(volumes, vol)
+		if vol.VolumeSource.PersistentVolumeClaim != nil {
+			toRemoveClaimNames = append(toRemoveClaimNames, vol.VolumeSource.PersistentVolumeClaim.ClaimName)
+		}
 	}
 
 	if err := removeVolumeClaimTemplatesFromVMAnnotation(vm, toRemoveClaimNames); err != nil {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
after enject cdrom, container disk volume didn't removed

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
fix the clean up logic 

**Related Issue:**
https://github.com/harvester/harvester/issues/3914

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Create a windows vm from windows iso template
2. Enject all cd-rom disk by `EnjectCDROM`
3. check yaml by `Edit Yaml`

containerDisk volume should be removed