### PR TITLE
additional inventory status check in power action apis

### DIFF
--- a/pkg/api/node/formatter_test.go
+++ b/pkg/api/node/formatter_test.go
@@ -291,6 +291,9 @@ var (
 				"name":      testNode.Name,
 				"namespace": defaultAddonNamespace,
 			},
+			"status": map[string]interface{}{
+				"status": nodeReady,
+			},
 		},
 	}
 
@@ -436,7 +439,7 @@ func Test_powerActionPossible(t *testing.T) {
 	fakeHTTP := httptest.NewRecorder()
 	err = h.powerActionPossible(fakeHTTP, testNode.Name)
 	assert.NoError(err, "expected no error while querying powerActionPossible")
-	assert.Equal(fakeHTTP.Result().StatusCode, http.StatusOK, "expected to find node")
+	assert.Equal(fakeHTTP.Result().StatusCode, http.StatusNoContent, "expected to find node")
 }
 
 func Test_powerAction(t *testing.T) {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Error during validation of seeder addon: https://github.com/harvester/seeder/pull/9#pullrequestreview-1478498920

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces additional checks in power action api's to ensure inventory is ready before power action can be performed.

In addition the default http response code for the powerActionPossible api call has been changed.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
