### PR TITLE
Keep source reserved memory after vm clone

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -47,6 +47,12 @@ const (
 	sshAnnotation = "harvesterhci.io/sshNames"
 )
 
+var (
+	cloneVMAnnotationKeys = []string{
+		util.AnnotationReservedMemory,
+	}
+)
+
 type vmActionHandler struct {
 	namespace                 string
 	vms                       ctlkubevirtv1.VirtualMachineClient
@@ -1243,6 +1249,11 @@ func getClonedVMYamlFromSourceVM(newVMName string, sourceVM *kubevirtv1.VirtualM
 			Labels:      sourceVM.Labels,
 		},
 		Spec: *sourceVM.Spec.DeepCopy(),
+	}
+	for _, cloneVMAnnoKey := range cloneVMAnnotationKeys {
+		if sourceAnnoValue, keyExist := sourceVM.Annotations[cloneVMAnnoKey]; keyExist {
+			newVM.Annotations[cloneVMAnnoKey] = sourceAnnoValue
+		}
 	}
 	newVM.Spec.Template.Spec.Hostname = newVM.Name
 	newVM.Spec.Template.ObjectMeta.Labels[builder.LabelKeyVirtualMachineName] = newVM.Name


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Keep source reserved memory after vm clone

**Related Issue:**
https://github.com/harvester/harvester/issues/3912

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Go to create a vm
1. Provide a reserved memory count for the vm (good for windows vms)
1. Clone the vm (clone volume data mode)
1. Check both `edit as yaml` and also just the `config -> advanced options -> show more`
