### PR TITLE
refactor: remove mount logic in harvester

### DIFF
--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -5,14 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
-	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	"github.com/rancher/apiserver/pkg/apierror"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/schemas/validation"
@@ -282,24 +279,6 @@ func (h *ActionHandler) snapshot(ctx context.Context, pvcNamespace, pvcName, sna
 	csiDriverInfo, err := settings.GetCSIDriverInfo(provisioner)
 	if err != nil {
 		return err
-	}
-
-	if provisioner == longhorntypes.LonghornDriverName {
-		volume, err := h.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
-		if err != nil {
-			return fmt.Errorf("failed to get volume %s/%s, error: %s", pvc.Namespace, pvc.Spec.VolumeName, err.Error())
-		}
-		volCpy := volume.DeepCopy()
-		if volume.Status.State == lhv1beta2.VolumeStateDetached || volume.Status.State == lhv1beta2.VolumeStateDetaching {
-			volCpy.Spec.NodeID = volume.Status.OwnerID
-		}
-
-		if !reflect.DeepEqual(volCpy, volume) {
-			logrus.Infof("mount detached volume %s to the node %s", volCpy.Name, volCpy.Spec.NodeID)
-			if _, err = h.volumes.Update(volCpy); err != nil {
-				return err
-			}
-		}
 	}
 
 	volumeSnapshotClassName := csiDriverInfo.VolumeSnapshotClassName

--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -8,15 +8,12 @@ import (
 
 	"github.com/gorilla/mux"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
-	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	"github.com/rancher/apiserver/pkg/apierror"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/pkg/generated/controllers/storage/v1"
 	"github.com/rancher/wrangler/pkg/schemas/validation"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
@@ -128,42 +125,6 @@ func (h *ActionHandler) restore(ctx context.Context, snapshotNamespace, snapshot
 	if _, err = h.pvcs.Create(newPVC); err != nil {
 		logrus.Errorf("failed to restore volume snapshot %s/%s", snapshotNamespace, snapshotName)
 		return err
-	}
-
-	if sc.Provisioner == longhorntypes.LonghornDriverName {
-		if err = h.mountSourcePVC(volumeSnapshot); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (h *ActionHandler) mountSourcePVC(volumeSnapshot *snapshotv1.VolumeSnapshot) error {
-	if volumeSnapshot.Spec.Source.PersistentVolumeClaimName == nil {
-		return nil
-	}
-
-	pvc, err := h.pvcCache.Get(volumeSnapshot.Namespace, *volumeSnapshot.Spec.Source.PersistentVolumeClaimName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("can't find pvc %s/%s, err: %w", volumeSnapshot.Namespace, *volumeSnapshot.Spec.Source.PersistentVolumeClaimName, err)
-	}
-
-	volume, err := h.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
-	if err != nil {
-		return fmt.Errorf("failed to get volume %s/%s, error: %s", util.LonghornSystemNamespaceName, pvc.Spec.VolumeName, err.Error())
-	}
-
-	if volume.Status.State == lhv1beta2.VolumeStateDetached || volume.Status.State == lhv1beta2.VolumeStateDetaching {
-		volCpy := volume.DeepCopy()
-		volCpy.Spec.NodeID = volume.Status.OwnerID
-		logrus.Infof("mount detached volume %s to the node %s", volCpy.Name, volCpy.Spec.NodeID)
-		if _, err = h.volumes.Update(volCpy); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -74,8 +74,8 @@ func RegisterBackup(ctx context.Context, management *config.Management, opts con
 	storageClasses := management.StorageFactory.Storage().V1().StorageClass()
 	vms := management.VirtFactory.Kubevirt().V1().VirtualMachine()
 	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
-	volumes := management.LonghornFactory.Longhorn().V1beta2().Volume()
 	lhbackups := management.LonghornFactory.Longhorn().V1beta2().Backup()
+	volumes := management.LonghornFactory.Longhorn().V1beta2().Volume()
 	snapshots := management.SnapshotFactory.Snapshot().V1().VolumeSnapshot()
 	snapshotContents := management.SnapshotFactory.Snapshot().V1().VolumeSnapshotContent()
 	snapshotClass := management.SnapshotFactory.Snapshot().V1().VolumeSnapshotClass()
@@ -101,9 +101,8 @@ func RegisterBackup(ctx context.Context, management *config.Management, opts con
 		vmsCache:                  vms.Cache(),
 		vmis:                      vmis,
 		vmisCache:                 vmis.Cache(),
-		volumeCache:               volumes.Cache(),
-		volumes:                   volumes,
 		lhbackupCache:             lhbackups.Cache(),
+		volumeCache:               volumes.Cache(),
 		snapshots:                 snapshots,
 		snapshotCache:             snapshots.Cache(),
 		snapshotContents:          snapshotContents,
@@ -132,9 +131,8 @@ type Handler struct {
 	pvcCache                  ctlcorev1.PersistentVolumeClaimCache
 	secretCache               ctlcorev1.SecretCache
 	storageClassCache         ctlstoragev1.StorageClassCache
-	volumeCache               ctllonghornv2.VolumeCache
-	volumes                   ctllonghornv2.VolumeClient
 	lhbackupCache             ctllonghornv2.BackupCache
+	volumeCache               ctllonghornv2.VolumeCache
 	snapshots                 ctlsnapshotv1.VolumeSnapshotClient
 	snapshotCache             ctlsnapshotv1.VolumeSnapshotCache
 	snapshotContents          ctlsnapshotv1.VolumeSnapshotContentClient
@@ -168,13 +166,6 @@ func (h *Handler) OnBackupChange(key string, vmBackup *harvesterv1.VirtualMachin
 			return nil, h.setStatusError(vmBackup, err)
 		}
 
-		// check if the VM is running, if not make sure the volumes are mounted to the host
-		if !sourceVM.Status.Ready || !sourceVM.Status.Created {
-			// mount volumes after creating VolumeSnapshots, so detaching volumes controller doesn't detach the volumes
-			if err := h.mountLonghornVolumes(sourceVM); err != nil {
-				return nil, h.setStatusError(vmBackup, err)
-			}
-		}
 		return nil, nil
 	}
 

--- a/pkg/controller/master/backup/backup_status.go
+++ b/pkg/controller/master/backup/backup_status.go
@@ -7,13 +7,10 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	longhorntypes "github.com/longhorn/longhorn-manager/types"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/util"
@@ -141,47 +138,6 @@ func (h *Handler) resolveVolSnapshotRef(namespace string, controllerRef *metav1.
 		return nil
 	}
 	return backup
-}
-
-// mountLonghornVolumes helps to mount the volumes to host if it is detached
-func (h *Handler) mountLonghornVolumes(vm *kubevirtv1.VirtualMachine) error {
-	for _, vol := range vm.Spec.Template.Spec.Volumes {
-		if vol.PersistentVolumeClaim == nil {
-			continue
-		}
-		name := vol.PersistentVolumeClaim.ClaimName
-
-		pvc, err := h.pvcCache.Get(vm.Namespace, name)
-		if err != nil {
-			return fmt.Errorf("failed to get pvc %s/%s, error: %s", name, vm.Namespace, err.Error())
-		}
-
-		sc, err := h.storageClassCache.Get(*pvc.Spec.StorageClassName)
-		if err != nil {
-			return err
-		}
-		if sc.Provisioner != longhorntypes.LonghornDriverName {
-			continue
-		}
-
-		volume, err := h.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
-		if err != nil {
-			return fmt.Errorf("failed to get volume %s/%s, error: %s", name, vm.Namespace, err.Error())
-		}
-
-		volCpy := volume.DeepCopy()
-		if volume.Status.State == lhv1beta2.VolumeStateDetached || volume.Status.State == lhv1beta2.VolumeStateDetaching {
-			volCpy.Spec.NodeID = volume.Status.OwnerID
-		}
-
-		if !reflect.DeepEqual(volCpy, volume) {
-			logrus.Infof("mount detached volume %s to the node %s", volCpy.Name, volCpy.Spec.NodeID)
-			if _, err = h.volumes.Update(volCpy); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func getVolumeSnapshotContentName(volumeBackup harvesterv1.VolumeBackup) string {

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -15,7 +15,6 @@ import (
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	lhdatastore "github.com/longhorn/longhorn-manager/datastore"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	lhutil "github.com/longhorn/longhorn-manager/util"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/name"
@@ -478,11 +477,6 @@ func (h *RestoreHandler) reconcileResources(
 	// reconcile restoring volumes and create new PVC from CSI volumeSnapshot if not exist
 	isVolumesReady, err := h.reconcileVolumeRestores(vmRestore, backup)
 	if err != nil {
-		return nil, false, err
-	}
-
-	// mount volumes after creating PVCs, so detaching volumes controller doesn't detach the volumes
-	if err := h.mountLonghornVolumes(backup); err != nil {
 		return nil, false, err
 	}
 
@@ -1125,44 +1119,4 @@ func (h *RestoreHandler) constructVolumeSnapshotContentName(restoreNamespace, re
 	// VolumeSnapshotContent is cluster-scoped resource,
 	// so adding restoreNamespace to its name to prevent conflict in different namespace with same restore name and backup
 	return name.SafeConcatName("restore", restoreNamespace, restoreName, volumeBackupName)
-}
-
-// mountLonghornVolumes helps to mount the volumes to host if it is detached
-func (h *RestoreHandler) mountLonghornVolumes(backup *harvesterv1.VirtualMachineBackup) error {
-	// we only need to mount LH Volumes for snapshot type.
-	if backup.Spec.Type == harvesterv1.Backup {
-		return nil
-	}
-
-	for _, vb := range backup.Status.VolumeBackups {
-		pvcNamespace := vb.PersistentVolumeClaim.ObjectMeta.Namespace
-		pvcName := vb.PersistentVolumeClaim.ObjectMeta.Name
-
-		pvc, err := h.pvcCache.Get(pvcNamespace, pvcName)
-		if err != nil {
-			return fmt.Errorf("failed to get pvc %s/%s, error: %s", pvcNamespace, pvcName, err.Error())
-		}
-
-		if provisioner := util.GetProvisionedPVCProvisioner(pvc); provisioner != longhorntypes.LonghornDriverName {
-			continue
-		}
-
-		volume, err := h.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
-		if err != nil {
-			return fmt.Errorf("failed to get volume %s/%s, error: %s", util.LonghornSystemNamespaceName, pvc.Spec.VolumeName, err.Error())
-		}
-
-		volCpy := volume.DeepCopy()
-		if volume.Status.State == lhv1beta2.VolumeStateDetached || volume.Status.State == lhv1beta2.VolumeStateDetaching {
-			volCpy.Spec.NodeID = volume.Status.OwnerID
-		}
-
-		if !reflect.DeepEqual(volCpy, volume) {
-			logrus.Infof("mount detached volume %s to the node %s", volCpy.Name, volCpy.Spec.NodeID)
-			if _, err = h.volumes.Update(volCpy); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
**Solution:**
LH introduces VolumeAttachment CRD after v1.5. It can automatically attach/detach volume when there is a request from LH API / controller / CSI. We can just leverage LH mechanism and remove our implementation.

**Related Issue:**
https://github.com/harvester/harvester/issues/4907

**Test plan:**

### Setup

1. Create a 3-node harvester from this branch.
2. Setup backup-target.

### Case 1: snapshot can work on a stopped VM.

1. Create a VM.
2. After the VM is ready, stop the VM.
3. Check VM volumes are detached.
4. Take a snapshot on the VM. The snapshot can be ready.

### Case 2: restore a snapshot from detached volumes can work.

1. Follow Case 1.
2. Make sure VM volumes are detached.
3. Restore the snapshot to a new VM. The new VM can be ready.
4. Restore the snapshot to replace the old VM. The old VM can be ready.

### Case 3: backup can work on a stopped VM.

1. Create a VM.
2. After the VM is ready, stop the VM.
3. Check VM volumes are detached.
4. Take a backup on the VM. The backup can be ready.

### Case 4: race condition doesn't break VMBackup.

1. Create a VM.
2. After the VM is ready, stop the VM.
3. Check VM volumes are detached.
4. Take multiple backup on the VM in a short time. All backup can be ready.

### Case 5: restore a backup from detached volumes can work.

1. Follow Case 3.
2. Make sure VM volumes are detached.
3. Restore the backup to a new VM. The new VM can be ready.
4. Restore the backup to replace the old VM. The old VM can be ready.
