### PR TITLE
feat: keep vmi events in vm annotations for debugging

### DIFF
--- a/pkg/controller/master/event/event_controller.go
+++ b/pkg/controller/master/event/event_controller.go
@@ -1,0 +1,85 @@
+package event
+
+import (
+	"encoding/json"
+
+	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
+	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+type Controller struct {
+	vmClient    ctlkubevirtv1.VirtualMachineClient
+	vmCache     ctlkubevirtv1.VirtualMachineCache
+	eventClient v1.EventController
+}
+
+func (ctr *Controller) SyncEvent(_ string, event *corev1.Event) (*corev1.Event, error) {
+	if event == nil {
+		return event, nil
+	}
+
+	if event.InvolvedObject.Kind == "VirtualMachineInstance" {
+		if err := ctr.updateVMEventRecord(event, event.InvolvedObject.Namespace, event.InvolvedObject.Name); err != nil {
+			logrus.Errorf("failed to update event record: %v", err)
+			return event, err
+		}
+	}
+
+	return event, nil
+}
+
+func (ctr *Controller) updateVMEventRecord(event *corev1.Event, vmiNamespace, vmiName string) error {
+	var (
+		oldEvents       []*corev1.Event
+		newEvents       []*corev1.Event
+		eventRecords    string
+		newEventRecords []byte
+		latestEvents    []*corev1.Event
+		keepLatestCount = 5
+		err             error
+	)
+
+	vm, err := ctr.vmCache.Get(vmiNamespace, vmiName)
+	if err != nil {
+		logrus.Errorf("failed to get vm: %v", err)
+		return nil
+	}
+	vmDp := vm.DeepCopy()
+
+	eventRecords, _ = vmDp.Annotations[util.AnnotationVMIEventRecords]
+
+	if eventRecords != "" {
+		if err = json.Unmarshal([]byte(eventRecords), &oldEvents); err != nil {
+			logrus.Errorf("updateVMEventRecord: failed to unmarshal eventRecords: %v", err)
+			return err
+		}
+	}
+
+	// When we append new events, we should trim it by keepLatestCount.
+	// Make sure we don't put too many events in the annotation.
+	newEvents = append(oldEvents, event)
+
+	if len(newEvents) > keepLatestCount {
+		latestEvents = newEvents[len(newEvents)-keepLatestCount:]
+	} else {
+		latestEvents = newEvents
+	}
+
+	if newEventRecords, err = json.Marshal(latestEvents); err != nil {
+		logrus.Errorf("updateVMEventRecord: failed to marshal latestEvents: %v", err)
+		return err
+	}
+
+	vmDp.Annotations[util.AnnotationVMIEventRecords] = string(newEventRecords)
+
+	if _, err := ctr.vmClient.Update(vmDp); err != nil {
+		logrus.Errorf("updateVMEventRecord: failed to update vm: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/master/event/register.go
+++ b/pkg/controller/master/event/register.go
@@ -1,0 +1,30 @@
+package event
+
+import (
+	"context"
+
+	"github.com/harvester/harvester/pkg/config"
+)
+
+const (
+	eventControllerSyncEvent = "EventController.SyncEvent"
+)
+
+func Register(ctx context.Context, management *config.Management, options config.Options) error {
+	var (
+		vmClient    = management.VirtFactory.Kubevirt().V1().VirtualMachine()
+		vmCache     = management.VirtFactory.Kubevirt().V1().VirtualMachine().Cache()
+		eventClient = management.CoreFactory.Core().V1().Event()
+	)
+
+	eventCtrl := &Controller{
+		vmClient:    vmClient,
+		vmCache:     vmCache,
+		eventClient: eventClient,
+	}
+
+	eClient := management.CoreFactory.Core().V1().Event()
+	eClient.OnChange(ctx, eventControllerSyncEvent, eventCtrl.SyncEvent)
+
+	return nil
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/controller/master/addon"
 	"github.com/harvester/harvester/pkg/controller/master/backup"
+	"github.com/harvester/harvester/pkg/controller/master/event"
 	"github.com/harvester/harvester/pkg/controller/master/image"
 	"github.com/harvester/harvester/pkg/controller/master/keypair"
 	"github.com/harvester/harvester/pkg/controller/master/mcmsettings"
@@ -50,6 +51,7 @@ var registerFuncs = []registerFunc{
 	storagenetwork.Register,
 	nodedrain.Register,
 	mcmsettings.Register,
+	event.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -16,6 +16,7 @@ const (
 	AnnotationHash                 = prefix + "/hash"
 	AnnotationRunStrategy          = prefix + "/vmRunStrategy"
 	AnnotationSnapshotFreezeFS     = prefix + "/snapshotFreezeFS"
+	AnnotationVMIEventRecords      = prefix + "/vmiEventRecords"
 	LabelImageDisplayName          = prefix + "/imageDisplayName"
 	LabelSetting                   = prefix + "/setting"
 	LabelVMName                    = prefix + "/vmName"


### PR DESCRIPTION
## Problem

Since there are very different reasons causes VM shutdown, we would like to keep this information as debugging information. Considering the event retention period, it would be better store these events in somewhere.

## Solution

I find out we could use event controller which I originally thought I can't use. That means we could save event by `event.InvolvedObject` into anywhere we would like.

We could keep these information in annotation like below demo screenshot. But, when I test my ideal, I found out there is an annotation limitation `metadata.annotations: Too long: must have at most 262144 bytes`. 

Although it seems to be abled to be addressed, but I think it would be better we just store latest X number events instead of all events. So, in this proposal, I use five as latest X number to store events, and it could be discussed surely.

## Related Issue

https://github.com/harvester/harvester/issues/3588

## Test plan

1. Create VM 
2. Stop VM from GUI

![image](https://github.com/harvester/harvester/assets/6960289/873af17c-79a7-4aba-be79-a0c3cfd82d4c)

However, for some cases, it would notify multiple same events in short period of time. It might override too much events.
![image](https://github.com/harvester/harvester/assets/6960289/718f4f71-abb3-4a73-88ac-9ada2d2b161a)

### Example events

- [normal events](https://gist.github.com/Yu-Jack/683e0ec7009034bdf22c56607dc7e449#file-example-events-js)
- [repeated events](https://gist.github.com/Yu-Jack/683e0ec7009034bdf22c56607dc7e449?permalink_comment_id=4783926#gistcomment-4783926)

## Additional DIscussion

I know it would be over-design at this moment. But, it would be large code base if we detect different kind and handle different behavior over time. We don't need to optimize it now surely, I just keep information about CoR pattern here for further investigation. The related branch is https://github.com/Yu-Jack/harvester/commit/84ba7af570a831156d557b25462e72aa75664357.