### PR TITLE
Bump eventrouter to v0.1.1 and replace repo

### DIFF
--- a/package/upgrade/addons/logging_addon.yaml
+++ b/package/upgrade/addons/logging_addon.yaml
@@ -55,7 +55,7 @@ spec:
       controlNamespace: cattle-logging-system
       workloadOverrides:
         containers:
-        - image: banzaicloud/eventrouter:v0.1.0
+        - image: rancher/harvester-eventrouter:v0.1.1
           name: event-tailer
           resources:
             limits:


### PR DESCRIPTION

**Problem:**
https://github.com/harvester/security/issues/31

**Solution:**
Fork the original project, replace the base image, and replace the docker build with the dapper build.

**Related Issue:**
https://github.com/harvester/security/issues/31

**Test plan:**
1. Edit the rancher-logging addon yaml.
2. Replace `banzaicloud/eventrouter:v0.1.0` to `rancher/harvester-eventrouter:v0.1.1`
3. Enable the rancher-logging.
