### PR TITLE
refactor: move vmbackup metadata to namespace folder

### DIFF
--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"time"
@@ -804,7 +803,7 @@ func (h *Handler) deleteVMBackupMetadata(vmBackup *harvesterv1.VirtualMachineBac
 		return err
 	}
 
-	destURL := filepath.Join(metadataFolderPath, getVMBackupMetadataFileName(vmBackup.Namespace, vmBackup.Name))
+	destURL := getVMBackupMetadataFilePath(vmBackup.Namespace, vmBackup.Name)
 	if exist := bsDriver.FileExists(destURL); exist {
 		logrus.Debugf("delete vm backup metadata %s/%s in backup target %s", vmBackup.Namespace, vmBackup.Name, target.Type)
 		return bsDriver.Remove(destURL)
@@ -868,7 +867,7 @@ func (h *Handler) uploadVMBackupMetadata(vmBackup *harvesterv1.VirtualMachineBac
 	}
 
 	shouldUpload := true
-	destURL := filepath.Join(metadataFolderPath, getVMBackupMetadataFileName(vmBackup.Namespace, vmBackup.Name))
+	destURL := getVMBackupMetadataFilePath(vmBackup.Namespace, vmBackup.Name)
 	if bsDriver.FileExists(destURL) {
 		if remoteVMBackupMetadata, err := loadBackupMetadataInBackupTarget(destURL, bsDriver); err != nil {
 			return err

--- a/pkg/controller/master/backup/util.go
+++ b/pkg/controller/master/backup/util.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -225,6 +226,6 @@ func getSecretRefName(vmName string, secretName string) string {
 	return fmt.Sprintf("vm-%s-%s-ref", vmName, wranglername.Hex(secretName, 8))
 }
 
-func getVMBackupMetadataFileName(vmBackupNamespace, vmBackupName string) string {
-	return fmt.Sprintf("%s-%s.cfg", vmBackupNamespace, vmBackupName)
+func getVMBackupMetadataFilePath(vmBackupNamespace, vmBackupName string) string {
+	return filepath.Join(metadataFolderPath, vmBackupNamespace, fmt.Sprintf("%s.cfg", vmBackupName))
 }


### PR DESCRIPTION
**Problem:**

We use `<vmbackup-namespace>-<vmbackup-name>.cfg` as metadata file in backup target. If there is a vmbackup with namespace `a` and name `b-c`, it conflicts with namespace `a-b` and name `c`.

**Solution:**
Make `namespace` as a folder.

**Related Issue:**
https://github.com/harvester/harvester/issues/4612

**Test plan:**
1. Create Harv v1.2.1 cluster.
2. Create a VM as `vm1`.
3. Setup backup target.
4. Create a VMBackup as `b1`.
5. Check the folder in backup target. There is a file `default-b1.cfg`.
6. Build a new image from this PR.
7. Replace `harvester/harvester` deployment image with this PR.
8. Check harvester pod log. There is a message like `move vm backup metadata default/b1 from harvester/vmbackups/default-b1.cfg to harvester/vmbackups/default/b1.cfg`.
9. Check the folder in backup target. There is no file `default-b1.cfg`, but there is a file path like `default/b1.cfg`.
10. Restore the `b1` VMBackup as a new VM `vm2`. The content in both VMs is same.
11. Stop `vm1`.
12. Replace the `vm1` VM with `b1` VMBackup. There is no error in restoring process.
13. Delete the `b1` VMBackup.
14. Check the folder in backup target.  There is a file `default/b1.cfg` is removed.
