### PR TITLE
added a handler to patch apps.catalog object if it corresponds to addon

### DIFF
--- a/pkg/controller/master/addon/addon.go
+++ b/pkg/controller/master/addon/addon.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"strings"
 
 	helmv1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
 	ctlhelmv1 "github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io/v1"
+	"github.com/rancher/norman/types/slice"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	ctlappsv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/batch/v1"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
@@ -22,25 +26,39 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 )
 
+const (
+	managedChartKey = "catalog.cattle.io/managed"
+)
+
+var (
+	// aditionalApps contains list of apps which need to be annotated to managed
+	// but are not related to a harvester addon
+	additionalApps = []string{"cattle-system/rancher", "cattle-system/rancher-webhook"}
+)
+
 type Handler struct {
 	helm  ctlhelmv1.HelmChartController
 	addon ctlharvesterv1.AddonController
 	job   ctlcorev1.JobController
+	app   ctlappsv1.AppController
 }
 
 func Register(ctx context.Context, management *config.Management, opts config.Options) error {
 	addonController := management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 	helmController := management.HelmFactory.Helm().V1().HelmChart()
 	jobController := management.BatchFactory.Batch().V1().Job()
+	appController := management.CatalogFactory.Catalog().V1().App()
 	h := &Handler{
 		helm:  helmController,
 		addon: addonController,
 		job:   jobController,
+		app:   appController,
 	}
 
 	addonController.OnChange(ctx, "deploy-addon", h.OnAddonChange)
 	addonController.OnChange(ctx, "monitor-addon", h.MonitorAddon)
 	addonController.OnChange(ctx, "monitor-changes", h.MonitorChanges)
+	appController.OnChange(ctx, "monitor-apps-catalog", h.PatchApps)
 	relatedresource.Watch(ctx, "watch-helmcharts", h.ReconcileHelmChartOwners, addonController, helmController)
 	return nil
 }
@@ -305,4 +323,41 @@ func (h *Handler) redeployNeeded(a *harvesterv1.Addon) (*helmv1.HelmChart, bool,
 	}
 
 	return hc, redeployChart, nil
+}
+
+// PatchApps will watch apps.catalog.cattle.io and patch Charts.yaml with additional annotation 'catalog.cattle.io/managed'
+// this is needed to ensure that addons cannot be upgrade directly from the apps with rancher mcm enabled on harvester
+func (h *Handler) PatchApps(key string, app *catalogv1.App) (*catalogv1.App, error) {
+	if app == nil || app.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	// check if harvester addon exists //
+	var patchNeeded bool
+	if slice.ContainsString(additionalApps, key) {
+		patchNeeded = true
+	} else {
+		_, err := h.addon.Cache().Get(app.Namespace, app.Name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// ignoring app since it doesnt match an addon
+				return app, nil
+			}
+			return app, fmt.Errorf("error fetching app %s: %v", app.Name, err)
+		}
+		patchNeeded = true
+	}
+
+	if patchNeeded {
+		appCopy := app.DeepCopy()
+		if appCopy.Spec.Chart.Metadata.Annotations == nil {
+			appCopy.Spec.Chart.Metadata.Annotations = make(map[string]string)
+		}
+		appCopy.Spec.Chart.Metadata.Annotations[managedChartKey] = "true"
+		if !reflect.DeepEqual(appCopy, app) {
+			return h.app.Update(appCopy)
+		}
+	}
+
+	return app, nil
 }

--- a/tests/integration/controllers/addons_test.go
+++ b/tests/integration/controllers/addons_test.go
@@ -7,6 +7,8 @@ import (
 	ctlhelmv1 "github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	ctlappsv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	ctlbatchv1 "github.com/rancher/wrangler/pkg/generated/controllers/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,10 +20,15 @@ import (
 var _ = Describe("verify helm chart is create and addon gets to desired state", func() {
 
 	var a *harvesterv1.Addon
+	var app *catalogv1.App
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
 	var jobController ctlbatchv1.JobController
+	var appController ctlappsv1.AppController
+
 	var jobName string
+
+	const managedChartKey = "catalog.cattle.io/managed"
 	BeforeEach(func() {
 		a = &harvesterv1.Addon{
 			ObjectMeta: metav1.ObjectMeta{
@@ -39,10 +46,22 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 			},
 		}
 
+		app = &catalogv1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-addon-create",
+				Namespace: "default",
+			},
+			Spec: catalogv1.ReleaseSpec{
+				Chart: &catalogv1.Chart{
+					Metadata: &catalogv1.Metadata{},
+				},
+			},
+		}
 		Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			jobController = scaled.Management.BatchFactory.Batch().V1().Job()
+			appController = scaled.Management.CatalogFactory.Catalog().V1().App()
 			_, err := addonController.Create(a)
 			return err
 		}).ShouldNot(HaveOccurred())
@@ -143,6 +162,29 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 				return nil
 			}, "60s", "5s").ShouldNot(HaveOccurred())
 		})
+
+		By("creating an app is created", func() {
+			Eventually(func() error {
+				_, err := appController.Create(app)
+				return err
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
+		By("ensuring app is patched", func() {
+			Eventually(func() error {
+				appObj, err := appController.Get(app.Namespace, app.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if val, ok := appObj.Spec.Chart.Metadata.Annotations[managedChartKey]; ok && val == "true" {
+					return nil
+				}
+
+				return fmt.Errorf("waiting for key to be added to annotations on app")
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
 	})
 
 	AfterEach(func() {

--- a/tests/integration/controllers/manifest/app-crd.yaml
+++ b/tests/integration/controllers/manifest/app-crd.yaml
@@ -1,0 +1,197 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: apps.catalog.cattle.io
+spec:
+  conversion:
+    strategy: None
+  group: catalog.cattle.io
+  names:
+    categories:
+      - catalog
+    kind: App
+    listKind: AppList
+    plural: apps
+    singular: app
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.chart.metadata.name
+          name: Chart
+          type: string
+        - jsonPath: .spec.chart.metadata.version
+          name: Version
+          type: string
+        - jsonPath: .spec.name
+          name: Release Name
+          type: string
+        - jsonPath: .spec.version
+          name: Release Version
+          type: string
+        - jsonPath: .spec.info.status
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                chart:
+                  nullable: true
+                  properties:
+                    metadata:
+                      nullable: true
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            nullable: true
+                            type: string
+                          nullable: true
+                          type: object
+                        apiVersion:
+                          nullable: true
+                          type: string
+                        appVersion:
+                          nullable: true
+                          type: string
+                        condition:
+                          nullable: true
+                          type: string
+                        deprecated:
+                          type: boolean
+                        description:
+                          nullable: true
+                          type: string
+                        home:
+                          nullable: true
+                          type: string
+                        icon:
+                          nullable: true
+                          type: string
+                        keywords:
+                          items:
+                            nullable: true
+                            type: string
+                          nullable: true
+                          type: array
+                        kubeVersion:
+                          nullable: true
+                          type: string
+                        maintainers:
+                          items:
+                            properties:
+                              email:
+                                nullable: true
+                                type: string
+                              name:
+                                nullable: true
+                                type: string
+                              url:
+                                nullable: true
+                                type: string
+                            type: object
+                          nullable: true
+                          type: array
+                        name:
+                          nullable: true
+                          type: string
+                        sources:
+                          items:
+                            nullable: true
+                            type: string
+                          nullable: true
+                          type: array
+                        tags:
+                          nullable: true
+                          type: string
+                        type:
+                          nullable: true
+                          type: string
+                        version:
+                          nullable: true
+                          type: string
+                      type: object
+                    values:
+                      nullable: true
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                helmVersion:
+                  type: integer
+                info:
+                  nullable: true
+                  properties:
+                    deleted:
+                      nullable: true
+                      type: string
+                    description:
+                      nullable: true
+                      type: string
+                    firstDeployed:
+                      nullable: true
+                      type: string
+                    lastDeployed:
+                      nullable: true
+                      type: string
+                    notes:
+                      nullable: true
+                      type: string
+                    readme:
+                      nullable: true
+                      type: string
+                    status:
+                      nullable: true
+                      type: string
+                  type: object
+                name:
+                  nullable: true
+                  type: string
+                namespace:
+                  nullable: true
+                  type: string
+                resources:
+                  items:
+                    properties:
+                      apiVersion:
+                        nullable: true
+                        type: string
+                      kind:
+                        nullable: true
+                        type: string
+                      name:
+                        nullable: true
+                        type: string
+                      namespace:
+                        nullable: true
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                values:
+                  nullable: true
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                version:
+                  type: integer
+              type: object
+            status:
+              properties:
+                observedGeneration:
+                  type: integer
+                summary:
+                  properties:
+                    error:
+                      type: boolean
+                    state:
+                      nullable: true
+                      type: string
+                    transitioning:
+                      type: boolean
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/tests/integration/controllers/suite_test.go
+++ b/tests/integration/controllers/suite_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher/lasso/pkg/controller"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/generic"
 	batchv1 "k8s.io/api/batch/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -43,7 +44,7 @@ var (
 	scaled           *config.Scaled
 	testEnv          *envtest.Environment
 	scheme           = runtime.NewScheme()
-	crdList          = []string{"./manifest/helm-crd.yaml", "../../../deploy/charts/harvester-crd/templates/harvesterhci.io_addons.yaml"}
+	crdList          = []string{"./manifest/helm-crd.yaml", "./manifest/app-crd.yaml", "../../../deploy/charts/harvester-crd/templates/harvesterhci.io_addons.yaml"}
 )
 
 const (
@@ -80,6 +81,9 @@ var _ = BeforeSuite(func() {
 	MustNotError(err)
 
 	err = batchv1.AddToScheme(scheme)
+	MustNotError(err)
+
+	err = catalogv1.AddToScheme(scheme)
 	MustNotError(err)
 
 	factory, err := controller.NewSharedControllerFactoryFromConfig(cfg, scheme)


### PR DESCRIPTION

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When mcm mode is enabled in rancher the users can browse to apps catalog on the local cluster and edit / update existing harvester integrations like, monitoring, logging, and any optional addons.

These should only be upgraded as part of the harvester upgrade.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces additional logic in addon controller to perform the following:
* patch apps.catalog object corresponding to addons to ensure they are reported as "managed" by rancher, which should prevent a user to update said chart from rancher marketplace
* patch predefined list of apps as "managed" for the same effect. For example, `rancher` deployment is marked managed to avoid it from being upgraded from the app store.
**Related Issue:**
https://github.com/rancher/dashboard/issues/8800
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
