### PR TITLE
bump support-bundlekit to v0.0.28

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -472,7 +472,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.20
+    tag: v0.0.28
 
 generalJob:
   image:


### PR DESCRIPTION
**Problem:**
Bump support-bundle-kit to v0.0.28 for v1.1 branch

**Solution:**
Support-bundle-kit to v0.0.25 for v1.1 branch

**Related Issue:**
#4267 

**Test plan:**

**Deploy to running Harvester**
- Building Harvester cluster from v1.1 branch
- Changing `setting->support-bundle-image` to `v0.0.28`
- Generating support bundle
- Checking if deployment `supportbundle-manager-bundle-xxxx` successfully deploying image `rancher/support-bundle-kit:v0.0.28`
- Using support-bundle-kit simulator to check if the downloaded SB works normally

**Building new Harvester with this PR**
- Building ISO from this branch, and creating Harvester cluster with the ISO
- Generating support bundle
- After Harvester brought up, Check if deployment `supportbundle-manager-bundle-xxxx` successfully deploying image `rancher/support-bundle-kit:v0.0.25`
- Using support-bundle-kit simulator to check if the downloaded SB works normally

**Checking download large dummy Support Bundle**
- In either of the above two environments
- Changing `setting->support-bundle-image` to `webberhuang/support-bundle-kit:v0.0.28_5gb-sb-testing` to create a dummy 5GB SB
- Generating and downloading support bundle
- Checking if SB successfully downloaded
