### PR TITLE
Upgrade: minor optimization of preloading phase

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -198,7 +198,6 @@ import_image_archives_from_repo() {
       image_list_url="$UPGRADE_REPO_BUNDLE_ROOT/$list"
       archive_url="$UPGRADE_REPO_BUNDLE_ROOT/$archive"
       image_list_file="${tmp_image_archives}/$(basename $list)"
-      archive_file="${tmp_image_archives}/${archive_name}.tar"
 
       # Check if images already exist
       curl -sfL $image_list_url | sort > $image_list_file
@@ -208,9 +207,7 @@ import_image_archives_from_repo() {
         continue
       fi
 
-      curl -sfL $archive_url | zstd -d -f --no-progress -o $archive_file
-      $CTR -n k8s.io image import $archive_file
-      rm -f $archive_file
+      curl -fL $archive_url | zstdcat | $CTR -n k8s.io images import --no-unpack -
     done
   rm -rf $tmp_image_archives
 }


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
There are some optimizations we can do in the prepare script.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- Chain commands with pipes, this reduces the image loading time and eliminates temporary space requirement.
  - We don't save the tarball to disk anymore. This reduce the chance to cause kubelet image GC on disk pressure.
- Do not unpack the image in containerd.
  - Images are unpacked only when containers use them. This reduces the disk pressure as well. It's a tradeoff of space saving to a little bit container starting overhead.
 
**Results**
(capture with running Harvester VMs in WD SN750 NVMe disk):

### Single node upgrade
| Before |      After     |
|:------:|:--------------:|
| 04m53s | 2m38s          |

### 3-node upgrade

| Before |      After     |
|:------:|:--------------:|
| 7m | 3m52s          |

**Related Issue:**

https://github.com/harvester/harvester/issues/4208

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Create a Harvester cluster.
- Patch the rancher/harvester-upgrade:<current_version> with the PR change.
- Upgrade to a newer version. The new ISO needs to contain different images in image tarballs for testing. Otherwise, the preload script will skip the preloading. One tip is to start a v1.2.0-rc3 cluster and upgrade to a master build ISO.
- The upgrade should succeed, and the `upgrade-preapre-node-xxx` job should be faster than previous upgrades.




