### PR TITLE
CI: Publish the harvester-cluster-repo image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -409,6 +409,86 @@ steps:
     event:
       - tag
 
+- name: docker-publish-cluster-repo-branch
+  image: plugins/docker
+  settings:
+    context: dist/harvester-cluster-repo
+    custom_dns: 1.1.1.1
+    dockerfile: dist/harvester-cluster-repo/Dockerfile
+    repo: "rancher/harvester-cluster-repo"
+    tag: ${DRONE_BRANCH}-head-amd64
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/head/master
+      - refs/head/v*
+    event:
+    - push
+
+- name: manifest-cluster-repo-branch
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    platforms:
+    - linux/amd64
+    target: "rancher/harvester-cluster-repo:${DRONE_BRANCH}-head"
+    template: "rancher/harvester-cluster-repo:${DRONE_BRANCH}-head-ARCH"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/head/master
+      - refs/head/v*
+    event:
+    - push
+
+- name: docker-publish-cluster-repo-tag
+  image: plugins/docker
+  settings:
+    context: dist/harvester-cluster-repo
+    custom_dns: 1.1.1.1
+    dockerfile: dist/harvester-cluster-repo/Dockerfile
+    repo: "rancher/harvester-cluster-repo"
+    tag: "${DRONE_TAG}-amd64"
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/tags/*
+    event:
+    - tag
+
+- name: manifest-cluster-repo-tag
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    platforms:
+      - linux/amd64
+    target: "rancher/harvester-cluster-repo:${DRONE_TAG}"
+    template: "rancher/harvester-cluster-repo:${DRONE_TAG}-ARCH"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/tags/*
+    event:
+    - tag
+
 trigger:
   event:
     - tag

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -20,4 +20,5 @@ HARVESTER_DIR=../harvester
 
 mkdir -p ${HARVESTER_DIR}/dist/artifacts
 cp dist/artifacts/* ${HARVESTER_DIR}/dist/artifacts
+cp -r dist/harvester-cluster-repo  ${HARVESTER_DIR}/dist
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The image rancher/harvester-cluster-repo is built on the installer side and shipped in the package tarball.
We need to publish the image to the docker hub as well, sometimes it's easier to debug.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Publish the image.

**Related Issue:**
https://github.com/harvester/harvester/issues/2670

**Note**: This PR requires https://github.com/harvester/harvester-installer/pull/496 to be merged first.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
