### PR TITLE
feat: bump kubevirt and vmdp

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -27,7 +27,7 @@ kubevirt-operator:
     operator:
       image:
         repository: registry.suse.com/suse/sles/15.4/virt-operator
-        tag: &kubevirtVersion 0.54.0-150400.3.10.4
+        tag: &kubevirtVersion 0.54.0-150400.3.19.1
     ## The following images are placeholder for images in use.
     ## They are not used by the kubevirt-operator chart.
     controller:

--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -506,7 +506,7 @@ spec:
               claimName: pvc-rootdisk
             name: rootdisk
           - containerDisk:
-              image: registry.suse.com/suse/vmdp/vmdp:2.5.3
+              image: registry.suse.com/suse/vmdp/vmdp:2.5.4.2
               imagePullPolicy: IfNotPresent
             name: virtio-container-disk
 `


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
- need to fix os-pkg CVE issues of kubevirt images
- bump the vmdp driver to the newer version that SUSE supports https://www.suse.com/lifecycle#product-suse-linux-enterprise-virtual-machine-driver-pack

**Solution:**
- bump kubevirt image to `0.54.0-150400.3.19.1`, only contains os package update.
- bump vmdp Windows driver image to [v2.5.4.2](https://github.com/SUSE/vmdp/releases/tag/v2.5.4.2)

**Related Issue:**
https://github.com/harvester/harvester/issues/4367

**Test plan:**
  -  Bump Kubevirt Image
      - spin up a new Harvester cluster with the new ISO build
      - ensure the kubevirt pods in the `harvester-system` are all running correctly
      - test basic VM CRUD should works

 - VMDP
    - check the windows template contains the latest vmdp image `2.5.4.2` (support new install only)
    - follow the steps in https://docs.harvesterhci.io/v1.1/vm/create-windows-vm and ensure the new vmdp driver works

Related PR: https://github.com/harvester/harvester-installer/pull/551
