### PR TITLE
Upgrade: adjust new active.img file size to 3G

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -549,13 +549,24 @@ upgrade_os() {
   tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
   mount $tmp_rootfs_squashfs $tmp_rootfs_mount
 
+  tmp_elemental_config_dir=$(mktemp -d -p $HOST_DIR/tmp)
+  # adjust new active.img size
+  cat > $tmp_elemental_config_dir/config.yaml <<EOF
+upgrade:
+  system:
+    size: 3072
+EOF
+
   # replace the fixed elemental CLI for fix elemental upgrade issues
   new_elemental_cli=$SCRIPT_DIR/elemental
   target_elemental_cli=$HOST_DIR/usr/bin/elemental
   elemental_upgrade_log="${UPGRADE_TMP_DIR#"$HOST_DIR"}/elemental-upgrade-$(date +%Y%m%d%H%M%S).log"
   local ret=0
   mount --bind $new_elemental_cli $target_elemental_cli
-  chroot $HOST_DIR elemental upgrade --logfile "$elemental_upgrade_log" --directory ${tmp_rootfs_mount#"$HOST_DIR"} || ret=$?
+  chroot $HOST_DIR elemental upgrade \
+    --logfile "$elemental_upgrade_log" \
+    --directory ${tmp_rootfs_mount#"$HOST_DIR"} \
+    --config-dir ${tmp_elemental_config_dir#"$HOST_DIR"} || ret=$?
   if [ "$ret" != 0 ]; then
     echo "elemental upgrade failed with return code: $ret"
     cat "$HOST_DIR$elemental_upgrade_log"


### PR DESCRIPTION
To be consistent with previous versions.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Elemental calculates the image size automatically. So right now the image is near 1.5 G, which is inconsistent with previous versions.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Use elemental config and change the image size back to 3G.

**Related Issue:**
https://github.com/harvester/harvester/issues/4479

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Create a 1.1.2 cluster.
- Upgrade to an ISO contains the PR change.
- Check active.img and passive.img size is 3G.
```
node1:~ # ls -alh /run/initramfs/cos-state/cOS/*
-rw-r--r-- 1 root root 3.0G Sep  5 16:15 /run/initramfs/cos-state/cOS/active.img
-rw-r--r-- 1 root root 3.0G Sep  5 16:15 /run/initramfs/cos-state/cOS/passive.img
```
