### PR TITLE
add opt-in Longhorn network policy

### DIFF
--- a/deploy/charts/harvester/templates/longhorn-network-policy.yaml
+++ b/deploy/charts/harvester/templates/longhorn-network-policy.yaml
@@ -165,4 +165,24 @@ spec:
     - ports:
         - protocol: TCP
           port: 9502
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cattle-monitoring-prometheus
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: cattle-monitoring-system
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: rancher-monitoring-prometheus
 {{- end -}}

--- a/deploy/charts/harvester/templates/longhorn-network-policy.yaml
+++ b/deploy/charts/harvester/templates/longhorn-network-policy.yaml
@@ -1,0 +1,168 @@
+{{ if .Values.enableLonghornNetworkPolicy -}}
+# Source: longhorn/templates/network-policies/backing-image-data-source-network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backing-image-data-source
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: backing-image-data-source
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: longhorn-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: instance-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: backing-image-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: backing-image-data-source
+---
+# Source: longhorn/templates/network-policies/backing-image-manager-network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backing-image-manager
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: backing-image-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: longhorn-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: instance-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: backing-image-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: backing-image-data-source
+---
+# Source: longhorn/templates/network-policies/instance-manager-networking.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: instance-manager
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: instance-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: longhorn-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: instance-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: backing-image-manager
+        - podSelector:
+            matchLabels:
+              longhorn.io/component: backing-image-data-source
+---
+# Source: longhorn/templates/network-policies/manager-network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-manager
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: longhorn-manager
+        - podSelector:
+            matchLabels:
+              app: longhorn-ui
+        - podSelector:
+            matchLabels:
+              app: longhorn-csi-plugin
+        - podSelector:
+            matchLabels:
+              longhorn.io/managed-by: longhorn-manager
+            matchExpressions:
+              - { key: recurring-job.longhorn.io, operator: Exists }
+        - podSelector:
+            matchExpressions:
+              - { key: longhorn.io/job-task, operator: Exists }
+        - podSelector:
+            matchLabels:
+              app: longhorn-driver-deployer
+---
+# Source: longhorn/templates/network-policies/recovery-backend-network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-recovery-backend
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9503
+---
+# Source: longhorn/templates/network-policies/webhook-network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-conversion-webhook
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9501
+---
+# Source: longhorn/templates/network-policies/webhook-network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-admission-webhook
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9502
+{{- end -}}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -510,3 +510,5 @@ snapshot-validation-webhook:
     repository: registry.k8s.io/sig-storage/snapshot-validation-webhook
     tag: v5.0.1
     pullPolicy: IfNotPresent
+
+enableLonghornNetworkPolicy: true


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Need to add opt-in Longhorn network policy to secure its backend API.

**Solution:**
Enable the opt-in Longhorn network policy

**Related Issue:**
https://github.com/longhorn/longhorn/discussions/3031

**Test plan:**
-  Cases1: Users from the other namespaces should not be able to access the longhorn backend API
   - get the longhorn-backed svc IP via `kubectl get svc -n longhorn-system | grep longhorn-backend`
   - start a VM in a namespace e.g., default and exec into the VM pod via `$kubectl exec -it $pod bash`
   - run `curl http://$ip:9500/v1` and you will get a JSON response
   - after applying the LH network policy rules, users are no longer able to curl the Longhorn backend API in any other pods except those pods defined by the network policy.
- Case 2: admin user can still access the Longhorn dashboard UI
- Case 3&4: users should be able to create and restore VM backups, VM snapshot,s and volume snapshots
- Case 5: users can still use the Harvester csi-driver in the guest k8s cluster as before.
   - create an nginx pod and add persistent pvc using the `harvester` storage class in the guest rke2 cluster. 
   - check if both the pod and its mount point is running successfully.
<img width="2354" alt="image" src="https://github.com/harvester/harvester/assets/4569037/54c748d9-88e4-4b0d-b590-b563c791e672">
<img width="2047" alt="image" src="https://github.com/harvester/harvester/assets/4569037/4271aab9-2425-4110-93fc-f6fa49d2a928">


