### PR TITLE
additional logic to track addon while it is being disabled

### DIFF
--- a/pkg/apis/harvesterhci.io/v1beta1/addon.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/addon.go
@@ -7,10 +7,11 @@ import (
 type AddonState string
 
 const (
-	AddonEnabled   AddonState = "AddonEnabled"
-	AddonDeployed  AddonState = "AddonDeploySuccessful"
-	AddonFailed    AddonState = "AddonDeployFailed"
-	DisablingAddon AddonState = "DisablingAddon"
+	AddonEnabled         AddonState = "AddonEnabled"
+	AddonDeployed        AddonState = "AddonDeploySuccessful"
+	AddonFailed          AddonState = "AddonDeployFailed"
+	DisablingAddon       AddonState = "DisablingAddon"
+	AddonDisablingFailed AddonState = "AddonDisablingFailed"
 )
 
 // +genclient

--- a/pkg/apis/harvesterhci.io/v1beta1/addon.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/addon.go
@@ -7,9 +7,10 @@ import (
 type AddonState string
 
 const (
-	AddonEnabled  AddonState = "AddonEnabled"
-	AddonDeployed AddonState = "AddonDeploySuccessful"
-	AddonFailed   AddonState = "AddonDeployFailed"
+	AddonEnabled   AddonState = "AddonEnabled"
+	AddonDeployed  AddonState = "AddonDeploySuccessful"
+	AddonFailed    AddonState = "AddonDeployFailed"
+	DisablingAddon AddonState = "DisablingAddon"
 )
 
 // +genclient

--- a/pkg/controller/master/addon/addon.go
+++ b/pkg/controller/master/addon/addon.go
@@ -178,11 +178,9 @@ func (h *Handler) OnAddonChange(key string, aObj *harvesterv1.Addon) (*harvester
 				return h.addon.UpdateStatus(a)
 			}
 			return h.removeHelmChart(a)
-		} else {
-			a.Status.Status = ""
-			return h.addon.UpdateStatus(a)
 		}
-
+		a.Status.Status = ""
+		return h.addon.UpdateStatus(a)
 	}
 	return nil, nil
 }

--- a/pkg/controller/master/addon/addon.go
+++ b/pkg/controller/master/addon/addon.go
@@ -167,6 +167,14 @@ func (h *Handler) OnAddonChange(key string, a *harvesterv1.Addon) (*harvesterv1.
 	}
 
 	if !a.Spec.Enabled && ok {
+		// update status to DisablingAddon
+		// this is used by validating webhook to ensure no changes can be done to addon
+		// while until uninstall is complete
+		if a.Status.Status != harvesterv1.DisablingAddon {
+			aCopy := a.DeepCopy()
+			aCopy.Status.Status = harvesterv1.DisablingAddon
+			return h.addon.UpdateStatus(aCopy)
+		}
 		return h.removeHelmChart(a)
 	}
 	return nil, nil

--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -79,5 +79,9 @@ func validateUpdatedAddon(newAddon *v1beta1.Addon, oldAddon *v1beta1.Addon) erro
 		return werror.NewBadRequest("addon is currently disabling and cannot be enabled")
 	}
 
+	if oldAddon.Status.Status == v1beta1.AddonEnabled && !newAddon.Spec.Enabled {
+		return werror.NewBadRequest("addon is currently being deployed and cannot be disabled")
+	}
+
 	return nil
 }

--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -75,5 +75,9 @@ func validateUpdatedAddon(newAddon *v1beta1.Addon, oldAddon *v1beta1.Addon) erro
 		return werror.NewBadRequest("chart field cannot be changed.")
 	}
 
+	if oldAddon.Status.Status == v1beta1.DisablingAddon && newAddon.Spec.Enabled {
+		return werror.NewBadRequest("addon is currently disabling and cannot be enabled")
+	}
+
 	return nil
 }

--- a/pkg/webhook/resources/addon/validator_test.go
+++ b/pkg/webhook/resources/addon/validator_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	// corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -100,6 +99,72 @@ func Test_validateUpdatedAddon(t *testing.T) {
 				},
 			},
 			expectedError: true,
+		},
+		{
+			name: "cannot change disabling addon",
+			oldAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       false,
+					ValuesContent: "sample",
+				},
+				Status: harvesterv1.AddonStatus{
+					Status: harvesterv1.DisablingAddon,
+				},
+			},
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1-changed",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+				Status: harvesterv1.AddonStatus{
+					Status: harvesterv1.DisablingAddon,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "disable addon",
+			oldAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       false,
+					ValuesContent: "sample",
+				},
+				Status: harvesterv1.AddonStatus{
+					Status: harvesterv1.DisablingAddon,
+				},
+			},
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       false,
+					ValuesContent: "sample",
+				},
+				Status: harvesterv1.AddonStatus{},
+			},
+			expectedError: false,
 		},
 	}
 

--- a/pkg/webhook/resources/addon/validator_test.go
+++ b/pkg/webhook/resources/addon/validator_test.go
@@ -166,10 +166,44 @@ func Test_validateUpdatedAddon(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name: "disable enabling addon",
+			oldAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "disable-enabling-addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       true,
+					ValuesContent: "sample",
+				},
+				Status: harvesterv1.AddonStatus{
+					Status: harvesterv1.AddonEnabled,
+				},
+			},
+			newAddon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "disable-enabling-addon1",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Repo:          "repo1",
+					Chart:         "chart1",
+					Version:       "version1",
+					Enabled:       false,
+					ValuesContent: "sample",
+				},
+				Status: harvesterv1.AddonStatus{
+					Status: harvesterv1.AddonEnabled,
+				},
+			},
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range testCases {
-		err := validateUpdatedAddon(tc.oldAddon, tc.newAddon)
+		err := validateUpdatedAddon(tc.newAddon, tc.oldAddon)
 		if tc.expectedError {
 			assert.NotNil(t, err, tc.name)
 		} else {

--- a/tests/integration/controllers/addons_test.go
+++ b/tests/integration/controllers/addons_test.go
@@ -631,6 +631,20 @@ var _ = Describe("enable and disable successful addon", func() {
 			}, "30s", "5s").ShouldNot(HaveOccurred())
 		})
 
+		By("check addon gets to DisablingAddon state", func() {
+			Eventually(func() error {
+				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("error fetching addon: %v", err)
+				}
+
+				if aObj.Status.Status != harvesterv1.DisablingAddon && aObj.Status.Status != "" {
+					return fmt.Errorf("waiting for addon to be disabled, current state is :%s", aObj.Status.Status)
+				}
+				return nil
+			}, "30s", "5s").ShouldNot(HaveOccurred())
+		})
+
 		By("helm chart is missing", func() {
 			Eventually(func() error {
 				_, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When an Addon is disabled, it should become a new disabling status, and if user click enable again, the action should be denied, to make sure the enable will wait until the previous disable action is finished. To avoid potential race condition.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Introduction of a DisablingAddon state, and additional validation logic in the harvester webhook.

**Related Issue:**
https://github.com/harvester/harvester/issues/4108

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
