### PR TITLE
Improve warning message if free system disk space is insufficient for upgrading

### DIFF
--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -38,6 +38,7 @@ const (
 	rkeInternalIPAnnotation        = "rke2.io/internal-ip"
 	managedChartNamespace          = "fleet-local"
 	defaultMinFreeDiskSpace uint64 = 30 * 1024 * 1024 * 1024 // 30GB
+	freeSystemPartitionMsg         = "df -h '/usr/local/'"
 )
 
 func NewValidator(
@@ -282,7 +283,8 @@ func (v *upgradeValidator) checkDiskSpace(node *corev1.Node, minFreeDiskSpace ui
 	if *summary.Node.Fs.AvailableBytes < minFreeDiskSpace {
 		min := units.BytesSize(float64(minFreeDiskSpace))
 		avail := units.BytesSize(float64(*summary.Node.Fs.AvailableBytes))
-		return werror.NewBadRequest(fmt.Sprintf("Node %q has insufficient free space (%s). An upgrade requires at least %s of free space.", node.Name, avail, min))
+		return werror.NewBadRequest(fmt.Sprintf("Node %q has insufficient free system partition space %s (%s). The upgrade requires at least %s of free system partition space on each node.",
+			node.Name, avail, freeSystemPartitionMsg, min))
 	}
 	return nil
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Improve warning message if free system disk space is insufficient for upgrading

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
In the error message, adding information about free system disk space

**Related Issue:**
https://github.com/harvester/harvester/issues/2935#issuecomment-1580231584

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Use this branch to build a new ISO.
2. Create a new Harvester cluster. One of the nodes' disk space should be 250G.
3. If every node's `/usr/local` free space is more than 30G, you can use `dd` to write files to make sure one of the nodes is less than 30G. For example: `dd if=/dev/zero of=/usr/local/test.img bs=1G count=5`.
4. Create a test version.
    ```yaml
    apiVersion: harvesterhci.io/v1beta1
    kind: Version
    metadata:
      name: master
      namespace: harvester-system
    spec:
      isoURL: http://192.168.0.55:8080/iso/harvester-master-amd64.iso
    ```
4. Click upgrade on the dashboard. We should get an error message mentioning `/usr/local`.
![upgrade_insufficient](https://github.com/harvester/harvester/assets/19387129/f83b85cc-ad9f-4842-8b1e-9faa11d299aa)
