### PR TITLE
Add cattle-logging-system to SB by default

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -155,6 +155,7 @@ func (m *Manager) getCollectNamespaces() string {
 		"harvester-system",
 		"local",
 		"longhorn-system",
+		"cattle-logging-system",
 	}
 
 	extraNamespaces := settings.SupportBundleNamespaces.Get()


### PR DESCRIPTION
Add cattle-logging-system to SB by default.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The `cattle-logging-system` is not in the default namespace list of support-bundle.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

https://github.com/harvester/harvester/issues/4309

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install Harvester
2. Enable `rancher-logging` addon
3. Wait sometime
4. Generate a support-bundle file
5. The `cattle-logging-system` related PODs and CRDs should be collected in support-bundle file