### PR TITLE
Do not delete pod affinity in patchAffinity

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -257,18 +257,19 @@ func (m *vmMutator) patchAffinity(vm *kubevirtv1.VirtualMachine, patchOps types.
 	}
 
 	affinity := makeAffinityFromVMTemplate(vm.Spec.Template)
-	nodeSelector := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	requiredNodeSelector := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	preferredNodeSelector := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 
 	newVMNetworks := vm.Spec.Template.Spec.Networks
 	logrus.Debugf("newNetworks: %+v", newVMNetworks)
 
-	if err := m.addNodeSelectorTerms(vm.Namespace, nodeSelector, newVMNetworks); err != nil {
+	if err := m.addNodeSelectorTerms(vm.Namespace, requiredNodeSelector, newVMNetworks); err != nil {
 		return patchOps, err
 	}
 
 	// The .spec.affinity could not be like `{nodeAffinity:requireDuringSchedulingIgnoreDuringExecution:[]}` if there is not any rules.
-	if len(nodeSelector.NodeSelectorTerms) == 0 {
-		return append(patchOps, fmt.Sprintf(`{"op":"replace","path":"/spec/template/spec/affinity","value":{}}`)), nil
+	if len(requiredNodeSelector.NodeSelectorTerms) == 0 && len(preferredNodeSelector) == 0 {
+		affinity.NodeAffinity = nil
 	}
 
 	bytes, err := json.Marshal(affinity)

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -335,7 +335,32 @@ func TestPatchAffinity(t *testing.T) {
 			},
 		},
 	}
-
+	vm6 := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Affinity: &v1.Affinity{
+						PodAffinity: &v1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+								{
+									TopologyKey: "topology.kubernetes.io/zone",
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "default",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Pod: &kubevirtv1.PodNetwork{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	net1 := &cniv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "net1",
@@ -457,6 +482,19 @@ func TestPatchAffinity(t *testing.T) {
 							},
 						},
 					},
+					},
+				},
+			},
+		},
+		{
+			name: "keep pod affinity",
+			vm:   vm6,
+			affinity: &v1.Affinity{
+				PodAffinity: &v1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+						{
+							TopologyKey: "topology.kubernetes.io/zone",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
If user use pod network in vm, pod affinity will be deleted by patchAffinity webhook

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
fix the logic
add a new unit test case

**Related Issue:**
https://github.com/harvester/harvester/issues/2317

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
add a new unit test case