### PR TITLE
upgrade pcidevices addon to v0.2.5-rc2

### DIFF
--- a/package/upgrade/addons/pcidevices-controller.yaml
+++ b/package/upgrade/addons/pcidevices-controller.yaml
@@ -3,14 +3,12 @@ kind: Addon
 metadata:
   name: pcidevices-controller
   namespace: harvester-system
-  labels:
-    addon.harvesterhci.io/experimental: "true"
 spec:
   repo: http://harvester-cluster-repo.cattle-system.svc/charts
-  version: "0.2.5-rc1"
+  version: "0.2.5-rc2"
   chart: harvester-pcidevices-controller
   enabled: false
   valuesContent: |
     image:
-      tag: v0.2.5-rc1
+      tag: v0.2.5-rc2
     fullnameOverride: harvester-pcidevices-controller


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR upgrades pcidevices controller addon to v0.2.5-rc2 and also drops the experimental label.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
