### PR TITLE
feat: fix flipping between Paused and Running

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -3,12 +3,17 @@ package virtualmachine
 import (
 	"context"
 
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
 	"github.com/harvester/harvester/pkg/util/resourcequota"
 )
 
 const (
 	vmControllerCreatePVCsFromAnnotationControllerName           = "VMController.CreatePVCsFromAnnotation"
+	vmControllerRestartFromPausedIOErrorControllerName           = "VMController.RestartFromPausedIOError"
 	vmiControllerUnsetOwnerOfPVCsControllerName                  = "VMIController.UnsetOwnerOfPVCs"
 	vmiControllerReconcileFromHostLabelsControllerName           = "VMIController.ReconcileFromHostLabels"
 	vmControllerSetDefaultManagementNetworkMac                   = "VMController.SetDefaultManagementNetworkMacAddress"
@@ -17,46 +22,61 @@ const (
 	vmControllerManagePVCOwnerControllerName                     = "VMController.ManageOwnerOfPVCs"
 	vmControllerSetHaltIfInsufficientResourceQuotaControllerName = "VMController.SetHaltIfInsufficientResourceQuota"
 	vmiControllerSetHaltIfOccurExceededQuotaControllerName       = "VMIController.StopVMIfExceededQuota"
+	settingControllerVMForceRestartPolicyControllerName          = "SettingController.VMForceRestartPolicy"
 	harvesterUnsetOwnerOfPVCsFinalizer                           = "harvesterhci.io/VMController.UnsetOwnerOfPVCs"
 	oldWranglerFinalizer                                         = "wrangler.cattle.io/VMController.UnsetOwnerOfPVCs"
 )
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
 	var (
-		nsCache        = management.CoreFactory.Core().V1().Namespace().Cache()
-		podCache       = management.CoreFactory.Core().V1().Pod().Cache()
-		rqCache        = management.HarvesterCoreFactory.Core().V1().ResourceQuota().Cache()
-		pvcClient      = management.CoreFactory.Core().V1().PersistentVolumeClaim()
-		pvcCache       = pvcClient.Cache()
-		vmClient       = management.VirtFactory.Kubevirt().V1().VirtualMachine()
-		vmCache        = vmClient.Cache()
-		nodeClient     = management.CoreFactory.Core().V1().Node()
-		nodeCache      = nodeClient.Cache()
-		vmiClient      = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
-		vmiCache       = vmiClient.Cache()
-		vmBackupClient = management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup()
-		vmBackupCache  = vmBackupClient.Cache()
-		snapshotClient = management.SnapshotFactory.Snapshot().V1().VolumeSnapshot()
-		vmimCache      = management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache()
-		snapshotCache  = snapshotClient.Cache()
-		recorder       = management.NewRecorder(vmControllerSetHaltIfInsufficientResourceQuotaControllerName, "", "")
+		nsCache             = management.CoreFactory.Core().V1().Namespace().Cache()
+		podCache            = management.CoreFactory.Core().V1().Pod().Cache()
+		rqCache             = management.HarvesterCoreFactory.Core().V1().ResourceQuota().Cache()
+		pvCache             = management.CoreFactory.Core().V1().PersistentVolume().Cache()
+		pvcClient           = management.CoreFactory.Core().V1().PersistentVolumeClaim()
+		pvcCache            = pvcClient.Cache()
+		vmClient            = management.VirtFactory.Kubevirt().V1().VirtualMachine()
+		vmCache             = vmClient.Cache()
+		nodeClient          = management.CoreFactory.Core().V1().Node()
+		nodeCache           = nodeClient.Cache()
+		vmiClient           = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
+		vmiCache            = vmiClient.Cache()
+		vmBackupClient      = management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup()
+		vmBackupCache       = vmBackupClient.Cache()
+		snapshotClient      = management.SnapshotFactory.Snapshot().V1().VolumeSnapshot()
+		vmimCache           = management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache()
+		snapshotCache       = snapshotClient.Cache()
+		longhornVolumeCache = management.LonghornFactory.Longhorn().V1beta2().Volume().Cache()
+		recorder            = management.NewRecorder(vmControllerSetHaltIfInsufficientResourceQuotaControllerName, "", "")
 	)
+
+	virtSubsrcConfig := rest.CopyConfig(management.RestConfig)
+	virtSubsrcConfig.GroupVersion = &k8sschema.GroupVersion{Group: "subresources.kubevirt.io", Version: "v1"}
+	virtSubsrcConfig.APIPath = "/apis"
+	virtSubsrcConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	virtSubresourceClient, err := rest.RESTClientFor(virtSubsrcConfig)
+	if err != nil {
+		return err
+	}
 
 	// registers the vm controller
 	var vmCtrl = &VMController{
-		pvcClient:      pvcClient,
-		pvcCache:       pvcCache,
-		vmClient:       vmClient,
-		vmController:   vmClient,
-		vmiClient:      vmiClient,
-		vmiCache:       vmiCache,
-		vmBackupClient: vmBackupClient,
-		vmBackupCache:  vmBackupCache,
-		snapshotClient: snapshotClient,
-		snapshotCache:  snapshotCache,
-		recorder:       recorder,
+		pvCache:             pvCache,
+		pvcClient:           pvcClient,
+		pvcCache:            pvcCache,
+		vmClient:            vmClient,
+		vmController:        vmClient,
+		vmiClient:           vmiClient,
+		vmiCache:            vmiCache,
+		vmBackupClient:      vmBackupClient,
+		vmBackupCache:       vmBackupCache,
+		snapshotClient:      snapshotClient,
+		snapshotCache:       snapshotCache,
+		longhornVolumeCache: longhornVolumeCache,
+		recorder:            recorder,
 
-		vmrCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache),
+		vmrCalculator:             resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache),
+		virtSubresourceRestClient: virtSubresourceClient,
 	}
 	var virtualMachineClient = management.VirtFactory.Kubevirt().V1().VirtualMachine()
 	virtualMachineClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)
@@ -64,6 +84,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	virtualMachineClient.OnChange(ctx, vmControllerStoreRunStrategyControllerName, vmCtrl.StoreRunStrategy)
 	virtualMachineClient.OnChange(ctx, vmControllerSyncLabelsToVmi, vmCtrl.SyncLabelsToVmi)
 	virtualMachineClient.OnChange(ctx, vmControllerSetHaltIfInsufficientResourceQuotaControllerName, vmCtrl.SetHaltIfInsufficientResourceQuota)
+	virtualMachineClient.OnChange(ctx, vmControllerRestartFromPausedIOErrorControllerName, vmCtrl.RestartFromPausedIOError)
 
 	// registers the vmi controller
 	var virtualMachineCache = virtualMachineClient.Cache()
@@ -89,5 +110,11 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 	virtualMachineInstanceClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
 
+	var settingCtl = &SettingController{
+		vmController: vmClient,
+		vmCache:      vmCache,
+	}
+	var settingClient = management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
+	settingClient.OnChange(ctx, settingControllerVMForceRestartPolicyControllerName, settingCtl.OnVMForceRestartPolicyChanged)
 	return nil
 }

--- a/pkg/controller/master/virtualmachine/setting_controller.go
+++ b/pkg/controller/master/virtualmachine/setting_controller.go
@@ -1,0 +1,41 @@
+package virtualmachine
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	kubevirtctrl "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/settings"
+)
+
+type SettingController struct {
+	vmController kubevirtctrl.VirtualMachineController
+	vmCache      kubevirtctrl.VirtualMachineCache
+}
+
+func (h *SettingController) OnVMForceRestartPolicyChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil ||
+		setting.Name != settings.VMForceRestartPolicySettingName || setting.Value == "" {
+		return setting, nil
+	}
+
+	vmForceRestartPolicy, err := settings.DecodeVMForceRestartPolicy(setting.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	if !vmForceRestartPolicy.Enable {
+		return setting, nil
+	}
+
+	vms, err := h.vmCache.List(corev1.NamespaceAll, labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vm := range vms {
+		h.vmController.Enqueue(vm.Namespace, vm.Name)
+	}
+	return setting, nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -41,6 +41,7 @@ var (
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
+	VMForceRestartPolicySet                = NewSetting(VMForceRestartPolicySettingName, InitVMForceRestartPolicy())
 	OvercommitConfig                       = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":150,"storage":200}`)
 	VipPools                               = NewSetting(VipPoolsConfigSettingName, "")
 	AutoDiskProvisionPaths                 = NewSetting("auto-disk-provision-paths", "")
@@ -59,6 +60,7 @@ const (
 	AdditionalCASettingName                           = "additional-ca"
 	BackupTargetSettingName                           = "backup-target"
 	VMForceResetPolicySettingName                     = "vm-force-reset-policy"
+	VMForceRestartPolicySettingName                   = "vm-force-restart-policy"
 	SupportBundleTimeoutSettingName                   = "support-bundle-timeout"
 	HTTPProxySettingName                              = "http-proxy"
 	OvercommitConfigSettingName                       = "overcommit-config"
@@ -204,6 +206,10 @@ type VMForceResetPolicy struct {
 	Period int64 `json:"period"`
 }
 
+type VMForceRestartPolicy struct {
+	Enable bool `json:"enable"`
+}
+
 func InitBackupTargetToString() string {
 	target := &BackupTarget{}
 	targetStr, err := json.Marshal(target)
@@ -248,6 +254,26 @@ func InitVMForceResetPolicy() string {
 
 func DecodeVMForceResetPolicy(value string) (*VMForceResetPolicy, error) {
 	policy := &VMForceResetPolicy{}
+	if err := json.Unmarshal([]byte(value), policy); err != nil {
+		return nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, value)
+	}
+
+	return policy, nil
+}
+
+func InitVMForceRestartPolicy() string {
+	policy := &VMForceRestartPolicy{
+		Enable: false,
+	}
+	policyStr, err := json.Marshal(policy)
+	if err != nil {
+		logrus.Errorf("failed to init %s, error: %s", VMForceRestartPolicySettingName, err.Error())
+	}
+	return string(policyStr)
+}
+
+func DecodeVMForceRestartPolicy(value string) (*VMForceRestartPolicy, error) {
+	policy := &VMForceRestartPolicy{}
 	if err := json.Unmarshal([]byte(value), policy); err != nil {
 		return nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, value)
 	}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -72,6 +72,7 @@ type validateSettingFunc func(setting *v1beta1.Setting) error
 var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.HTTPProxySettingName:                              validateHTTPProxy,
 	settings.VMForceResetPolicySettingName:                     validateVMForceResetPolicy,
+	settings.VMForceRestartPolicySettingName:                   validateVMForceRestartPolicy,
 	settings.SupportBundleImageName:                            validateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName:                   validateSupportBundleTimeout,
 	settings.OvercommitConfigSettingName:                       validateOvercommitConfig,
@@ -254,6 +255,18 @@ func validateVMForceResetPolicy(setting *v1beta1.Setting) error {
 	}
 
 	if _, err := settings.DecodeVMForceResetPolicy(setting.Value); err != nil {
+		return werror.NewInvalidError(err.Error(), "value")
+	}
+
+	return nil
+}
+
+func validateVMForceRestartPolicy(setting *v1beta1.Setting) error {
+	if setting.Value == "" {
+		return nil
+	}
+
+	if _, err := settings.DecodeVMForceRestartPolicy(setting.Value); err != nil {
 		return werror.NewInvalidError(err.Error(), "value")
 	}
 


### PR DESCRIPTION
**Problem:**
VM status flipping between Paused and Running when host accidentally restarts.

**Solution:**
Check whether VM is stuck in PasuedIOError when the related Volume is healthy.

**Related Issue:**
https://github.com/harvester/harvester/issues/4633

**Test plan:**
1. Create a 3-node harvester cluster.
2. Provision a 3-node RKE2 cluster on the harvester and wait for it's ready.
3. Choose one node to stop kubelet.
    a. Find the pid of kubelet process by `ps -aux | grep kubelet`.
    b. Freeze the kubelet process by `kill -STOP <kubelet-pid>`. 
4. After the node is unavailable. Run `shutdown now -r`.
5. After the node is running again, the VM can't be ready.
