### PR TITLE
Revert "Upgrade: wrap the elemental CLI for fixing the upgrade failure"

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,13 +1,3 @@
-FROM registry.suse.com/bci/bci-base:15.4 AS temp_elemental
-
-RUN zypper rm -y container-suseconnect && \
-    zypper --no-gpg-checks ref && \
-    zypper in -y curl tar gzip && zypper clean -a
-
-RUN mkdir -p /tmp/elemental_cli && \
-    curl -sfL https://github.com/rancher/elemental-cli/releases/download/v0.1.1/elemental-v0.1.1-Linux-x86_64.tar.gz | tar -xz -C /tmp/elemental_cli
-
-
 FROM registry.suse.com/bci/bci-base:15.4
 
 ARG ARCH=amd64
@@ -23,8 +13,6 @@ RUN curl -sfL https://storage.googleapis.com/kubernetes-release/release/${KUBECT
 RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v0.55.2/virtctl-v0.55.2-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/latest/download/wharfie-amd64  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
-
-COPY --from=temp_elemental /tmp/elemental_cli /usr/local/bin/elemental_cli
 
 COPY do_upgrade_node.sh /usr/local/bin/
 COPY upgrade_node.sh /usr/local/bin/

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -ex
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-ELEMENTAL_DIR="elemental_cli"
 
 source $SCRIPT_DIR/lib.sh
 UPGRADE_TMP_DIR=$HOST_DIR/usr/local/upgrade_tmp
@@ -11,10 +10,6 @@ clean_up_tmp_files()
   if [ -n "$tmp_rootfs_mount" ]; then
     echo "Try to unmount $tmp_rootfs_mount..."
     umount $tmp_rootfs_mount || echo "Umount $tmp_rootfs_mount failed with return code: $?"
-  fi
-  if [ -n "$target_elemental_cli" ]; then
-    echo "Try to unmount $target_elemental_cli..."
-    umount $target_elemental_cli || echo "Umount $target_elemental_cli failed with return code: $?"
   fi
   echo "Clean up tmp files..."
   if [ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]; then
@@ -536,12 +531,8 @@ upgrade_os() {
   tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
   mount $tmp_rootfs_squashfs $tmp_rootfs_mount
 
-  # replace the fixed elemental CLI for fix elemental upgrade issues
-  new_elemental_cli=$SCRIPT_DIR/$ELEMENTAL_DIR/elemental
-  target_elemental_cli=$HOST_DIR/usr/bin/elemental
   elemental_upgrade_log="${UPGRADE_TMP_DIR#"$HOST_DIR"}/elemental-upgrade-$(date +%Y%m%d%H%M%S).log"
   local ret=0
-  mount --bind $new_elemental_cli $target_elemental_cli
   chroot $HOST_DIR elemental upgrade --logfile "$elemental_upgrade_log" --directory ${tmp_rootfs_mount#"$HOST_DIR"} || ret=$?
   if [ "$ret" != 0 ]; then
     echo "elemental upgrade failed with return code: $ret"
@@ -557,7 +548,6 @@ upgrade_os() {
   GRUBENV_FILE="/oem/grubenv"
   chroot $HOST_DIR /bin/bash -c "if ! [ -f ${GRUBENV_FILE} ]; then grub2-editenv ${GRUBENV_FILE} create; fi"
 
-  umount $target_elemental_cli
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 


### PR DESCRIPTION
This reverts commit be92fd08225486dc48fa7e2368de8290f8c46fb4.

    - We do not need to wrap elemental CLI for upgrade issue after v1.1.2.
    - Do not revert the cleanup

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Do not need to wrap elemental CLI. After v1.1.2, we already avoided the upgrade issue with the duplicated label.

**Solution:**
Revert the previous patch to wrap new elemental cli

**Related Issue:**

**Test plan:**
Upgrade should work
