### PR TITLE
minor change to patch capi-controller deployment

### DIFF
--- a/pkg/controller/master/rancher/embedded_rancher.go
+++ b/pkg/controller/master/rancher/embedded_rancher.go
@@ -2,12 +2,15 @@ package rancher
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"time"
 
 	rancherv3api "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	ranchersettings "github.com/rancher/rancher/pkg/settings"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/harvester/harvester/pkg/settings"
@@ -100,4 +103,39 @@ func (h *Handler) syncCACert(setting *rancherv3api.Setting) error {
 	caCertsCopy.Default = cacert
 	_, err := h.RancherSettings.Update(caCertsCopy)
 	return err
+}
+
+// PatchCAPIDeployment is used to patch env variables for capi-deployment created by rancher.
+// This ensures that capi-controller reconciles the local rancher cluster using the kubeconfig in the local-kubeconfig
+// secret in fleet-local namespace. Without this patch, capi-controller identifies itself as running on the workload
+// cluster and patches the config, to use in-cluster api endpoint (kubernetes default) service, which does not recognize
+// the rancher generated token in the local-kubeconfig secret
+func (h *Handler) PatchCAPIDeployment(_ string, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+	if deployment == nil || !deployment.DeletionTimestamp.IsZero() {
+		return deployment, nil
+	}
+
+	if !isCapiDeployment(deployment) {
+		return deployment, nil
+	}
+
+	deploymentObjCopy := deployment.DeepCopy()
+	for i := range deploymentObjCopy.Spec.Template.Spec.Containers {
+		if len(deploymentObjCopy.Spec.Template.Spec.Containers[i].Env) > 0 {
+			deploymentObjCopy.Spec.Template.Spec.Containers[i].Env = []corev1.EnvVar{}
+		}
+	}
+
+	if !reflect.DeepEqual(deploymentObjCopy.Spec.Template.Spec.Containers, deployment.Spec.Template.Spec.Containers) {
+		return h.Deployments.Update(deploymentObjCopy)
+	}
+
+	return deployment, nil
+}
+
+func isCapiDeployment(deployment *appsv1.Deployment) bool {
+	if deployment.Name == capiControllerDeploymentName && deployment.Namespace == capiControllerDeploymentNamespace {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/master/rancher/embedded_rancher_test.go
+++ b/pkg/controller/master/rancher/embedded_rancher_test.go
@@ -1,0 +1,145 @@
+package rancher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+var (
+	capiDeployment = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      capiControllerDeploymentName,
+			Namespace: capiControllerDeploymentNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "manager",
+							Env: []corev1.EnvVar{
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+								{
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								{
+									Name: "POD_UID",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.uid",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	nonCapiDeployment = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hello-world",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "manager",
+							Env: []corev1.EnvVar{
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+								{
+									Name: "POD_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								{
+									Name: "POD_UID",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.uid",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func Test_PatchCAPIDeployment(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(capiDeployment, nonCapiDeployment)
+	deployment := fakeclients.DeploymentClient(client.AppsV1().Deployments)
+	h := &Handler{
+		Deployments: deployment,
+	}
+
+	var tests = []struct {
+		Name             string
+		Deployment       *appsv1.Deployment
+		ExpectEnvRemoved bool
+	}{
+		{
+			Name:             "capi-deployment",
+			Deployment:       capiDeployment,
+			ExpectEnvRemoved: true,
+		},
+		{
+			Name:             "non capi-deployment",
+			Deployment:       nonCapiDeployment,
+			ExpectEnvRemoved: false,
+		},
+	}
+
+	assert := require.New(t)
+
+	for _, tt := range tests {
+		deploymentObj, err := h.PatchCAPIDeployment("", tt.Deployment)
+		assert.NoError(err, "expected no error during reconcile of deployment in case %s", tt.Name)
+		if tt.ExpectEnvRemoved {
+			for _, v := range deploymentObj.Spec.Template.Spec.Containers {
+				assert.Empty(v.Env, fmt.Sprintf("expected to find no env variables in test case: %s", tt.Name))
+			}
+		} else {
+			for _, v := range deploymentObj.Spec.Template.Spec.Containers {
+				assert.NotEmpty(v.Env, fmt.Sprintf("expected to find no env variables in test case: %s", tt.Name))
+			}
+		}
+	}
+}

--- a/pkg/util/fakeclients/deployment.go
+++ b/pkg/util/fakeclients/deployment.go
@@ -13,26 +13,33 @@ import (
 type DeploymentClient func(string) appsv1type.DeploymentInterface
 
 func (c DeploymentClient) Update(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-	panic("implement me")
+	return c(deployment.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
 }
+
 func (c DeploymentClient) Get(namespace, name string, options metav1.GetOptions) (*appsv1.Deployment, error) {
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
+
 func (c DeploymentClient) Create(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
 	return c(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
 }
+
 func (c DeploymentClient) UpdateStatus(*appsv1.Deployment) (*appsv1.Deployment, error) {
 	panic("implement me")
 }
+
 func (c DeploymentClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
 	panic("implement me")
 }
+
 func (c DeploymentClient) List(namespace string, opts metav1.ListOptions) (*appsv1.DeploymentList, error) {
 	panic("implement me")
 }
+
 func (c DeploymentClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
+
 func (c DeploymentClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *appsv1.Deployment, err error) {
 	panic("implement me")
 }


### PR DESCRIPTION
PR to patch capi-controller env variables. 

Needed for version upgrade to rancher 2.7.9 to work:

https://github.com/harvester/harvester-installer/pull/605


**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
A standalone capi-controller has been introduced in rancher v2.7.9.

The capi-controller is unable to reconcile the local rancher cluster.

capi-controller ties to generate a client for local cluster:

https://github.com/kubernetes-sigs/cluster-api/blob/main/controllers/remote/cluster_cache_tracker.go#L284-L349

It detects that the controller is running on the workload cluster being managed:

https://github.com/kubernetes-sigs/cluster-api/blob/main/controllers/remote/cluster_cache_tracker.go#L352-L375

As a result of this it patches the rest.Config to use the kubernetes default svc endpoint, however the `local-kubeconfig` token is generated by Rancher and not authenticated by rancher.

As a result the machines are never reconciled and controller keeps reporting the following error:

```
E1213 04:58:03.781942       1 controller.go:329] "Reconciler error" err="failed to create cluster accessor: error creating client for self-hosted cluster: error creating dynamic rest mapper for remote cluster \"fleet-local/local\": the server has asked for the client to provide credentials" controller="machine" controllerGroup="cluster.x-k8s.io" 
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The workaround is to patch the env variables for capi-controller.

This causes the `runningOnWorkloadCluster` check to fail, and local cluster is managed via the `local-kubeconfig` via the public rancher endpoint, and nodes are able to reconcile correctly.

**Related Issue:**
https://github.com/harvester/harvester/issues/4782
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
