### PR TITLE
Change the default value of ui-brand to harvester

### DIFF
--- a/pkg/controller/master/rancher/embedded_rancher.go
+++ b/pkg/controller/master/rancher/embedded_rancher.go
@@ -14,7 +14,8 @@ import (
 )
 
 var UpdateRancherUISettings = map[string]string{
-	"ui-pl": "Harvester",
+	"ui-pl":    "Harvester",
+	"ui-brand": "harvester",
 }
 
 func (h *Handler) RancherSettingOnChange(key string, setting *rancherv3api.Setting) (*rancherv3api.Setting, error) {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
https://github.com/harvester/harvester/issues/4315

**Solution:**
Change the default value of ui-brand to "Harvester".

**Related Issue:**
https://github.com/harvester/harvester/issues/4315

**Test plan:**
Build and run the harvester image, watch the ui-brand setting, and its default value is "Harvester".
