### PR TITLE
Trim space for all values in backup secret in order to pass the longhorn webhook

### DIFF
--- a/pkg/controller/master/backup/backup_target.go
+++ b/pkg/controller/master/backup/backup_target.go
@@ -208,6 +208,11 @@ func getBackupSecretData(target *settings.BackupTarget) (map[string]string, erro
 	data[util.HTTPSProxyEnv] = httpProxyConfig.HTTPSProxy
 	data[util.NoProxyEnv] = util.AddBuiltInNoProxy(httpProxyConfig.NoProxy)
 
+	// trim spaces for all values in order to pass the Longhorn webhook, refer to https://github.com/longhorn/longhorn-manager/pull/970
+	for k, v := range data {
+		data[k] = strings.TrimSpace(v)
+	}
+
 	return data, nil
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Due to the AWS go client issue https://github.com/aws/aws-sdk-go/issues/689, 
Longhorn has a issue https://github.com/longhorn/longhorn/issues/811, 
so Longhorn add a fix https://github.com/longhorn/longhorn-manager/pull/970
Although aws/aws-sdk-go issue https://github.com/aws/aws-sdk-go/issues/689  has been fixed by https://github.com/aws/aws-sdk-go/pull/690, Longhorn's webhook is still retained. 

If the user add blank lines to the Harvester backup related settings, due to Harvester is using a newer version of the aws-sdk-go , it can pass the Harvester's own backup target setting webhook, but can not  pass the Longhorn's backup secret webhook in https://github.com/longhorn/longhorn-manager/pull/970

After failing to update longhorn's backup secret, method `OnBackupTargetChange`  returns prematurely in [here ](https://github.com/harvester/harvester/blob/a58ac82f3ace6907c9cda3fb4ff9278fc015dde0/pkg/controller/master/backup/backup_target.go#L99), without executing method [reUpdateBackupTargetSettingSecret](https://github.com/harvester/harvester/blob/a58ac82f3ace6907c9cda3fb4ff9278fc015dde0/pkg/controller/master/backup/backup_target.go#L142) which remove the sensitive fields in the `backup-target` setting

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
When updating longhorn's backup secret, strim blank lines to avoid being rejected by the longhorn webhook

**Related Issue:**
https://github.com/harvester/harvester/issues/4360

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. prepare a https minio server, refer to https://github.com/minio/minio/blob/master/docs/tls/README.md#generate-use-self-signed-keys-certificates
2. for the "first-time" / "original" time in adding a Minio Connection with Custom additional-ca cert, ensure that when pasting in the cert, add extra new lines
3. then fill out the rest for the backup-target, the region, access key, secret access key
4. check the result
- no longhorn webhook error
- no sensitive fields leak

https://github.com/harvester/harvester/issues/4360#issuecomment-1678209639