### PR TITLE
feat: use number version in upgrade Dockerfile

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -sfL https://storage.googleapis.com/kubernetes-release/release/${KUBECT
 
 RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v0.55.2/virtctl-v0.55.2-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
-    curl -sfL https://github.com/rancher/wharfie/releases/latest/download/wharfie-amd64  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
+    curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.2/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 
 COPY --from=temp_elemental /usr/bin/elemental /usr/local/bin/elemental
 


### PR DESCRIPTION
**Problem:**
We used latest version to get yq and wharfie. The CI may be broken if latest version doesn't have artifacts like https://github.com/rancher/wharfie/releases/tag/v0.6.3.

**Solution:**
Use number version.

**Related Issue:**
https://github.com/harvester/harvester/issues/4676

**Test plan:**
N/A
