### PR TITLE
Upgrade: fix RKE2 is not upgraded in the single node case

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -605,10 +605,6 @@ command_single_node_upgrade() {
   echo "wait for fleet bundles before upgrading RKE2"
   # wait all fleet bundles in limited time
   wait_for_fleet_bundles
-  # scale down fleet-agent, scale up will be done in upgrade controller
-  echo "scale down fleet-agent"
-  kubectl scale --replicas=0 deployment/fleet-agent -n cattle-fleet-local-system
-  kubectl rollout status deployment fleet-agent -n cattle-fleet-local-system
 
   # update max-pods to 200 #
   set_max_pods
@@ -619,8 +615,6 @@ command_single_node_upgrade() {
   clean_rke2_archives
 
   convert_nodenetwork_to_vlanconfig
-
-  # the fleet-agent will be scaled up via the pkg/controller/upgrade/upgrade_controller.go
 
   # Upgrade OS
   upgrade_os

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -38,7 +38,6 @@ func Register(ctx context.Context, management *config.Management, options config
 	machines := management.ClusterFactory.Cluster().V1alpha4().Machine()
 	secrets := management.CoreFactory.Core().V1().Secret()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
-	deployments := management.AppsFactory.Apps().V1().Deployment()
 	lhSettings := management.LonghornFactory.Longhorn().V1beta2().Setting()
 
 	controller := &upgradeHandler{
@@ -63,7 +62,6 @@ func Register(ctx context.Context, management *config.Management, options config
 		pvcClient:         pvcs,
 		clusterClient:     clusters,
 		clusterCache:      clusters.Cache(),
-		deploymentClient:  deployments,
 		lhSettingClient:   lhSettings,
 		lhSettingCache:    lhSettings.Cache(),
 	}

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -12,7 +12,6 @@ import (
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	provisioningctrl "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
-	ctlappsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/batch/v1"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -88,9 +87,8 @@ type upgradeHandler struct {
 	serviceClient ctlcorev1.ServiceClient
 	pvcClient     ctlcorev1.PersistentVolumeClaimClient
 
-	clusterClient    provisioningctrl.ClusterClient
-	clusterCache     provisioningctrl.ClusterCache
-	deploymentClient ctlappsv1.DeploymentClient
+	clusterClient provisioningctrl.ClusterClient
+	clusterCache  provisioningctrl.ClusterCache
 
 	lhSettingClient ctllhv1.SettingClient
 	lhSettingCache  ctllhv1.SettingCache
@@ -333,24 +331,6 @@ func (h *upgradeHandler) cleanup(upgrade *harvesterv1.Upgrade, cleanJobs bool) e
 	repo := NewUpgradeRepo(h.ctx, upgrade, h)
 	if err := repo.deleteVM(); err != nil {
 		return err
-	}
-
-	// For single node case, we scale fleet agent deployment replicas to 0 before upgrading RKE2.
-	// Restore the replica back when upgrade is done.
-	if upgrade.Status.SingleNode != "" {
-		fleetAgentDP, err := h.deploymentClient.Get("cattle-fleet-local-system", "fleet-agent", metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		logrus.Debugf("Replicas of fleet agent deployment: %d", *fleetAgentDP.Spec.Replicas)
-		if fleetAgentDP.Spec.Replicas != nil && *fleetAgentDP.Spec.Replicas == 0 {
-			logrus.Infof("Scale replicas of fleet agent deployment to 1")
-			toUpdate := fleetAgentDP.DeepCopy()
-			*toUpdate.Spec.Replicas = 1
-			if _, err := h.deploymentClient.Update(toUpdate); err != nil {
-				return err
-			}
-		}
 	}
 
 	// remove rkeConfig in fleet-local/local cluster


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
RKE2 is pending for upgrade in single node upgrade case.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The cluster is waiting for the `mcc-local-managed-system-upgrade-controller` bundle.  The bundle can't be ready due to no fleet-agent pod running. Previously, we scaled down fleet-agent to avoid hitting http:///github.com/rancher/fleet/issues/637. Since https://github.com/rancher/fleet/issues/637 is fixed, we can remove the workaround.

**Related Issue:**
https://github.com/harvester/harvester/issues/4119

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Create a single node 1.1.2 cluster.
- Upgrade to the PR version; the upgrade should succeed.
**note**: need to test with https://github.com/harvester/harvester/pull/4149