### PR TITLE
enable qcow raw image build on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,6 +60,7 @@ steps:
     ref:
       include:
       - "refs/heads/master"
+      - "refs/heads/release-*"
       - "refs/heads/v*"
     event:
     - push
@@ -107,6 +108,7 @@ steps:
     ref:
       include:
       - "refs/heads/master"
+      - "refs/heads/release-*"
       - "refs/heads/v*"
     event:
     - push
@@ -155,6 +157,7 @@ steps:
     ref:
       include:
       - "refs/heads/master"
+      - "refs/heads/release-*"
       - "refs/heads/v*"
     event:
     - push
@@ -217,6 +220,7 @@ steps:
     ref:
       include:
       - "refs/heads/master"
+      - "refs/heads/release-*"
       - "refs/heads/v*"
     event:
     - push
@@ -256,6 +260,7 @@ steps:
     ref:
       include:
       - "refs/heads/master"
+      - "refs/heads/release-*"
       - "refs/heads/v*"
     event:
     - push
@@ -295,6 +300,7 @@ steps:
     ref:
       include:
       - "refs/heads/master"
+      - "refs/heads/release-*"
       - "refs/heads/v*"
     event:
     - push
@@ -417,6 +423,7 @@ trigger:
     - push
   ref:
     - "refs/heads/master"
+    - "refs/heads/release-*"
     - "refs/heads/v*"
     - "refs/tags/*"
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,7 @@ steps:
 
 - name: build
   image: rancher/dapper:v0.5.8
+  privileged: true
   environment:
     CODECOV_TOKEN:
       from_secret: codecov_token
@@ -350,6 +351,7 @@ steps:
 
 - name: build
   image: rancher/dapper:v0.5.8
+  privileged: true
   commands:
   - dapper build-iso
   volumes:

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -73,7 +73,7 @@ COPY --from=elemental /usr/bin/elemental /usr/bin/elemental
 # -- for dapper
 ENV DAPPER_RUN_ARGS --privileged --network host -v /run/containerd/containerd.sock:/run/containerd/containerd.sock
 ENV GO111MODULE off
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS GOPROXY PUSH RKE2_IMAGE_REPO USE_LOCAL_IMAGES CODECOV_TOKEN
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS GOPROXY PUSH RKE2_IMAGE_REPO USE_LOCAL_IMAGES CODECOV_TOKEN BUILD_QCOW DRONE_BUILD_EVENT
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester/
 ENV DAPPER_OUTPUT ./bin ./dist ./package
 ENV DAPPER_DOCKER_SOCKET true

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -13,7 +13,12 @@ git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 http
 
 cd ../harvester-installer/scripts
 
-./ci
+if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    echo "Building ISO image with BUILD_QCOW enabled"
+    BUILD_QCOW=true ./ci
+else
+    ./ci
+fi
 
 cd ..
 HARVESTER_DIR=../harvester


### PR DESCRIPTION
**Problem:**
for install mode, the qcow raw image build is disabled by default, need to enable it on tag releases.

**Solution:**
enable qcow raw image build on a tag.

**Related Issue:**
https://github.com/harvester/harvester/issues/2198
Related PR: https://github.com/harvester/harvester-installer/pull/457


**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
