### PR TITLE
Do not add empty required node affinity in patchAffinity

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -273,8 +273,12 @@ func (m *vmMutator) patchAffinity(vm *kubevirtv1.VirtualMachine, patchOps types.
 	}
 
 	// The .spec.affinity could not be like `{nodeAffinity:requireDuringSchedulingIgnoreDuringExecution:[]}` if there is not any rules.
-	if len(requiredNodeSelector.NodeSelectorTerms) == 0 && len(preferredNodeSelector) == 0 {
-		affinity.NodeAffinity = nil
+	if len(requiredNodeSelector.NodeSelectorTerms) == 0 {
+		if len(preferredNodeSelector) == 0 {
+			affinity.NodeAffinity = nil
+		} else {
+			affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = nil
+		}
 	}
 
 	bytes, err := json.Marshal(affinity)

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -361,6 +361,33 @@ func TestPatchAffinity(t *testing.T) {
 			},
 		},
 	}
+	vm7 := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+								{
+									Weight: 1,
+									Preference: v1.NodeSelectorTerm{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      "topology.kubernetes.io/zone",
+												Operator: v1.NodeSelectorOpIn,
+												Values:   []string{"zone1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	net1 := &cniv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "net1",
@@ -494,6 +521,28 @@ func TestPatchAffinity(t *testing.T) {
 					RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 						{
 							TopologyKey: "topology.kubernetes.io/zone",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no empty required affinity",
+			vm:   vm7,
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+						{
+							Weight: 1,
+							Preference: v1.NodeSelectorTerm{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "topology.kubernetes.io/zone",
+										Operator: v1.NodeSelectorOpIn,
+										Values:   []string{"zone1"},
+									},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
clean empty required node affinity in patchAffinity

**Related Issue:**
https://github.com/harvester/harvester/issues/4136

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Create a VM with a Preferred node scheduling rule
