### PR TITLE
feat: bump general image to 15.5 and use it for promote job

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -489,7 +489,7 @@ generalJob:
   image:
     imagePullPolicy: IfNotPresent
     repository: registry.suse.com/bci/bci-base
-    tag: 15.4
+    tag: 15.5
 
 whereabouts:
   enabled: true

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -45,7 +45,7 @@ const (
 
 	defaultSpecManagementNumber = 3
 
-	promoteImage         = "busybox:1.32.0"
+	promoteImage         = "registry.suse.com/bci/bci-base:15.5"
 	promoteRootMountPath = "/host"
 
 	promoteScriptsMountPath = "/harvester-helpers"


### PR DESCRIPTION
Update general job to SLE 15.5 and replace busybox with SLE 15.5 in promote job.

**Related Issue:**
https://github.com/harvester/harvester/issues/4839

**Test plan:**
Provision 3-node harvester in airgap environment.
