### PR TITLE
upgrade: create necessary RBAC rules for new CSI driver

### DIFF
--- a/cmd/upgradehelper/get_cloud_providers.go
+++ b/cmd/upgradehelper/get_cloud_providers.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+var getCloudProviderCmd = &cobra.Command{
+	Use:   "get-cloud-provider",
+	Short: "Get ClusterRole with Harvester Cloud Provider",
+	Long:  `A command for getting the ClusterRole with "harvesterhci.io:cloudprovider"`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := getCloudProvider(); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(getCloudProviderCmd)
+}
+
+func getCloudProvider() error {
+	logrus.Debug("Getting ClusterRole with Harvester Cloud Provider")
+	clientset, err := util.GetK8sClientset()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	rolebindings, err := clientset.RbacV1().RoleBindings("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	output := []string{}
+	for _, rolebinding := range rolebindings.Items {
+		if rolebinding.RoleRef.Name == "harvesterhci.io:cloudprovider" {
+			item := fmt.Sprintf("%s/%s", rolebinding.Namespace, rolebinding.Name)
+			output = append(output, item)
+		}
+	}
+
+	// format the output as we wanted
+	for _, item := range output {
+		fmt.Printf("%s\n", item)
+	}
+	return nil
+}

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1299,6 +1299,77 @@ wait_for_deployment() {
   done
 }
 
+upgrade_rbac() {
+
+  # only versions before v1.2.2 that upgrading to v1.2.2 need this patch
+  if [[ ! "${UPGRADE_PREVIOUS_VERSION%%-rc*}" < "v1.2.2" ]]; then
+    echo "Only versions before v1.2.2 need this patch."
+    return
+  fi
+
+  full_names=$(upgrade-helper get-cloud-provider)
+  ret=$?
+  if [ -z "$full_names" ] || [ $ret != 0 ]; then
+    echo "No rolebinding harvesterhci.io:cloudprovider found or command failed, we can skip to patch rbac this moment."
+    return
+  fi
+
+  if kubectl get clusterrole harvesterhci.io:csi-driver 2> /dev/null; then
+    echo "ClusterRole harvesterhci.io:csi-driver already exists, skip to create it."
+  else
+    create_clusterrole_for_csi_driver
+  fi
+
+  # to handle multiple guest clusters
+  for item in $full_names
+  do
+    namespace=$(echo "$item" |awk -F '/' '{print $1}')
+    service_account=$(echo "$item" |awk -F '/' '{print $2}')
+
+    echo "Creating ClusterRoleBinding with ${namespace}/${service_account} ..."
+    cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: $namespace-$service_account
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: harvesterhci.io:csi-driver
+subjects:
+- kind: ServiceAccount
+  name: $service_account
+  namespace: $namespace
+EOF
+
+  done
+
+}
+
+create_clusterrole_for_csi_driver() {
+  echo "Creating ClusterRole harvesterhci.io:csi-driver ..."
+
+  cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: apiserver
+    app.kubernetes.io/name: harvester
+    app.kubernetes.io/part-of: harvester
+  name: harvesterhci.io:csi-driver
+rules:
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+EOF
+}
+
 wait_repo
 detect_repo
 detect_upgrade
@@ -1318,5 +1389,6 @@ upgrade_monitoring
 upgrade_logging_event_audit
 apply_extra_manifests
 upgrade_addons
+upgrade_rbac
 # wait fleet bundles upto 90 seconds
 wait_for_fleet_bundles 9

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -3,9 +3,13 @@ package util
 import (
 	"context"
 	"fmt"
+	"os"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
 
@@ -18,4 +22,35 @@ func VirtClientUpdateVmi(ctx context.Context, client rest.Interface, managementN
 		Body(obj).
 		Do(ctx).
 		Error()
+}
+
+func getK8sClientsetInCluster() (*kubernetes.Clientset, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+func getK8sClientsetLocal() (*kubernetes.Clientset, error) {
+	configStr := os.Getenv("KUBECONFIG")
+	if configStr == "" {
+		return nil, fmt.Errorf("unable to get local config, please make sure the kubeconfig is set")
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", configStr)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+func GetK8sClientset() (*kubernetes.Clientset, error) {
+	if clientset, err := getK8sClientsetInCluster(); err == nil {
+		return clientset, nil
+	}
+	logrus.Debugf("Unable to get in cluster config, trying local config ...")
+	if clientset, err := getK8sClientsetLocal(); err == nil {
+		return clientset, nil
+	}
+	return nil, fmt.Errorf("unable to get local config, please make sure the kubeconfig is set")
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The harvester CSI driver (v0.1.4 and later version) allows the user to specify the StorageClass they want. To validate it, we need to add new ClusterRole and ClusterRoleBinding for the RBAC.

**Solution:**
Create ClusterRole and ClusterRoleBinding when upgrading

**Related Issue:**
https://github.com/harvester/harvester/issues/5294

**Test plan:**
1. create 3 nodes harvester cluster
2. create guest cluster
3. execute upgrade
4. make sure both `ClusterRole` and `ClusterRoleBinding` are created

**ClusterRole**
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  creationTimestamp: "2023-12-18T11:01:06Z"
  labels:
    app.kubernetes.io/component: apiserver
    app.kubernetes.io/name: harvester
    app.kubernetes.io/part-of: harvester
  name: harvesterhci.io:csi-driver
  resourceVersion: "4411502"
  uid: e5736906-d080-4c3f-8f7a-affab4205a94
rules:
- apiGroups:
  - storage.k8s.io
  resources:
  - storageclasses
  verbs:
  - get
  - list
  - watch
```

**ClusterRoleBinding**
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  creationTimestamp: "2023-12-18T11:30:07Z"
  name: default-rke2-guest-01
  resourceVersion: "4462961"
  uid: 7a11d03a-090f-4b12-927f-f7a88ae061a3
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: harvesterhci.io:csi-driver
subjects:
- kind: ServiceAccount
  name: rke2-guest-01
  namespace: default
```
Please also check the `ServiceAccount` related info (name, namespace) should be the same as your guest cluster.