### PR TITLE
feat: add supportbundle manager env

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -91,6 +91,14 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string, pullPolicy
 									Value: sb.Name,
 								},
 								{
+									Name:  "SUPPORT_BUNDLE_DESCRIPTION",
+									Value: sb.Spec.Description,
+								},
+								{
+									Name:  "SUPPORT_BUNDLE_ISSUE_URL",
+									Value: sb.Spec.IssueURL,
+								},
+								{
 									Name:  "SUPPORT_BUNDLE_DEBUG",
 									Value: "true",
 								},


### PR DESCRIPTION
**Problem:**
https://github.com/rancher/support-bundle-kit/pull/81#issuecomment-1780546702

**Solution:**
When create support manager, give it description and issue URL env. And [downstream support bundle kit PR](https://github.com/rancher/support-bundle-kit/pull/81) will accept env value to create metadata.yaml.

**Related Issue:**
https://github.com/harvester/harvester/issues/4630

**Test plan:**
In the harvester dashboard, create support bundle with following condition

- Empty description and issue URL
- Filled description and empty issue URL

After download support bundle, check `metadata.yaml`

![image](https://github.com/harvester/harvester/assets/6960289/ad89e068-43c7-43d5-baf7-bb976243e728)
![image](https://github.com/harvester/harvester/assets/6960289/d63b41f2-0847-4654-b1ef-0f0ac79ff1dc)
![Pasted_Image_2023_10_26__4_07 PM](https://github.com/harvester/harvester/assets/6960289/032babd7-f135-412e-bf11-4bb436e343b5)


