### PR TITLE
fix: add one more condition to check vm is stopped or not

### DIFF
--- a/pkg/util/virtualmachine/virtualmachine.go
+++ b/pkg/util/virtualmachine/virtualmachine.go
@@ -1,0 +1,52 @@
+package virtualmachine
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+)
+
+// IsVMStopped checks VM is stopped or not. It will check two cases
+// 1. VM is stopped from GUI
+// 2. VM is stopped inside VM
+// These two cases are all stopped case.
+func IsVMStopped(
+	vm *kubevirtv1.VirtualMachine,
+	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
+) (bool, error) {
+	strategy, err := vm.RunStrategy()
+	if err != nil {
+		return false, fmt.Errorf("error getting run strategy for vm %s in namespace %s: %v", vm.Name, vm.Namespace, err)
+	}
+
+	// VM is stopped from GUI
+	if strategy == kubevirtv1.RunStrategyHalted {
+		return true, nil
+	}
+
+	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
+		return false, nil
+	}
+
+	// When vm is stopped inside VM, the vmi will not be deleted.
+	// The status of vmi will be "Succeeded".
+	vmi, err := vmiCache.Get(vm.Namespace, vm.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Debugf("VM %s/%s is deleted", vm.Namespace, vm.Name)
+			return true, nil
+		}
+		return false, fmt.Errorf("error getting vmi %s in namespace %s: %v", vm.Name, vm.Namespace, err)
+	}
+
+	if vmi.IsFinal() {
+		logrus.Debugf("VM %s/%s is stopped inside VM", vm.Namespace, vm.Name)
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/util/virtualmachine/virtualmachine_test.go
+++ b/pkg/util/virtualmachine/virtualmachine_test.go
@@ -1,0 +1,139 @@
+package virtualmachine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corefake "k8s.io/client-go/kubernetes/fake"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func Test_IsVMStopped(t *testing.T) {
+	type input struct {
+		vmi       *kubevirtv1.VirtualMachineInstance
+		vm        *kubevirtv1.VirtualMachine
+		namespace string
+	}
+
+	testCases := []struct {
+		desc     string
+		input    input
+		expected func(isStopped bool, err error, desc string)
+	}{
+		{
+			desc: "when vm is stopped inside vm case",
+			input: input{
+				namespace: "default",
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Phase: kubevirtv1.Succeeded,
+					},
+				},
+				vm: &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						RunStrategy: runStrategyTransformerHelper(kubevirtv1.RunStrategyRerunOnFailure),
+					},
+					Status: kubevirtv1.VirtualMachineStatus{
+						PrintableStatus: kubevirtv1.VirtualMachineStatusStopped,
+					},
+				},
+			},
+			expected: func(isStopped bool, err error, desc string) {
+				assert.Equal(t, true, isStopped, desc)
+				assert.Equal(t, nil, err, desc)
+			},
+		},
+		{
+			desc: "when vm is stopped from GUI case",
+			input: input{
+				namespace: "default",
+				vmi:       nil,
+				vm: &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						RunStrategy: runStrategyTransformerHelper(kubevirtv1.RunStrategyHalted),
+					},
+					Status: kubevirtv1.VirtualMachineStatus{
+						PrintableStatus: kubevirtv1.VirtualMachineStatusStopped,
+					},
+				},
+			},
+			expected: func(isStopped bool, err error, desc string) {
+				assert.Equal(t, true, isStopped, desc)
+				assert.Equal(t, nil, err, desc)
+			},
+		},
+		{
+			desc: "when vm is running",
+			input: input{
+				namespace: "default",
+				vmi:       nil,
+				vm: &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						RunStrategy: runStrategyTransformerHelper(kubevirtv1.RunStrategyRerunOnFailure),
+					},
+					Status: kubevirtv1.VirtualMachineStatus{
+						PrintableStatus: kubevirtv1.VirtualMachineStatusRunning,
+					},
+				},
+			},
+			expected: func(isStopped bool, err error, desc string) {
+				assert.Equal(t, false, isStopped, desc)
+				assert.Equal(t, nil, err, desc)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var (
+			clientset     = fake.NewSimpleClientset()
+			coreclientset = corefake.NewSimpleClientset()
+		)
+
+		if _, err := coreclientset.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: tc.input.namespace,
+			},
+		}, metav1.CreateOptions{}); err != nil {
+			assert.Nil(t, err, "failed to create namespace", tc.desc)
+		}
+
+		if _, err := clientset.KubevirtV1().VirtualMachines(tc.input.namespace).Create(context.TODO(), tc.input.vm, metav1.CreateOptions{}); tc.input.vm != nil && err != nil {
+			assert.Nil(t, err, "failed to create fake vm", tc.desc)
+		}
+		if _, err := clientset.KubevirtV1().VirtualMachineInstances(tc.input.namespace).Create(context.TODO(), tc.input.vmi, metav1.CreateOptions{}); tc.input.vmi != nil && err != nil {
+			assert.Nil(t, err, "failed to create fake vmi", tc.desc)
+		}
+
+		vmiCache := fakeclients.VirtualMachineInstanceCache(clientset.KubevirtV1().VirtualMachineInstances)
+		isStopped, err := IsVMStopped(tc.input.vm, vmiCache)
+
+		tc.expected(isStopped, err, tc.desc)
+	}
+}
+
+func runStrategyTransformerHelper(input kubevirtv1.VirtualMachineRunStrategy) *kubevirtv1.VirtualMachineRunStrategy {
+	temp := input
+	return &temp
+}

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -199,7 +199,7 @@ func (v *vmValidator) checkResizeVolumes(oldVM, newVM *kubevirtv1.VirtualMachine
 	if isResizeVolume {
 		stopped, err := vmUtil.IsVMStopped(newVM, v.vmiCache)
 		if err != nil {
-			return werror.NewInternalError(fmt.Sprintf("failed to get run strategy, err: %s", err.Error()))
+			return werror.NewInternalError(fmt.Sprintf("failed to get vm is stopped or not, err: %s", err.Error()))
 		}
 
 		if !stopped {

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/resourcequota"
+	vmUtil "github.com/harvester/harvester/pkg/util/virtualmachine"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
 	webhookutil "github.com/harvester/harvester/pkg/webhook/util"
@@ -31,10 +32,12 @@ func NewValidator(
 	rqCache ctlharvestercorev1.ResourceQuotaCache,
 	vmBackupCache ctlharvesterv1.VirtualMachineBackupCache,
 	vmimCache ctlkubevirtv1.VirtualMachineInstanceMigrationCache,
+	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
 ) types.Validator {
 	return &vmValidator{
 		pvcCache:      pvcCache,
 		vmBackupCache: vmBackupCache,
+		vmiCache:      vmiCache,
 
 		rqCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache),
 	}
@@ -44,6 +47,7 @@ type vmValidator struct {
 	types.DefaultValidator
 	pvcCache      v1.PersistentVolumeClaimCache
 	vmBackupCache ctlharvesterv1.VirtualMachineBackupCache
+	vmiCache      ctlkubevirtv1.VirtualMachineInstanceCache
 
 	rqCalculator *resourcequota.Calculator
 }
@@ -193,14 +197,16 @@ func (v *vmValidator) checkResizeVolumes(oldVM, newVM *kubevirtv1.VirtualMachine
 	}
 
 	if isResizeVolume {
-		runStrategy, err := newVM.RunStrategy()
+		stopped, err := vmUtil.IsVMStopped(newVM, v.vmiCache)
 		if err != nil {
 			return werror.NewInternalError(fmt.Sprintf("failed to get run strategy, err: %s", err.Error()))
 		}
-		if runStrategy != kubevirtv1.RunStrategyHalted {
+
+		if !stopped {
 			return werror.NewInvalidError("please stop the VM before resizing volumes", fmt.Sprintf("metadata.annotations.%s", util.AnnotationVolumeClaimTemplates))
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -51,7 +51,8 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.Core.PersistentVolumeClaim().Cache(),
 			clients.HarvesterCoreFactory.Core().V1().ResourceQuota().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
-			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache()),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache()),
 		virtualmachineimage.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
 			clients.Core.PersistentVolumeClaim().Cache(),


### PR DESCRIPTION
**Problem:**
There is a difference between `Stopping vm inside vm` and `Stopping vm from GUI`
- `Stopping vm inside vm` remains the VMI and virt-launcher, and `VM.Spec.RunStrategy` is not changed.
- `Stopping vm from GUI` deletes the VMI and virt-launcher, and `VM.Spec.RunStrategy` is changed to `Halt`.

The webhook validates VM is stopped or not by `VM.Spec.RunStrategy: Halt` only.


**Solution:**
After discussing with @FrankYang0529 , I think we should add one more case to pass webhook validator. It would be better not to change resource status because it's existing kubevirt issue here https://github.com/harvester/harvester/issues/2265#issuecomment-1125758792 until fixed.

**Related Issue:**
https://github.com/harvester/harvester/issues/4778

**Test plan:**

These two test cases are already tested successfully.

### Stop inside VM case
1. Create VM in harvester UI and add one more disk like following example. Here I use alpinelinux to boot VM.
![image](https://github.com/harvester/harvester/assets/6960289/4596a3c2-0673-4b18-82ea-03d5bf6f45c4)
2. Start VM
3. Login to node and run `lsblk` to check additional disk size is 3G.
4. Run `poweroff` command to stop inside VM instead of GUI.
5. Resize additional disk size to 4G
6. Start VM
7. Login to node and run `lsblk` to check additional disk size is 4G or not.

### Stop from GUI case
1. Create VM in harvester UI and add one more disk like following example. Here I use alpinelinux to boot VM.
![image](https://github.com/harvester/harvester/assets/6960289/4596a3c2-0673-4b18-82ea-03d5bf6f45c4)
2. Start VM
3. Login to node and run `lsblk` to check additional disk size is 3G.
4. Stop VM from GUI
5. Resize additional disk size to 4G
6. Start VM
7. Login to node and run `lsblk` to check additional disk size is 4G.