### PR TITLE
fix(upgrade):  fix CreateImageFromISO side effect

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -107,8 +107,8 @@ func getISODisplayNameImageName(upgradeName string, version string) string {
 func (r *Repo) CreateImageFromISO(isoURL string, checksum string) (*harvesterv1.VirtualMachineImage, error) {
 	imageSpec := &harvesterv1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    harvesterSystemNamespace,
-			GenerateName: "harvester-iso-",
+			Namespace: harvesterSystemNamespace,
+			Name:      r.upgrade.Name,
 			Labels: map[string]string{
 				harvesterUpgradeLabel: r.upgrade.Name,
 			},


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

After the creation of the `Upgrade` object, the controller adds a finalizer, causing its `resourceVersion` to bump. Therefore the controller processing the outdated object needs to apply the changes again with the newest version (at the time). The order of object processing is not guaranteed, so the problematic behavior happens somewhat randomly. The calls of the `CreateImageFromISO` function are the side effect here. We should handle it more carefully, otherwise, it will download the ISO image multiple times with different names.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

If the CreateImageFromISO is called multiple times in an upgrade, there will be multiple VMImages downloaded and associate to the same upgrade. This commit turns the randomly generate names of VMImages into fixed ones so that we can detect the duplication earlier and take the existing VMimage as our target image.

**Related Issue:**

#3940 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Bring up a Harvester single node cluster in v1.1.2 and swap the harvester image with the one containing this PR
2. Start an upgrade with `logEnabled: false` to increase the happening chance of the issue
3. Check the harvester Pod's log, and there should be only one VMImage for the upgrade

```
time="2023-05-29T07:58:29Z" level=info msg="Initialize upgrade harvester-system/test-upgrade"
time="2023-05-29T07:58:29Z" level=info msg="Upgrade observability is administratively disabled"
time="2023-05-29T07:58:29Z" level=info msg="Creating upgrade repo image"
time="2023-05-29T07:58:29Z" level=info msg="Creating upgrade repo image"
time="2023-05-29T07:58:29Z" level=info msg="Reuse the existing image: harvester-system/test-upgrade"
time="2023-05-29T07:58:29Z" level=info msg="Creating upgrade repo image"
time="2023-05-29T07:58:29Z" level=info msg="Reuse the existing image: harvester-system/test-upgrade"
time="2023-05-29T07:58:29Z" level=info msg="handle upgrade harvester-system/test-upgrade with labels map[harvesterhci.io/latestUpgrade:true harvesterhci.io/upgradeState:LoggingInfraPrepared]"
time="2023-05-29T07:58:29Z" level=info msg="handle upgrade harvester-system/test-upgrade with labels map[harvesterhci.io/latestUpgrade:true harvesterhci.io/upgradeState:LoggingInfraPrepared]"
time="2023-05-29T07:58:44Z" level=info msg="handle upgrade harvester-system/test-upgrade with labels map[harvesterhci.io/latestUpgrade:true harvesterhci.io/upgradeState:LoggingInfraPrepared]"
time="2023-05-29T07:58:44Z" level=info msg="Starting upgrade repo VM"
...
```

4. Upgrade success