### PR TITLE
feat: set default macaddress when vmi is removed

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -87,7 +87,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		vmCache:   vmCache,
 		vmiClient: virtualMachineInstanceClient,
 	}
-	virtualMachineInstanceClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
+	virtualMachineInstanceClient.OnRemove(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
 
 	return nil
 }


### PR DESCRIPTION
**Problem:**
After we updated KubeVirt to v1.0.0, the actual generation is different from expected. The root cause is that we set macaddress to VM and don't restart the VM.

![image](https://github.com/harvester/harvester/assets/4927361/b76487ed-81d7-494c-a53b-d66413c81cba)

![image](https://github.com/harvester/harvester/assets/4927361/9dec64ff-3634-4a27-b2b2-3b8b197339a9)

**Solution:**
Set interfaces to VM when VMI is deleted.

**Related Issue:**
https://github.com/harvester/harvester/issues/4866
https://github.com/harvester/harvester/issues/4909

**Test plan:**

### Restart VM.
1. Create a VM. There is no warning message on the dashboard.
2. Check macaddress in `vmi.status.interfaces`.
3. Click `Restart` on the dashboard.
4. Check the macaddress is set to `vm.spec.template.spec.domain.devices.interfaces`.

### Use command to stop VM and start again on dashboard.
1. Create a VM. There is no warning message on the dashboard.
2. Run `sudo shutdown now` in the VM.
3. Check macaddress in `vmi.status.interfaces`. VMI status is Succeed in this step.
4. Click `Start` on the dashboard.
5. Check the macaddress is set to `vm.spec.template.spec.domain.devices.interfaces`.

### Migrate VM doesn't delete VMI, so the macaddress is not set to the VM, but it's still same in the new pod
1. Create a VM. There is no warning message on the dashboard.
2. Check macaddress in `vmi.status.interfaces`.
3. Click `Migrate` on the dashboard.
4. Check macaddress again in `vmi.status.interfaces`. They're same. Also, there is no warning message on the dashboard.