### PR TITLE
Prevent VM's "TerminationGracePeriod" from negative value

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -108,6 +108,11 @@ func (m *vmMutator) Update(request *types.Request, oldObj runtime.Object, newObj
 		return nil, err
 	}
 
+	patchOps, err = m.patchTerminationGracePeriodSeconds(newVM, patchOps)
+	if err != nil {
+		return nil, err
+	}
+
 	return patchOps, nil
 }
 
@@ -400,6 +405,7 @@ func (m *vmMutator) patchTerminationGracePeriodSeconds(vm *kubevirtv1.VirtualMac
 	if s.Value != "" {
 		value = s.Value
 	}
+
 	patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/terminationGracePeriodSeconds", "value": %s}`, value))
 	return patchOps, nil
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Harvester can create or update VM's `TerminationGracePeriod` with a negative value.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Prevent negative value for VM's `TerminationGracePeriod` during creation or update via vm validator webhook.

In addition, vm mutator sets the default value for `TerminationGracePeriod` field during the update. Make the handling consistent between creation and update.

**Related Issue:**
Issue #3946

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Case1: Setting negative `TerminationGracePeriod` for VM creation
- Create a virtual machine
- Expand Advanced Options
- Set a negative value to `TerminationGracePeriod` and save
- We should see the operation be prohibited by webhook with msg _`Termination grace period can't be negative`_ ![vm_create_grace_period](https://github.com/harvester/harvester/assets/19387129/30427e0b-0138-4a88-8090-dd3914fe5ae6)

Case2: Setting negative `TerminationGracePeriod` value for VM update
- Create a virtual machine with default `TerminationGracePeriod` value
- Open the edit page for the newly created VM
- Set a negative value to `TerminationGracePeriod` and save
-  We should see the operation be prohibited by webhook ![vm_edit_grace_period](https://github.com/harvester/harvester/assets/19387129/5de3b068-a127-4123-9da0-92acf3f8e14b)

