### PR TITLE
fix(upgradelog): adjust format of collected logs

### DIFF
--- a/pkg/api/upgradelog/handler.go
+++ b/pkg/api/upgradelog/handler.go
@@ -30,28 +30,16 @@ const (
 	defaultJobBackoffLimit int32 = 5
 	logPackagingScript           = `
 #!/usr/bin/env sh
-set -ex
+set -e
+
+echo "clean up stale archives, if any"
+
+rm -vf /archive/*.zip
 
 echo "start to package upgrade logs"
 
-tmpdir=$(mktemp -d)
-mkdir $tmpdir/logs
-
-cd /archive/logs
-
-for f in *.log
-do
-	awk '{$1=$2=""; print $0}' $f | jq -r .message > $tmpdir/logs/$f || ret=$?
-	if [ -n "$ret" ]; then
-		echo "Failed to process the file $f with ret=$ret"
-		echo "Copy the original file to the destination"
-		cp $f $tmpdir/logs/$f
-		unset ret
-	fi
-done
-
-cd $tmpdir
-zip -r /archive/$ARCHIVE_NAME ./logs/
+cd /archive
+zip -r $ARCHIVE_NAME ./logs/
 echo "done"
 `
 )


### PR DESCRIPTION
This is to optimize the disk utilization, especially for the `log-archive` volume.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Previously, the content of log files may include lots of unnecessary metadata, and we discard them at the log-packaging level. But those data still occupy precious disk space. If the upgrade gets into trouble, there will be bloated log files in the volume, causing the log-packager Job to fail to package the logs (due to no space left). 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

We relieve the issue to a certain degree by the following improvements:

- Trim down the redundant fields (`.kubernetes` metadata) in the log entries at the very beginning of the log pipeline.
- No more JSON processing in the log-packaging step
- Previously generated log archive files will be purged every time a new one is generated
- ~~Skip processing invalid JSON-format lines instead of giving up on the whole file. The problematic lines will be prepended with a `PARSE_ERROR` token.~~
- ~~Expand the default `log-archive` volume to **10Gi**~~

~~Also, we added a timestamp field for every log entry for ease to identify the order among log files.~~

**Related Issue:**

#4222

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Provision a Harvester cluster (single-node is ok) with an ISO image which contains the PR
2. Upgrade the cluster with the same ISO image
3. Download the upgrade log archive by clicking the "Download Log" button on the upgrade dialog
4. Check if the content of the downloaded log files is correct
5. Download the upgrade log archive again
6. Find out the fluentd Pod and exec a shell to check the generated archive file. There should be only one archive file, which is the newest (check the timestamp on the filename):
```
$ kubectl -n harvester-system get pods -l harvesterhci.io/upgradeLogComponent=aggregator
NAME                                             READY   STATUS    RESTARTS   AGE
test-upgrade-master-upgradelog-infra-fluentd-0   2/2     Running   0          44s

$ kubectl -n harvester-system exec -it test-upgrade-master-upgradelog-infra-fluentd-0 -c fluentd -- sh

# ls /archive/
```