### PR TITLE
Drone: publish cluster-repo images on release-* branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -418,6 +418,7 @@ steps:
     - drone-publish.rancher.io
     ref:
       - refs/heads/master
+      - refs/heads/release-*
       - refs/heads/v*
     event:
     - push
@@ -438,6 +439,7 @@ steps:
     - drone-publish.rancher.io
     ref:
       - refs/heads/master
+      - refs/heads/release-*
       - refs/heads/v*
     event:
     - push


### PR DESCRIPTION
Fix CI jobs of release branches not publishing `harvester-cluster-repo` images (merge event).
e.g., https://drone-publish.rancher.io/harvester/harvester/1162/3/3