### PR TITLE
fix: wrong SupportBundle CRD addtionalPrinterColumns path

### DIFF
--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_supportbundles.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_supportbundles.yaml
@@ -20,7 +20,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.issueURL
+    - jsonPath: .spec.issueURL
       name: ISSUE_URL
       type: string
     - jsonPath: .spec.description

--- a/pkg/apis/harvesterhci.io/v1beta1/supportbundle.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/supportbundle.go
@@ -12,7 +12,7 @@ var (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=sb;sbs,scope=Namespaced
-// +kubebuilder:printcolumn:name="ISSUE_URL",type=string,JSONPath=`.status.issueURL`
+// +kubebuilder:printcolumn:name="ISSUE_URL",type=string,JSONPath=`.spec.issueURL`
 // +kubebuilder:printcolumn:name="DESCRIPTION",type="string",JSONPath=`.spec.description`
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=`.metadata.creationTimestamp`
 


### PR DESCRIPTION
**Problem:**
Fix showing SupportBundle CR incorrectly.

**Solution:**
Modify the additionalPrinterColumns path of SupportBundle CRD to right path.

**Related Issue:**
https://github.com/harvester/harvester/issues/4630

**Test plan:**
https://github.com/harvester/harvester/issues/4630#issuecomment-1772296750, after modifying CRD, execute `kubectl get supportbundles` to check output. If there is no any SupportBundle CR, just create a new one by following below data.

```yaml
apiVersion: harvesterhci.io/v1beta1
kind: SupportBundle
metadata:
    name: "test01"
spec:
    issueURL: "this is issueURL"
    description: "this is description"
```

Before
![image](https://github.com/harvester/harvester/assets/6960289/ce1bf930-0f9d-48cd-9f50-00dcf7221924)

After
![image](https://github.com/harvester/harvester/assets/6960289/6bbb2b08-636b-4256-90ac-dbefb497e17a)
