### PR TITLE
Generate code coverage report for integration tests

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
             - name: RANCHER_SERVER_URL
               value: {{  .Values.rancherURL }}
 {{- end }}
+{{- if .Values.enableGoCoverDir }}
+            - name: GOCOVERDIR
+              value: /go-cover-dir
+{{- end }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -104,6 +108,16 @@ spec:
 {{- if .Values.containers.apiserver.resources }}
           resources:
 {{ toYaml .Values.containers.apiserver.resources | indent 12 }}
+{{- end }}
+{{- if .Values.enableGoCoverDir }}
+          volumeMounts:
+          - name: go-cover-dir
+            mountPath: /go-cover-dir
+      volumes:
+      - name: go-cover-dir
+        hostPath:
+          path: /usr/local/go-cover-dir/
+          type: DirectoryOrCreate
 {{- end }}
 {{- if .Values.securityContext }}
       securityContext:
@@ -158,6 +172,10 @@ spec:
           value: {{ .Values.webhook.debug | quote }}
         - name: HARVESTER_CONTROLLER_USER_NAME
           value: {{ .Values.webhook.controllerUser | default (print "system:serviceaccount:" .Release.Namespace ":harvester")  | quote }}
+{{- if .Values.enableGoCoverDir }}
+        - name: GOCOVERDIR
+          value: /go-cover-dir
+{{- end }}
         image: {{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag }}
         name: harvester-webhook
         args: []
@@ -168,3 +186,13 @@ spec:
         ports:
         - name: https
           containerPort: {{ .Values.webhook.httpsPort }}
+{{- if .Values.enableGoCoverDir }}
+        volumeMounts:
+        - name: go-cover-dir
+          mountPath: /go-cover-dir
+      volumes:
+      - name: go-cover-dir
+        hostPath:
+          path: /usr/local/go-cover-dir/
+          type: DirectoryOrCreate
+{{- end }}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -512,3 +512,5 @@ snapshot-validation-webhook:
     pullPolicy: IfNotPresent
 
 enableLonghornNetworkPolicy: true
+
+enableGoCoverDir: false

--- a/scripts/build
+++ b/scripts/build
@@ -10,6 +10,14 @@ if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
 
+# add coverage flags if there is no tag and it's on master or a version branch like v1.3
+COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMIT_TAG=$(git tag --points-at HEAD | head -n 1)
+if [[ "$COMMIT_TAG" == "" ]] && [[ "$COMMIT_BRANCH" == master || "$COMMIT_BRANCH" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+    COVERPKG="-coverpkg=github.com/harvester/harvester/..."
+    COVER_FLAGS="-cover $COVERPKG"
+fi
+
 LINKFLAGS="-X github.com/harvester/harvester/pkg/version.Version=$VERSION
            -X github.com/harvester/harvester/pkg/version.GitCommit=$COMMIT
            -X github.com/harvester/harvester/pkg/settings.InjectDefaults=$DEFAULT_VALUES $LINKFLAGS"
@@ -18,7 +26,7 @@ build_binary () {
     local BINARY="$1"
     local PKG_PATH="$2"
 
-    CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS"  -o "bin/${BINARY}" "${PKG_PATH}"
+    CGO_ENABLED=0 go build -o "bin/${BINARY}" -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" $COVER_FLAGS "${PKG_PATH}"
     if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
         GOOS=darwin go build -ldflags "$LINKFLAGS"  -o "bin/${BINARY}-darwin" "${PKG_PATH}"
         GOOS=windows go build -ldflags "$LINKFLAGS" -o "bin/${BINARY}-windows" "${PKG_PATH}"


### PR DESCRIPTION
**Problem:**
Most of our test cases are e2e test. We need a way to get integration test code coverage.

**Solution:**
Bump golang to v1.20+ and add `-cover` to build script.

https://go.dev/testing/coverage/

**Related Issue:**
https://github.com/harvester/harvester/issues/2666

**Test plan:**
1. Clone the branch and merge it to master locally.
2. Run `REPO=frankyang make build-iso`.
3. Use the ISO to create a new cluster.
4. After the cluster is ready, add `enableGoCoverDir: true` to `harvester` ManagedChart.
5. We will see there is a `/coverdatafiles` folder in harvester pod.
6. Kill one harvester pod and we will see files with `covcounters` prefix in the folder.
7. Use `k cp harvester-system/<harvester-pod-name>:/go-cover-dir go-cover-dir` to copy files to local.
8. Run `go tool covdata percent -i=go-cover-dir` and we can see the coverage rate.
9. Run `go tool covdata textfmt -i=go-cover-dir -o profile.txt` and we can change the data to a text file.
10. Run `go tool cover -html=profile.txt` and we can open a website to check which code is covered.

**Additional context:**
* [X] Wait for https://github.com/harvester/harvester/pull/4620.
