### PR TITLE
Fix mergeStorageClassParams for vmimage clone

### DIFF
--- a/pkg/webhook/resources/virtualmachineimage/mutator.go
+++ b/pkg/webhook/resources/virtualmachineimage/mutator.go
@@ -105,10 +105,10 @@ func (m *virtualMachineImageMutator) getStorageClass(storageClassName string) (*
 func mergeStorageClassParams(image *harvesterv1.VirtualMachineImage, storageClass *storagev1.StorageClass) map[string]string {
 	params := util.GetImageDefaultStorageClassParameters()
 	var mergeParams map[string]string
-	if image.Spec.StorageClassParameters != nil {
-		mergeParams = image.Spec.StorageClassParameters
-	} else if storageClass != nil {
+	if storageClass != nil {
 		mergeParams = storageClass.Parameters
+	} else if image.Spec.StorageClassParameters != nil {
+		mergeParams = image.Spec.StorageClassParameters
 	}
 	var allowPatchParams = []string{
 		longhorntypes.OptionNodeSelector, longhorntypes.OptionDiskSelector,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently, image's `Spec.StorageClassParameters` has a higher priority than image's `harvesterhci.io/storageClassName
` annotation.

Modifying storageclass does not work during vm clone.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
change the priority of image's `Spec.StorageClassParameters` and image's `harvesterhci.io/storageClassName
` annotation



**Related Issue:**
https://github.com/harvester/harvester/issues/4506

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. create a storageclass (name=`any-replicas-1` replicas=1)
2. create a new vm image (name=`image-test-r1` storageclass=`any-replicas-1`), the replicas should be 1
3. create a new vm image (name=`image-test-r3` storageclass=`harvester-longhorn`), the replicas should be 3
4. clone the vm image `image-test-r1` to create a new vm image   (name=`image-test-r1-clone-r3` storageclass=`harvester-longhorn`), the replicas should be 3
5. clone the vm image `image-test-r3` to create a new vm image   (name=`image-test-r3-clone-r1` storageclass=`any-replicas-1`), the replicas should be 1