### PR TITLE
Publish harvester-cluster-repo image (v1.1)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -418,6 +418,7 @@ steps:
     - drone-publish.rancher.io
     ref:
       - refs/heads/master
+      - refs/heads/release-*
       - refs/heads/v*
     event:
     - push
@@ -438,6 +439,7 @@ steps:
     - drone-publish.rancher.io
     ref:
       - refs/heads/master
+      - refs/heads/release-*
       - refs/heads/v*
     event:
     - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,6 @@ steps:
     instance:
       - drone-publish.rancher.io
     ref:
-      - refs/head/master
       - refs/tags/*
     event:
       - tag
@@ -82,7 +81,6 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
     - refs/tags/*
     event:
     - tag
@@ -129,7 +127,6 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
     - refs/tags/*
     event:
     - tag
@@ -177,7 +174,6 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
     - refs/tags/*
     event:
     - tag
@@ -235,7 +231,6 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
     - refs/tags/*
     event:
     - tag
@@ -274,7 +269,6 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
     - refs/tags/*
     event:
     - tag
@@ -313,7 +307,6 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-    - refs/head/master
     - refs/tags/*
     event:
     - tag
@@ -343,7 +336,6 @@ steps:
     instance:
       - drone-publish.rancher.io
     ref:
-      - refs/head/master
       - refs/tags/*
     event:
       - tag
@@ -425,8 +417,8 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-      - refs/head/master
-      - refs/head/v*
+      - refs/heads/master
+      - refs/heads/v*
     event:
     - push
 
@@ -445,8 +437,8 @@ steps:
     instance:
     - drone-publish.rancher.io
     ref:
-      - refs/head/master
-      - refs/head/v*
+      - refs/heads/master
+      - refs/heads/v*
     event:
     - push
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -409,6 +409,86 @@ steps:
     event:
       - tag
 
+- name: docker-publish-cluster-repo-branch
+  image: plugins/docker
+  settings:
+    context: dist/harvester-cluster-repo
+    custom_dns: 1.1.1.1
+    dockerfile: dist/harvester-cluster-repo/Dockerfile
+    repo: "rancher/harvester-cluster-repo"
+    tag: ${DRONE_BRANCH}-head-amd64
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/head/master
+      - refs/head/v*
+    event:
+    - push
+
+- name: manifest-cluster-repo-branch
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    platforms:
+    - linux/amd64
+    target: "rancher/harvester-cluster-repo:${DRONE_BRANCH}-head"
+    template: "rancher/harvester-cluster-repo:${DRONE_BRANCH}-head-ARCH"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/head/master
+      - refs/head/v*
+    event:
+    - push
+
+- name: docker-publish-cluster-repo-tag
+  image: plugins/docker
+  settings:
+    context: dist/harvester-cluster-repo
+    custom_dns: 1.1.1.1
+    dockerfile: dist/harvester-cluster-repo/Dockerfile
+    repo: "rancher/harvester-cluster-repo"
+    tag: "${DRONE_TAG}-amd64"
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/tags/*
+    event:
+    - tag
+
+- name: manifest-cluster-repo-tag
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    platforms:
+      - linux/amd64
+    target: "rancher/harvester-cluster-repo:${DRONE_TAG}"
+    template: "rancher/harvester-cluster-repo:${DRONE_TAG}-ARCH"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      - refs/tags/*
+    event:
+    - tag
+
 trigger:
   event:
     - tag

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -20,4 +20,5 @@ HARVESTER_DIR=../harvester
 
 mkdir -p ${HARVESTER_DIR}/dist/artifacts
 cp dist/artifacts/* ${HARVESTER_DIR}/dist/artifacts
+cp -r dist/harvester-cluster-repo  ${HARVESTER_DIR}/dist
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The image rancher/harvester-cluster-repo is built on the installer side and shipped in the package tarball.
We need to publish the image to the docker hub as well, sometimes it's easier to debug.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Publish the image.

**Related Issue:**
https://github.com/harvester/harvester/issues/4349

**Include two more clean-up changes from v1.2 branch**
- fedb1b29b4971a04453511cd380b18a0e0c83519
- f0e170baed5f1ee43ad2761d5f70c17a1cca3b54

**Note**: This PR requires https://github.com/harvester/harvester-installer/pull/581 to be merged first.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
