### PR TITLE
build: precheck the length of CHART_VERSION

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -38,6 +38,15 @@ fi
 # Drop the v prefix for Chart Version to follow existing pattern.
 CHART_VERSION="$(echo ${CHART_VERSION} | sed -E 's/^v//')"
 
+# The length of metadata.label is no more than 63 characters.
+# We limit the CHART_VERSION less than or equal to 50 characters and it would be safe.
+CHART_VERSION_LEN=${#CHART_VERSION}
+if [[ $CHART_VERSION_LEN > 50 ]]; then
+    echo "Please reduce the length of CHART_VERSION, it should less than or equal to 50 characters."
+    echo "Current CHART_VERSION(${CHART_VERSION_LEN}): ${CHART_VERSION}"
+    exit 1
+fi
+
 if [ -z "$ARCH" ]; then
     ARCH=$(go env GOHOSTARCH)
 fi


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
If we create a long branch name, we will encounter the following error when we install ISO from it.
```
harvester-node-0:~ # kubectl get bundle -A
NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
fleet-local   fleet-agent-local                             1/1
fleet-local   local-managed-system-agent                    1/1
fleet-local   mcc-harvester                                 0/1                       ErrApplied(1) [Cluster fleet-local/local: failed to create resource: ServiceAccount "harvester" is invalid: metadata.labels: Invalid value: "harvester-0.0.0-add-new-cluster-role-for-csi-driver-2d8c77fe-dirty": must be no more than 63 characters]
fleet-local   mcc-harvester-crd                             1/1
fleet-local   mcc-local-managed-system-upgrade-controller   1/1
fleet-local   mcc-rancher-logging-crd                       1/1
fleet-local   mcc-rancher-monitoring-crd                    1/1
```

**Solution:**
We can do some precheck to avoid it.

**Related Issue:**
https://github.com/harvester/harvester/issues/4882

**Test plan:**
1. Create a long enough branch name to build.
2. It should fail.
