### PR TITLE
snapshot/backup: freeze guest fs if possible

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -14,6 +14,7 @@ const (
 	AnnotationReservedMemory       = prefix + "/reservedMemory"
 	AnnotationHash                 = prefix + "/hash"
 	AnnotationRunStrategy          = prefix + "/vmRunStrategy"
+	AnnotationSnapshotFreezeFS     = prefix + "/snapshotFreezeFS"
 	LabelImageDisplayName          = prefix + "/imageDisplayName"
 	LabelVMName                    = prefix + "/vmName"
 


### PR DESCRIPTION



**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Snapshots and backups are currently "crash-consistent" (i.e., the snapshots contain whatever the guest's disk contains at the time of the snapshot as if the power cable was unplugged.)

This means that the snapshot doesn't include any I/O that the guest's kernel hasn't flushed to disk, so there's a possibility that a user might take a snapshot but due to their guest's I/O patterns the snapshot might not contain exactly what the user expected it to at the time the snapshot was issued.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

In order to take more consistent snapshots, check to see if the QEMU guest agent is running in the guest at the time of snapshot. If it is, send a freeze-fs message to sync the filesystems prior to the snapshot to improve the consistency of snapshots/backups in Harvester.

**Related Issue:** https://github.com/harvester/harvester/issues/1723

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Test case 1: ensure VM backup/snapshot controller is not regressed

1. In the VM: Write some data to a file (`echo 123 > test.txt && sync`)
2. Create a VM Snapshot
3. Expected result: VM Snapshot succeeds

Test case 2: guest agent, nontrivial amount of data, produces a consistent snapshot

1. In the VM: install and/or enable qemu-guest-agent
2. In the VM: Write a nontrivial amount of data to a file (`dd if=/dev/urandom of=test.txt bs=1M count=1000 status=progress`)
4. Create a VM Snapshot
5. In the VM: Measure `test.txt` (`sha256sum test.txt`). Keep note of this output for asserting at end of test case.
6. Restore into new VM.
7. In the new VM: Measure `test.txt` (`sha256sum test.txt`).
8. Expected result: SHAs are the same
9. Expected result: In the original VM: qemu-guest-agent reports freezing file systems (`sudo journalctl -u qemu-guest-agent | grep -q "guest-fsfreeze called" && echo ok || echo fail`) -- should print "ok"

Test case 3: no guest agent, nontrivial amount of data likely produces inconsistent snapshot

1. In the VM: disable and/or uninstall qemu-guest-agent
2. In the VM: Write a nontrivial amount of data to a file (`dd if=/dev/urandom of=test.txt bs=1M count=1000 status=progress`)
3. Create a VM Snapshot
4. In the VM: Measure `test.txt` (`sha256sum test.txt`). Keep note of this output for asserting at end of test case.
5. Restore into new VM.
6. In the new VM: Measure `test.txt` (`sha256sum test.txt`).
7. Expected result: One of: [SHAs match (unlikely), SHAs are different (likely), new VM test.txt does not exist (possible)] -- it's possible the amount of data written in the test case will need to be increased if this test case does not reproduce an inconsistent snapshot.

---

Notes: in order to best reproduce this, I have had to automate SSH'ing into the guest, running the `dd` command and then apply a VirtualMachineBackup type: snapshot with kubectl to ensure the snapshot is taken before all of the guest's pending I/O flushes to disk. It's far superior to my slow human reflexes lol
