### PR TITLE
Fix harvester POD booting restarts error due to webhook is not ready

### DIFF
--- a/pkg/data/add.go
+++ b/pkg/data/add.go
@@ -6,8 +6,8 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 )
 
-// Init adds built-in resources
-func Init(ctx context.Context, mgmtCtx *config.Management, options config.Options) error {
+// Init adds built-in resources, the `basic` part, which does not rely on webhook
+func InitBasicData(ctx context.Context, mgmtCtx *config.Management, options config.Options) error {
 	if err := createCRDs(ctx, mgmtCtx.RestConfig); err != nil {
 		return err
 	}
@@ -22,6 +22,13 @@ func Init(ctx context.Context, mgmtCtx *config.Management, options config.Option
 		return err
 	}
 
+	// createTemplates and createSecrets are called later in InitAdditional
+	return nil
+}
+
+// Init adds built-in resources, the `additional` part, which relies on webhook
+// Called after the `harvester-webhook` is ready
+func InitAdditionalData(ctx context.Context, mgmtCtx *config.Management, options config.Options) error {
 	// Not applying the built-in templates and secrets in case users have edited them.
 	if err := createTemplates(mgmtCtx, publicNamespace); err != nil {
 		return err

--- a/tests/framework/dsl/action.go
+++ b/tests/framework/dsl/action.go
@@ -13,9 +13,9 @@ const (
 	commonTimeoutInterval = 10
 	commonPollingInterval = 1
 
-	vmTimeoutInterval  = 300
+	vmTimeoutInterval  = 500
 	vmPollingInterval  = 2
-	pvcTimeoutInterval = 300
+	pvcTimeoutInterval = 500
 	pvcPollingInterval = 2
 )
 

--- a/tests/integration/api/vm_apis_utils_test.go
+++ b/tests/integration/api/vm_apis_utils_test.go
@@ -22,7 +22,8 @@ const (
 	testVMUpdatedCPUCore = 2
 	testVMUpdatedMemory  = "200Mi"
 
-	testVMDiskSize = "10Mi"
+	// Longhorn limits the volume size to be >= 100M
+	testVMDiskSize = "120Mi"
 
 	testVMInterfaceName  = "default"
 	testVMInterfaceModel = "virtio"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Harvester POD does not wait harvester-webhook in proper sequence.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Harvester POD waits for harvester-webhook properly.

**Related Issue:**
https://github.com/harvester/harvester/issues/4416

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install a new cluster, e.g. single-node cluser
2. Restart the cluster several times
3. `kubectl get pods -n harvester-system`, the `RESTARTS` of Harvester POD should be same as others.
