### PR TITLE
fix(upgrade): skip restarting RKE2 servers

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -243,6 +243,18 @@ wait_evacuation_pdb_gone()
   done
 }
 
+recover_rancher_system_agent() {
+  # only versions before v1.2.0 that upgrading to v1.2.0 need to recover the workaround
+  if [ -z "$UPGRADE_PREVIOUS_VERSION" ]; then
+    detect_upgrade
+  fi
+  if [[ ! "${UPGRADE_PREVIOUS_VERSION%%-rc*}" < "v1.2.0" ]]; then
+    echo "Only versions before v1.2.0 need to recover this patch."
+    return
+  fi
+  chroot "$HOST_DIR" /bin/bash -c "rm -rf /run/systemd/system/rancher-system-agent.service.d && systemctl daemon-reload && systemctl restart rancher-system-agent.service"
+}
+
 wait_longhorn_engines() {
   node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true -o json | jq -r '.items | length')
 
@@ -369,6 +381,8 @@ EOF
 }
 
 command_pre_drain() {
+  recover_rancher_system_agent
+
   wait_longhorn_engines
 
   shutdown_non_migrate_able_vms
@@ -593,6 +607,8 @@ command_post_drain() {
 
 command_single_node_upgrade() {
   echo "Upgrade single node"
+
+  recover_rancher_system_agent
 
   wait_repo
   detect_repo


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

There will be machine plan (`custom-xxxxx` Secrets) changes after Rancher upgrades from v2.6.x to v2.7.x during Harvester upgrades. The RKE2 server/agent on the nodes will be restarted by `rancher-system-agent` while Rancher detects the changes and tries to reconcile them. This behavior brings down LH volumes and then causes various types of issues to the Pods and VMs associated with the volumes.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Adding an environment variable `INSTALL_RKE2_SKIP_ENABLE=true` to make `rancher-system-agent`  to NOT restart `rke2-server`/`rke2-agent` triggered by machine plan reconciliation during Rancher upgrade (from v2.6.x to v2.7.x). This is kind of a workaround. We add a systemd service drop-in file for `rancher-system-agent` to feed an additional environment file, then reload and restart the service. The environment variable will take effect until we remove it at the node pre-drain phase.

**Related Issue:**

#4095 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a multi-node Harvester cluster in v1.1.2
2. Upgrade with the ISO containing the fix
3. Monitor the `rke2-server`/`rke2-agent` on the nodes during the apply-manifest phase with the following commands, to see if they get restarted (they should **NOT** be restarted)
```
# on the nodes, check the "Active" timestamp
sudo systemctl status rke2-server.service # if it's a worker node, use "rke2-agent.service" instead
```
4. The upgrade should be successful