### PR TITLE
Upgrade: wrap latest elemental CLI

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,3 +1,6 @@
+# source reference: https://build.opensuse.org/package/show/isv:Rancher:Elemental:Stable:Teal53/builder-image
+FROM registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-builder-image/5.3:0.3.1 AS temp_elemental
+
 FROM registry.suse.com/bci/bci-base:15.4
 
 ARG ARCH=amd64
@@ -13,6 +16,8 @@ RUN curl -sfL https://storage.googleapis.com/kubernetes-release/release/${KUBECT
 RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v0.55.2/virtctl-v0.55.2-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/latest/download/wharfie-amd64  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
+
+COPY --from=temp_elemental /usr/bin/elemental /usr/local/bin/elemental
 
 COPY do_upgrade_node.sh /usr/local/bin/
 COPY upgrade_node.sh /usr/local/bin/

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -11,6 +11,10 @@ clean_up_tmp_files()
     echo "Try to unmount $tmp_rootfs_mount..."
     umount $tmp_rootfs_mount || echo "Umount $tmp_rootfs_mount failed with return code: $?"
   fi
+  if [ -n "$target_elemental_cli" ]; then
+    echo "Try to unmount $target_elemental_cli..."
+    umount $target_elemental_cli || echo "Umount $target_elemental_cli failed with return code: $?"
+  fi
   echo "Clean up tmp files..."
   if [ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]; then
     echo "Try to remove $NEW_OS_SQUASHFS_IMAGE_FILE..."
@@ -531,8 +535,12 @@ upgrade_os() {
   tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
   mount $tmp_rootfs_squashfs $tmp_rootfs_mount
 
+  # replace the fixed elemental CLI for fix elemental upgrade issues
+  new_elemental_cli=$SCRIPT_DIR/elemental
+  target_elemental_cli=$HOST_DIR/usr/bin/elemental
   elemental_upgrade_log="${UPGRADE_TMP_DIR#"$HOST_DIR"}/elemental-upgrade-$(date +%Y%m%d%H%M%S).log"
   local ret=0
+  mount --bind $new_elemental_cli $target_elemental_cli
   chroot $HOST_DIR elemental upgrade --logfile "$elemental_upgrade_log" --directory ${tmp_rootfs_mount#"$HOST_DIR"} || ret=$?
   if [ "$ret" != 0 ]; then
     echo "elemental upgrade failed with return code: $ret"
@@ -548,6 +556,7 @@ upgrade_os() {
   GRUBENV_FILE="/oem/grubenv"
   chroot $HOST_DIR /bin/bash -c "if ! [ -f ${GRUBENV_FILE} ]; then grub2-editenv ${GRUBENV_FILE} create; fi"
 
+  umount $target_elemental_cli
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 


### PR DESCRIPTION
    - We still need the latest elemental CLI for upgrading.
      That is because we need to change bootargs from COS_ACTIVE to
      COS_STATE.

    - Get back the wrap mechanism
    - Revert "Revert "Upgrade: wrap the elemental CLI for fixing the upgrade failure""
      This reverts commit 20ca0b3e737ede6b64787284d49e38aa2f9601e9.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We still need the latest elemental CLI for upgrading.
That is because we need to change bootargs from COS_ACTIVE to COS_STATE. 

**Solution:**
Get back the wrap mechanism

**Related Issue:**
https://github.com/harvester/harvester/issues/4113

**Test plan:**
Upgrade to latest elemental-toolkit based ISO should work.
