### PR TITLE
fix: prevent vmrestore with delete policy if there is vmbackup snapshot

### DIFF
--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -9,20 +9,23 @@ import (
 )
 
 const (
-	VMBackupBySourceUIDIndex            = "harvesterhci.io/vmbackup-by-source-uid"
-	VMRestoreByTargetNamespaceAndName   = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
-	VMRestoreByVMBackupNamespaceAndName = "harvesterhci.io/vmrestore-by-vmbackup-namespace-and-name"
+	VMBackupBySourceUIDIndex              = "harvesterhci.io/vmbackup-by-source-uid"
+	VMRestoreByTargetNamespaceAndName     = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
+	VMRestoreByVMBackupNamespaceAndName   = "harvesterhci.io/vmrestore-by-vmbackup-namespace-and-name"
+	VMBackupSnapshotByPVCNamespaceAndName = "harvesterhci.io/vmbackup-snapshot-by-pvc-namespace-and-name"
 )
 
 func RegisterIndexers(clients *clients.Clients) {
 	vmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
-	vmRestoreCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache()
 	vmBackupCache.AddIndexer(VMBackupBySourceUIDIndex, vmBackupBySourceUID)
+	vmBackupCache.AddIndexer(VMBackupSnapshotByPVCNamespaceAndName, vmBackupSnapshotByPVCNamespaceAndName)
+
+	vmRestoreCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache()
 	vmRestoreCache.AddIndexer(VMRestoreByTargetNamespaceAndName, vmRestoreByTargetNamespaceAndName)
 	vmRestoreCache.AddIndexer(VMRestoreByVMBackupNamespaceAndName, vmRestoreByVMBackupNamespaceAndName)
 
-	podInformer := clients.CoreFactory.Core().V1().Pod().Cache()
-	podInformer.AddIndexer(indexeres.PodByVMNameIndex, indexeres.PodByVMName)
+	podCache := clients.CoreFactory.Core().V1().Pod().Cache()
+	podCache.AddIndexer(indexeres.PodByVMNameIndex, indexeres.PodByVMName)
 }
 
 func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
@@ -30,6 +33,19 @@ func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error
 		return []string{string(*obj.Status.SourceUID)}, nil
 	}
 	return []string{}, nil
+}
+
+func vmBackupSnapshotByPVCNamespaceAndName(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
+	if obj.Spec.Type == harvesterv1.Backup || obj.Status == nil {
+		return []string{}, nil
+	}
+
+	result := make([]string, 0, len(obj.Status.VolumeBackups))
+	for _, volumeBackup := range obj.Status.VolumeBackups {
+		pvc := volumeBackup.PersistentVolumeClaim
+		result = append(result, fmt.Sprintf("%s/%s", pvc.ObjectMeta.Namespace, pvc.ObjectMeta.Name))
+	}
+	return result, nil
 }
 
 func vmRestoreByTargetNamespaceAndName(obj *harvesterv1.VirtualMachineRestore) ([]string, error) {

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -224,7 +224,7 @@ func (v *restoreValidator) checkBackup(vmRestore *v1beta1.VirtualMachineRestore,
 		}
 
 		if len(vmBackupSnapshotNames) != 0 {
-			return fmt.Errorf("can't use delete policy, %s is used by VMBackup snapshots %s", pvcNamespaceAndName, strings.Join(vmBackupSnapshotNames, ","))
+			return fmt.Errorf("can't use delete policy, the volume %q is used by the VM Snapshot(s) %s", pvcNamespaceAndName, strings.Join(vmBackupSnapshotNames, ", "))
 		}
 	}
 	return nil


### PR DESCRIPTION
**Problem:**
Restore from snapshot not work if target VM is restore-replaced from backup

**Solution:**
Add webhook to prevent vmrestore with deletion policy if there is vmbackup snapshot with same pvcs.

**Related Issue:**
https://github.com/harvester/harvester/issues/4604

**Test plan:**
1. Config backup-target
2. Create VM, wait VM `Running`
3. Take Backup, wait backup `Ready`
4. Take VM Snapshot, wait snapshot `Ready`
5. Stop VM, wait VM `Off`
6. Replace source vm from backup with deletion policy, webhook denies the request
7. Replace source vm from backup with retain policy, wait VM `Running`
8. Stop VM again
9. Replace source vm from snapshot, wait VM `Running`
10. Restore (New) from snapshot 
