### PR TITLE
Rectify backing image name

### DIFF
--- a/pkg/api/image/schema.go
+++ b/pkg/api/image/schema.go
@@ -18,6 +18,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		ImageCache:                  scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
 		BackingImageDataSources:     scaled.LonghornFactory.Longhorn().V1beta2().BackingImageDataSource(),
 		BackingImageDataSourceCache: scaled.LonghornFactory.Longhorn().V1beta2().BackingImageDataSource().Cache(),
+		BackingImageCache:           scaled.LonghornFactory.Longhorn().V1beta2().BackingImage().Cache(),
 	}
 
 	t := schema.Template{

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -3,27 +3,69 @@ package util
 import (
 	"fmt"
 
+	lhdatastore "github.com/longhorn/longhorn-manager/datastore"
+	"github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	longhorntypes "github.com/longhorn/longhorn-manager/types"
+	lhutil "github.com/longhorn/longhorn-manager/util"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 )
 
-func GetBackingImageName(image *harvesterv1.VirtualMachineImage) string {
+func backingImageLegacyName(image *harvesterv1.VirtualMachineImage) string {
 	return fmt.Sprintf("%s-%s", image.Namespace, image.Name)
+}
+
+func GetBackingImage(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (*v1beta2.BackingImage, error) {
+	bi, err := backingImageCache.Get(LonghornSystemNamespaceName, backingImageLegacyName(image))
+	if err == nil {
+		return bi, nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	rectifyName := lhutil.AutoCorrectName(backingImageLegacyName(image), lhdatastore.NameMaximumLength)
+	return backingImageCache.Get(LonghornSystemNamespaceName, rectifyName)
+}
+
+func GetBackingImageName(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (string, error) {
+	bi, err := GetBackingImage(backingImageCache, image)
+	if err == nil {
+		return bi.Name, nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return "", err
+	}
+
+	return lhutil.AutoCorrectName(backingImageLegacyName(image), lhdatastore.NameMaximumLength), nil
+}
+
+func GetBackingImageDataSourceName(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (string, error) {
+	//In LH design, backingimagedatasource name is identical with backingimage
+	return GetBackingImageName(backingImageCache, image)
 }
 
 func GetImageStorageClassName(imageName string) string {
 	return fmt.Sprintf("longhorn-%s", imageName)
 }
 
-func GetImageStorageClassParameters(image *harvesterv1.VirtualMachineImage) map[string]string {
+func GetImageStorageClassParameters(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (map[string]string, error) {
+	biName, err := GetBackingImageName(backingImageCache, image)
+	if err != nil {
+		return nil, err
+	}
+
 	params := map[string]string{
-		LonghornOptionBackingImageName: GetBackingImageName(image),
+		LonghornOptionBackingImageName: biName,
 	}
 	for k, v := range image.Spec.StorageClassParameters {
 		params[k] = v
 	}
-	return params
+	return params, nil
 }
 
 func GetImageDefaultStorageClassParameters() map[string]string {


### PR DESCRIPTION
**Problem:**

Longhorn has a 40 characters name length limitation for backing images. If it exceeds the limitation, [webhook will automatically change the backing image name](https://github.com/longhorn/longhorn-manager/blob/432b6d40f02a6fdffd8389df9d779016775f1d3a/webhook/resources/backingimage/mutator.go#L50).

And this violates Harvester's naming convention for `virtualimage`, `backingimage` and `storageclass`:
- `backingimage name` =` <virutalimage namsespace>`-`<virutalimage name>`
- `storageclass name` = `longhorn-<virutalimage name>`

**Solution:**
Rectify the backing image name to align Longhorn's webhook

**Related Issue:**
#4520 

**Test plan on Master Environment:**
- Prerequisites
  1. Applying the following yaml to create virtualimage:
      ```
      apiVersion: harvesterhci.io/v1beta1
      kind: VirtualMachineImage
      metadata:
        name: ubuntu-bionic-123456789012345678901234567890
        namespace: default
      spec:
        checksum: ""
        displayName: ubuntu-bionic
        pvcName: ""
        pvcNamespace: ""
        retry: 3
        sourceType: download
        storageClassParameters:
          migratable: "true"
          numberOfReplicas: "3"
          staleReplicaTimeout: "30"
        url: https://cloud-images.ubuntu.com/bionic/20230607/bionic-server-cloudimg-amd64.img
      ```
  2. Creating VM from this virtualimage
  
- Results without this patch:
  1. backingimage `default-ubuntu-bionic-123456789-xxxxxxxx` created
  2. storageclass `longhorn-ubuntu-bionic-123456789012345678901234567890`
      - `paramters.backingImage` points to `default-ubuntu-bionic-123456789012345678901234567890` (**mismatch**)
  3. VM creation appears volume provision issue `missing backing image default-ubuntu-bionic-123456789012345678901234567890 unable to create volume` 
  4. Backing image requires manual deletion to cleanup

- Results with this patch:
  1. backingimage `default-ubuntu-bionic-123456789-xxxxxxxx` created
  2. storageclass `longhorn-ubuntu-bionic-123456789012345678901234567890`
      -   `paramters.backingImage` points to `default-ubuntu-bionic-123456789-xxxxxxxx` (**match**)
  3. VM creation success

**Test plan for Backward Compatibility:**
- Prerequisites
  1. Build Harvester Cluster with v1.1.2
  2. Applying the following yaml to create virtualimage:
      ```
      apiVersion: harvesterhci.io/v1beta1
      kind: VirtualMachineImage
      metadata:
        name: ubuntu-bionic-123456789012345678901234567890
        namespace: default
      spec:
        checksum: ""
        displayName: ubuntu-bionic
        pvcName: ""
        pvcNamespace: ""
        retry: 3
        sourceType: download
        storageClassParameters:
          migratable: "true"
          numberOfReplicas: "3"
          staleReplicaTimeout: "30"
        url: https://cloud-images.ubuntu.com/bionic/20230607/bionic-server-cloudimg-amd64.img
      ```
  3. There should be a backingimage `default-ubuntu-bionic-123456789012345678901234567890` created
  4. storageclass `longhorn-ubuntu-bionic-123456789012345678901234567890`
      - `paramters.backingImage` points to `default-ubuntu-bionic-123456789012345678901234567890` (**match**)
   5. Build Harvester from this ISO, and upgrade to it
- Steps: 
  1.  VM creation with this image success
  2. Deleting the VM, related volume, and image success 
