### PR TITLE
introduction of mcm setting controller

### DIFF
--- a/pkg/controller/master/mcmsettings/clusterrepo.go
+++ b/pkg/controller/master/mcmsettings/clusterrepo.go
@@ -1,0 +1,37 @@
+package mcmsettings
+
+import (
+	"reflect"
+
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/wrangler/pkg/slice"
+)
+
+const (
+	HideClusterRepoKey   = "clusterrepo.cattle.io/hidden"
+	HideClusterRepoValue = "true"
+)
+
+var (
+	// clusterReposToPatch contains the name of clusterrepo objects which need to be patched with the hide annotation
+	// values are in the key format
+	clusterReposToPatch = []string{"harvester-charts", "rancher-charts", "rancher-rke2-charts", "rancher-stable"}
+)
+
+func (h *mcmSettingsHandler) patchClusterRepos(key string, repo *catalogv1.ClusterRepo) (*catalogv1.ClusterRepo, error) {
+	if repo == nil || repo.DeletionTimestamp != nil {
+		return repo, nil
+	}
+
+	if slice.ContainsString(clusterReposToPatch, key) {
+		repoCopy := repo.DeepCopy()
+		if repoCopy.Annotations == nil {
+			repoCopy.Annotations = make(map[string]string)
+		}
+		repoCopy.Annotations[HideClusterRepoKey] = HideClusterRepoValue
+		if !reflect.DeepEqual(repoCopy, repo) {
+			return h.clusterRepoClient.Update(repoCopy)
+		}
+	}
+	return repo, nil
+}

--- a/pkg/controller/master/mcmsettings/register.go
+++ b/pkg/controller/master/mcmsettings/register.go
@@ -1,0 +1,41 @@
+package mcmsettings
+
+import (
+	"context"
+
+	ctlcatalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
+	ctlrancherv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+
+	"github.com/harvester/harvester/pkg/config"
+)
+
+const (
+	serverURLHandler   = "server-url-handler"
+	vipService         = "kube-system/ingress-expose"
+	clusterRepoHandler = "cluster-repo-handler"
+)
+
+type mcmSettingsHandler struct {
+	svcCache              ctlcorev1.ServiceCache
+	rancherSettingsClient ctlrancherv3.SettingClient
+	rancherSettingsCache  ctlrancherv3.SettingCache
+	clusterRepoClient     ctlcatalogv1.ClusterRepoClient
+}
+
+func Register(ctx context.Context, management *config.Management, options config.Options) error {
+	svcController := management.CoreFactory.Core().V1().Service()
+	rancherSettingController := management.RancherManagementFactory.Management().V3().Setting()
+	clusterRepoController := management.CatalogFactory.Catalog().V1().ClusterRepo()
+
+	h := &mcmSettingsHandler{
+		svcCache:              svcController.Cache(),
+		rancherSettingsClient: rancherSettingController,
+		rancherSettingsCache:  rancherSettingController.Cache(),
+		clusterRepoClient:     clusterRepoController,
+	}
+
+	svcController.OnChange(ctx, serverURLHandler, h.updateServerURL)
+	clusterRepoController.OnChange(ctx, clusterRepoHandler, h.patchClusterRepos)
+	return nil
+}

--- a/pkg/controller/master/mcmsettings/serverurl.go
+++ b/pkg/controller/master/mcmsettings/serverurl.go
@@ -1,0 +1,51 @@
+package mcmsettings
+
+import (
+	"fmt"
+
+	ranchersettings "github.com/rancher/rancher/pkg/settings"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	PatchedByHarvesterKey   = "harvesterhci.io/patched-by-controller"
+	PatchedByHarvesterValue = "true"
+)
+
+// updateServerURL will reconcile ingress-expose service in kube-system namespace and set the
+// external IP to rancher server-url setting
+func (h *mcmSettingsHandler) updateServerURL(key string, svc *corev1.Service) (*corev1.Service, error) {
+	if svc == nil || svc.DeletionTimestamp != nil {
+		return svc, nil
+	}
+
+	if key != vipService {
+		return svc, nil
+	}
+
+	if len(svc.Status.LoadBalancer.Ingress) != 1 {
+		return svc, fmt.Errorf("expected to find 1 load balancer ip for svc %s but got %v", key, svc.Spec.ExternalIPs)
+	}
+
+	serverURLSetting, err := h.rancherSettingsCache.Get(ranchersettings.ServerURL.Name)
+	if err != nil {
+		return svc, fmt.Errorf("error querying rancher server-url setting: %v", err)
+	}
+
+	if val, ok := serverURLSetting.Annotations[PatchedByHarvesterKey]; ok && val == PatchedByHarvesterValue {
+		return svc, nil
+	}
+
+	serverURLSettingCopy := serverURLSetting.DeepCopy()
+	serverURLSettingCopy.Value = fmt.Sprintf("https://%s", svc.Status.LoadBalancer.Ingress[0].IP)
+	if serverURLSettingCopy.Annotations == nil {
+		serverURLSettingCopy.Annotations = make(map[string]string)
+	}
+
+	serverURLSettingCopy.Annotations[PatchedByHarvesterKey] = PatchedByHarvesterValue
+	if _, err := h.rancherSettingsClient.Update(serverURLSettingCopy); err != nil {
+		return svc, err
+	}
+
+	return svc, nil
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/backup"
 	"github.com/harvester/harvester/pkg/controller/master/image"
 	"github.com/harvester/harvester/pkg/controller/master/keypair"
+	"github.com/harvester/harvester/pkg/controller/master/mcmsettings"
 	"github.com/harvester/harvester/pkg/controller/master/migration"
 	"github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/controller/master/nodedrain"
@@ -48,6 +49,7 @@ var registerFuncs = []registerFunc{
 	addon.Register,
 	storagenetwork.Register,
 	nodedrain.Register,
+	mcmsettings.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/tests/integration/controllers/clusterrepo_test.go
+++ b/tests/integration/controllers/clusterrepo_test.go
@@ -1,0 +1,95 @@
+package controllers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	ctlcatalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/controller/master/mcmsettings"
+)
+
+var _ = Describe("verify cluster repos are patched", func() {
+	var harvestercharts, partnercharts *catalogv1.ClusterRepo
+	var clusterRepoController ctlcatalogv1.ClusterRepoController
+
+	BeforeEach(func() {
+		harvestercharts = &catalogv1.ClusterRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "harvester-charts",
+			},
+			Spec: catalogv1.RepoSpec{},
+		}
+
+		partnercharts = &catalogv1.ClusterRepo{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rancher-partner-charts",
+			},
+			Spec: catalogv1.RepoSpec{},
+		}
+
+		clusterRepoController = scaled.Management.CatalogFactory.Catalog().V1().ClusterRepo()
+		Eventually(func() error {
+			_, err := clusterRepoController.Create(harvestercharts)
+			return err
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+
+		Eventually(func() error {
+			_, err := clusterRepoController.Create(partnercharts)
+			return err
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+
+	})
+
+	It("verify cluster repo annotations", func() {
+		By("checking annotation on harvester-charts", func() {
+			Eventually(func() error {
+				obj, err := clusterRepoController.Get(harvestercharts.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if obj.Annotations == nil {
+					return fmt.Errorf("expected to find annotations on cluster repo")
+				}
+
+				if val, ok := obj.Annotations[mcmsettings.HideClusterRepoKey]; ok && val == mcmsettings.HideClusterRepoValue {
+					return nil
+				}
+
+				return fmt.Errorf("waiting for hide key/value: %s/%s to be annotated on cluster repo", mcmsettings.HideClusterRepoKey, mcmsettings.HideClusterRepoValue)
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
+		By("checking annotation on rancher-partner-charts", func() {
+			Consistently(func() error {
+				obj, err := clusterRepoController.Get(partnercharts.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if obj.Annotations == nil {
+					return nil
+				}
+
+				if _, ok := obj.Annotations[mcmsettings.HideClusterRepoKey]; !ok {
+					return nil
+				}
+
+				return fmt.Errorf("key/value %s/%s should not have been annotated on cluster repo", mcmsettings.HideClusterRepoKey, mcmsettings.HideClusterRepoValue)
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+	})
+	AfterEach(func() {
+		Eventually(func() error {
+			return clusterRepoController.Delete(harvestercharts.Name, &metav1.DeleteOptions{})
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+
+		Eventually(func() error {
+			return clusterRepoController.Delete(partnercharts.Name, &metav1.DeleteOptions{})
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+	})
+
+})

--- a/tests/integration/controllers/manifest/clusterrepos-crd.yaml
+++ b/tests/integration/controllers/manifest/clusterrepos-crd.yaml
@@ -1,0 +1,124 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterrepos.catalog.cattle.io
+spec:
+  conversion:
+    strategy: None
+  group: catalog.cattle.io
+  names:
+    categories:
+      - catalog
+    kind: ClusterRepo
+    listKind: ClusterRepoList
+    plural: clusterrepos
+    singular: clusterrepo
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                basicAuthSecretName:
+                  nullable: true
+                  type: string
+                caBundle:
+                  nullable: true
+                  type: string
+                clientSecret:
+                  nullable: true
+                  properties:
+                    name:
+                      nullable: true
+                      type: string
+                    namespace:
+                      nullable: true
+                      type: string
+                  type: object
+                disableSameOriginCheck:
+                  type: boolean
+                enabled:
+                  nullable: true
+                  type: boolean
+                forceUpdate:
+                  nullable: true
+                  type: string
+                gitBranch:
+                  nullable: true
+                  type: string
+                gitRepo:
+                  nullable: true
+                  type: string
+                insecureSkipTLSVerify:
+                  type: boolean
+                serviceAccount:
+                  nullable: true
+                  type: string
+                serviceAccountNamespace:
+                  nullable: true
+                  type: string
+                url:
+                  nullable: true
+                  type: string
+              type: object
+            status:
+              properties:
+                branch:
+                  nullable: true
+                  type: string
+                commit:
+                  nullable: true
+                  type: string
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        nullable: true
+                        type: string
+                      lastUpdateTime:
+                        nullable: true
+                        type: string
+                      message:
+                        nullable: true
+                        type: string
+                      reason:
+                        nullable: true
+                        type: string
+                      status:
+                        nullable: true
+                        type: string
+                      type:
+                        nullable: true
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                downloadTime:
+                  nullable: true
+                  type: string
+                indexConfigMapName:
+                  nullable: true
+                  type: string
+                indexConfigMapNamespace:
+                  nullable: true
+                  type: string
+                indexConfigMapResourceVersion:
+                  nullable: true
+                  type: string
+                observedGeneration:
+                  type: integer
+                url:
+                  nullable: true
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/tests/integration/controllers/manifest/ranchersettings-crd.yaml
+++ b/tests/integration/controllers/manifest/ranchersettings-crd.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: settings.management.cattle.io
+spec:
+  conversion:
+    strategy: None
+  group: management.cattle.io
+  names:
+    kind: Setting
+    listKind: SettingList
+    plural: settings
+    singular: setting
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .value
+          name: Value
+          type: string
+      name: v3
+      schema:
+        openAPIV3Schema:
+          properties:
+            customized:
+              type: boolean
+            default:
+              nullable: true
+              type: string
+            source:
+              nullable: true
+              type: string
+            value:
+              nullable: true
+              type: string
+          type: object
+      served: true
+      storage: true

--- a/tests/integration/controllers/server_url_test.go
+++ b/tests/integration/controllers/server_url_test.go
@@ -1,0 +1,132 @@
+package controllers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	ctlmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/controller/master/mcmsettings"
+)
+
+const (
+	address       = "172.19.109.0"
+	addressUpdate = "172.19.109.1"
+)
+
+var _ = Describe("verify svc kube-system/ingress-expose is synced to server-url setting", func() {
+
+	var svc *corev1.Service
+	var setting *managementv3.Setting
+	var svcController ctlcorev1.ServiceController
+	var settingController ctlmgmtv3.SettingController
+
+	BeforeEach(func() {
+		svc = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ingress-expose",
+				Namespace: "kube-system",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port: 8443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							IP: address,
+						},
+					},
+				}},
+		}
+
+		setting = &managementv3.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "server-url",
+			},
+		}
+
+		svcController = scaled.Management.CoreFactory.Core().V1().Service()
+		settingController = scaled.Management.RancherManagementFactory.Management().V3().Setting()
+
+		Eventually(func() error {
+			svcObj, err := svcController.Create(svc)
+			if err != nil {
+				return err
+			}
+			svcObj.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: address}}
+			_, err = svcController.UpdateStatus(svcObj)
+			return err
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+
+		Eventually(func() error {
+			_, err := settingController.Create(setting)
+			return err
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+	})
+
+	It("verify sync of setting", func() {
+		By("checking value of server-url", func() {
+			Eventually(func() error {
+				settingObj, err := settingController.Get(setting.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				val, ok := settingObj.Annotations[mcmsettings.PatchedByHarvesterKey]
+
+				if ok && val == mcmsettings.PatchedByHarvesterValue && settingObj.Value == fmt.Sprintf("https://%s", address) {
+					return nil
+				}
+				return fmt.Errorf("waiting for setting value to be correct. current value: %s", settingObj.Value)
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
+		By("changing ingress-expose address", func() {
+			Eventually(func() error {
+				svcObj, err := svcController.Get(svc.Namespace, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				svcObj.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: addressUpdate}}
+				_, err = svcController.UpdateStatus(svcObj)
+				return err
+			}).ShouldNot(HaveOccurred())
+		})
+
+		By("checking value of server-url has not changed", func() {
+			Consistently(func() error {
+				settingObj, err := settingController.Get(setting.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				val, ok := settingObj.Annotations[mcmsettings.PatchedByHarvesterKey]
+
+				if ok && val == mcmsettings.PatchedByHarvesterValue && settingObj.Value == fmt.Sprintf("https://%s", address) {
+					return nil
+				}
+				return fmt.Errorf("expected server-url to not have changed: %s", settingObj.Value)
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+	})
+	AfterEach(func() {
+		Eventually(func() error {
+			return svcController.Delete(svc.Namespace, svc.Name, &metav1.DeleteOptions{})
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+
+		Eventually(func() error {
+			return settingController.Delete(setting.Name, &metav1.DeleteOptions{})
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+	})
+})

--- a/tests/integration/runtime/crds.go
+++ b/tests/integration/runtime/crds.go
@@ -31,6 +31,7 @@ func createCRDs(ctx context.Context, restConfig *rest.Config) error {
 			createHelmChartCRD(),
 			createLonghornVolumeCRD(),
 			createLonghornReplicaCRD(),
+			createClusterRepoCRD(),
 		).
 		BatchWait()
 }
@@ -88,4 +89,11 @@ func createLonghornVolumeCRD() wcrd.CRD {
 
 func createLonghornReplicaCRD() wcrd.CRD {
 	return crd.FromGV(lhv1beta2.SchemeGroupVersion, "Replica", lhv1beta2.Replica{})
+}
+
+func createClusterRepoCRD() wcrd.CRD {
+	clusterrepo := crd.FromGV(catalogv1.SchemeGroupVersion, "ClusterRepo", catalogv1.ClusterRepo{})
+	clusterrepo.PluralName = "clusterrepos"
+	clusterrepo.SingularName = "clusterrepo"
+	return clusterrepo
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
With mcm mode enabled, provisioning of downstream clusters fails as server_url is not set.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
mcm setting controller syncs ip from `ingress-expose` service in `kube-system` namespace into server-url setting of rancher.

**Related Issue:**
https://github.com/harvester/harvester/issues/3973
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
* Install or upgrade to 1.2.0/master
* once harvester is up check status of server-url setting `kubectl get setting.management server-url`
* server-url value should match the external-ip on ingress-expose service in kube-system namespace.
