### PR TITLE
additional taints for sbk and integration tests

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -22,7 +22,9 @@ import (
 )
 
 const (
-	HarvesterServiceAccount   = "harvester"
+	HarvesterServiceAccount = "harvester"
+	//AdditionalTaintToleration value when passed to SUPPORT_BUNDLE_TAINT_TOLERATION env variable, is processed as v1.TolerationOpExists
+	//which allows the support-bundle-kit pods to be scheduled on nodes with custom taints
 	AdditionalTaintToleration = ":"
 )
 

--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	HarvesterServiceAccount = "harvester"
+	HarvesterServiceAccount   = "harvester"
+	AdditionalTaintToleration = ":"
 )
 
 type Manager struct {
@@ -118,6 +119,10 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string, pullPolicy
 								{
 									Name:  "SUPPORT_BUNDLE_EXTRA_COLLECTORS",
 									Value: m.getExtraCollectors(),
+								},
+								{
+									Name:  "SUPPORT_BUNDLE_TAINT_TOLERATION",
+									Value: AdditionalTaintToleration,
 								},
 							},
 							Ports: []corev1.ContainerPort{

--- a/tests/integration/api/supportbundle_test.go
+++ b/tests/integration/api/supportbundle_test.go
@@ -1,0 +1,90 @@
+package api_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctlappsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+)
+
+var _ = Describe("create a supportbundle request and verify taints on daemonset", func() {
+	var sbk *harvesterv1.SupportBundle
+	var sbc ctlharvesterv1.SupportBundleController
+	var dsc ctlappsv1.DaemonSetCache
+	var sc ctlharvesterv1.SettingController
+	var requiredToleration *corev1.Toleration
+
+	BeforeEach(func() {
+		sbk = &harvesterv1.SupportBundle{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample",
+				Namespace: "harvester-system",
+			},
+			Spec: harvesterv1.SupportBundleSpec{
+				IssueURL:    "fake issue",
+				Description: "fake description",
+			},
+		}
+
+		requiredToleration = &corev1.Toleration{
+			Operator: corev1.TolerationOpExists,
+		}
+
+		scaled := harvester.Scaled()
+		sc = scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting()
+		sbc = scaled.HarvesterFactory.Harvesterhci().V1beta1().SupportBundle()
+		dsc = scaled.AppsFactory.Apps().V1().DaemonSet().Cache()
+
+		Eventually(func() error {
+			_, err := sbc.Create(sbk)
+			return err
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+	})
+
+	It("check a daemonset exists with correct annotations", func() {
+		By("checking support-bundle-image setting is populated", func() {
+			Eventually(func() error {
+				sbi, err := sc.Get("support-bundle-image", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				sbi.Value = `{"repository":"rancher/support-bundle-kit","tag":"master-head","imagePullPolicy":"IfNotPresent"}`
+				_, err = sc.Update(sbi)
+				return err
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
+		By("checking ds is created", func() {
+			Eventually(func() error {
+				dsList, err := dsc.List("harvester-system", labels.NewSelector())
+				if err != nil {
+					return err
+				}
+
+				for _, v := range dsList {
+					if strings.Contains(v.Name, "supportbundle") && v.Spec.Template.Spec.Tolerations[0].MatchToleration(requiredToleration) {
+						return nil
+					}
+				}
+
+				return fmt.Errorf("waiting for ds to be created or toleration to exist")
+			}, "90s", "5s").ShouldNot(HaveOccurred())
+		})
+
+	})
+	AfterEach(func() {
+		Eventually(func() error {
+			err := sbc.Delete(sbk.Namespace, sbk.Name, &metav1.DeleteOptions{})
+			return err
+		}, "30s", "5s").ShouldNot(HaveOccurred())
+
+	})
+})


### PR DESCRIPTION


**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
As part of the upgrade process in a multi-node cluster the harvester upgrade process taints the nodes with `kubevirt.io/drain=draining:NoSchedule` taint. 
In case of issues during upgrade the support-bundle-kit manager deploys the support-bundle-agent daemonset which cannot deploy pods to the tainted node.

As a result the support bundle contains incomplete information.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
support-bundle-kit introduced for custom taints via https://github.com/rancher/support-bundle-kit/pull/68

The PR leverages this to pass an additional `v1.TolerationOpExists`  taint, which now allows the support-bundle-agent daemonset to deploy pods to target nodes with custom taints.

**Related Issue:**
https://github.com/harvester/harvester/issues/3702
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
