### PR TITLE
update the max supported ccm & csi version setting

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -50,7 +50,7 @@ var (
 	RancherManagerSupport   = NewSetting(RancherManagerSupportSettingName, "false")
 
 	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
-	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.2.0","harvester-csi-provider":">=0.0.1 <0.2.0"}`)
+	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.3.0","harvester-csi-provider":">=0.0.1 <0.3.0"}`)
 )
 
 const (


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Starting from Harvester CCM v0.2.0, it will introduce a breaking upgrade change; the minimum supported Harvester version would be >=v1.2.0.

**Solution:**
Update the `HarvesterCSICCMSettingName` default value so that the RKE2 cluster with newer CCM & CSI versions can be installed on the Harvester cluster(>=1.2.0) only.

| Harvester version | RKE2 with CCM <0.2 | RKE2 with new CCM version >= v0.2 (https://github.com/harvester/harvester/issues/2134) |
| -- | -- | -- |
| `>= v1.2.0` | Yes | Yes |
| `< v1.2.0` | Yes | No |

**Related Issue:**
https://github.com/harvester/harvester/issues/3404

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
