### PR TITLE
feat: delete unused support bundle after a period of time

### DIFF
--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -11,6 +11,7 @@ import (
 	ctlappsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	settingctl "github.com/harvester/harvester/pkg/controller/master/setting"
@@ -18,6 +19,8 @@ import (
 	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
 )
+
+const supportBundleExistTimeLimit = 10 * time.Minute
 
 // Handler generates support bundles for the cluster
 type Handler struct {
@@ -70,10 +73,37 @@ func (h *Handler) OnSupportBundleChanged(key string, sb *harvesterv1.SupportBund
 	case types.StateGenerating:
 		logrus.Debugf("[%s] support bundle is being generated", sb.Name)
 		return h.checkManagerStatus(sb)
+	case types.StateError, types.StateReady:
+		return h.checkExistTime(sb)
 	default:
 		logrus.Debugf("[%s] noop for state %s", sb.Name, sb.Status.State)
 		return sb, nil
 	}
+}
+
+// checkExistTime checks if the support bundle has been updated for more than supportBundleExistTimeLimit minutes
+// If yes, that means the support bundle file is not be retrieved, and it should be deleted.
+func (h *Handler) checkExistTime(sb *harvesterv1.SupportBundle) (*harvesterv1.SupportBundle, error) {
+	t, err := time.Parse(time.RFC3339, sb.Status.Conditions[0].LastUpdateTime)
+	if err != nil {
+		logrus.Debugf("[%s] fail to parse %s", sb.Name, sb.Status.Conditions[0].LastUpdateTime)
+		return sb, err
+	}
+
+	existTime := time.Now().Sub(t)
+
+	logrus.Debugf("[%s] support bundle status: %s exist time is %s", sb.Name, sb.Status.State, existTime.String())
+	if existTime < supportBundleExistTimeLimit {
+		h.supportBundleController.EnqueueAfter(sb.Namespace, sb.Name, supportBundleExistTimeLimit)
+		return sb, err
+	}
+
+	if err := h.supportBundles.Delete(sb.Namespace, sb.Name, &metav1.DeleteOptions{}); err != nil {
+		return sb, err
+	}
+
+	logrus.Infof("[%s] support bundle is deleted", sb.Name)
+	return nil, nil
 }
 
 func (h *Handler) updateSupportBundleImageSetting() error {

--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -20,8 +20,6 @@ import (
 	"github.com/harvester/harvester/pkg/settings"
 )
 
-const supportBundleExistTimeLimit = 10 * time.Minute
-
 // Handler generates support bundles for the cluster
 type Handler struct {
 	supportBundles          v1beta1.SupportBundleClient
@@ -91,10 +89,11 @@ func (h *Handler) checkExistTime(sb *harvesterv1.SupportBundle) (*harvesterv1.Su
 	}
 
 	existTime := time.Now().Sub(t)
+	limit := settings.SupportBundleExistTimeLimitSeconds.GetDuration() * time.Second
 
 	logrus.Debugf("[%s] support bundle status: %s exist time is %s", sb.Name, sb.Status.State, existTime.String())
-	if existTime < supportBundleExistTimeLimit {
-		h.supportBundleController.EnqueueAfter(sb.Namespace, sb.Name, supportBundleExistTimeLimit)
+	if existTime < limit {
+		h.supportBundleController.EnqueueAfter(sb.Namespace, sb.Name, limit)
 		return sb, err
 	}
 

--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -86,7 +86,7 @@ func (h *Handler) OnSupportBundleChanged(key string, sb *harvesterv1.SupportBund
 func (h *Handler) checkExistTime(sb *harvesterv1.SupportBundle) (*harvesterv1.SupportBundle, error) {
 	t, err := time.Parse(time.RFC3339, harvesterv1.SupportBundleInitialized.GetLastUpdated(sb))
 	if err != nil {
-		logrus.Debugf("[%s] fail to parse %s", sb.Name, sb.Status.Conditions[0].LastUpdateTime)
+		logrus.Debugf("[%s] fail to parse %s", sb.Name, harvesterv1.SupportBundleInitialized.GetLastUpdated(sb))
 		return sb, err
 	}
 
@@ -103,7 +103,7 @@ func (h *Handler) checkExistTime(sb *harvesterv1.SupportBundle) (*harvesterv1.Su
 
 	logrus.Debugf("[%s] support bundle status: %s exist time is %s", sb.Name, sb.Status.State, existTime.String())
 	if existTime < expiredTime {
-		h.supportBundleController.EnqueueAfter(sb.Namespace, sb.Name, expiredTime)
+		h.supportBundleController.EnqueueAfter(sb.Namespace, sb.Name, expiredTime-existTime)
 		return sb, err
 	}
 

--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -89,11 +89,11 @@ func (h *Handler) checkExistTime(sb *harvesterv1.SupportBundle) (*harvesterv1.Su
 	}
 
 	existTime := time.Now().Sub(t)
-	limit := settings.SupportBundleExistTimeLimitSeconds.GetDuration() * time.Second
+	expiredTime := settings.SupportBundleExpirationSeconds.GetDuration() * time.Second
 
 	logrus.Debugf("[%s] support bundle status: %s exist time is %s", sb.Name, sb.Status.State, existTime.String())
-	if existTime < limit {
-		h.supportBundleController.EnqueueAfter(sb.Namespace, sb.Name, limit)
+	if existTime < expiredTime {
+		h.supportBundleController.EnqueueAfter(sb.Namespace, sb.Name, expiredTime)
 		return sb, err
 	}
 

--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -90,7 +90,7 @@ func (h *Handler) checkExistTime(sb *harvesterv1.SupportBundle) (*harvesterv1.Su
 	}
 
 	existTime := time.Now().Sub(t)
-	expiredTime := settings.SupportBundleExpirationSeconds.GetDuration() * time.Second
+	expiredTime := settings.SupportBundleExpiration.GetDuration() * time.Minute
 
 	logrus.Debugf("[%s] support bundle status: %s exist time is %s", sb.Name, sb.Status.State, existTime.String())
 	if existTime < expiredTime {

--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -19,7 +19,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/supportbundle/types"
 	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
-	"github.com/harvester/harvester/pkg/util"
+	supportBundleUtil "github.com/harvester/harvester/pkg/util/supportbundle"
 )
 
 // Handler generates support bundles for the cluster
@@ -96,7 +96,7 @@ func (h *Handler) checkExistTime(sb *harvesterv1.SupportBundle) (*harvesterv1.Su
 	)
 
 	if expiration := settings.SupportBundleExpiration.GetInt(); expiration == 0 {
-		expiredTime = time.Duration(util.SupportBundleExpirationDefault) * time.Minute
+		expiredTime = time.Duration(supportBundleUtil.SupportBundleExpirationDefault) * time.Minute
 	} else {
 		expiredTime = time.Duration(expiration) * time.Minute
 	}

--- a/pkg/controller/master/supportbundle/controller_test.go
+++ b/pkg/controller/master/supportbundle/controller_test.go
@@ -1,0 +1,119 @@
+package supportbundle
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corefake "k8s.io/client-go/kubernetes/fake"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/controller/master/supportbundle/types"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func Test_checkExistTime(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	coreclientset := corefake.NewSimpleClientset()
+	namespace := "test-support-bundle"
+
+	if _, err := coreclientset.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		assert.Nil(t, err, "failed to create namespace", namespace)
+	}
+
+	handler := Handler{
+		supportBundles:          fakeclients.SupportBundleClient(clientset.HarvesterhciV1beta1().SupportBundles),
+		supportBundleController: fakeclients.SupportBundleClient(clientset.HarvesterhciV1beta1().SupportBundles),
+	}
+
+	tests := []struct {
+		name             string
+		getSupportBundle func() *harvesterv1.SupportBundle
+		expected         func(*harvesterv1.SupportBundle, error, string)
+	}{
+		{
+			name: "ready state",
+			getSupportBundle: func() *harvesterv1.SupportBundle {
+				sb := &harvesterv1.SupportBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test1",
+						Namespace: namespace,
+					},
+					Status: harvesterv1.SupportBundleStatus{
+						State: types.StateReady,
+					},
+				}
+				harvesterv1.SupportBundleInitialized.True(sb)
+				sb.Status.Conditions[0].LastUpdateTime = time.Now().Add(-35 * time.Minute).Format(time.RFC3339)
+				return sb
+			},
+			expected: func(sb *harvesterv1.SupportBundle, err error, name string) {
+				assert.Nil(t, sb, name)
+				assert.True(t, apierrors.IsNotFound(err), name)
+			},
+		},
+		{
+			name: "error state",
+			getSupportBundle: func() *harvesterv1.SupportBundle {
+				sb := &harvesterv1.SupportBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test2",
+						Namespace: namespace,
+					},
+					Status: harvesterv1.SupportBundleStatus{
+						State: types.StateError,
+					},
+				}
+				harvesterv1.SupportBundleInitialized.False(sb)
+				harvesterv1.SupportBundleInitialized.Message(sb, "custom error")
+				sb.Status.Conditions[0].LastUpdateTime = time.Now().Add(-35 * time.Minute).Format(time.RFC3339)
+				return sb
+			},
+			expected: func(sb *harvesterv1.SupportBundle, err error, name string) {
+				assert.Nil(t, sb, name)
+				assert.True(t, apierrors.IsNotFound(err), name)
+			},
+		},
+		{
+			name: "non-final state should not be deleted",
+			getSupportBundle: func() *harvesterv1.SupportBundle {
+				sb := &harvesterv1.SupportBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test3",
+						Namespace: namespace,
+					},
+					Status: harvesterv1.SupportBundleStatus{
+						State: "other state",
+					},
+				}
+				return sb
+			},
+			expected: func(sb *harvesterv1.SupportBundle, err error, name string) {
+				assert.Equal(t, sb.Name, "test3", name)
+				assert.Equal(t, sb.Status.State, "other state", name)
+				assert.Nil(t, err, name)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		sb := tc.getSupportBundle()
+		_, err := clientset.HarvesterhciV1beta1().SupportBundles(namespace).Create(context.Background(), sb, metav1.CreateOptions{})
+		assert.Nil(t, err, tc.name)
+
+		_, err = handler.OnSupportBundleChanged("", sb)
+		assert.Nil(t, err, tc.name)
+
+		sb, err = clientset.HarvesterhciV1beta1().SupportBundles(namespace).Get(context.Background(), sb.Name, metav1.GetOptions{})
+		tc.expected(sb, err, tc.name)
+	}
+}

--- a/pkg/controller/master/supportbundle/controller_test.go
+++ b/pkg/controller/master/supportbundle/controller_test.go
@@ -53,7 +53,7 @@ func Test_checkExistTime(t *testing.T) {
 					},
 				}
 				harvesterv1.SupportBundleInitialized.True(sb)
-				sb.Status.Conditions[0].LastUpdateTime = time.Now().Add(-35 * time.Minute).Format(time.RFC3339)
+				harvesterv1.SupportBundleInitialized.LastUpdated(sb, time.Now().Add(-35*time.Minute).Format(time.RFC3339))
 				return sb
 			},
 			expected: func(sb *harvesterv1.SupportBundle, err error, name string) {
@@ -75,7 +75,7 @@ func Test_checkExistTime(t *testing.T) {
 				}
 				harvesterv1.SupportBundleInitialized.False(sb)
 				harvesterv1.SupportBundleInitialized.Message(sb, "custom error")
-				sb.Status.Conditions[0].LastUpdateTime = time.Now().Add(-35 * time.Minute).Format(time.RFC3339)
+				harvesterv1.SupportBundleInitialized.LastUpdated(sb, time.Now().Add(-35*time.Minute).Format(time.RFC3339))
 				return sb
 			},
 			expected: func(sb *harvesterv1.SupportBundle, err error, name string) {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/harvester/harvester/pkg/util"
+	supportBundleUtil "github.com/harvester/harvester/pkg/util/supportbundle"
 )
 
 var (
@@ -38,8 +38,8 @@ var (
 	SSLParameters                          = NewSetting(SSLParametersName, "{}")
 	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
 	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
-	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")                                      // Unit is minute. 0 means disable timeout.
-	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, util.SupportBundleExpirationDefaultStr) // Unit is minute.
+	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")                                                   // Unit is minute. 0 means disable timeout.
+	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, supportBundleUtil.SupportBundleExpirationDefaultStr) // Unit is minute.
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -38,7 +38,7 @@ var (
 	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
 	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
 	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
-	SupportBundleExistTimeLimitSeconds     = NewSetting(SupportBundleExistTimeLimitSecondsSettingName, "1800")
+	SupportBundleExpirationSeconds         = NewSetting(SupportBundleExpirationSecondsSettingName, "1800")
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
@@ -80,7 +80,7 @@ const (
 	HarvesterCSICCMSettingName                        = "harvester-csi-ccm-versions"
 	StorageNetworkName                                = "storage-network"
 	DefaultVMTerminationGracePeriodSecondsSettingName = "default-vm-termination-grace-period-seconds"
-	SupportBundleExistTimeLimitSecondsSettingName     = "support-bundle-exist-time-seconds"
+	SupportBundleExpirationSecondsSettingName         = "support-bundle-expiration-seconds"
 	NTPServersSettingName                             = "ntp-servers"
 )
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -37,8 +37,8 @@ var (
 	SSLParameters                          = NewSetting(SSLParametersName, "{}")
 	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
 	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
-	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
-	SupportBundleExpirationSeconds         = NewSetting(SupportBundleExpirationSecondsSettingName, "1800")
+	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")    // Unit is minute. 0 means disable timeout.
+	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, "30") // Unit is minute.
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
@@ -80,7 +80,7 @@ const (
 	HarvesterCSICCMSettingName                        = "harvester-csi-ccm-versions"
 	StorageNetworkName                                = "storage-network"
 	DefaultVMTerminationGracePeriodSecondsSettingName = "default-vm-termination-grace-period-seconds"
-	SupportBundleExpirationSecondsSettingName         = "support-bundle-expiration-seconds"
+	SupportBundleExpirationSettingName                = "support-bundle-expiration"
 	NTPServersSettingName                             = "ntp-servers"
 )
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -37,6 +38,7 @@ var (
 	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
 	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
 	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10") // Unit is minute. 0 means disable timeout.
+	SupportBundleExistTimeLimitSeconds     = NewSetting(SupportBundleExistTimeLimitSecondsSettingName, "1800")
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
@@ -78,6 +80,7 @@ const (
 	HarvesterCSICCMSettingName                        = "harvester-csi-ccm-versions"
 	StorageNetworkName                                = "storage-network"
 	DefaultVMTerminationGracePeriodSecondsSettingName = "default-vm-termination-grace-period-seconds"
+	SupportBundleExistTimeLimitSecondsSettingName     = "support-bundle-exist-time-seconds"
 	NTPServersSettingName                             = "ntp-servers"
 )
 
@@ -152,6 +155,10 @@ func (s Setting) GetInt() int {
 		return 0
 	}
 	return i
+}
+
+func (s Setting) GetDuration() time.Duration {
+	return time.Duration(s.GetInt())
 }
 
 func SetProvider(p Provider) error {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -144,16 +144,23 @@ func (s Setting) Get() string {
 }
 
 func (s Setting) GetInt() int {
-	v := s.Get()
-	i, err := strconv.Atoi(v)
-	if err == nil {
-		return i
+	var (
+		i   int
+		err error
+		v   = s.Get()
+	)
+
+	if v != "" {
+		if i, err = strconv.Atoi(v); err == nil {
+			return i
+		}
+		logrus.Errorf("failed to parse setting %s=%s as int: %v", s.Name, v, err)
 	}
-	logrus.Errorf("failed to parse setting %s=%s as int: %v", s.Name, v, err)
-	i, err = strconv.Atoi(s.Default)
-	if err != nil {
+
+	if i, err = strconv.Atoi(s.Default); err != nil {
 		return 0
 	}
+
 	return i
 }
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -7,9 +7,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/harvester/harvester/pkg/util"
 )
 
 var (
@@ -37,8 +38,8 @@ var (
 	SSLParameters                          = NewSetting(SSLParametersName, "{}")
 	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
 	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
-	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")    // Unit is minute. 0 means disable timeout.
-	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, "30") // Unit is minute.
+	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")                                      // Unit is minute. 0 means disable timeout.
+	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, util.SupportBundleExpirationDefaultStr) // Unit is minute.
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
@@ -162,10 +163,6 @@ func (s Setting) GetInt() int {
 	}
 
 	return i
-}
-
-func (s Setting) GetDuration() time.Duration {
-	return time.Duration(s.GetInt())
 }
 
 func SetProvider(p Provider) error {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -102,4 +102,8 @@ const (
 	RancherInternalServerURLSetting          = "internal-server-url"
 	APIServerURLKey                          = "apiServerURL"
 	APIServerCAKey                           = "apiServerCA"
+
+	// SupportBundleExpirationDefault and SupportBundleExpirationDefaultStr these two value should be changed together.
+	SupportBundleExpirationDefault    = 30
+	SupportBundleExpirationDefaultStr = "30"
 )

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -102,8 +102,4 @@ const (
 	RancherInternalServerURLSetting          = "internal-server-url"
 	APIServerURLKey                          = "apiServerURL"
 	APIServerCAKey                           = "apiServerCA"
-
-	// SupportBundleExpirationDefault and SupportBundleExpirationDefaultStr these two value should be changed together.
-	SupportBundleExpirationDefault    = 30
-	SupportBundleExpirationDefaultStr = "30"
 )

--- a/pkg/util/fakeclients/supportbundle.go
+++ b/pkg/util/fakeclients/supportbundle.go
@@ -1,0 +1,110 @@
+package fakeclients
+
+import (
+	"context"
+	"time"
+
+	"github.com/rancher/wrangler/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harv1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+)
+
+type SupportBundleClient func(string) harv1type.SupportBundleInterface
+
+func (c SupportBundleClient) Update(sb *harvesterv1.SupportBundle) (*harvesterv1.SupportBundle, error) {
+	return c(sb.Namespace).Update(context.TODO(), sb, metav1.UpdateOptions{})
+}
+
+func (c SupportBundleClient) Get(namespace, name string, options metav1.GetOptions) (*harvesterv1.SupportBundle, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c SupportBundleClient) Create(sb *harvesterv1.SupportBundle) (*harvesterv1.SupportBundle, error) {
+	return c(sb.Namespace).Create(context.TODO(), sb, metav1.CreateOptions{})
+}
+
+func (c SupportBundleClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return c(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+func (c SupportBundleClient) List(namespace string, opts metav1.ListOptions) (*harvesterv1.SupportBundleList, error) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) UpdateStatus(*harvesterv1.SupportBundle) (*harvesterv1.SupportBundle, error) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *harvesterv1.SupportBundle, err error) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) Informer() cache.SharedIndexInformer {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) GroupVersionKind() schema.GroupVersionKind {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) AddGenericHandler(ctx context.Context, name string, handler generic.Handler) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) AddGenericRemoveHandler(ctx context.Context, name string, handler generic.Handler) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) Updater() generic.Updater {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) OnChange(ctx context.Context, name string, sync ctlharvesterv1.SupportBundleHandler) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) OnRemove(ctx context.Context, name string, sync ctlharvesterv1.SupportBundleHandler) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) Cache() ctlharvesterv1.SupportBundleCache {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) Enqueue(namespace, name string) {
+	panic("implement me")
+}
+
+func (c SupportBundleClient) EnqueueAfter(namespace, name string, duration time.Duration) {
+	// do nothing
+}
+
+type SupportBundleCache func(string) harv1type.SupportBundleInterface
+
+func (c SupportBundleCache) Get(namespace, name string) (*harvesterv1.SupportBundle, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c SupportBundleCache) List(namespace string, selector labels.Selector) ([]*harvesterv1.SupportBundle, error) {
+	panic("implement me")
+}
+
+func (c SupportBundleCache) AddIndexer(indexName string, indexer ctlharvesterv1.SupportBundleIndexer) {
+	panic("implement me")
+}
+
+func (c SupportBundleCache) GetByIndex(indexName, key string) ([]*harvesterv1.SupportBundle, error) {
+	panic("implement me")
+}

--- a/pkg/util/supportbundle/constants.go
+++ b/pkg/util/supportbundle/constants.go
@@ -1,0 +1,7 @@
+package supportbundle
+
+const (
+	// SupportBundleExpirationDefault and SupportBundleExpirationDefaultStr these two value should be changed together.
+	SupportBundleExpirationDefault    = 30
+	SupportBundleExpirationDefaultStr = "30"
+)

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -75,6 +75,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.VMForceResetPolicySettingName:                     validateVMForceResetPolicy,
 	settings.SupportBundleImageName:                            validateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName:                   validateSupportBundleTimeout,
+	settings.SupportBundleExpirationSecondsSettingName:         validateSupportBundleExpirationSeconds,
 	settings.OvercommitConfigSettingName:                       validateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateSSLCertificates,
@@ -91,6 +92,7 @@ var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
 	settings.VMForceResetPolicySettingName:                     validateUpdateVMForceResetPolicy,
 	settings.SupportBundleImageName:                            validateUpdateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName:                   validateUpdateSupportBundleTimeout,
+	settings.SupportBundleExpirationSecondsSettingName:         validateUpdateSupportBundleSeconds,
 	settings.OvercommitConfigSettingName:                       validateUpdateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateUpdateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateUpdateSSLCertificates,
@@ -539,6 +541,25 @@ func validateSupportBundleTimeout(setting *v1beta1.Setting) error {
 
 func validateUpdateSupportBundleTimeout(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleTimeout(newSetting)
+}
+
+func validateSupportBundleExpirationSeconds(setting *v1beta1.Setting) error {
+	if setting.Value == "" {
+		return nil
+	}
+
+	i, err := strconv.Atoi(setting.Value)
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), "value")
+	}
+	if i < 10 {
+		return werror.NewInvalidError("expiration seconds should be greater than 10 seconds", "value")
+	}
+	return nil
+}
+
+func validateUpdateSupportBundleSeconds(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	return validateSupportBundleExpirationSeconds(newSetting)
 }
 
 func validateSSLCertificates(setting *v1beta1.Setting) error {

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -75,7 +75,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.VMForceResetPolicySettingName:                     validateVMForceResetPolicy,
 	settings.SupportBundleImageName:                            validateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName:                   validateSupportBundleTimeout,
-	settings.SupportBundleExpirationSecondsSettingName:         validateSupportBundleExpirationSeconds,
+	settings.SupportBundleExpirationSettingName:                validateSupportBundleExpiration,
 	settings.OvercommitConfigSettingName:                       validateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateSSLCertificates,
@@ -92,7 +92,7 @@ var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
 	settings.VMForceResetPolicySettingName:                     validateUpdateVMForceResetPolicy,
 	settings.SupportBundleImageName:                            validateUpdateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName:                   validateUpdateSupportBundleTimeout,
-	settings.SupportBundleExpirationSecondsSettingName:         validateUpdateSupportBundleSeconds,
+	settings.SupportBundleExpirationSettingName:                validateUpdateSupportBundle,
 	settings.OvercommitConfigSettingName:                       validateUpdateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateUpdateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateUpdateSSLCertificates,
@@ -543,7 +543,7 @@ func validateUpdateSupportBundleTimeout(oldSetting *v1beta1.Setting, newSetting 
 	return validateSupportBundleTimeout(newSetting)
 }
 
-func validateSupportBundleExpirationSeconds(setting *v1beta1.Setting) error {
+func validateSupportBundleExpiration(setting *v1beta1.Setting) error {
 	if setting.Value == "" {
 		return nil
 	}
@@ -552,14 +552,14 @@ func validateSupportBundleExpirationSeconds(setting *v1beta1.Setting) error {
 	if err != nil {
 		return werror.NewInvalidError(err.Error(), "value")
 	}
-	if i < 10 {
-		return werror.NewInvalidError("expiration seconds should be greater than 10 seconds", "value")
+	if i < 0 {
+		return werror.NewInvalidError("expiration can't be negative", "value")
 	}
 	return nil
 }
 
-func validateUpdateSupportBundleSeconds(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
-	return validateSupportBundleExpirationSeconds(newSetting)
+func validateUpdateSupportBundle(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	return validateSupportBundleExpiration(newSetting)
 }
 
 func validateSSLCertificates(setting *v1beta1.Setting) error {

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -121,6 +121,62 @@ func Test_validateSupportBundleTimeout(t *testing.T) {
 	}
 }
 
+func Test_validateSupportBundleExpirationSeconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
+	}{
+		{
+			name: "invalid int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				Value:      "not int",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "negative int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				Value:      "-1",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty input",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				Value:      "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "int less than 10 seconds",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				Value:      "1",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "positive int bigger than 10 seconds",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				Value:      "20",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSupportBundleExpirationSeconds(tt.args)
+			assert.Equal(t, tt.expectedErr, err != nil)
+		})
+	}
+}
+
 func Test_validateSSLProtocols(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -121,7 +121,7 @@ func Test_validateSupportBundleTimeout(t *testing.T) {
 	}
 }
 
-func Test_validateSupportBundleExpirationSeconds(t *testing.T) {
+func Test_validateSupportBundleExpiration(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        *v1beta1.Setting
@@ -130,7 +130,7 @@ func Test_validateSupportBundleExpirationSeconds(t *testing.T) {
 		{
 			name: "invalid int",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSettingName},
 				Value:      "not int",
 			},
 			expectedErr: true,
@@ -138,7 +138,7 @@ func Test_validateSupportBundleExpirationSeconds(t *testing.T) {
 		{
 			name: "negative int",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSettingName},
 				Value:      "-1",
 			},
 			expectedErr: true,
@@ -146,24 +146,16 @@ func Test_validateSupportBundleExpirationSeconds(t *testing.T) {
 		{
 			name: "empty input",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSettingName},
 				Value:      "",
 			},
 			expectedErr: false,
 		},
 		{
-			name: "int less than 10 seconds",
+			name: "positive int",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
-				Value:      "1",
-			},
-			expectedErr: true,
-		},
-		{
-			name: "positive int bigger than 10 seconds",
-			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSecondsSettingName},
-				Value:      "20",
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleExpirationSettingName},
+				Value:      "10",
 			},
 			expectedErr: false,
 		},
@@ -171,7 +163,7 @@ func Test_validateSupportBundleExpirationSeconds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSupportBundleExpirationSeconds(tt.args)
+			err := validateSupportBundleExpiration(tt.args)
 			assert.Equal(t, tt.expectedErr, err != nil)
 		})
 	}


### PR DESCRIPTION
**Problem:**

Support bundle CR isn't deleted due to refreshing window or something which terminates the downloading process. The leftover support bundle manager occupies the cluster resource.

**Solution:**

***We choose 30 minutes in the end***

Check the exist time with `SupportBundleInitialized` status (This status is in final state).

if this time is longer than 10 minutes, that means it might be broken or error, then delete the support bundle CR. 

I think 10 minutes is enough to wait after the support bundle is ready for downloading.

**Related Issue:**

https://github.com/harvester/harvester/issues/4922

**Test plan:**

1. Create support bundle in harvester dashboard.
2. Refresh the window to avoid the harvester dashboard to trigger download API.
3. Support bundle CR should be deleted after x seconds.
  Go to settings to change `support-bundle-expiration` to like 1 (mean 1 minute), support bundle will be delete in 1 minute. Then, use `k get supportbundles -n harvester-system` to check resource.
