### PR TITLE
promote: make promote script can only promote the node to etcd role

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -20,6 +20,21 @@ metadata:
 data:
   promote.sh: |-
     {{`KUBECTL="/host/$(readlink /host/var/lib/rancher/rke2/bin)/kubectl"
+    ROLE_LABELS="rke.cattle.io/control-plane-role=true rke.cattle.io/etcd-role=true"
+    ETCD_ONLY=false
+    if [[ -n "$1" ]]; then
+      ETCD_ONLY=true
+      ROLE_LABELS=$1
+    fi
+
+    case $ROLE_LABELS in
+      "rke.cattle.io/control-plane-role=true rke.cattle.io/etcd-role=true" | "rke.cattle.io/etcd-role=true")
+    ;;
+      *)
+      echo "ROLE $ROLE_LABELS is not supported."
+      exit 1
+    ;;
+    esac
 
     get_machine_from_node() {
       $KUBECTL get node $HARVESTER_PROMOTE_NODE_NAME -o jsonpath='{.metadata.annotations.cluster\.x-k8s\.io/machine}'
@@ -79,17 +94,29 @@ data:
     EOF
 
     # For how to promote nodes, see: https://github.com/rancher/rancher/issues/36480#issuecomment-1039253499
-    ROLE_LABELS="rke.cattle.io/control-plane-role=true rke.cattle.io/etcd-role=true"
     $KUBECTL label --overwrite -n fleet-local machines.cluster.x-k8s.io $CUSTOM_MACHINE $ROLE_LABELS
     $KUBECTL label --overwrite -n fleet-local secret $PLAN_SECRET $ROLE_LABELS
     $KUBECTL label --overwrite -n fleet-local rkebootstraps.rke.cattle.io $CUSTOM_MACHINE $ROLE_LABELS
 
     while true
     do
-      CONTROL_PLANE=$($KUBECTL get node $HOSTNAME -o go-template=$'{{index .metadata.labels "node-role.kubernetes.io/control-plane"}}\n' || true)
+      if [[ $ETCD_ONLY == true ]]; then
+        ETCD_STATE=$($KUBECTL get node $HOSTNAME -o go-template=$'{{index .metadata.labels "node-role.kubernetes.io/etcd"}}\n' || true)
 
-      if [ "$CONTROL_PLANE" = "true" ]; then
-        break
+        if [ "$ETCD_STATE" = "true" ]; then
+          $KUBECTL taint nodes $HOSTNAME node-role.kubernetes.io/etcd=true:NoExecute
+          $KUBECTL patch managedchart harvester -n fleet-local --type=json -p='[{"op":"replace", "path":"/spec/values/replicas", "value": 2}]'
+          $KUBECTL patch managedchart harvester -n fleet-local --type=json -p='[{"op":"replace", "path":"/spec/values/webhook/replicas", "value": 2}]'
+          $KUBECTL annotate --overwrite deployment rancher -n cattle-system management.cattle.io/scale-available="2"
+          break
+        fi
+
+      else
+        CONTROL_PLANE=$($KUBECTL get node $HOSTNAME -o go-template=$'{{index .metadata.labels "node-role.kubernetes.io/control-plane"}}\n' || true)
+
+        if [ "$CONTROL_PLANE" = "true" ]; then
+          break
+        fi
       fi
       echo Waiting for promotion...
       sleep 2


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
we need to support witness node for 2+1 scenario (2 master node + 1 witness node)

**Solution:**
make promote controller can only promote the node to the `etcd`

**Related Issue:**
https://github.com/harvester/harvester/issues/3266

**Test plan:**
- How to build the ISO
We need this PR and https://github.com/harvester/harvester-installer/pull/604
You can change the `script/build-iso` to assign harvester-installer to the above PR
Then, build the ISO from the `harvester/harvester` as usual.

- Test scope
  - Installation: use both interactive and non-interactive mode
    - interactive mode: create 3 node cluster and select the etcd role with the third node
    - non-interactive mode: create 3 node cluster and use `install.role=etcd` with the third node
  - Cluster operations:
    - Whole basic operations need to verify and make sure there is no any workload be scheduled to the etcd node
    - Create downstream cluster and verify related operations. Also need to make sure there is no any workload be scheduled to the etcd node
    
  - Workloads on the etcd node
  The etcd nodes should only have the followings pods on it.
  ```
  harvester-system            harvester-node-manager-mjnjx                             1/1     Running     
  kube-system                 cloud-controller-manager-harvester-node-2                1/1     Running     
  kube-system                 etcd-harvester-node-2                                    1/1     Running     
  kube-system                 kube-proxy-harvester-node-2                              1/1     Running     
  kube-system                 rke2-canal-dxrbh                                         2/2     Running     
  kube-system                 rke2-multus-ds-zv98d                                     1/1     Running     
  ```

