### PR TITLE
Disable some RKE2 charts

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -69,6 +69,15 @@ data:
     audit-policy-file: /etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
     EOF
 
+    # Disable snapshot-controller related charts because we manage them in Harvester.
+    # RKE2 enables these charts by default after v1.25.7 (https://github.com/rancher/rke2/releases/tag/v1.25.7%2Brke2r1)
+    cat > /host/etc/rancher/rke2/config.yaml.d/40-disable-charts.yaml <<EOF
+    disable:
+    - rke2-snapshot-controller
+    - rke2-snapshot-controller-crd
+    - rke2-snapshot-validation-webhook
+    EOF
+
     # For how to promote nodes, see: https://github.com/rancher/rancher/issues/36480#issuecomment-1039253499
     ROLE_LABELS="rke.cattle.io/control-plane-role=true rke.cattle.io/etcd-role=true"
     $KUBECTL label --overwrite -n fleet-local machines.cluster.x-k8s.io $CUSTOM_MACHINE $ROLE_LABELS

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -387,6 +387,7 @@ command_pre_drain() {
   patch_logging_event_audit
 
   remove_rke2_canal_config
+  disable_rke2_charts
 }
 
 get_node_rke2_version() {
@@ -426,6 +427,17 @@ clean_rke2_archives() {
 
 remove_rke2_canal_config() {
   rm -f "$HOST_DIR/var/lib/rancher/rke2/server/manifests/rke2-canal-config.yaml"
+}
+
+# Disable snapshot-controller related charts because we manage them in Harvester.
+# RKE2 enables these charts by default after v1.25.7 (https://github.com/rancher/rke2/releases/tag/v1.25.7%2Brke2r1)
+disable_rke2_charts() {
+  cat > "$HOST_DIR/etc/rancher/rke2/config.yaml.d/40-disable-charts.yaml" <<EOF
+disable:
+- rke2-snapshot-controller
+- rke2-snapshot-controller-crd
+- rke2-snapshot-validation-webhook
+EOF
 }
 
 convert_nodenetwork_to_vlanconfig() {
@@ -587,6 +599,7 @@ command_single_node_upgrade() {
   detect_repo
 
   remove_rke2_canal_config
+  disable_rke2_charts
 
   # Copy OS things, we need to shutdown repo VMs.
   NEW_OS_SQUASHFS_IMAGE_FILE=$(mktemp -p $UPGRADE_TMP_DIR)


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

These charts are managed as Harvester dependency charts. Thus we don't want RKE2 to deploy them.

- rke2-snapshot-controller
- rke2-snapshot-controller-crd
- rke2-snapshot-validation-webhook


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Disable the following charts:
- rke2-snapshot-controller
- rke2-snapshot-controller-crd
- rke2-snapshot-validation-webhook

There are two situations RKE2 might restart and load configuration files:
- A node is promoted.
- A node is upgraded from the previous version.

Add proper configuration files in these two cases.

**Related Issue:**

https://github.com/harvester/harvester/issues/3747

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
