### PR TITLE
fix(upgrade): remove version check for addon upgrades

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -624,14 +624,11 @@ pause_all_charts() {
 
 upgrade_addons()
 {
- local is_upgrade_required=$(lower_version_check $UPGRADE_PREVIOUS_VERSION v1.1.1)
- if [ ! -z "$is_upgrade_required" ]; then
-   wait_for_addons_crd
+  wait_for_addons_crd
   addons="vm-import-controller pcidevices-controller"
   for addon in $addons; do
     upgrade_addon $addon "harvester-system"
   done
-  fi
 }
 
 reuse_vlan_cn() {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

After upgrading from v1.1.2 to master-head, there are no PCI devices listed on the page when pcidevices-controller addon is turned on. The pcidevices didn't show up automatically.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The version checking is no longer valid. Removing it to make sure every Harvester upgrade will upgrade the addons.

**Related Issue:**

#3957 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install a v1.1.2 Harvester single-node cluster
2. Upgrade the cluster with an ISO image containing this fix
3. After the upgrade succeeded, check the version of the addons in the cluster. They should be upgraded (now only pcidevices-controller got newer release).

```
pcidevices-controller: 0.2.4 -> 0.2.5-rc1
```

4. Login Harvester UI and enable the pcidevices-controller addon
5. Wait for a few seconds; on the page "PCIDevices" there should be items pop up automatically
