### PR TITLE
fix(upgrade): check mountpoint exist before umount

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -28,13 +28,18 @@ cleanup_incomplete_state_file() {
   fi
 }
 
+is_mounted()
+{
+  mount | awk -v DIR="$1" '{ if ($3 == DIR) { exit 0 } } ENDFILE { exit 1 }'
+}
+
 clean_up_tmp_files()
 {
-  if [ -n "$tmp_rootfs_mount" ]; then
+  if [ -n "$tmp_rootfs_mount" ] && is_mounted "$tmp_rootfs_mount"; then
     echo "Try to unmount $tmp_rootfs_mount..."
     umount $tmp_rootfs_mount || echo "Umount $tmp_rootfs_mount failed with return code: $?"
   fi
-  if [ -n "$target_elemental_cli" ]; then
+  if [ -n "$target_elemental_cli" ] && is_mounted "$target_elemental_cli"; then
     echo "Try to unmount $target_elemental_cli..."
     umount $target_elemental_cli || echo "Umount $target_elemental_cli failed with return code: $?"
   fi


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The rootfs and elemental cli may be unmounted before the trap handler gets called. In that case, the handler won't be able to unmount those directories because they're already unmounted. Therefore, the script generates horrifying messages like `Umount /host/usr/bin/elemental failed with return code: 32` which scares the user. In fact, the upgrade process is still in good shape.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Check if the directories are mounted right before unmounting them.

**Related Issue:**

#4493

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a v1.2.0 Harvester cluster (single node is fine)
1. Build an custom ISO image with the fix
1. Upgrade the cluster with the custom ISO image
1. Check the logs when the upgrade progress is at the post-draining phase, there should be no `Umount xxx failed with return code: 32` errors