### PR TITLE
fix(support-bundle): download timed out

### DIFF
--- a/pkg/api/supportbundle/download_handler.go
+++ b/pkg/api/supportbundle/download_handler.go
@@ -42,7 +42,7 @@ func NewDownloadHandler(scaled *config.Scaled, namespace string) *DownloadHandle
 		supportBundleCache: scaled.HarvesterFactory.Harvesterhci().V1beta1().SupportBundle().Cache(),
 		podCache:           scaled.CoreFactory.Core().V1().Pod().Cache(),
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: 24 * time.Hour,
 		},
 	}
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Support bundle download timeout

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Extending the http client timeout

**Related Issue:**
https://github.com/harvester/harvester/issues/3383

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Making sure support bundle image is newer than v0.0.25(including), it fixed the download timeout on server side. ![support-bundle-kit](https://github.com/harvester/harvester/assets/19387129/5529cce1-7854-452d-900e-fafa60ceeae4)
- Generating support bundle, and making sure the download time requires longer than 30 seconds
  - Since download time depends on the amount of data in support bundle, I had some modifications to generate dummy support bundle for downloading, [100MB](https://github.com/WebberHuang1118/support-bundle-kit/tree/100MB-sb-testing) and [2GB](https://github.com/WebberHuang1118/support-bundle-kit/tree/2gb-sb-testing) respectively
  - For the environment with **local Harvester**, the support bundle image could change to `webberhuang/support-bundle-kit:v0.0.25-2gb-sb-testing`
  - For the environment **accessing Harvester through VPN**, the support bundle image could change to `webberhuang/support-bundle-kit:v0.0.25-100MB-sb-testing`
- Downloading generated support bundle

**Note:**
The download timeout is configured the same as Longhorn https://github.com/longhorn/longhorn-manager/pull/2066

