### PR TITLE
feat: fetch app generalJob image information from rancher apps

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -489,6 +489,9 @@ generalJob:
   image:
     imagePullPolicy: IfNotPresent
     repository: registry.suse.com/bci/bci-base
+    # However, in the Golang limitation, we couldn't parse like "tag": 12.20.
+    # So, we must use "tag": "12.20" instead.
+    # More details in PR-4896 (https://github.com/harvester/harvester/pull/4896)
     tag: 15.5
 
 whereabouts:
@@ -503,6 +506,7 @@ harvester-node-manager:
     imagePullPolicy: IfNotPresent
     repository: rancher/harvester-node-manager
     tag: master-head
+
 
 snapshot-validation-webhook:
   enabled: true

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -507,7 +507,6 @@ harvester-node-manager:
     repository: rancher/harvester-node-manager
     tag: master-head
 
-
 snapshot-validation-webhook:
   enabled: true
   image:

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -489,7 +489,7 @@ generalJob:
   image:
     imagePullPolicy: IfNotPresent
     repository: registry.suse.com/bci/bci-base
-    # However, in the Golang limitation, we couldn't parse like "tag": 12.20.
+    # In the Golang limitation, we couldn't parse like "tag": 12.20.
     # So, we must use "tag": "12.20" instead.
     # More details in PR-4896 (https://github.com/harvester/harvester/pull/4896)
     tag: 15.5

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -11,6 +11,7 @@ import (
 	ctlbatchv1 "github.com/rancher/wrangler/pkg/generated/controllers/batch/v1"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/name"
+	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -395,6 +396,7 @@ func isPromoteStatusIn(node *corev1.Node, statuses ...string) bool {
 func (h *PromoteHandler) createPromoteJob(node *corev1.Node) (*batchv1.Job, error) {
 	image, err := utilCatalog.FetchAppChartImage(h.appCache, h.namespace, releaseAppHarvesterName, []string{"generalJob", "image"})
 	if err != nil {
+		logrus.Errorf("failed to get harvester image (%s): %v", image.ImageName(), err)
 		return nil, err
 	}
 

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -74,7 +74,7 @@ type PromoteHandler struct {
 }
 
 // PromoteRegister registers the node controller
-func PromoteRegister(ctx context.Context, management *config.Management, options config.Options) (err error) {
+func PromoteRegister(ctx context.Context, management *config.Management, options config.Options) error {
 	nodes := management.CoreFactory.Core().V1().Node()
 	jobs := management.BatchFactory.Batch().V1().Job()
 	appCache := management.CatalogFactory.Catalog().V1().App().Cache()

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -96,15 +96,6 @@ func PromoteRegister(ctx context.Context, management *config.Management, options
 	return nil
 }
 
-func fetchPromoteImage(appCache catalogv1.AppCache, namespace, name string) (string, error) {
-	image, err := utilCatalog.FetchAppChartImage(appCache, namespace, name, []string{"generalJob", "image"})
-	if err != nil {
-		return "", err
-	}
-
-	return image.ImageName(), nil
-}
-
 // OnNodeChanged automate the upgrade of node roles
 // If the number of managements in the cluster is less than spec number,
 // the harvester oldest node will be automatically promoted to be management.
@@ -402,11 +393,12 @@ func isPromoteStatusIn(node *corev1.Node, statuses ...string) bool {
 }
 
 func (h *PromoteHandler) createPromoteJob(node *corev1.Node) (*batchv1.Job, error) {
-	promoteImage, err := fetchPromoteImage(h.appCache, h.namespace, releaseAppHarvesterName)
+	image, err := utilCatalog.FetchAppChartImage(h.appCache, h.namespace, releaseAppHarvesterName, []string{"generalJob", "image"})
 	if err != nil {
 		return nil, err
 	}
-	job := buildPromoteJob(h.namespace, node, promoteImage)
+
+	job := buildPromoteJob(h.namespace, node, image.ImageName())
 	return h.jobs.Create(job)
 }
 

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -11,7 +11,6 @@ import (
 	ctlbatchv1 "github.com/rancher/wrangler/pkg/generated/controllers/batch/v1"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/name"
-	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -396,8 +395,7 @@ func isPromoteStatusIn(node *corev1.Node, statuses ...string) bool {
 func (h *PromoteHandler) createPromoteJob(node *corev1.Node) (*batchv1.Job, error) {
 	image, err := utilCatalog.FetchAppChartImage(h.appCache, h.namespace, releaseAppHarvesterName, []string{"generalJob", "image"})
 	if err != nil {
-		logrus.Errorf("failed to get harvester image (%s): %v", image.ImageName(), err)
-		return nil, err
+		return nil, fmt.Errorf("failed to get harvester image (%s): %v", image.ImageName(), err)
 	}
 
 	job := buildPromoteJob(h.namespace, node, image.ImageName())

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -1,19 +1,12 @@
 package node
 
 import (
-	"context"
 	"reflect"
 	"testing"
 	"time"
 
-	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corefake "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
-	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
 
 type NodeBuilder struct {
@@ -634,47 +627,4 @@ func Test_selectPromoteNode(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_fetchPromoteImage(t *testing.T) {
-	var (
-		clientset     = fake.NewSimpleClientset()
-		coreclientset = corefake.NewSimpleClientset()
-		namespace     = "default"
-	)
-
-	if _, err := coreclientset.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
-	}, metav1.CreateOptions{}); err != nil {
-		assert.Nil(t, err, "failed to create namespace")
-	}
-
-	if _, err := clientset.CatalogV1().Apps(namespace).Create(context.Background(), &catalogv1.App{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: namespace,
-		},
-		Spec: catalogv1.ReleaseSpec{
-			Chart: &catalogv1.Chart{
-				Values: map[string]interface{}{
-					"generalJob": map[string]interface{}{
-						"image": map[string]interface{}{
-							"repository":      "test-repository",
-							"tag":             15.3,
-							"imagePullPolicy": "IfNotPresent",
-						},
-					},
-				},
-			},
-		},
-	}, metav1.CreateOptions{}); err != nil {
-		assert.Nil(t, err, "failed to create app")
-	}
-
-	promoteImage, err := fetchPromoteImage(fakeclients.AppCache(clientset.CatalogV1().Apps), namespace, "test")
-
-	assert.Nil(t, err, "failed to fetch promote image")
-	assert.Equal(t, "test-repository:15.3", promoteImage)
 }

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -673,9 +673,8 @@ func Test_fetchPromoteImage(t *testing.T) {
 		assert.Nil(t, err, "failed to create app")
 	}
 
-	if err := fetchPromoteImage(fakeclients.AppClient(clientset.CatalogV1().Apps), namespace, "test"); err != nil {
-		assert.Nil(t, err, "failed to fetch promote image")
-	}
+	promoteImage, err := fetchPromoteImage(fakeclients.AppCache(clientset.CatalogV1().Apps), namespace, "test")
 
+	assert.Nil(t, err, "failed to fetch promote image")
 	assert.Equal(t, "test-repository:15.3", promoteImage)
 }

--- a/pkg/controller/master/setting/support_bundle_image_test.go
+++ b/pkg/controller/master/setting/support_bundle_image_test.go
@@ -1,0 +1,66 @@
+package setting
+
+import (
+	"context"
+	"testing"
+
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterhciv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func Test_UpdateSupportBundleImage(t *testing.T) {
+	var (
+		clientset = fake.NewSimpleClientset()
+		namespace = "default"
+	)
+
+	_, err := clientset.HarvesterhciV1beta1().Settings().Create(
+		context.TODO(),
+		&harvesterhciv1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: settings.SupportBundleImageName,
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	assert.Nil(t, err, "failed to create setting")
+
+	err = UpdateSupportBundleImage(
+		fakeclients.HarvesterSettingClient(clientset.HarvesterhciV1beta1().Settings),
+		fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+		&catalogv1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.name",
+				Namespace: namespace,
+			},
+			Spec: catalogv1.ReleaseSpec{
+				Chart: &catalogv1.Chart{
+					Values: map[string]interface{}{
+						"support-bundle-kit": map[string]interface{}{
+							"image": map[string]interface{}{
+								"repository":      "test-repository",
+								"tag":             "v3.3",
+								"imagePullPolicy": "IfNotPresent",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err, "failed to update setting")
+
+	s, err := clientset.HarvesterhciV1beta1().Settings().Get(
+		context.TODO(),
+		settings.SupportBundleImageName,
+		metav1.GetOptions{})
+
+	assert.Nil(t, err, "failed to get setting")
+	assert.Equal(t, "{\"repository\":\"test-repository\",\"tag\":\"v3.3\",\"imagePullPolicy\":\"IfNotPresent\"}", s.Default)
+}

--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -62,7 +62,7 @@ func (h *Handler) OnSupportBundleChanged(key string, sb *harvesterv1.SupportBund
 		}
 		logrus.Debugf("[%s] support bundle image: %+v", sb.Name, image)
 
-		err = h.manager.Create(sb, fmt.Sprintf("%s:%s", image.Repository, image.Tag), image.ImagePullPolicy)
+		err = h.manager.Create(sb, image.ImageName(), image.ImagePullPolicy)
 		if err != nil {
 			return h.setError(sb, fmt.Sprintf("fail to create manager for %s: %s", sb.Name, err))
 		}

--- a/pkg/settings/image.go
+++ b/pkg/settings/image.go
@@ -1,0 +1,50 @@
+package settings
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Image struct {
+	Repository      string            `json:"repository"`
+	Tag             interface{}       `json:"tag"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
+}
+
+func (i Image) ImageName() string {
+	tag := i.GetTag()
+
+	if tag == "" && i.Repository == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s:%s", i.Repository, tag)
+}
+
+// GetTag gets correct format tag from Chart.Values
+// The tag might be "v12.2", 12.2 and "12.2" etc.
+// So we need to convert it in the case.
+func (i Image) GetTag() string {
+	var tag string
+
+	if i.Tag == nil {
+		return tag
+	}
+
+	switch t := i.Tag.(type) {
+	case string:
+		tag = t
+	case int, int32, int64:
+		tag = fmt.Sprintf("%d", t)
+	case float64:
+		dec := decimal.NewFromFloat(t)
+		tag = dec.String()
+	case float32:
+		dec := decimal.NewFromFloat32(t)
+		tag = dec.String()
+	}
+
+	return tag
+}

--- a/pkg/settings/image.go
+++ b/pkg/settings/image.go
@@ -16,7 +16,7 @@ type Image struct {
 func (i Image) ImageName() string {
 	tag := i.GetTag()
 
-	if tag == "" && i.Repository == "" {
+	if tag == "" || i.Repository == "" {
 		return ""
 	}
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -270,12 +269,6 @@ type SSLCertificate struct {
 type SSLParameter struct {
 	Protocols string `json:"protocols"`
 	Ciphers   string `json:"ciphers"`
-}
-
-type Image struct {
-	Repository      string            `json:"repository"`
-	Tag             string            `json:"tag"`
-	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
 }
 
 type CSIDriverInfo struct {

--- a/pkg/util/catalog/app.go
+++ b/pkg/util/catalog/app.go
@@ -1,0 +1,44 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	catalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/settings"
+)
+
+// FetchAppChartImage fetches image information from Spec.Values of Rancher RCD App.
+func FetchAppChartImage(appClient catalogv1.AppClient, namespace, name string, keyNames []string) (settings.Image, error) {
+	var image settings.Image
+
+	harvesterApp, err := appClient.Get(namespace, name, metav1.GetOptions{})
+	if err != nil {
+		return image, fmt.Errorf("cannot get %s/%s app: %v", namespace, name, err)
+	}
+
+	var (
+		ok    bool
+		bytes []byte
+		value = harvesterApp.Spec.Chart.Values
+	)
+
+	for _, key := range keyNames {
+		if value, ok = value[key].(map[string]interface{}); !ok {
+			return image, fmt.Errorf("cannot find %s in %s/%s app", key, namespace, name)
+		}
+	}
+
+	if bytes, err = json.Marshal(value); err != nil {
+		return image, fmt.Errorf("cannot marshal image in layer(%s) of %s/%s app: %v", strings.Join(keyNames, ","), namespace, name, err)
+	}
+
+	if err = json.Unmarshal(bytes, &image); err != nil {
+		return image, fmt.Errorf("cannot unmarshal image in layer(%s) of %s/%s app: %v", strings.Join(keyNames, ","), namespace, name, err)
+	}
+
+	return image, nil
+}

--- a/pkg/util/catalog/app.go
+++ b/pkg/util/catalog/app.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	catalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
+	"github.com/sirupsen/logrus"
 
 	"github.com/harvester/harvester/pkg/settings"
 )
@@ -27,7 +28,8 @@ func FetchAppChartImage(appCache catalogv1.AppCache, namespace, name string, key
 
 	for _, key := range keyNames {
 		if value, ok = value[key].(map[string]interface{}); !ok {
-			return image, fmt.Errorf("cannot find %s in %s/%s app", key, namespace, name)
+			logrus.Debugf("cannot find key %s in layer(%s) %s/%s app chart value: %v", key, strings.Join(keyNames, ","), namespace, name, value)
+			return image, fmt.Errorf("cannot find %s in layer(%s) %s/%s app", key, strings.Join(keyNames, ","), namespace, name)
 		}
 	}
 

--- a/pkg/util/catalog/app.go
+++ b/pkg/util/catalog/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 // FetchAppChartImage fetches image information from Spec.Values of Rancher RCD App.
@@ -23,14 +24,12 @@ func FetchAppChartImage(appCache catalogv1.AppCache, namespace, name string, key
 	var (
 		ok    bool
 		bytes []byte
-		value = harvesterApp.Spec.Chart.Values
+		value interface{}
 	)
 
-	for _, key := range keyNames {
-		if value, ok = value[key].(map[string]interface{}); !ok {
-			logrus.Debugf("fail to get value of path(%s)", strings.Join(keyNames, "."))
-			return image, fmt.Errorf("cannot find %s in path(%s) %s/%s app", key, strings.Join(keyNames, "."), namespace, name)
-		}
+	if value, ok = util.GetValue(harvesterApp.Spec.Chart.Values, keyNames...); !ok {
+		logrus.Debugf("fail to get value of path(%s)", strings.Join(keyNames, "."))
+		return image, fmt.Errorf("cannot find path(%s) %s/%s app", strings.Join(keyNames, "."), namespace, name)
 	}
 
 	if bytes, err = json.Marshal(value); err != nil {

--- a/pkg/util/catalog/app.go
+++ b/pkg/util/catalog/app.go
@@ -6,16 +6,15 @@ import (
 	"strings"
 
 	catalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/harvester/pkg/settings"
 )
 
 // FetchAppChartImage fetches image information from Spec.Values of Rancher RCD App.
-func FetchAppChartImage(appClient catalogv1.AppClient, namespace, name string, keyNames []string) (settings.Image, error) {
+func FetchAppChartImage(appCache catalogv1.AppCache, namespace, name string, keyNames []string) (settings.Image, error) {
 	var image settings.Image
 
-	harvesterApp, err := appClient.Get(namespace, name, metav1.GetOptions{})
+	harvesterApp, err := appCache.Get(namespace, name)
 	if err != nil {
 		return image, fmt.Errorf("cannot get %s/%s app: %v", namespace, name, err)
 	}

--- a/pkg/util/catalog/app.go
+++ b/pkg/util/catalog/app.go
@@ -21,14 +21,16 @@ func FetchAppChartImage(appCache catalogv1.AppCache, namespace, name string, key
 	}
 
 	var (
-		ok    bool
-		bytes []byte
-		value = harvesterApp.Spec.Chart.Values
+		ok            bool
+		bytes         []byte
+		value         = harvesterApp.Spec.Chart.Values
+		previousValue map[string]interface{}
 	)
 
 	for _, key := range keyNames {
+		previousValue = value
 		if value, ok = value[key].(map[string]interface{}); !ok {
-			logrus.Debugf("cannot find key %s in layer(%s) %s/%s app chart value: %v", key, strings.Join(keyNames, ","), namespace, name, value)
+			logrus.Debugf("cannot find key %s in layer(%s) %s/%s app chart value: %v", key, strings.Join(keyNames, ","), namespace, name, previousValue)
 			return image, fmt.Errorf("cannot find %s in layer(%s) %s/%s app", key, strings.Join(keyNames, ","), namespace, name)
 		}
 	}

--- a/pkg/util/catalog/app.go
+++ b/pkg/util/catalog/app.go
@@ -21,26 +21,24 @@ func FetchAppChartImage(appCache catalogv1.AppCache, namespace, name string, key
 	}
 
 	var (
-		ok            bool
-		bytes         []byte
-		value         = harvesterApp.Spec.Chart.Values
-		previousValue map[string]interface{}
+		ok    bool
+		bytes []byte
+		value = harvesterApp.Spec.Chart.Values
 	)
 
 	for _, key := range keyNames {
-		previousValue = value
 		if value, ok = value[key].(map[string]interface{}); !ok {
-			logrus.Debugf("cannot find key %s in layer(%s) %s/%s app chart value: %v", key, strings.Join(keyNames, ","), namespace, name, previousValue)
-			return image, fmt.Errorf("cannot find %s in layer(%s) %s/%s app", key, strings.Join(keyNames, ","), namespace, name)
+			logrus.Debugf("fail to get value of path(%s)", strings.Join(keyNames, "."))
+			return image, fmt.Errorf("cannot find %s in path(%s) %s/%s app", key, strings.Join(keyNames, "."), namespace, name)
 		}
 	}
 
 	if bytes, err = json.Marshal(value); err != nil {
-		return image, fmt.Errorf("cannot marshal image in layer(%s) of %s/%s app: %v", strings.Join(keyNames, ","), namespace, name, err)
+		return image, fmt.Errorf("cannot marshal image in path(%s) of %s/%s app: %v", strings.Join(keyNames, "."), namespace, name, err)
 	}
 
 	if err = json.Unmarshal(bytes, &image); err != nil {
-		return image, fmt.Errorf("cannot unmarshal image in layer(%s) of %s/%s app: %v", strings.Join(keyNames, ","), namespace, name, err)
+		return image, fmt.Errorf("cannot unmarshal image in path(%s) of %s/%s app: %v", strings.Join(keyNames, "."), namespace, name, err)
 	}
 
 	return image, nil

--- a/pkg/util/catalog/app_test.go
+++ b/pkg/util/catalog/app_test.go
@@ -111,7 +111,7 @@ func Test_FetchAppImage(t *testing.T) {
 			assert.Nil(t, err, "failed to create app", test.desc)
 		}
 
-		image, err := FetchAppChartImage(fakeclients.AppClient(clientset.CatalogV1().Apps), namespace, test.name, test.keys)
+		image, err := FetchAppChartImage(fakeclients.AppCache(clientset.CatalogV1().Apps), namespace, test.name, test.keys)
 		if err != nil {
 			if test.expectedError {
 				assert.NotNil(t, err, "expected error", test.desc)

--- a/pkg/util/catalog/app_test.go
+++ b/pkg/util/catalog/app_test.go
@@ -30,12 +30,12 @@ func Test_FetchAppImage(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc          string
-		name          string
-		values        map[string]interface{}
-		keys          []string
-		expected      string
-		expectedError bool
+		desc              string
+		name              string
+		values            map[string]interface{}
+		keys              []string
+		expectedImageName string
+		expectedError     bool
 	}{
 		{
 			desc: "Normal Case with float type",
@@ -49,9 +49,9 @@ func Test_FetchAppImage(t *testing.T) {
 					},
 				},
 			},
-			keys:          []string{"generalJob", "image"},
-			expected:      "test-repository:12.2",
-			expectedError: false,
+			keys:              []string{"generalJob", "image"},
+			expectedImageName: "test-repository:12.2",
+			expectedError:     false,
 		},
 		{
 			desc: "Normal Case with string type",
@@ -65,17 +65,17 @@ func Test_FetchAppImage(t *testing.T) {
 					},
 				},
 			},
-			keys:          []string{"generalJob", "image"},
-			expected:      "test-repository:v12.20",
-			expectedError: false,
+			keys:              []string{"generalJob", "image"},
+			expectedImageName: "test-repository:v12.20",
+			expectedError:     false,
 		},
 		{
-			desc:          "Not Found Case",
-			name:          "test3",
-			values:        map[string]interface{}{},
-			keys:          []string{"generalJob", "image"},
-			expected:      "",
-			expectedError: true,
+			desc:              "Not Found Case",
+			name:              "test3",
+			values:            map[string]interface{}{},
+			keys:              []string{"generalJob", "image"},
+			expectedImageName: "",
+			expectedError:     true,
 		},
 		{
 			desc: "Weird Case which should not happen in general",
@@ -89,9 +89,41 @@ func Test_FetchAppImage(t *testing.T) {
 					},
 				},
 			},
-			keys:          []string{"generalJob", "image"},
-			expected:      "",
-			expectedError: false,
+			keys:              []string{"generalJob", "image"},
+			expectedImageName: "",
+			expectedError:     false,
+		},
+		{
+			desc: "Weird Case 02 which should not happen in general",
+			name: "test5",
+			values: map[string]interface{}{
+				"generalJob": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository":      "",
+						"tag":             "v2",
+						"imagePullPolicy": "",
+					},
+				},
+			},
+			keys:              []string{"generalJob", "image"},
+			expectedImageName: "",
+			expectedError:     false,
+		},
+		{
+			desc: "Weird Case 03 which should not happen in general",
+			name: "test6",
+			values: map[string]interface{}{
+				"generalJob": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository":      "test-repository",
+						"tag":             "",
+						"imagePullPolicy": "",
+					},
+				},
+			},
+			keys:              []string{"generalJob", "image"},
+			expectedImageName: "",
+			expectedError:     false,
 		},
 	}
 
@@ -114,12 +146,12 @@ func Test_FetchAppImage(t *testing.T) {
 		image, err := FetchAppChartImage(fakeclients.AppCache(clientset.CatalogV1().Apps), namespace, test.name, test.keys)
 		if err != nil {
 			if test.expectedError {
-				assert.NotNil(t, err, "expected error", test.desc)
+				assert.NotNil(t, err, "expectedImageName error", test.desc)
 				continue
 			}
 			assert.Nil(t, err, "failed to fetch image", test.desc)
 		}
 
-		assert.Equal(t, test.expected, image.ImageName(), test.desc)
+		assert.Equal(t, test.expectedImageName, image.ImageName(), test.desc)
 	}
 }

--- a/pkg/util/catalog/app_test.go
+++ b/pkg/util/catalog/app_test.go
@@ -1,0 +1,125 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corefake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func Test_FetchAppImage(t *testing.T) {
+	var (
+		clientset     = fake.NewSimpleClientset()
+		coreclientset = corefake.NewSimpleClientset()
+		namespace     = "default"
+	)
+
+	if _, err := coreclientset.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		assert.Nil(t, err, "failed to create namespace")
+	}
+
+	tests := []struct {
+		desc          string
+		name          string
+		values        map[string]interface{}
+		keys          []string
+		expected      string
+		expectedError bool
+	}{
+		{
+			desc: "Normal Case with float type",
+			name: "test",
+			values: map[string]interface{}{
+				"generalJob": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository":      "test-repository",
+						"tag":             12.2,
+						"imagePullPolicy": "IfNotPresent",
+					},
+				},
+			},
+			keys:          []string{"generalJob", "image"},
+			expected:      "test-repository:12.2",
+			expectedError: false,
+		},
+		{
+			desc: "Normal Case with string type",
+			name: "test2",
+			values: map[string]interface{}{
+				"generalJob": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository":      "test-repository",
+						"tag":             "v12.20",
+						"imagePullPolicy": "IfNotPresent",
+					},
+				},
+			},
+			keys:          []string{"generalJob", "image"},
+			expected:      "test-repository:v12.20",
+			expectedError: false,
+		},
+		{
+			desc:          "Not Found Case",
+			name:          "test3",
+			values:        map[string]interface{}{},
+			keys:          []string{"generalJob", "image"},
+			expected:      "",
+			expectedError: true,
+		},
+		{
+			desc: "Weird Case which should not happen in general",
+			name: "test4",
+			values: map[string]interface{}{
+				"generalJob": map[string]interface{}{
+					"image": map[string]interface{}{
+						"repository":      "",
+						"tag":             "",
+						"imagePullPolicy": "",
+					},
+				},
+			},
+			keys:          []string{"generalJob", "image"},
+			expected:      "",
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+
+		if _, err := clientset.CatalogV1().Apps(namespace).Create(context.Background(), &catalogv1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      test.name,
+				Namespace: namespace,
+			},
+			Spec: catalogv1.ReleaseSpec{
+				Chart: &catalogv1.Chart{
+					Values: test.values,
+				},
+			},
+		}, metav1.CreateOptions{}); err != nil {
+			assert.Nil(t, err, "failed to create app", test.desc)
+		}
+
+		image, err := FetchAppChartImage(fakeclients.AppClient(clientset.CatalogV1().Apps), namespace, test.name, test.keys)
+		if err != nil {
+			if test.expectedError {
+				assert.NotNil(t, err, "expected error", test.desc)
+				continue
+			}
+			assert.Nil(t, err, "failed to fetch image", test.desc)
+		}
+
+		assert.Equal(t, test.expected, image.ImageName(), test.desc)
+	}
+}

--- a/pkg/util/fakeclients/app.go
+++ b/pkg/util/fakeclients/app.go
@@ -7,6 +7,8 @@ import (
 	ctlcatalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 
 	catalogv1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/catalog.cattle.io/v1"
 )
@@ -23,5 +25,39 @@ func (c AppCache) AddIndexer(indexName string, indexer ctlcatalogv1.AppIndexer) 
 	panic("implement me")
 }
 func (c AppCache) GetByIndex(indexName, key string) ([]*catalogv1.App, error) {
+	panic("implement me")
+}
+
+type AppClient func(string) catalogv1type.AppInterface
+
+func (c AppClient) Update(app *catalogv1.App) (*catalogv1.App, error) {
+	return c(app.Namespace).Update(context.TODO(), app, metav1.UpdateOptions{})
+}
+
+func (c AppClient) Get(namespace, name string, options metav1.GetOptions) (*catalogv1.App, error) {
+	return c(namespace).Get(context.TODO(), name, options)
+}
+
+func (c AppClient) Create(app *catalogv1.App) (*catalogv1.App, error) {
+	return c(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
+}
+
+func (c AppClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	panic("implement me")
+}
+
+func (c AppClient) List(namespace string, opts metav1.ListOptions) (*catalogv1.AppList, error) {
+	panic("implement me")
+}
+
+func (c AppClient) UpdateStatus(*catalogv1.App) (*catalogv1.App, error) {
+	panic("implement me")
+}
+
+func (c AppClient) Watch(namespace string, pts metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c AppClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *catalogv1.App, err error) {
 	panic("implement me")
 }

--- a/pkg/util/values.go
+++ b/pkg/util/values.go
@@ -1,0 +1,15 @@
+package util
+
+// GetValue retrieve value from map[string]interface{} by keys
+// example: GetValue(map[string]interface{}{"a": map[string]interface{}{"b": "c"}}, "a", "b") -> "c"
+func GetValue(data map[string]interface{}, keys ...string) (interface{}, bool) {
+	for i, key := range keys {
+		if i == len(keys)-1 {
+			val, ok := data[key]
+			return val, ok
+		}
+		data, _ = data[key].(map[string]interface{})
+	}
+
+	return nil, false
+}


### PR DESCRIPTION
## **Problem:**

It would be annoying to manage repository name and tag in different places, so it would be better to have a single source of truth. Currently, the image of promote job exists in [promote_controller.go](https://github.com/FrankYang0529/harvester/blob/197012aa566c55469472e4c8970d7f6a0912bfb2/pkg/controller/master/node/promote_controller.go#L48) and [helm chart](https://github.com/FrankYang0529/harvester/blob/197012aa566c55469472e4c8970d7f6a0912bfb2/deploy/charts/harvester/values.yaml#L491-L492).

## **Solution:**

Because the chart value is in the Rancher APP CR, so we could retrieve from there.

However, in the Golang limitation, we couldn't parse like `"tag": 12.20` in map such as [this playground](https://go.dev/play/p/dfJQ9xSlPeo). So, if we have that kind of version, we should use `"tag": "12.20"` instead in the future.

## **Related Issue:**

https://github.com/harvester/harvester/issues/4865

## **Test plan:**

- Try to create one management harvester cluster, and create another two harvester to join. 
  Testing Image: `jk82421/harvester:v1.2.1.7`
  ![image](https://github.com/harvester/harvester/assets/6960289/54bd748c-f79c-4387-a197-7114797bb380)
- Because I also modified the updateSupportBundleImage, so I tested it as well. I also added test case for this.
  Testing Image: `jk82421/harvester:v1.2.1.8`
  ![image](https://github.com/harvester/harvester/assets/6960289/baf9e328-6c5f-4663-803a-224ceaf9a3a5)
  ![image](https://github.com/harvester/harvester/assets/6960289/e336288a-f7a7-42b5-981f-d38c662aae14)





