### PR TITLE
feat: bump SLE to 15.5

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 
 # nfs-client is needed by the dep https://github.com/longhorn/backupstore to check backup store availability.
 RUN zypper -n rm container-suseconnect && \

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 
 RUN zypper -n rm container-suseconnect && \
     zypper -n install curl nfs-client && \

--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -2,7 +2,7 @@
 # ***NOTE*** Deprecated, we need to use the new elemental-cli in the next release.
 FROM registry.suse.com/rancher/elemental-builder-image/5.3:0.3.1 AS temp_elemental
 
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 
 ARG ARCH=amd64
 ENV ARCH=${ARCH}


### PR DESCRIPTION
**Problem:**
SLE 15 SP4 general ends on 31 Dec 2023.

**Solution:**
Bump SLE BCI images to to 15.5.

**Related Issue:**
https://github.com/harvester/harvester/issues/4757

**Test plan:**
Test basic operation can work.
