### PR TITLE
Chart values: bump node-disk-manager and node-manager image versions

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -388,7 +388,7 @@ harvester-node-disk-manager:
     repository: rancher/harvester-node-disk-manager
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.5.0
+    tag: v0.5.1
 
 csi-snapshotter:
   ## Specify whether to install the csi-snapshotter
@@ -502,7 +502,7 @@ harvester-node-manager:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/harvester-node-manager
-    tag: v0.1.5
+    tag: v0.1.7
 
 snapshot-validation-webhook:
   enabled: true


### PR DESCRIPTION
Bump image versions.
- Node-disk-manager: https://github.com/harvester/node-disk-manager/releases/tag/v0.5.1
- Node-manager: https://github.com/harvester/node-manager/releases/tag/v0.1.7