### PR TITLE
chart: add harvester ingress np

### DIFF
--- a/deploy/charts/harvester/templates/longhorn-network-policy.yaml
+++ b/deploy/charts/harvester/templates/longhorn-network-policy.yaml
@@ -185,4 +185,24 @@ spec:
         podSelector:
           matchLabels:
             app.kubernetes.io/instance: rancher-monitoring-prometheus
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: harvester
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: harvester-system
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: harvester
 {{- end -}}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When we try to upload a file to create the image, it would be stuck and then failed with an error message
`Dial tcp 10.53.159.208:9500: i/o timeout`

![image](https://github.com/harvester/harvester/assets/29251855/435e0e0d-5167-4fd4-8151-553715f1278e)

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Adding network policy ingress to longhorn-manager from Harvester

**Related Issue:**
#4182

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Using this branch to build a new Harvester ISO, and creating a Harvester cluster with this ISO
2. Creating an image
3. Uploading and selecting a file 
4. Checking the image state
5. The image should be uploaded successfully

**Test plan:**
Harvester-master/Harvester-1.2 doesn't appear issue #4182 before 2023/07/04 (included)
