### PR TITLE
Delete Backing Image with Foreground propagation

### DIFF
--- a/pkg/controller/master/image/vm_image_controller.go
+++ b/pkg/controller/master/image/vm_image_controller.go
@@ -217,7 +217,8 @@ func (h *vmImageHandler) createStorageClass(image *harvesterv1.VirtualMachineIma
 }
 
 func (h *vmImageHandler) deleteBackingImage(image *harvesterv1.VirtualMachineImage) error {
-	return h.backingImages.Delete(util.LonghornSystemNamespaceName, util.GetBackingImageName(image), &metav1.DeleteOptions{})
+	propagation := metav1.DeletePropagationForeground
+	return h.backingImages.Delete(util.LonghornSystemNamespaceName, util.GetBackingImageName(image), &metav1.DeleteOptions{PropagationPolicy: &propagation})
 }
 
 func (h *vmImageHandler) deleteStorageClass(image *harvesterv1.VirtualMachineImage) error {


### PR DESCRIPTION
Delete Backing Image with foreground propogation, which casacading the deleteion for Backingimagedatasource. It's the correct operation after Longhorn commit https://github.com/longhorn/longhorn-manager/pull/1791. And it's necessary especially for deleting Virtual Machine Image during the uploading process, Longhorn depends on this mechanism to reclaim temp or baking file.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Because Harvester doesn't delete backingimage with foreground propagation, it can't utilize Longhorn's design pattern. 
Once virtualmachineimage is deleted during upload processing, backingimage stuck in deletion status.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**
#1947

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Create image (uploading from local file) in Harvester
- Once a temp file is created in Harvester (at /var/lib/harvester/defaultdisk/tmp) ![bi_temp_file](https://github.com/harvester/harvester/assets/19387129/db790af1-224b-4071-91c8-ecb2bbed6f01)
- Delete the uploading image

**Expected Result:**
- Virtual Machine Image should be deleted with related resources, including backingimage, backingimagedatasoure, and backingimagemanager
- No temp file or backing image file left

**Note:**
- This PR couldn't be backported to v1.1, since it fits the scenario after Longhorn v1.3.3