### PR TITLE
Adapt Longhorn im-e/im-r pod unification

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -173,16 +173,16 @@ wait_longhorn_instance_manager_r() {
   kubectl get nodes -o json | jq -r '.items[].metadata.name' | while read -r node; do
     echo "Checking instance-manager-r pod on node $node..."
     while [ true ]; do
-      pod_count=$(kubectl get pod --selector=longhorn.io/node=$node,longhorn.io/instance-manager-type=replica -n longhorn-system -o json | jq -r '.items | length')
+      pod_count=$(kubectl get pod --selector=longhorn.io/node=$node,longhorn.io/instance-manager-type=aio -n longhorn-system -o json | jq -r '.items | length')
       if [ "$pod_count" != "1" ]; then
-        echo "instance-manager-r pod count is not 1 on node $node, will retry..."
+        echo "instance-manager (aio) pod count is not 1 on node $node, will retry..."
         sleep 5
         continue
       fi
 
-      container_image=$(kubectl get pod --selector=longhorn.io/node=$node,longhorn.io/instance-manager-type=replica -n longhorn-system -o json | jq -r '.items[0].spec.containers[0].image')
+      container_image=$(kubectl get pod --selector=longhorn.io/node=$node,longhorn.io/instance-manager-type=aio -n longhorn-system -o json | jq -r '.items[0].spec.containers[0].image')
       if [ "$container_image" != "$im_image" ]; then
-        echo "instance-manager-r pod image is not $im_image, will retry..."
+        echo "instance-manager (aio) pod image is not $im_image on node $node, will retry..."
         sleep 5
         continue
       fi


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

In Longhorn 1.5.x, im-r and im-e pods are consolidated into one pod. We should adapt the change and fix the waiting logic.



**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Filter pods with `aio` type label.

**Related Issue:**

https://github.com/harvester/harvester/issues/4879


**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

- Create a v1.2.1 cluster. Create some VMs.
- Build an ISO with the PR and upgrade to it.
- The upgrade should be OK.
