### PR TITLE
feat: bump golangci-lint to v1.55.2

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -43,7 +43,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     docker-ce=5:20.10.* \
     && rm -rf /var/lib/apt/lists/*
 ## install golangci
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2
 
 ## install controller-gen
 RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1

--- a/pkg/api/backuptarget/healthy_handler.go
+++ b/pkg/api/backuptarget/healthy_handler.go
@@ -35,7 +35,7 @@ func NewHealthyHandler(scaled *config.Scaled) *HealthyHandler {
 	}
 }
 
-func (h *HealthyHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+func (h *HealthyHandler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
 	backupTargetSetting, err := h.settingCache.Get(settings.BackupTargetSettingName)
 	if err != nil {
 		util.ResponseError(rw, http.StatusInternalServerError, fmt.Errorf("can't get %s setting, error: %w", settings.BackupTargetSettingName, err))

--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -136,7 +136,7 @@ func (h Handler) downloadImage(rw http.ResponseWriter, req *http.Request) error 
 	return nil
 }
 
-func (h Handler) uploadImage(rw http.ResponseWriter, req *http.Request) error {
+func (h Handler) uploadImage(_ http.ResponseWriter, req *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(req))
 	namespace := vars["namespace"]
 	name := vars["name"]

--- a/pkg/api/image/schema.go
+++ b/pkg/api/image/schema.go
@@ -11,7 +11,7 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 )
 
-func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 	imgHandler := Handler{
 		httpClient:                  http.Client{},
 		Images:                      scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage(),

--- a/pkg/api/keypair/formatter.go
+++ b/pkg/api/keypair/formatter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 )
 
-func Formatter(request *types.APIRequest, resource *types.RawResource) {
+func Formatter(_ *types.APIRequest, resource *types.RawResource) {
 	resource.Actions = nil
 	delete(resource.Links, "update")
 }

--- a/pkg/api/keypair/schema.go
+++ b/pkg/api/keypair/schema.go
@@ -16,7 +16,7 @@ const (
 	keygen = "keygen"
 )
 
-func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 	server.BaseSchemas.MustImportAndCustomize(harvesterv1.KeyGenInput{}, nil)
 	t := schema.Template{
 		ID: "harvesterhci.io.keypair",

--- a/pkg/api/node/schema.go
+++ b/pkg/api/node/schema.go
@@ -26,7 +26,7 @@ type PowerActionInput struct {
 	Operation string `json:"operation"`
 }
 
-func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 
 	dynamicClient, err := dynamic.NewForConfig(scaled.Management.RestConfig)
 	if err != nil {

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -27,7 +27,7 @@ func registerSchemas(scaled *config.Scaled, server *server.Server, options confi
 	return nil
 }
 
-func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
+func Setup(ctx context.Context, server *server.Server, _ *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
 	return registerSchemas(scaled, server, options,
 		image.RegisterSchema,

--- a/pkg/api/uiinfo/ui_info_handler.go
+++ b/pkg/api/uiinfo/ui_info_handler.go
@@ -14,13 +14,13 @@ type Handler struct {
 	settingsCache ctlharvesterv1.SettingCache
 }
 
-func NewUIInfoHandler(scaled *config.Scaled, option config.Options) *Handler {
+func NewUIInfoHandler(scaled *config.Scaled, _ config.Options) *Handler {
 	return &Handler{
 		settingsCache: scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 	}
 }
 
-func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
 	uiSource := settings.UISource.Get()
 	if uiSource == "auto" {
 		if !settings.IsRelease() {

--- a/pkg/api/upgradelog/schema.go
+++ b/pkg/api/upgradelog/schema.go
@@ -12,7 +12,7 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 )
 
-func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 	upgradeLogHandler := Handler{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,

--- a/pkg/api/vm/store.go
+++ b/pkg/api/vm/store.go
@@ -24,7 +24,7 @@ type vmStore struct {
 	pvcCache v1.PersistentVolumeClaimCache
 }
 
-func (s *vmStore) Delete(request *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (s *vmStore) Delete(request *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	removedDisks := request.Query["removedDisks"]
 	vm, err := s.vmCache.Get(request.Namespace, request.Name)
 	if err != nil {

--- a/pkg/api/vmtemplate/formatter.go
+++ b/pkg/api/vmtemplate/formatter.go
@@ -8,6 +8,6 @@ func formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.Links["versions"] = request.URLBuilder.Link(resource.Schema, resource.ID, "versions")
 }
 
-func versionFormatter(request *types.APIRequest, resource *types.RawResource) {
+func versionFormatter(_ *types.APIRequest, resource *types.RawResource) {
 	delete(resource.Links, "update")
 }

--- a/pkg/api/vmtemplate/schema.go
+++ b/pkg/api/vmtemplate/schema.go
@@ -13,7 +13,7 @@ const (
 	templateVersionSchemaID = "harvesterhci.io.virtualmachinetemplateversion"
 )
 
-func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 	templateVersionCache := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion().Cache()
 	th := &templateLinkHandler{
 		templateVersionCache: templateVersionCache,

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -58,7 +58,7 @@ func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusNoContent)
 }
 
-func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
+func (h *ActionHandler) do(_ http.ResponseWriter, r *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(r))
 	action := vars["action"]
 	pvcName := vars["name"]
@@ -102,7 +102,7 @@ func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
 	}
 }
 
-func (h *ActionHandler) exportVolume(ctx context.Context, imageNamespace, imageDisplayName, imageStorageClassName, pvcNamespace, pvcName string) error {
+func (h *ActionHandler) exportVolume(_ context.Context, imageNamespace, imageDisplayName, imageStorageClassName, pvcNamespace, pvcName string) error {
 	vmImage := &harvesterv1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "image-",
@@ -129,7 +129,7 @@ func (h *ActionHandler) exportVolume(ctx context.Context, imageNamespace, imageD
 	return nil
 }
 
-func (h *ActionHandler) cancelExpand(ctx context.Context, pvcNamespace, pvcName string) error {
+func (h *ActionHandler) cancelExpand(_ context.Context, pvcNamespace, pvcName string) error {
 	// get pvc
 	pvc, err := h.pvcCache.Get(pvcNamespace, pvcName)
 	if err != nil {
@@ -236,7 +236,7 @@ func (h *ActionHandler) tryUpdatePV(pvName string, update func(pv *corev1.Persis
 	})
 }
 
-func (h *ActionHandler) clone(ctx context.Context, pvcNamespace, pvcName, newPVCName string) error {
+func (h *ActionHandler) clone(_ context.Context, pvcNamespace, pvcName, newPVCName string) error {
 	pvc, err := h.pvcCache.Get(pvcNamespace, pvcName)
 	if err != nil {
 		return err
@@ -272,7 +272,7 @@ func (h *ActionHandler) clone(ctx context.Context, pvcNamespace, pvcName, newPVC
 	return nil
 }
 
-func (h *ActionHandler) snapshot(ctx context.Context, pvcNamespace, pvcName, snapshotName string) error {
+func (h *ActionHandler) snapshot(_ context.Context, pvcNamespace, pvcName, snapshotName string) error {
 	pvc, err := h.pvcCache.Get(pvcNamespace, pvcName)
 	if err != nil {
 		return err

--- a/pkg/api/volume/schema.go
+++ b/pkg/api/volume/schema.go
@@ -15,7 +15,7 @@ const (
 	pvcSchemaID = "persistentvolumeclaim"
 )
 
-func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 	server.BaseSchemas.MustImportAndCustomize(ExportVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(CloneVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(SnapshotVolumeInput{}, nil)

--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -46,7 +46,7 @@ func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusNoContent)
 }
 
-func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
+func (h *ActionHandler) do(_ http.ResponseWriter, r *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(r))
 	action := vars["action"]
 	snapshotName := vars["name"]
@@ -67,7 +67,7 @@ func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
 	}
 }
 
-func (h *ActionHandler) restore(ctx context.Context, snapshotNamespace, snapshotName, newPVCName, storageClassName string) error {
+func (h *ActionHandler) restore(_ context.Context, snapshotNamespace, snapshotName, newPVCName, storageClassName string) error {
 	volumeSnapshot, err := h.snapshotCache.Get(snapshotNamespace, snapshotName)
 	if err != nil {
 		return err

--- a/pkg/api/volumesnapshot/schema.go
+++ b/pkg/api/volumesnapshot/schema.go
@@ -15,7 +15,7 @@ const (
 	volumesnapshotSchemaID = "snapshot.storage.k8s.io.volumesnapshot"
 )
 
-func RegisterSchema(scaled *config.Scaled, server *server.Server, options config.Options) error {
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 	server.BaseSchemas.MustImportAndCustomize(RestoreSnapshotInput{}, nil)
 	actionHandler := ActionHandler{
 		pvcs:              scaled.CoreFactory.Core().V1().PersistentVolumeClaim(),

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -114,7 +114,7 @@ type Management struct {
 	starters []start.Starter
 }
 
-func SetupScaled(ctx context.Context, restConfig *rest.Config, opts *generic.FactoryOptions, namespace string) (context.Context, *Scaled, error) {
+func SetupScaled(ctx context.Context, restConfig *rest.Config, opts *generic.FactoryOptions) (context.Context, *Scaled, error) {
 	scaled := &Scaled{
 		Ctx: ctx,
 	}

--- a/pkg/controller/global/settings/register.go
+++ b/pkg/controller/global/settings/register.go
@@ -15,7 +15,7 @@ import (
 	"github.com/harvester/harvester/pkg/settings"
 )
 
-func Register(ctx context.Context, scaled *config.Scaled, server *server.Server, options config.Options) error {
+func Register(ctx context.Context, scaled *config.Scaled, _ *server.Server, _ config.Options) error {
 	sp := &settingsProvider{
 		context:        ctx,
 		settings:       scaled.HarvesterFactory.Harvesterhci().V1beta1().Setting(),

--- a/pkg/controller/global/setup.go
+++ b/pkg/controller/global/setup.go
@@ -15,7 +15,7 @@ var registerFuncs = []registerFunc{
 	settings.Register,
 }
 
-func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
+func Setup(ctx context.Context, server *server.Server, _ *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
 
 	for _, f := range registerFuncs {

--- a/pkg/controller/master/addon/addon.go
+++ b/pkg/controller/master/addon/addon.go
@@ -38,7 +38,7 @@ type Handler struct {
 	pvc   ctlcorev1.PersistentVolumeClaimController
 }
 
-func Register(ctx context.Context, management *config.Management, opts config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	addonController := management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 	helmController := management.HelmFactory.Helm().V1().HelmChart()
 	jobController := management.BatchFactory.Batch().V1().Job()
@@ -63,7 +63,7 @@ func Register(ctx context.Context, management *config.Management, opts config.Op
 }
 
 // MonitorAddonPerStatus will track the OnChange on addon, route actions per addon status
-func (h *Handler) MonitorAddonPerStatus(key string, aObj *harvesterv1.Addon) (*harvesterv1.Addon, error) {
+func (h *Handler) MonitorAddonPerStatus(_ string, aObj *harvesterv1.Addon) (*harvesterv1.Addon, error) {
 	if aObj == nil || aObj.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controller/master/addon/patch_grafana.go
+++ b/pkg/controller/master/addon/patch_grafana.go
@@ -12,7 +12,7 @@ import (
 )
 
 // MonitorAddonRancherMonitoring will track status change of rancher-monitroing addon
-func (h *Handler) MonitorAddonRancherMonitoring(key string, aObj *harvesterv1.Addon) (*harvesterv1.Addon, error) {
+func (h *Handler) MonitorAddonRancherMonitoring(_ string, aObj *harvesterv1.Addon) (*harvesterv1.Addon, error) {
 	if aObj == nil || aObj.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -66,7 +66,7 @@ const (
 var vmBackupKind = harvesterv1.SchemeGroupVersion.WithKind(vmBackupKindName)
 
 // RegisterBackup register the vmBackup and volumeSnapshot controller
-func RegisterBackup(ctx context.Context, management *config.Management, opts config.Options) error {
+func RegisterBackup(ctx context.Context, management *config.Management, _ config.Options) error {
 	vmBackups := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup()
 	pv := management.CoreFactory.Core().V1().PersistentVolume()
 	pvc := management.CoreFactory.Core().V1().PersistentVolumeClaim()
@@ -145,7 +145,7 @@ type Handler struct {
 }
 
 // OnBackupChange handles vm backup object on change and reconcile vm backup status
-func (h *Handler) OnBackupChange(key string, vmBackup *harvesterv1.VirtualMachineBackup) (*harvesterv1.VirtualMachineBackup, error) {
+func (h *Handler) OnBackupChange(_ string, vmBackup *harvesterv1.VirtualMachineBackup) (*harvesterv1.VirtualMachineBackup, error) {
 	if vmBackup == nil || vmBackup.DeletionTimestamp != nil {
 		return nil, nil
 	}
@@ -199,7 +199,7 @@ func (h *Handler) OnBackupChange(key string, vmBackup *harvesterv1.VirtualMachin
 }
 
 // OnBackupRemove remove remote vm backup metadata
-func (h *Handler) OnBackupRemove(key string, vmBackup *harvesterv1.VirtualMachineBackup) (*harvesterv1.VirtualMachineBackup, error) {
+func (h *Handler) OnBackupRemove(_ string, vmBackup *harvesterv1.VirtualMachineBackup) (*harvesterv1.VirtualMachineBackup, error) {
 	if vmBackup == nil || vmBackup.Status == nil || vmBackup.Status.BackupTarget == nil {
 		return nil, nil
 	}

--- a/pkg/controller/master/backup/backup_metadata.go
+++ b/pkg/controller/master/backup/backup_metadata.go
@@ -58,7 +58,7 @@ type MetadataHandler struct {
 }
 
 // RegisterBackupMetadata register the setting controller and resync vm backup metadata when backup target change
-func RegisterBackupMetadata(ctx context.Context, management *config.Management, opts config.Options) error {
+func RegisterBackupMetadata(ctx context.Context, management *config.Management, _ config.Options) error {
 	vmBackups := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup()
 	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	namespaces := management.CoreFactory.Core().V1().Namespace()
@@ -83,7 +83,7 @@ func RegisterBackupMetadata(ctx context.Context, management *config.Management, 
 }
 
 // OnBackupTargetChange resync vm metadata files when backup target change
-func (h *MetadataHandler) OnBackupTargetChange(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+func (h *MetadataHandler) OnBackupTargetChange(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
 	if setting == nil || setting.DeletionTimestamp != nil ||
 		setting.Name != settings.BackupTargetSettingName || setting.Value == "" {
 		return nil, nil

--- a/pkg/controller/master/backup/backup_status.go
+++ b/pkg/controller/master/backup/backup_status.go
@@ -104,7 +104,7 @@ func (h *Handler) updateConditions(vmBackup *harvesterv1.VirtualMachineBackup) e
 	return nil
 }
 
-func (h *Handler) updateVolumeSnapshotChanged(key string, snapshot *snapshotv1.VolumeSnapshot) (*snapshotv1.VolumeSnapshot, error) {
+func (h *Handler) updateVolumeSnapshotChanged(_ string, snapshot *snapshotv1.VolumeSnapshot) (*snapshotv1.VolumeSnapshot, error) {
 	if snapshot == nil || snapshot.DeletionTimestamp != nil {
 		return nil, nil
 	}
@@ -188,7 +188,7 @@ func getVolumeSnapshotContentName(volumeBackup harvesterv1.VolumeBackup) string 
 	return fmt.Sprintf("%s-vsc", *volumeBackup.Name)
 }
 
-func (h *Handler) OnLHBackupChanged(key string, lhBackup *lhv1beta2.Backup) (*lhv1beta2.Backup, error) {
+func (h *Handler) OnLHBackupChanged(_ string, lhBackup *lhv1beta2.Backup) (*lhv1beta2.Backup, error) {
 	if lhBackup == nil || lhBackup.DeletionTimestamp != nil || lhBackup.Status.SnapshotName == "" {
 		return nil, nil
 	}

--- a/pkg/controller/master/backup/backup_target.go
+++ b/pkg/controller/master/backup/backup_target.go
@@ -38,7 +38,7 @@ const (
 )
 
 // RegisterBackupTarget register the setting controller and reconsile longhorn setting when backup target changed
-func RegisterBackupTarget(ctx context.Context, management *config.Management, opts config.Options) error {
+func RegisterBackupTarget(ctx context.Context, management *config.Management, _ config.Options) error {
 	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	secrets := management.CoreFactory.Core().V1().Secret()
 	longhornSettings := management.LonghornFactory.Longhorn().V1beta2().Setting()
@@ -69,7 +69,7 @@ type TargetHandler struct {
 }
 
 // OnBackupTargetChange handles backupTarget setting object on change
-func (h *TargetHandler) OnBackupTargetChange(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+func (h *TargetHandler) OnBackupTargetChange(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
 	if setting == nil || setting.DeletionTimestamp != nil ||
 		setting.Name != settings.BackupTargetSettingName {
 		return setting, nil
@@ -247,7 +247,7 @@ func (h *TargetHandler) updateBackupTargetSecret(target *settings.BackupTarget) 
 		}
 	}
 
-	return h.updateLonghornBackupTargetSecretSetting(target)
+	return h.updateLonghornBackupTargetSecretSetting()
 }
 
 func (h *TargetHandler) resetBackupTargetSecret() error {
@@ -278,7 +278,7 @@ func (h *TargetHandler) resetBackupTargetSecret() error {
 	return nil
 }
 
-func (h *TargetHandler) updateLonghornBackupTargetSecretSetting(target *settings.BackupTarget) error {
+func (h *TargetHandler) updateLonghornBackupTargetSecretSetting() error {
 	targetSecret, err := h.longhornSettingCache.Get(util.LonghornSystemNamespaceName, longhornBackupTargetSecretSettingName)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -103,7 +103,7 @@ type RestoreHandler struct {
 	restClient *rest.RESTClient
 }
 
-func RegisterRestore(ctx context.Context, management *config.Management, opts config.Options) error {
+func RegisterRestore(ctx context.Context, management *config.Management, _ config.Options) error {
 	restores := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore()
 	backups := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup()
 	vms := management.VirtFactory.Kubevirt().V1().VirtualMachine()
@@ -163,7 +163,7 @@ func RegisterRestore(ctx context.Context, management *config.Management, opts co
 
 // RestoreOnChanged handles vmRestore CRD object on change, it will help to create the new PVCs and either replace them
 // with existing VM or used for the new VM.
-func (h *RestoreHandler) RestoreOnChanged(key string, restore *harvesterv1.VirtualMachineRestore) (*harvesterv1.VirtualMachineRestore, error) {
+func (h *RestoreHandler) RestoreOnChanged(_ string, restore *harvesterv1.VirtualMachineRestore) (*harvesterv1.VirtualMachineRestore, error) {
 	if restore == nil || restore.DeletionTimestamp != nil {
 		return nil, nil
 	}
@@ -202,7 +202,7 @@ func (h *RestoreHandler) RestoreOnChanged(key string, restore *harvesterv1.Virtu
 // Since we would like to prevent LH Backups from being removed when users delete the VM,
 // we use Retain policy in VolumeSnapshotContent.
 // We need to delete VolumeSnapshotContent by restore controller, or there will have remaining VolumeSnapshotContent in the system.
-func (h *RestoreHandler) RestoreOnRemove(key string, restore *harvesterv1.VirtualMachineRestore) (*harvesterv1.VirtualMachineRestore, error) {
+func (h *RestoreHandler) RestoreOnRemove(_ string, restore *harvesterv1.VirtualMachineRestore) (*harvesterv1.VirtualMachineRestore, error) {
 	if restore == nil || restore.Status == nil {
 		return nil, nil
 	}
@@ -263,7 +263,7 @@ func getVolumeName(pvc *corev1.PersistentVolumeClaim) (string, error) {
 }
 
 // PersistentVolumeClaimOnChange watching the PVCs on change and enqueue the vmRestore if it has the restore annotation
-func (h *RestoreHandler) PersistentVolumeClaimOnChange(key string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+func (h *RestoreHandler) PersistentVolumeClaimOnChange(_ string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
 	if pvc == nil || pvc.DeletionTimestamp != nil {
 		return nil, nil
 	}
@@ -303,7 +303,7 @@ func (h *RestoreHandler) PersistentVolumeClaimOnChange(key string, pvc *corev1.P
 	return nil, nil
 }
 
-func (h *RestoreHandler) LHEngineOnChange(key string, lhEngine *lhv1beta2.Engine) (*lhv1beta2.Engine, error) {
+func (h *RestoreHandler) LHEngineOnChange(_ string, lhEngine *lhv1beta2.Engine) (*lhv1beta2.Engine, error) {
 	if lhEngine == nil || lhEngine.DeletionTimestamp != nil || len(lhEngine.Status.RestoreStatus) == 0 {
 		return nil, nil
 	}
@@ -361,7 +361,7 @@ func (h *RestoreHandler) LHEngineOnChange(key string, lhEngine *lhv1beta2.Engine
 }
 
 // VMOnChange watching the VM on change and enqueue the vmRestore if it has the restore annotation
-func (h *RestoreHandler) VMOnChange(key string, vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+func (h *RestoreHandler) VMOnChange(_ string, vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
 	if vm == nil || vm.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controller/master/image/register.go
+++ b/pkg/controller/master/image/register.go
@@ -13,7 +13,7 @@ const (
 	backingImageControllerName = "backing-image-controller"
 )
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	backingImages := management.LonghornFactory.Longhorn().V1beta2().BackingImage()
 	images := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage()
 	storageClasses := management.StorageFactory.Storage().V1().StorageClass()

--- a/pkg/controller/master/keypair/controller.go
+++ b/pkg/controller/master/keypair/controller.go
@@ -14,7 +14,7 @@ type Handler struct {
 	keyPairClient ctlharvesterv1.KeyPairClient
 }
 
-func (h *Handler) OnKeyPairChanged(key string, keyPair *harvesterv1.KeyPair) (*harvesterv1.KeyPair, error) {
+func (h *Handler) OnKeyPairChanged(_ string, keyPair *harvesterv1.KeyPair) (*harvesterv1.KeyPair, error) {
 	if keyPair == nil || keyPair.DeletionTimestamp != nil {
 		return keyPair, nil
 	}

--- a/pkg/controller/master/keypair/register.go
+++ b/pkg/controller/master/keypair/register.go
@@ -10,7 +10,7 @@ const (
 	controllerAgentName = "vm-keypair-controller"
 )
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	keyPairs := management.HarvesterFactory.Harvesterhci().V1beta1().KeyPair()
 	controller := &Handler{
 		keyPairClient: keyPairs,

--- a/pkg/controller/master/mcmsettings/register.go
+++ b/pkg/controller/master/mcmsettings/register.go
@@ -25,7 +25,7 @@ type mcmSettingsHandler struct {
 	configMapClient       ctlcorev1.ConfigMapClient
 }
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	rancherSettingController := management.RancherManagementFactory.Management().V3().Setting()
 	clusterRepoController := management.CatalogFactory.Catalog().V1().ClusterRepo()
 	configMapController := management.CoreFactory.Core().V1().ConfigMap()

--- a/pkg/controller/master/node/maintain_controller.go
+++ b/pkg/controller/master/node/maintain_controller.go
@@ -29,7 +29,7 @@ type maintainNodeHandler struct {
 }
 
 // MaintainRegister registers the node controller
-func MaintainRegister(ctx context.Context, management *config.Management, options config.Options) error {
+func MaintainRegister(ctx context.Context, management *config.Management, _ config.Options) error {
 	nodes := management.CoreFactory.Core().V1().Node()
 	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	maintainNodeHandler := &maintainNodeHandler{
@@ -44,7 +44,7 @@ func MaintainRegister(ctx context.Context, management *config.Management, option
 }
 
 // OnNodeChanged updates node maintenance status when all VMs are migrated
-func (h *maintainNodeHandler) OnNodeChanged(key string, node *corev1.Node) (*corev1.Node, error) {
+func (h *maintainNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil || node.DeletionTimestamp != nil {
 		return node, nil
 	}

--- a/pkg/controller/master/node/node_volume_detach_controller.go
+++ b/pkg/controller/master/node/node_volume_detach_controller.go
@@ -39,7 +39,7 @@ type nodeVolumeDetachController struct {
 }
 
 // VolumeDetachRegister registers the node volume detach controller
-func VolumeDetachRegister(ctx context.Context, management *config.Management, options config.Options) error {
+func VolumeDetachRegister(ctx context.Context, management *config.Management, _ config.Options) error {
 	nodes := management.CoreFactory.Core().V1().Node()
 	pods := management.CoreFactory.Core().V1().Pod()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
@@ -62,7 +62,7 @@ func VolumeDetachRegister(ctx context.Context, management *config.Management, op
 }
 
 // OnNodeChanged is called when a node is changed
-func (c *nodeVolumeDetachController) OnNodeChanged(key string, node *corev1.Node) (*corev1.Node, error) {
+func (c *nodeVolumeDetachController) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil || node.DeletionTimestamp != nil {
 		return node, nil
 	}

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -99,7 +99,7 @@ func PromoteRegister(ctx context.Context, management *config.Management, options
 // OnNodeChanged automate the upgrade of node roles
 // If the number of managements in the cluster is less than spec number,
 // the harvester oldest node will be automatically promoted to be management.
-func (h *PromoteHandler) OnNodeChanged(key string, node *corev1.Node) (*corev1.Node, error) {
+func (h *PromoteHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil || node.DeletionTimestamp != nil {
 		return node, nil
 	}
@@ -133,7 +133,7 @@ func (h *PromoteHandler) OnNodeChanged(key string, node *corev1.Node) (*corev1.N
 // If the node corresponding to the promote job has been removed, delete the job.
 // If the promote job executes successfully, the node's promote status will be marked as complete and schedulable
 // If the promote job fails, the node's promote status will be marked as failed.
-func (h *PromoteHandler) OnJobChanged(key string, job *batchv1.Job) (*batchv1.Job, error) {
+func (h *PromoteHandler) OnJobChanged(_ string, job *batchv1.Job) (*batchv1.Job, error) {
 	if job == nil || job.DeletionTimestamp != nil {
 		return job, nil
 	}
@@ -164,7 +164,7 @@ func (h *PromoteHandler) OnJobChanged(key string, job *batchv1.Job) (*batchv1.Jo
 
 // OnJobRemove
 // If the running promote job is deleted, the node's promote status will be marked as unknown
-func (h *PromoteHandler) OnJobRemove(key string, job *batchv1.Job) (*batchv1.Job, error) {
+func (h *PromoteHandler) OnJobRemove(_ string, job *batchv1.Job) (*batchv1.Job, error) {
 	if job == nil {
 		return job, nil
 	}

--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -44,7 +44,7 @@ type ControllerHandler struct {
 	context                      context.Context
 }
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	nodes := management.CoreFactory.Core().V1().Node()
 	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	vms := management.VirtFactory.Kubevirt().V1().VirtualMachine()
@@ -68,7 +68,7 @@ func Register(ctx context.Context, management *config.Management, options config
 }
 
 // OnNodeChange handles reconcile logic for node drains
-func (ndc *ControllerHandler) OnNodeChange(key string, node *corev1.Node) (*corev1.Node, error) {
+func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil || node.DeletionTimestamp != nil {
 		return node, nil
 	}

--- a/pkg/controller/master/rancher/embedded_rancher.go
+++ b/pkg/controller/master/rancher/embedded_rancher.go
@@ -21,7 +21,7 @@ var UpdateRancherUISettings = map[string]string{
 	"ui-brand": "harvester",
 }
 
-func (h *Handler) RancherSettingOnChange(key string, setting *rancherv3api.Setting) (*rancherv3api.Setting, error) {
+func (h *Handler) RancherSettingOnChange(_ string, setting *rancherv3api.Setting) (*rancherv3api.Setting, error) {
 	if setting == nil || setting.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controller/master/rancher/pod_resources.go
+++ b/pkg/controller/master/rancher/pod_resources.go
@@ -19,7 +19,7 @@ const (
 	LimitsAnnotation   = "management.cattle.io/pod-limits"
 )
 
-func (h *Handler) PodResourcesOnChanged(key string, node *corev1.Node) (*corev1.Node, error) {
+func (h *Handler) PodResourcesOnChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil {
 		return node, nil
 	}

--- a/pkg/controller/master/setting/vip_pools_config_test.go
+++ b/pkg/controller/master/setting/vip_pools_config_test.go
@@ -187,9 +187,8 @@ func TestSyncVipPoolsConfig(t *testing.T) {
 		if strings.Contains(tc.name, "fail") {
 			assert.EqualError(t, actual.err, tc.expected.err.Error())
 			continue
-		} else {
-			assert.NoError(t, actual.err)
 		}
+		assert.NoError(t, actual.err)
 
 		var clientset = fake.NewSimpleClientset()
 		if tc.given.setting != nil {

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -62,7 +62,7 @@ func register(ctx context.Context, management *config.Management, options config
 	return nil
 }
 
-func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
+func Setup(ctx context.Context, _ *server.Server, controllers *server.Controllers, options config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
 
 	go leader.RunOrDie(ctx, "", "harvester-controllers", controllers.K8s, func(ctx context.Context) {

--- a/pkg/controller/master/storagenetwork/storage_network.go
+++ b/pkg/controller/master/storagenetwork/storage_network.go
@@ -111,7 +111,7 @@ type Handler struct {
 }
 
 // register the setting controller and reconsile longhorn setting when storage network changed
-func Register(ctx context.Context, management *config.Management, opts config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	longhornSettings := management.LonghornFactory.Longhorn().V1beta2().Setting()
 	longhornVolumes := management.LonghornFactory.Longhorn().V1beta2().Volume()
@@ -166,7 +166,7 @@ func (h *Handler) setConfiguredCondition(setting *harvesterv1.Setting, finish bo
 }
 
 // webhook needs check if VMs are off
-func (h *Handler) OnStorageNetworkChange(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+func (h *Handler) OnStorageNetworkChange(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
 	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != settings.StorageNetworkName {
 		return setting, nil
 	}

--- a/pkg/controller/master/supportbundle/controller.go
+++ b/pkg/controller/master/supportbundle/controller.go
@@ -36,7 +36,7 @@ type Handler struct {
 	manager *Manager
 }
 
-func (h *Handler) OnSupportBundleChanged(key string, sb *harvesterv1.SupportBundle) (*harvesterv1.SupportBundle, error) {
+func (h *Handler) OnSupportBundleChanged(_ string, sb *harvesterv1.SupportBundle) (*harvesterv1.SupportBundle, error) {
 	if sb == nil || sb.DeletionTimestamp != nil {
 		return sb, nil
 	}

--- a/pkg/controller/master/supportbundle/register.go
+++ b/pkg/controller/master/supportbundle/register.go
@@ -12,7 +12,7 @@ const (
 	controllerAgentName = "supportbundle-controller"
 )
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	sbs := management.HarvesterFactory.Harvesterhci().V1beta1().SupportBundle()
 	nodeCache := management.CoreFactory.Core().V1().Node().Cache()
 	podCache := management.CoreFactory.Core().V1().Pod().Cache()

--- a/pkg/controller/master/template/register.go
+++ b/pkg/controller/master/template/register.go
@@ -12,7 +12,7 @@ const (
 	vmImageControllerAgentName         = "vm-image-in-template-controller"
 )
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	templates := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate()
 	templateVersions := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion()
 	vmImages := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage()

--- a/pkg/controller/master/template/template_controller.go
+++ b/pkg/controller/master/template/template_controller.go
@@ -16,7 +16,7 @@ type templateHandler struct {
 	templateController   ctlharvesterv1.VirtualMachineTemplateController
 }
 
-func (h *templateHandler) OnChanged(key string, tp *harvesterv1.VirtualMachineTemplate) (*harvesterv1.VirtualMachineTemplate, error) {
+func (h *templateHandler) OnChanged(_ string, tp *harvesterv1.VirtualMachineTemplate) (*harvesterv1.VirtualMachineTemplate, error) {
 	if tp == nil || tp.DeletionTimestamp != nil {
 		return tp, nil
 	}

--- a/pkg/controller/master/template/template_controller_test.go
+++ b/pkg/controller/master/template/template_controller_test.go
@@ -310,15 +310,15 @@ func (c fakeTemplateVersionCache) Get(namespace, name string) (*harvesterv1.Virt
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c fakeTemplateVersionCache) List(namespace string, selector labels.Selector) (ret []*harvesterv1.VirtualMachineTemplateVersion, err error) {
+func (c fakeTemplateVersionCache) List(_ string, _ labels.Selector) ([]*harvesterv1.VirtualMachineTemplateVersion, error) {
 	panic("implement me")
 }
 
-func (c fakeTemplateVersionCache) AddIndexer(indexName string, indexer ctlharvesterv1.VirtualMachineTemplateVersionIndexer) {
+func (c fakeTemplateVersionCache) AddIndexer(_ string, _ ctlharvesterv1.VirtualMachineTemplateVersionIndexer) {
 	panic("implement me")
 }
 
-func (c fakeTemplateVersionCache) GetByIndex(indexName, key string) (ret []*harvesterv1.VirtualMachineTemplateVersion, err error) {
+func (c fakeTemplateVersionCache) GetByIndex(_, _ string) ([]*harvesterv1.VirtualMachineTemplateVersion, error) {
 	panic("implement me")
 }
 

--- a/pkg/controller/master/template/template_version_controller.go
+++ b/pkg/controller/master/template/template_version_controller.go
@@ -30,7 +30,7 @@ type templateVersionHandler struct {
 	mu                 sync.RWMutex //use mutex to avoid create duplicated version
 }
 
-func (h *templateVersionHandler) OnChanged(key string, tv *harvesterv1.VirtualMachineTemplateVersion) (*harvesterv1.VirtualMachineTemplateVersion, error) {
+func (h *templateVersionHandler) OnChanged(_ string, tv *harvesterv1.VirtualMachineTemplateVersion) (*harvesterv1.VirtualMachineTemplateVersion, error) {
 	if tv == nil || tv.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controller/master/template/vm_image_controller.go
+++ b/pkg/controller/master/template/vm_image_controller.go
@@ -16,7 +16,7 @@ type vmImageHandler struct {
 	templateVersionController ctlharvesterv1.VirtualMachineTemplateVersionController
 }
 
-func (h *vmImageHandler) OnChanged(key string, vmImage *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
+func (h *vmImageHandler) OnChanged(_ string, vmImage *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
 	if vmImage == nil || vmImage.DeletionTimestamp != nil {
 		return nil, nil
 	}

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -523,7 +523,7 @@ func (p *upgradeBuilder) ImageReadyCondition(status corev1.ConditionStatus, reas
 	return p
 }
 
-func (p *upgradeBuilder) RepoProvisionedCondition(status corev1.ConditionStatus, reason, message string) *upgradeBuilder {
+func (p *upgradeBuilder) RepoProvisionedCondition(status corev1.ConditionStatus, _, _ string) *upgradeBuilder {
 	setRepoProvisionedCondition(p.upgrade, status, "", "")
 	return p
 }

--- a/pkg/controller/master/upgrade/image_controller.go
+++ b/pkg/controller/master/upgrade/image_controller.go
@@ -17,7 +17,7 @@ type vmImageHandler struct {
 	upgradeCache  ctlharvesterv1.UpgradeCache
 }
 
-func (h *vmImageHandler) OnChanged(key string, image *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
+func (h *vmImageHandler) OnChanged(_ string, image *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
 	if image == nil || image.DeletionTimestamp != nil || image.Labels == nil || image.Namespace != upgradeNamespace || image.Labels[harvesterUpgradeLabel] == "" {
 		return image, nil
 	}

--- a/pkg/controller/master/upgrade/job_controller.go
+++ b/pkg/controller/master/upgrade/job_controller.go
@@ -60,7 +60,7 @@ type jobHandler struct {
 	nodeCache    ctlcorev1.NodeCache
 }
 
-func (h *jobHandler) OnChanged(key string, job *batchv1.Job) (*batchv1.Job, error) {
+func (h *jobHandler) OnChanged(_ string, job *batchv1.Job) (*batchv1.Job, error) {
 	if job == nil || job.DeletionTimestamp != nil || job.Labels == nil || (job.Namespace != upgradeNamespace && job.Namespace != sucNamespace) {
 		return job, nil
 	}

--- a/pkg/controller/master/upgrade/node_controller.go
+++ b/pkg/controller/master/upgrade/node_controller.go
@@ -29,7 +29,7 @@ type nodeHandler struct {
 	secretClient  ctlcorev1.SecretClient
 }
 
-func (h *nodeHandler) OnChanged(key string, node *corev1.Node) (*corev1.Node, error) {
+func (h *nodeHandler) OnChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil || node.DeletionTimestamp != nil || node.Annotations == nil {
 		return node, nil
 	}

--- a/pkg/controller/master/upgrade/plan_controller.go
+++ b/pkg/controller/master/upgrade/plan_controller.go
@@ -25,7 +25,7 @@ type planHandler struct {
 	planClient    upgradectlv1.PlanClient
 }
 
-func (h *planHandler) OnChanged(key string, plan *upgradev1.Plan) (*upgradev1.Plan, error) {
+func (h *planHandler) OnChanged(_ string, plan *upgradev1.Plan) (*upgradev1.Plan, error) {
 	if plan == nil || plan.DeletionTimestamp != nil {
 		return plan, nil
 	}

--- a/pkg/controller/master/upgrade/plan_controller_test.go
+++ b/pkg/controller/master/upgrade/plan_controller_test.go
@@ -113,8 +113,10 @@ func TestPlanHandler_OnChanged(t *testing.T) {
 		if tc.expected.plan != nil {
 			actual.plan, err = handler.planClient.Get(sucNamespace, tc.expected.plan.Name, metav1.GetOptions{})
 			assert.Nil(t, err)
-			sanitizeStatus(&tc.expected.plan.Status)
+			expectedPlanStatus := tc.expected.plan.Status
+			sanitizeStatus(&expectedPlanStatus)
 			sanitizeStatus(&actual.plan.Status)
+			tc.expected.plan.Status = expectedPlanStatus
 		}
 
 		assert.Equal(t, tc.expected, actual, "case %q", tc.name)

--- a/pkg/controller/master/upgrade/pod_controller.go
+++ b/pkg/controller/master/upgrade/pod_controller.go
@@ -19,7 +19,7 @@ type podHandler struct {
 	upgradeCache  ctlharvesterv1.UpgradeCache
 }
 
-func (h *podHandler) OnChanged(key string, pod *v1.Pod) (*v1.Pod, error) {
+func (h *podHandler) OnChanged(_ string, pod *v1.Pod) (*v1.Pod, error) {
 	if pod == nil || pod.DeletionTimestamp != nil || pod.Labels == nil || pod.Namespace != upgradeNamespace || pod.Labels[harvesterUpgradeLabel] == "" {
 		return pod, nil
 	}

--- a/pkg/controller/master/upgrade/secret_controller.go
+++ b/pkg/controller/master/upgrade/secret_controller.go
@@ -30,7 +30,7 @@ type secretHandler struct {
 	machineCache  clusterv1ctl.MachineCache
 }
 
-func (h *secretHandler) OnChanged(key string, secret *v1.Secret) (*v1.Secret, error) {
+func (h *secretHandler) OnChanged(_ string, secret *v1.Secret) (*v1.Secret, error) {
 	if secret == nil || secret.DeletionTimestamp != nil || secret.Namespace != rancherPlanSecretNamespace || secret.Annotations == nil || secret.Type != rancherPlanSecretType {
 		return secret, nil
 	}
@@ -150,9 +150,8 @@ func checkEligibleToDrain(upgrade *harvesterv1.Upgrade, nodeName string) error {
 		}
 		if status.State == StateSucceeded || status.State == nodeStateImagesPreloaded {
 			continue
-		} else {
-			return fmt.Errorf("%s is in \"%s\" state so %s is not allowed to run any kind of job", name, status, nodeName)
 		}
+		return fmt.Errorf("%s is in \"%s\" state so %s is not allowed to run any kind of job", name, status, nodeName)
 	}
 	return nil
 }

--- a/pkg/controller/master/upgrade/setting_controller.go
+++ b/pkg/controller/master/upgrade/setting_controller.go
@@ -11,7 +11,7 @@ type settingHandler struct {
 	versionSyncer *versionSyncer
 }
 
-func (h *settingHandler) OnChanged(key string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+func (h *settingHandler) OnChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
 	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != "server-version" {
 		return setting, nil
 	}

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -94,7 +94,7 @@ type upgradeHandler struct {
 	lhSettingCache  ctllhv1.SettingCache
 }
 
-func (h *upgradeHandler) OnChanged(key string, upgrade *harvesterv1.Upgrade) (*harvesterv1.Upgrade, error) {
+func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*harvesterv1.Upgrade, error) {
 	if upgrade == nil || upgrade.DeletionTimestamp != nil {
 		return upgrade, nil
 	}

--- a/pkg/controller/master/upgradelog/common.go
+++ b/pkg/controller/master/upgradelog/common.go
@@ -576,7 +576,7 @@ func newAddonBuilder(name string) *addonBuilder {
 	}
 }
 
-func (p *addonBuilder) Enable(value bool) *addonBuilder {
+func (p *addonBuilder) Enable(_ bool) *addonBuilder {
 	p.addon.Spec.Enabled = true
 	return p
 }

--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -21,7 +21,7 @@ const (
 	oldWranglerFinalizer                                         = "wrangler.cattle.io/VMController.UnsetOwnerOfPVCs"
 )
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	var (
 		nsCache        = management.CoreFactory.Core().V1().Namespace().Cache()
 		podCache       = management.CoreFactory.Core().V1().Pod().Cache()

--- a/pkg/controller/master/virtualmachine/vmi_controller_test.go
+++ b/pkg/controller/master/virtualmachine/vmi_controller_test.go
@@ -1417,14 +1417,14 @@ func (c fakeVirtualMachineCache) Get(namespace, name string) (*kubevirtv1.Virtua
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c fakeVirtualMachineCache) List(namespace string, selector labels.Selector) ([]*kubevirtv1.VirtualMachine, error) {
+func (c fakeVirtualMachineCache) List(_ string, _ labels.Selector) ([]*kubevirtv1.VirtualMachine, error) {
 	panic("implement me")
 }
 
-func (c fakeVirtualMachineCache) AddIndexer(indexName string, indexer kubevirtctrl.VirtualMachineIndexer) {
+func (c fakeVirtualMachineCache) AddIndexer(_ string, _ kubevirtctrl.VirtualMachineIndexer) {
 	panic("implement me")
 }
 
-func (c fakeVirtualMachineCache) GetByIndex(indexName, key string) ([]*kubevirtv1.VirtualMachine, error) {
+func (c fakeVirtualMachineCache) GetByIndex(_, _ string) ([]*kubevirtv1.VirtualMachine, error) {
 	panic("implement me")
 }

--- a/pkg/controller/master/virtualmachine/vmi_network_controller_test.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller_test.go
@@ -238,7 +238,7 @@ func (c fakeVMClient) Update(vm *kubevirtv1.VirtualMachine) (*kubevirtv1.Virtual
 	return c(vm.Namespace).Update(context.TODO(), vm, metav1.UpdateOptions{})
 }
 
-func (c fakeVMClient) UpdateStatus(vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+func (c fakeVMClient) UpdateStatus(*kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
 	panic("implement me")
 }
 
@@ -268,15 +268,15 @@ func (c fakeVMCache) Get(namespace, name string) (*kubevirtv1.VirtualMachine, er
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c fakeVMCache) List(namespace string, selector labels.Selector) ([]*kubevirtv1.VirtualMachine, error) {
+func (c fakeVMCache) List(_ string, _ labels.Selector) ([]*kubevirtv1.VirtualMachine, error) {
 	panic("implement me")
 }
 
-func (c fakeVMCache) AddIndexer(indexName string, indexer kv1ctl.VirtualMachineIndexer) {
+func (c fakeVMCache) AddIndexer(_ string, _ kv1ctl.VirtualMachineIndexer) {
 	panic("implement me")
 }
 
-func (c fakeVMCache) GetByIndex(indexName, key string) ([]*kubevirtv1.VirtualMachine, error) {
+func (c fakeVMCache) GetByIndex(_, _ string) ([]*kubevirtv1.VirtualMachine, error) {
 	panic("implement me")
 }
 
@@ -290,7 +290,7 @@ func (c fakeVMIClient) Update(vm *kubevirtv1.VirtualMachineInstance) (*kubevirtv
 	return c(vm.Namespace).Update(context.TODO(), vm, metav1.UpdateOptions{})
 }
 
-func (c fakeVMIClient) UpdateStatus(vm *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+func (c fakeVMIClient) UpdateStatus(*kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
 	panic("implement me")
 }
 

--- a/pkg/genswagger/main.go
+++ b/pkg/genswagger/main.go
@@ -127,7 +127,8 @@ func createConfig() *common.Config {
 func addSummaryForMethods(swagger *spec.Swagger) {
 	t := reflect.TypeOf(new(spec.Operation))
 	for _, path := range swagger.Paths.Paths {
-		v := reflect.ValueOf(&path.PathItemProps).Elem()
+		pathItemProps := path.PathItemProps
+		v := reflect.ValueOf(&pathItemProps).Elem()
 		for j := 0; j < v.NumField(); j++ {
 			f := v.Field(j)
 			if t == f.Type() && !f.IsNil() {

--- a/pkg/genswagger/rest/webservices.go
+++ b/pkg/genswagger/rest/webservices.go
@@ -302,4 +302,4 @@ func ResourcePath(resource string, namespaced bool) string {
 	return fmt.Sprintf("/%s/{name:[a-z0-9][a-z0-9\\-]*}", resource)
 }
 
-func Noop(request *restful.Request, response *restful.Response) {}
+func Noop(*restful.Request, *restful.Response) {}

--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -31,7 +31,7 @@ const (
 	VolumeSnapshotBySourcePVCIndex     = "harvesterhci.io/volumesnapshot-by-source-pvc"
 )
 
-func Setup(ctx context.Context, server *server.Server, controllers *server.Controllers, options config.Options) error {
+func Setup(ctx context.Context, _ *server.Server, _ *server.Controllers, _ config.Options) error {
 	scaled := config.ScaledWithContext(ctx)
 	management := scaled.Management
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -191,7 +191,7 @@ func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 
 	var scaled *config.Scaled
 
-	s.Context, scaled, err = config.SetupScaled(s.Context, s.RESTConfig, factoryOpts, options.Namespace)
+	s.Context, scaled, err = config.SetupScaled(s.Context, s.RESTConfig, factoryOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/crd/init.go
+++ b/pkg/util/crd/init.go
@@ -139,7 +139,7 @@ func (f *Factory) CreateCRDs(ctx context.Context, updateIfExisted bool, crds ...
 	return crdStatus, nil
 }
 
-func (f *Factory) createCRD(ctx context.Context, crdDef crd.CRD, ready map[string]*apiext.CustomResourceDefinition) (*apiext.CustomResourceDefinition, error) {
+func (f *Factory) createCRD(ctx context.Context, crdDef crd.CRD, _ map[string]*apiext.CustomResourceDefinition) (*apiext.CustomResourceDefinition, error) {
 	crd, err := crdDef.ToCustomResourceDefinition()
 	if err != nil {
 		return nil, err

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -51,7 +51,6 @@ func IsRetriableNetworkError(err error) bool {
 		return true
 	} else if errors.Is(err, syscall.EHOSTUNREACH) {
 		return true
-	} else {
-		return false
 	}
+	return false
 }

--- a/pkg/util/fakeclients/addon.go
+++ b/pkg/util/fakeclients/addon.go
@@ -27,9 +27,9 @@ func (c AddonCache) List(namespace string, selector labels.Selector) ([]*harvest
 	}
 	return result, err
 }
-func (c AddonCache) AddIndexer(indexName string, indexer ctlharvesterv1.AddonIndexer) {
+func (c AddonCache) AddIndexer(_ string, _ ctlharvesterv1.AddonIndexer) {
 	panic("implement me")
 }
-func (c AddonCache) GetByIndex(indexName, key string) ([]*harvesterv1.Addon, error) {
+func (c AddonCache) GetByIndex(_, _ string) ([]*harvesterv1.Addon, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/app.go
+++ b/pkg/util/fakeclients/app.go
@@ -18,13 +18,13 @@ type AppCache func(string) catalogv1type.AppInterface
 func (c AppCache) Get(namespace, name string) (*catalogv1.App, error) {
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
-func (c AppCache) List(namespace string, selector labels.Selector) ([]*catalogv1.App, error) {
+func (c AppCache) List(_ string, _ labels.Selector) ([]*catalogv1.App, error) {
 	panic("implement me")
 }
-func (c AppCache) AddIndexer(indexName string, indexer ctlcatalogv1.AppIndexer) {
+func (c AppCache) AddIndexer(_ string, _ ctlcatalogv1.AppIndexer) {
 	panic("implement me")
 }
-func (c AppCache) GetByIndex(indexName, key string) ([]*catalogv1.App, error) {
+func (c AppCache) GetByIndex(_, _ string) ([]*catalogv1.App, error) {
 	panic("implement me")
 }
 
@@ -42,11 +42,11 @@ func (c AppClient) Create(app *catalogv1.App) (*catalogv1.App, error) {
 	return c(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 }
 
-func (c AppClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c AppClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c AppClient) List(namespace string, opts metav1.ListOptions) (*catalogv1.AppList, error) {
+func (c AppClient) List(_ string, _ metav1.ListOptions) (*catalogv1.AppList, error) {
 	panic("implement me")
 }
 
@@ -54,10 +54,10 @@ func (c AppClient) UpdateStatus(*catalogv1.App) (*catalogv1.App, error) {
 	panic("implement me")
 }
 
-func (c AppClient) Watch(namespace string, pts metav1.ListOptions) (watch.Interface, error) {
+func (c AppClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c AppClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *catalogv1.App, err error) {
+func (c AppClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *catalogv1.App, err error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/clusterflow.go
+++ b/pkg/util/fakeclients/clusterflow.go
@@ -19,39 +19,39 @@ func (c ClusterFlowClient) Create(clusterFlow *loggingv1.ClusterFlow) (*loggingv
 	clusterFlow.Namespace = ""
 	return c().Create(context.TODO(), clusterFlow, metav1.CreateOptions{})
 }
-func (c ClusterFlowClient) Update(clusterFlow *loggingv1.ClusterFlow) (*loggingv1.ClusterFlow, error) {
+func (c ClusterFlowClient) Update(*loggingv1.ClusterFlow) (*loggingv1.ClusterFlow, error) {
 	panic("implement me")
 }
-func (c ClusterFlowClient) UpdateStatus(clusterFlow *loggingv1.ClusterFlow) (*loggingv1.ClusterFlow, error) {
+func (c ClusterFlowClient) UpdateStatus(*loggingv1.ClusterFlow) (*loggingv1.ClusterFlow, error) {
 	panic("implement me")
 }
-func (c ClusterFlowClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
-	return c().Delete(context.TODO(), name, metav1.DeleteOptions{})
+func (c ClusterFlowClient) Delete(_, name string, options *metav1.DeleteOptions) error {
+	return c().Delete(context.TODO(), name, *options)
 }
-func (c ClusterFlowClient) Get(namespace, name string, options metav1.GetOptions) (*loggingv1.ClusterFlow, error) {
-	return c().Get(context.TODO(), name, metav1.GetOptions{})
+func (c ClusterFlowClient) Get(_, name string, options metav1.GetOptions) (*loggingv1.ClusterFlow, error) {
+	return c().Get(context.TODO(), name, options)
 }
-func (c ClusterFlowClient) List(namespace string, opts metav1.ListOptions) (*loggingv1.ClusterFlowList, error) {
+func (c ClusterFlowClient) List(_ string, _ metav1.ListOptions) (*loggingv1.ClusterFlowList, error) {
 	panic("implement me")
 }
-func (c ClusterFlowClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c ClusterFlowClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c ClusterFlowClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *loggingv1.ClusterFlow, err error) {
+func (c ClusterFlowClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *loggingv1.ClusterFlow, err error) {
 	panic("implement me")
 }
 
 type ClusterFlowCache func() loggingv1type.ClusterFlowInterface
 
-func (c ClusterFlowCache) Get(namespace, name string) (*loggingv1.ClusterFlow, error) {
+func (c ClusterFlowCache) Get(_, _ string) (*loggingv1.ClusterFlow, error) {
 	panic("implement me")
 }
-func (c ClusterFlowCache) List(namespace string, selector labels.Selector) ([]*loggingv1.ClusterFlow, error) {
+func (c ClusterFlowCache) List(_ string, _ labels.Selector) ([]*loggingv1.ClusterFlow, error) {
 	panic("implement me")
 }
-func (c ClusterFlowCache) AddIndexer(indexName string, indexer ctlloggingv1.ClusterFlowIndexer) {
+func (c ClusterFlowCache) AddIndexer(_ string, _ ctlloggingv1.ClusterFlowIndexer) {
 	panic("implement me")
 }
-func (c ClusterFlowCache) GetByIndex(indexName, key string) ([]*loggingv1.ClusterFlow, error) {
+func (c ClusterFlowCache) GetByIndex(_, _ string) ([]*loggingv1.ClusterFlow, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/clusteroutput.go
+++ b/pkg/util/fakeclients/clusteroutput.go
@@ -19,39 +19,39 @@ func (c ClusterOutputClient) Create(clusterOutput *loggingv1.ClusterOutput) (*lo
 	clusterOutput.Namespace = ""
 	return c().Create(context.TODO(), clusterOutput, metav1.CreateOptions{})
 }
-func (c ClusterOutputClient) Update(clusterOutput *loggingv1.ClusterOutput) (*loggingv1.ClusterOutput, error) {
+func (c ClusterOutputClient) Update(*loggingv1.ClusterOutput) (*loggingv1.ClusterOutput, error) {
 	panic("implement me")
 }
-func (c ClusterOutputClient) UpdateStatus(clusterOutput *loggingv1.ClusterOutput) (*loggingv1.ClusterOutput, error) {
+func (c ClusterOutputClient) UpdateStatus(*loggingv1.ClusterOutput) (*loggingv1.ClusterOutput, error) {
 	panic("implement me")
 }
-func (c ClusterOutputClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
-	return c().Delete(context.TODO(), name, metav1.DeleteOptions{})
+func (c ClusterOutputClient) Delete(_, name string, options *metav1.DeleteOptions) error {
+	return c().Delete(context.TODO(), name, *options)
 }
-func (c ClusterOutputClient) Get(namespace, name string, options metav1.GetOptions) (*loggingv1.ClusterOutput, error) {
-	return c().Get(context.TODO(), name, metav1.GetOptions{})
+func (c ClusterOutputClient) Get(_, name string, options metav1.GetOptions) (*loggingv1.ClusterOutput, error) {
+	return c().Get(context.TODO(), name, options)
 }
-func (c ClusterOutputClient) List(namespace string, opts metav1.ListOptions) (*loggingv1.ClusterOutputList, error) {
+func (c ClusterOutputClient) List(_ string, _ metav1.ListOptions) (*loggingv1.ClusterOutputList, error) {
 	panic("implement me")
 }
-func (c ClusterOutputClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c ClusterOutputClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c ClusterOutputClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *loggingv1.ClusterOutput, err error) {
+func (c ClusterOutputClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (*loggingv1.ClusterOutput, error) {
 	panic("implement me")
 }
 
 type ClusterOutputCache func() loggingv1type.ClusterOutputInterface
 
-func (c ClusterOutputCache) Get(namespace, name string) (*loggingv1.ClusterOutput, error) {
+func (c ClusterOutputCache) Get(_, _ string) (*loggingv1.ClusterOutput, error) {
 	panic("implement me")
 }
-func (c ClusterOutputCache) List(namespace string, selector labels.Selector) ([]*loggingv1.ClusterOutput, error) {
+func (c ClusterOutputCache) List(_ string, _ labels.Selector) ([]*loggingv1.ClusterOutput, error) {
 	panic("implement me")
 }
-func (c ClusterOutputCache) AddIndexer(indexName string, indexer ctlloggingv1.ClusterOutputIndexer) {
+func (c ClusterOutputCache) AddIndexer(_ string, _ ctlloggingv1.ClusterOutputIndexer) {
 	panic("implement me")
 }
-func (c ClusterOutputCache) GetByIndex(indexName, key string) ([]*loggingv1.ClusterOutput, error) {
+func (c ClusterOutputCache) GetByIndex(_, _ string) ([]*loggingv1.ClusterOutput, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/configmap.go
+++ b/pkg/util/fakeclients/configmap.go
@@ -24,7 +24,7 @@ func (c ConfigmapClient) Update(configMap *v1.ConfigMap) (*v1.ConfigMap, error) 
 	return c(configMap.Namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
 }
 
-func (c ConfigmapClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c ConfigmapClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
@@ -36,11 +36,11 @@ func (c ConfigmapClient) List(namespace string, opts metav1.ListOptions) (*v1.Co
 	return c(namespace).List(context.TODO(), opts)
 }
 
-func (c ConfigmapClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c ConfigmapClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c ConfigmapClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error) {
+func (c ConfigmapClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *v1.ConfigMap, err error) {
 	panic("implement me")
 }
 
@@ -64,10 +64,10 @@ func (c ConfigmapCache) List(namespace string, selector labels.Selector) ([]*v1.
 	return result, err
 }
 
-func (c ConfigmapCache) AddIndexer(indexName string, indexer ctlcorev1.ConfigMapIndexer) {
+func (c ConfigmapCache) AddIndexer(_ string, _ ctlcorev1.ConfigMapIndexer) {
 	panic("implement me")
 }
 
-func (c ConfigmapCache) GetByIndex(indexName, key string) ([]*v1.ConfigMap, error) {
+func (c ConfigmapCache) GetByIndex(_, _ string) ([]*v1.ConfigMap, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/deployment.go
+++ b/pkg/util/fakeclients/deployment.go
@@ -17,7 +17,7 @@ func (c DeploymentClient) Update(deployment *appsv1.Deployment) (*appsv1.Deploym
 }
 
 func (c DeploymentClient) Get(namespace, name string, options metav1.GetOptions) (*appsv1.Deployment, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 
 func (c DeploymentClient) Create(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
@@ -28,18 +28,18 @@ func (c DeploymentClient) UpdateStatus(*appsv1.Deployment) (*appsv1.Deployment, 
 	panic("implement me")
 }
 
-func (c DeploymentClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c DeploymentClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c DeploymentClient) List(namespace string, opts metav1.ListOptions) (*appsv1.DeploymentList, error) {
+func (c DeploymentClient) List(_ string, _ metav1.ListOptions) (*appsv1.DeploymentList, error) {
 	panic("implement me")
 }
 
-func (c DeploymentClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c DeploymentClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c DeploymentClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *appsv1.Deployment, err error) {
+func (c DeploymentClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *appsv1.Deployment, err error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/harvestersetting.go
+++ b/pkg/util/fakeclients/harvestersetting.go
@@ -23,7 +23,7 @@ func (c HarvesterSettingClient) Update(s *v1beta1.Setting) (*v1beta1.Setting, er
 	return c().Update(context.TODO(), s, metav1.UpdateOptions{})
 }
 
-func (c HarvesterSettingClient) UpdateStatus(s *v1beta1.Setting) (*v1beta1.Setting, error) {
+func (c HarvesterSettingClient) UpdateStatus(_ *v1beta1.Setting) (*v1beta1.Setting, error) {
 	panic("implement me")
 }
 
@@ -53,14 +53,14 @@ func (c HarvesterSettingCache) Get(name string) (*v1beta1.Setting, error) {
 	return c().Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c HarvesterSettingCache) List(selector labels.Selector) ([]*v1beta1.Setting, error) {
+func (c HarvesterSettingCache) List(_ labels.Selector) ([]*v1beta1.Setting, error) {
 	panic("implement me")
 }
 
-func (c HarvesterSettingCache) AddIndexer(indexName string, indexer harvesterv1ctl.SettingIndexer) {
+func (c HarvesterSettingCache) AddIndexer(_ string, _ harvesterv1ctl.SettingIndexer) {
 	panic("implement me")
 }
 
-func (c HarvesterSettingCache) GetByIndex(indexName, key string) ([]*v1beta1.Setting, error) {
+func (c HarvesterSettingCache) GetByIndex(_, _ string) ([]*v1beta1.Setting, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/job.go
+++ b/pkg/util/fakeclients/job.go
@@ -15,7 +15,7 @@ type JobClient func(string) batchv1type.JobInterface
 func (c JobClient) Update(job *batchv1.Job) (*batchv1.Job, error) {
 	return c(job.Namespace).Update(context.TODO(), job, metav1.UpdateOptions{})
 }
-func (c JobClient) Get(namespace, name string, options metav1.GetOptions) (*batchv1.Job, error) {
+func (c JobClient) Get(_, _ string, _ metav1.GetOptions) (*batchv1.Job, error) {
 	panic("implement me")
 }
 func (c JobClient) Create(*batchv1.Job) (*batchv1.Job, error) {
@@ -24,15 +24,15 @@ func (c JobClient) Create(*batchv1.Job) (*batchv1.Job, error) {
 func (c JobClient) UpdateStatus(*batchv1.Job) (*batchv1.Job, error) {
 	panic("implement me")
 }
-func (c JobClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c JobClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
-func (c JobClient) List(namespace string, opts metav1.ListOptions) (*batchv1.Job, error) {
+func (c JobClient) List(_ string, _ metav1.ListOptions) (*batchv1.Job, error) {
 	panic("implement me")
 }
-func (c JobClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c JobClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c JobClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *batchv1.Job, err error) {
+func (c JobClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *batchv1.Job, err error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/logging.go
+++ b/pkg/util/fakeclients/logging.go
@@ -18,26 +18,26 @@ type LoggingClient func() loggingv1type.LoggingInterface
 func (c LoggingClient) Create(logging *loggingv1.Logging) (*loggingv1.Logging, error) {
 	return c().Create(context.TODO(), logging, metav1.CreateOptions{})
 }
-func (c LoggingClient) Update(logging *loggingv1.Logging) (*loggingv1.Logging, error) {
+func (c LoggingClient) Update(_ *loggingv1.Logging) (*loggingv1.Logging, error) {
 	panic("implement me")
 }
-func (c LoggingClient) UpdateStatus(logging *loggingv1.Logging) (*loggingv1.Logging, error) {
+func (c LoggingClient) UpdateStatus(_ *loggingv1.Logging) (*loggingv1.Logging, error) {
 	panic("implement me")
 }
 func (c LoggingClient) Delete(name string, options *metav1.DeleteOptions) error {
-	return c().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	return c().Delete(context.TODO(), name, *options)
 }
 func (c LoggingClient) Get(name string, options metav1.GetOptions) (*loggingv1.Logging, error) {
-	return c().Get(context.TODO(), name, metav1.GetOptions{})
+	return c().Get(context.TODO(), name, options)
 }
-func (c LoggingClient) List(opts metav1.ListOptions) (*loggingv1.LoggingList, error) {
+func (c LoggingClient) List(_ metav1.ListOptions) (*loggingv1.LoggingList, error) {
 	panic("implement me")
 }
 
-func (c LoggingClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c LoggingClient) Watch(_ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c LoggingClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *loggingv1.Logging, err error) {
+func (c LoggingClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (result *loggingv1.Logging, err error) {
 	panic("implement me")
 }
 
@@ -46,12 +46,12 @@ type LoggingCache func() loggingv1type.LoggingInterface
 func (c LoggingCache) Get(name string) (*loggingv1.Logging, error) {
 	return c().Get(context.TODO(), name, metav1.GetOptions{})
 }
-func (c LoggingCache) List(selector labels.Selector) ([]*loggingv1.Logging, error) {
+func (c LoggingCache) List(_ labels.Selector) ([]*loggingv1.Logging, error) {
 	panic("implement me")
 }
-func (c LoggingCache) AddIndexer(indexName string, indexer ctlloggingv1.LoggingIndexer) {
+func (c LoggingCache) AddIndexer(_ string, _ ctlloggingv1.LoggingIndexer) {
 	panic("implement me")
 }
-func (c LoggingCache) GetByIndex(indexName, key string) ([]*loggingv1.Logging, error) {
+func (c LoggingCache) GetByIndex(_, _ string) ([]*loggingv1.Logging, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/longhornreplica.go
+++ b/pkg/util/fakeclients/longhornreplica.go
@@ -23,7 +23,7 @@ func (c LonghornReplicaClient) Update(replica *lhv1beta2.Replica) (*lhv1beta2.Re
 	return c(replica.Namespace).Update(context.TODO(), replica, metav1.UpdateOptions{})
 }
 
-func (c LonghornReplicaClient) UpdateStatus(replica *lhv1beta2.Replica) (*lhv1beta2.Replica, error) {
+func (c LonghornReplicaClient) UpdateStatus(_ *lhv1beta2.Replica) (*lhv1beta2.Replica, error) {
 	panic("implement me")
 }
 
@@ -68,10 +68,10 @@ func (c LonghornReplicaCache) List(namespace string, selector labels.Selector) (
 	return returnReplicas, nil
 }
 
-func (c LonghornReplicaCache) AddIndexer(indexName string, indexer ctllhv1.ReplicaIndexer) {
+func (c LonghornReplicaCache) AddIndexer(_ string, _ ctllhv1.ReplicaIndexer) {
 	panic("implement me")
 }
 
-func (c LonghornReplicaCache) GetByIndex(indexName, key string) ([]*lhv1beta2.Replica, error) {
+func (c LonghornReplicaCache) GetByIndex(_, _ string) ([]*lhv1beta2.Replica, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/longhornsetting.go
+++ b/pkg/util/fakeclients/longhornsetting.go
@@ -23,7 +23,7 @@ func (c LonghornSettingClient) Update(setting *lhv1beta2.Setting) (*lhv1beta2.Se
 	return c(setting.Namespace).Update(context.TODO(), setting, metav1.UpdateOptions{})
 }
 
-func (c LonghornSettingClient) UpdateStatus(setting *lhv1beta2.Setting) (*lhv1beta2.Setting, error) {
+func (c LonghornSettingClient) UpdateStatus(_ *lhv1beta2.Setting) (*lhv1beta2.Setting, error) {
 	panic("implement me")
 }
 
@@ -53,14 +53,14 @@ func (c LonghornSettingCache) Get(namespace, name string) (*lhv1beta2.Setting, e
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c LonghornSettingCache) List(namespace string, selector labels.Selector) ([]*lhv1beta2.Setting, error) {
+func (c LonghornSettingCache) List(_ string, _ labels.Selector) ([]*lhv1beta2.Setting, error) {
 	panic("implement me")
 }
 
-func (c LonghornSettingCache) AddIndexer(indexName string, indexer ctllhv1.SettingIndexer) {
+func (c LonghornSettingCache) AddIndexer(_ string, _ ctllhv1.SettingIndexer) {
 	panic("implement me")
 }
 
-func (c LonghornSettingCache) GetByIndex(indexName, key string) ([]*lhv1beta2.Setting, error) {
+func (c LonghornSettingCache) GetByIndex(_, _ string) ([]*lhv1beta2.Setting, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/longhornvolume.go
+++ b/pkg/util/fakeclients/longhornvolume.go
@@ -23,7 +23,7 @@ func (c LonghornVolumeClient) Update(volume *lhv1beta2.Volume) (*lhv1beta2.Volum
 	return c(volume.Namespace).Update(context.TODO(), volume, metav1.UpdateOptions{})
 }
 
-func (c LonghornVolumeClient) UpdateStatus(volume *lhv1beta2.Volume) (*lhv1beta2.Volume, error) {
+func (c LonghornVolumeClient) UpdateStatus(*lhv1beta2.Volume) (*lhv1beta2.Volume, error) {
 	panic("implement me")
 }
 
@@ -68,10 +68,10 @@ func (c LonghornVolumeCache) List(namespace string, selector labels.Selector) ([
 	return returnVolumes, nil
 }
 
-func (c LonghornVolumeCache) AddIndexer(indexName string, indexer ctllhv1.VolumeIndexer) {
+func (c LonghornVolumeCache) AddIndexer(_ string, _ ctllhv1.VolumeIndexer) {
 	panic("implement me")
 }
 
-func (c LonghornVolumeCache) GetByIndex(indexName, key string) ([]*lhv1beta2.Volume, error) {
+func (c LonghornVolumeCache) GetByIndex(_, _ string) ([]*lhv1beta2.Volume, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/managedchart.go
+++ b/pkg/util/fakeclients/managedchart.go
@@ -21,7 +21,7 @@ func (c ManagedChartClient) Update(managedChart *mgmtv3.ManagedChart) (*mgmtv3.M
 	return c(managedChart.Namespace).Update(context.TODO(), managedChart, metav1.UpdateOptions{})
 }
 func (c ManagedChartClient) Get(namespace, name string, options metav1.GetOptions) (*mgmtv3.ManagedChart, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 func (c ManagedChartClient) Create(managedChart *mgmtv3.ManagedChart) (*mgmtv3.ManagedChart, error) {
 	if managedChart.GenerateName != "" {
@@ -30,18 +30,18 @@ func (c ManagedChartClient) Create(managedChart *mgmtv3.ManagedChart) (*mgmtv3.M
 	return c(managedChart.Namespace).Create(context.TODO(), managedChart, metav1.CreateOptions{})
 }
 func (c ManagedChartClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
-	return c(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	return c(namespace).Delete(context.TODO(), name, *options)
 }
-func (c ManagedChartClient) List(namespace string, opts metav1.ListOptions) (*mgmtv3.ManagedChartList, error) {
+func (c ManagedChartClient) List(_ string, _ metav1.ListOptions) (*mgmtv3.ManagedChartList, error) {
 	panic("implement me")
 }
 func (c ManagedChartClient) UpdateStatus(*mgmtv3.ManagedChart) (*mgmtv3.ManagedChart, error) {
 	panic("implement me")
 }
-func (c ManagedChartClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c ManagedChartClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c ManagedChartClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *mgmtv3.ManagedChart, err error) {
+func (c ManagedChartClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *mgmtv3.ManagedChart, err error) {
 	panic("implement me")
 }
 
@@ -61,9 +61,9 @@ func (c ManagedChartCache) List(namespace string, selector labels.Selector) ([]*
 	}
 	return result, err
 }
-func (c ManagedChartCache) AddIndexer(indexName string, indexer ctlmgmtv3.ManagedChartIndexer) {
+func (c ManagedChartCache) AddIndexer(_ string, _ ctlmgmtv3.ManagedChartIndexer) {
 	panic("implement me")
 }
-func (c ManagedChartCache) GetByIndex(indexName, key string) ([]*mgmtv3.ManagedChart, error) {
+func (c ManagedChartCache) GetByIndex(_, _ string) ([]*mgmtv3.ManagedChart, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/namespace.go
+++ b/pkg/util/fakeclients/namespace.go
@@ -33,11 +33,11 @@ func (c NamespaceCache) List(selector labels.Selector) ([]*v1.Namespace, error) 
 	return result, err
 }
 
-func (c NamespaceCache) AddIndexer(indexName string, indexer ctlcorev1.NamespaceIndexer) {
+func (c NamespaceCache) AddIndexer(_ string, _ ctlcorev1.NamespaceIndexer) {
 	panic("implement me")
 }
 
-func (c NamespaceCache) GetByIndex(indexName, key string) ([]*v1.Namespace, error) {
+func (c NamespaceCache) GetByIndex(_, _ string) ([]*v1.Namespace, error) {
 	panic("implement me")
 }
 
@@ -48,18 +48,18 @@ func (c NamespaceClient) Update(namespace *v1.Namespace) (*v1.Namespace, error) 
 }
 
 func (c NamespaceClient) Get(name string, options metav1.GetOptions) (*v1.Namespace, error) {
-	return c().Get(context.TODO(), name, metav1.GetOptions{})
+	return c().Get(context.TODO(), name, options)
 }
 
 func (c NamespaceClient) Create(namespace *v1.Namespace) (*v1.Namespace, error) {
 	return c().Create(context.TODO(), namespace, metav1.CreateOptions{})
 }
 
-func (c NamespaceClient) Delete(name string, options *metav1.DeleteOptions) error {
+func (c NamespaceClient) Delete(_ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c NamespaceClient) List(opts metav1.ListOptions) (*v1.NamespaceList, error) {
+func (c NamespaceClient) List(metav1.ListOptions) (*v1.NamespaceList, error) {
 	panic("implement me")
 }
 
@@ -67,10 +67,10 @@ func (c NamespaceClient) UpdateStatus(*v1.Namespace) (*v1.Namespace, error) {
 	panic("implement me")
 }
 
-func (c NamespaceClient) Watch(pts metav1.ListOptions) (watch.Interface, error) {
+func (c NamespaceClient) Watch(metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c NamespaceClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Namespace, err error) {
+func (c NamespaceClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (result *v1.Namespace, err error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/networkattachmentdefinition.go
+++ b/pkg/util/fakeclients/networkattachmentdefinition.go
@@ -33,10 +33,10 @@ func (c NetworkAttachmentDefinitionCache) List(namespace string, selector labels
 	return nads, nil
 }
 
-func (c NetworkAttachmentDefinitionCache) AddIndexer(indexName string, indexer ctlcniv1.NetworkAttachmentDefinitionIndexer) {
+func (c NetworkAttachmentDefinitionCache) AddIndexer(_ string, _ ctlcniv1.NetworkAttachmentDefinitionIndexer) {
 	panic("implement me")
 }
 
-func (c NetworkAttachmentDefinitionCache) GetByIndex(indexName, key string) ([]*cniv1.NetworkAttachmentDefinition, error) {
+func (c NetworkAttachmentDefinitionCache) GetByIndex(_, _ string) ([]*cniv1.NetworkAttachmentDefinition, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/node.go
+++ b/pkg/util/fakeclients/node.go
@@ -33,11 +33,11 @@ func (c NodeCache) List(selector labels.Selector) ([]*v1.Node, error) {
 	return result, err
 }
 
-func (c NodeCache) AddIndexer(indexName string, indexer ctlcorev1.NodeIndexer) {
+func (c NodeCache) AddIndexer(_ string, _ ctlcorev1.NodeIndexer) {
 	panic("implement me")
 }
 
-func (c NodeCache) GetByIndex(indexName, key string) ([]*v1.Node, error) {
+func (c NodeCache) GetByIndex(_, _ string) ([]*v1.Node, error) {
 	panic("implement me")
 }
 
@@ -48,18 +48,18 @@ func (c NodeClient) Update(node *v1.Node) (*v1.Node, error) {
 }
 
 func (c NodeClient) Get(name string, options metav1.GetOptions) (*v1.Node, error) {
-	return c().Get(context.TODO(), name, metav1.GetOptions{})
+	return c().Get(context.TODO(), name, options)
 }
 
 func (c NodeClient) Create(node *v1.Node) (*v1.Node, error) {
 	return c().Create(context.TODO(), node, metav1.CreateOptions{})
 }
 
-func (c NodeClient) Delete(name string, options *metav1.DeleteOptions) error {
+func (c NodeClient) Delete(_ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c NodeClient) List(opts metav1.ListOptions) (*v1.NodeList, error) {
+func (c NodeClient) List(metav1.ListOptions) (*v1.NodeList, error) {
 	panic("implement me")
 }
 
@@ -67,10 +67,10 @@ func (c NodeClient) UpdateStatus(*v1.Node) (*v1.Node, error) {
 	panic("implement me")
 }
 
-func (c NodeClient) Watch(pts metav1.ListOptions) (watch.Interface, error) {
+func (c NodeClient) Watch(metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c NodeClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Node, err error) {
+func (c NodeClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (result *v1.Node, err error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/plan.go
+++ b/pkg/util/fakeclients/plan.go
@@ -19,24 +19,24 @@ func (c PlanClient) Update(plan *upgradeapiv1.Plan) (*upgradeapiv1.Plan, error) 
 	return c(plan.Namespace).Update(context.TODO(), plan, metav1.UpdateOptions{})
 }
 func (c PlanClient) Get(namespace, name string, options metav1.GetOptions) (*upgradeapiv1.Plan, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 func (c PlanClient) Create(plan *upgradeapiv1.Plan) (*upgradeapiv1.Plan, error) {
 	return c(plan.Namespace).Create(context.TODO(), plan, metav1.CreateOptions{})
 }
-func (c PlanClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c PlanClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
-func (c PlanClient) List(namespace string, opts metav1.ListOptions) (*upgradeapiv1.PlanList, error) {
+func (c PlanClient) List(_ string, _ metav1.ListOptions) (*upgradeapiv1.PlanList, error) {
 	panic("implement me")
 }
 func (c PlanClient) UpdateStatus(*upgradeapiv1.Plan) (*upgradeapiv1.Plan, error) {
 	panic("implement me")
 }
-func (c PlanClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c PlanClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c PlanClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *upgradeapiv1.Plan, err error) {
+func (c PlanClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *upgradeapiv1.Plan, err error) {
 	panic("implement me")
 }
 
@@ -46,14 +46,14 @@ func (c PlanCache) Get(namespace, name string) (*upgradeapiv1.Plan, error) {
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c PlanCache) List(namespace string, selector labels.Selector) ([]*upgradeapiv1.Plan, error) {
+func (c PlanCache) List(_ string, _ labels.Selector) ([]*upgradeapiv1.Plan, error) {
 	panic("implement me")
 }
 
-func (c PlanCache) AddIndexer(indexName string, indexer upgradectlv1.PlanIndexer) {
+func (c PlanCache) AddIndexer(_ string, _ upgradectlv1.PlanIndexer) {
 	panic("implement me")
 }
 
-func (c PlanCache) GetByIndex(indexName, key string) ([]*upgradeapiv1.Plan, error) {
+func (c PlanCache) GetByIndex(_, _ string) ([]*upgradeapiv1.Plan, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/pvc.go
+++ b/pkg/util/fakeclients/pvc.go
@@ -25,7 +25,7 @@ func (c PersistentVolumeClaimClient) Update(volume *corev1.PersistentVolumeClaim
 	return c(volume.Namespace).Update(context.TODO(), volume, metav1.UpdateOptions{})
 }
 
-func (c PersistentVolumeClaimClient) UpdateStatus(volume *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+func (c PersistentVolumeClaimClient) UpdateStatus(*corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
 	panic("implement me")
 }
 
@@ -55,11 +55,11 @@ func (c PersistentVolumeClaimCache) Get(namespace, name string) (*corev1.Persist
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c PersistentVolumeClaimCache) List(namespace string, selector labels.Selector) ([]*corev1.PersistentVolumeClaim, error) {
+func (c PersistentVolumeClaimCache) List(_ string, _ labels.Selector) ([]*corev1.PersistentVolumeClaim, error) {
 	panic("implement me")
 }
 
-func (c PersistentVolumeClaimCache) AddIndexer(indexName string, indexer ctlv1.PersistentVolumeClaimIndexer) {
+func (c PersistentVolumeClaimCache) AddIndexer(_ string, _ ctlv1.PersistentVolumeClaimIndexer) {
 	panic("implement me")
 }
 

--- a/pkg/util/fakeclients/resourcequota.go
+++ b/pkg/util/fakeclients/resourcequota.go
@@ -34,11 +34,11 @@ func (c ResourceQuotaCache) List(namespace string, selector labels.Selector) ([]
 	return result, err
 }
 
-func (c ResourceQuotaCache) AddIndexer(indexName string, indexer ctlharvcorev1.ResourceQuotaIndexer) {
+func (c ResourceQuotaCache) AddIndexer(_ string, _ ctlharvcorev1.ResourceQuotaIndexer) {
 	panic("implement me")
 }
 
-func (c ResourceQuotaCache) GetByIndex(indexName, key string) ([]*v1.ResourceQuota, error) {
+func (c ResourceQuotaCache) GetByIndex(_, _ string) ([]*v1.ResourceQuota, error) {
 	panic("implement me")
 }
 
@@ -49,18 +49,18 @@ func (c ResourceQuotaClient) Update(quota *v1.ResourceQuota) (*v1.ResourceQuota,
 }
 
 func (c ResourceQuotaClient) Get(namespace string, name string, options metav1.GetOptions) (*v1.ResourceQuota, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 
 func (c ResourceQuotaClient) Create(quota *v1.ResourceQuota) (*v1.ResourceQuota, error) {
 	return c(quota.Namespace).Create(context.TODO(), quota, metav1.CreateOptions{})
 }
 
-func (c ResourceQuotaClient) Delete(namespace string, name string, options *metav1.DeleteOptions) error {
+func (c ResourceQuotaClient) Delete(_ string, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c ResourceQuotaClient) List(namespace string, opts metav1.ListOptions) (*v1.ResourceQuotaList, error) {
+func (c ResourceQuotaClient) List(_ string, _ metav1.ListOptions) (*v1.ResourceQuotaList, error) {
 	panic("implement me")
 }
 
@@ -68,10 +68,10 @@ func (c ResourceQuotaClient) UpdateStatus(*v1.ResourceQuota) (*v1.ResourceQuota,
 	panic("implement me")
 }
 
-func (c ResourceQuotaClient) Watch(namespace string, pts metav1.ListOptions) (watch.Interface, error) {
+func (c ResourceQuotaClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c ResourceQuotaClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ResourceQuota, err error) {
+func (c ResourceQuotaClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *v1.ResourceQuota, err error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/service.go
+++ b/pkg/util/fakeclients/service.go
@@ -22,7 +22,7 @@ func (c ServiceClient) Update(service *corev1.Service) (*corev1.Service, error) 
 	return c(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
 }
 
-func (c ServiceClient) UpdateStatus(service *corev1.Service) (*corev1.Service, error) {
+func (c ServiceClient) UpdateStatus(*corev1.Service) (*corev1.Service, error) {
 	panic("implement me")
 }
 
@@ -52,14 +52,14 @@ func (c ServiceCache) Get(namespace, name string) (*corev1.Service, error) {
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c ServiceCache) List(namespace string, selector labels.Selector) ([]*corev1.Service, error) {
+func (c ServiceCache) List(_ string, _ labels.Selector) ([]*corev1.Service, error) {
 	panic("implement me")
 }
 
-func (c ServiceCache) AddIndexer(indexName string, indexer ctlv1.ServiceIndexer) {
+func (c ServiceCache) AddIndexer(_ string, _ ctlv1.ServiceIndexer) {
 	panic("implement me")
 }
 
-func (c ServiceCache) GetByIndex(indexName, key string) ([]*corev1.Service, error) {
+func (c ServiceCache) GetByIndex(_, _ string) ([]*corev1.Service, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/storageclass.go
+++ b/pkg/util/fakeclients/storageclass.go
@@ -22,7 +22,7 @@ func (c StorageClassClient) Update(s *storagev1.StorageClass) (*storagev1.Storag
 	return c().Update(context.TODO(), s, metav1.UpdateOptions{})
 }
 
-func (c StorageClassClient) UpdateStatus(s *storagev1.StorageClass) (*storagev1.StorageClass, error) {
+func (c StorageClassClient) UpdateStatus(_ *storagev1.StorageClass) (*storagev1.StorageClass, error) {
 	panic("implement me")
 }
 
@@ -64,10 +64,10 @@ func (c StorageClassCache) List(selector labels.Selector) ([]*storagev1.StorageC
 	return result, err
 }
 
-func (c StorageClassCache) AddIndexer(indexName string, indexer ctlstoragev1.StorageClassIndexer) {
+func (c StorageClassCache) AddIndexer(_ string, _ ctlstoragev1.StorageClassIndexer) {
 	panic("implement me")
 }
 
-func (c StorageClassCache) GetByIndex(indexName, key string) ([]*storagev1.StorageClass, error) {
+func (c StorageClassCache) GetByIndex(_, _ string) ([]*storagev1.StorageClass, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/upgrade.go
+++ b/pkg/util/fakeclients/upgrade.go
@@ -18,25 +18,25 @@ type UpgradeClient func(string) harv1type.UpgradeInterface
 func (c UpgradeClient) Update(upgrade *harvesterv1.Upgrade) (*harvesterv1.Upgrade, error) {
 	return c(upgrade.Namespace).Update(context.TODO(), upgrade, metav1.UpdateOptions{})
 }
-func (c UpgradeClient) Get(namespace, name string, options metav1.GetOptions) (*harvesterv1.Upgrade, error) {
+func (c UpgradeClient) Get(_, _ string, _ metav1.GetOptions) (*harvesterv1.Upgrade, error) {
 	panic("implement me")
 }
 func (c UpgradeClient) Create(*harvesterv1.Upgrade) (*harvesterv1.Upgrade, error) {
 	panic("implement me")
 }
-func (c UpgradeClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c UpgradeClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
-func (c UpgradeClient) List(namespace string, opts metav1.ListOptions) (*harvesterv1.UpgradeList, error) {
+func (c UpgradeClient) List(_ string, _ metav1.ListOptions) (*harvesterv1.UpgradeList, error) {
 	panic("implement me")
 }
 func (c UpgradeClient) UpdateStatus(*harvesterv1.Upgrade) (*harvesterv1.Upgrade, error) {
 	panic("implement me")
 }
-func (c UpgradeClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c UpgradeClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c UpgradeClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *harvesterv1.Upgrade, err error) {
+func (c UpgradeClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *harvesterv1.Upgrade, err error) {
 	panic("implement me")
 }
 
@@ -56,9 +56,9 @@ func (c UpgradeCache) List(namespace string, selector labels.Selector) ([]*harve
 	}
 	return result, err
 }
-func (c UpgradeCache) AddIndexer(indexName string, indexer ctlharvesterv1.UpgradeIndexer) {
+func (c UpgradeCache) AddIndexer(_ string, _ ctlharvesterv1.UpgradeIndexer) {
 	panic("implement me")
 }
-func (c UpgradeCache) GetByIndex(indexName, key string) ([]*harvesterv1.Upgrade, error) {
+func (c UpgradeCache) GetByIndex(_, _ string) ([]*harvesterv1.Upgrade, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/upgradelog.go
+++ b/pkg/util/fakeclients/upgradelog.go
@@ -21,22 +21,22 @@ func (c UpgradeLogClient) Create(upgradeLog *harvesterv1.UpgradeLog) (*harvester
 func (c UpgradeLogClient) Update(upgradeLog *harvesterv1.UpgradeLog) (*harvesterv1.UpgradeLog, error) {
 	return c(upgradeLog.Namespace).Update(context.TODO(), upgradeLog, metav1.UpdateOptions{})
 }
-func (c UpgradeLogClient) UpdateStatus(upgradeLog *harvesterv1.UpgradeLog) (*harvesterv1.UpgradeLog, error) {
+func (c UpgradeLogClient) UpdateStatus(*harvesterv1.UpgradeLog) (*harvesterv1.UpgradeLog, error) {
 	panic("implement me")
 }
 func (c UpgradeLogClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
 	return c(namespace).Delete(context.TODO(), name, *options)
 }
 func (c UpgradeLogClient) Get(namespace, name string, options metav1.GetOptions) (*harvesterv1.UpgradeLog, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
-func (c UpgradeLogClient) List(namespace string, opts metav1.ListOptions) (*harvesterv1.UpgradeLogList, error) {
+func (c UpgradeLogClient) List(_ string, _ metav1.ListOptions) (*harvesterv1.UpgradeLogList, error) {
 	panic("implement me")
 }
-func (c UpgradeLogClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c UpgradeLogClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c UpgradeLogClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *harvesterv1.UpgradeLog, err error) {
+func (c UpgradeLogClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *harvesterv1.UpgradeLog, err error) {
 	panic("implement me")
 }
 
@@ -45,12 +45,12 @@ type UpgradeLogCache func(string) harv1type.UpgradeLogInterface
 func (c UpgradeLogCache) Get(namespace, name string) (*harvesterv1.UpgradeLog, error) {
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
-func (c UpgradeLogCache) List(namespace string, selector labels.Selector) ([]*harvesterv1.UpgradeLog, error) {
+func (c UpgradeLogCache) List(_ string, _ labels.Selector) ([]*harvesterv1.UpgradeLog, error) {
 	panic("implement me")
 }
-func (c UpgradeLogCache) AddIndexer(indexName string, indexer ctlharvesterv1.UpgradeLogIndexer) {
+func (c UpgradeLogCache) AddIndexer(_ string, _ ctlharvesterv1.UpgradeLogIndexer) {
 	panic("implement me")
 }
-func (c UpgradeLogCache) GetByIndex(indexName, key string) ([]*harvesterv1.UpgradeLog, error) {
+func (c UpgradeLogCache) GetByIndex(_, _ string) ([]*harvesterv1.UpgradeLog, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/version.go
+++ b/pkg/util/fakeclients/version.go
@@ -16,12 +16,12 @@ type VersionCache func(string) harv1type.VersionInterface
 func (c VersionCache) Get(namespace, name string) (*harvesterv1.Version, error) {
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
-func (c VersionCache) List(namespace string, selector labels.Selector) ([]*harvesterv1.Version, error) {
+func (c VersionCache) List(_ string, _ labels.Selector) ([]*harvesterv1.Version, error) {
 	panic("implement me")
 }
-func (c VersionCache) AddIndexer(indexName string, indexer ctlharvesterv1.VersionIndexer) {
+func (c VersionCache) AddIndexer(_ string, _ ctlharvesterv1.VersionIndexer) {
 	panic("implement me")
 }
-func (c VersionCache) GetByIndex(indexName, key string) ([]*harvesterv1.Version, error) {
+func (c VersionCache) GetByIndex(_, _ string) ([]*harvesterv1.Version, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/virtualmachine.go
+++ b/pkg/util/fakeclients/virtualmachine.go
@@ -24,18 +24,18 @@ func (c VirtualMachineClient) Update(virtualMachine *kubevirtv1api.VirtualMachin
 }
 
 func (c VirtualMachineClient) Get(namespace, name string, options metav1.GetOptions) (*kubevirtv1api.VirtualMachine, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 
 func (c VirtualMachineClient) Create(virtualMachine *kubevirtv1api.VirtualMachine) (*kubevirtv1api.VirtualMachine, error) {
 	return c(virtualMachine.Namespace).Create(context.TODO(), virtualMachine, metav1.CreateOptions{})
 }
 
-func (c VirtualMachineClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c VirtualMachineClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) List(namespace string, opts metav1.ListOptions) (*kubevirtv1api.VirtualMachineList, error) {
+func (c VirtualMachineClient) List(_ string, _ metav1.ListOptions) (*kubevirtv1api.VirtualMachineList, error) {
 	panic("implement me")
 }
 
@@ -43,11 +43,11 @@ func (c VirtualMachineClient) UpdateStatus(*kubevirtv1api.VirtualMachine) (*kube
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c VirtualMachineClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *kubevirtv1api.VirtualMachine, err error) {
+func (c VirtualMachineClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *kubevirtv1api.VirtualMachine, err error) {
 	panic("implement me")
 }
 
@@ -59,11 +59,11 @@ func (c VirtualMachineClient) GroupVersionKind() schema.GroupVersionKind {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) AddGenericHandler(ctx context.Context, name string, handler generic.Handler) {
+func (c VirtualMachineClient) AddGenericHandler(_ context.Context, _ string, _ generic.Handler) {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) AddGenericRemoveHandler(ctx context.Context, name string, handler generic.Handler) {
+func (c VirtualMachineClient) AddGenericRemoveHandler(_ context.Context, _ string, _ generic.Handler) {
 	panic("implement me")
 }
 
@@ -71,19 +71,19 @@ func (c VirtualMachineClient) Updater() generic.Updater {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) OnChange(ctx context.Context, name string, sync kubevirtctlv1.VirtualMachineHandler) {
+func (c VirtualMachineClient) OnChange(_ context.Context, _ string, _ kubevirtctlv1.VirtualMachineHandler) {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) OnRemove(ctx context.Context, name string, sync kubevirtctlv1.VirtualMachineHandler) {
+func (c VirtualMachineClient) OnRemove(_ context.Context, _ string, _ kubevirtctlv1.VirtualMachineHandler) {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) Enqueue(namespace, name string) {
+func (c VirtualMachineClient) Enqueue(_, _ string) {
 	panic("implement me")
 }
 
-func (c VirtualMachineClient) EnqueueAfter(namespace, name string, duration time.Duration) {
+func (c VirtualMachineClient) EnqueueAfter(_, _ string, _ time.Duration) {
 	panic("implement me")
 }
 
@@ -97,14 +97,14 @@ func (c VirtualMachineCache) Get(namespace, name string) (*kubevirtv1api.Virtual
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c VirtualMachineCache) List(namespace string, selector labels.Selector) ([]*kubevirtv1api.VirtualMachine, error) {
+func (c VirtualMachineCache) List(_ string, _ labels.Selector) ([]*kubevirtv1api.VirtualMachine, error) {
 	panic("implement me")
 }
 
-func (c VirtualMachineCache) AddIndexer(indexName string, indexer kubevirtctlv1.VirtualMachineIndexer) {
+func (c VirtualMachineCache) AddIndexer(_ string, _ kubevirtctlv1.VirtualMachineIndexer) {
 	panic("implement me")
 }
 
-func (c VirtualMachineCache) GetByIndex(indexName, key string) ([]*kubevirtv1api.VirtualMachine, error) {
+func (c VirtualMachineCache) GetByIndex(_, _ string) ([]*kubevirtv1api.VirtualMachine, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/virtualmachineimage.go
+++ b/pkg/util/fakeclients/virtualmachineimage.go
@@ -21,7 +21,7 @@ func (c VirtualMachineImageClient) Update(virtualMachineImage *harvesterv1.Virtu
 	return c(virtualMachineImage.Namespace).Update(context.TODO(), virtualMachineImage, metav1.UpdateOptions{})
 }
 func (c VirtualMachineImageClient) Get(namespace, name string, options metav1.GetOptions) (*harvesterv1.VirtualMachineImage, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 func (c VirtualMachineImageClient) Create(virtualMachineImage *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
 	if virtualMachineImage.GenerateName != "" {
@@ -29,19 +29,19 @@ func (c VirtualMachineImageClient) Create(virtualMachineImage *harvesterv1.Virtu
 	}
 	return c(virtualMachineImage.Namespace).Create(context.TODO(), virtualMachineImage, metav1.CreateOptions{})
 }
-func (c VirtualMachineImageClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c VirtualMachineImageClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
-func (c VirtualMachineImageClient) List(namespace string, opts metav1.ListOptions) (*harvesterv1.VirtualMachineImageList, error) {
+func (c VirtualMachineImageClient) List(_ string, _ metav1.ListOptions) (*harvesterv1.VirtualMachineImageList, error) {
 	panic("implement me")
 }
 func (c VirtualMachineImageClient) UpdateStatus(*harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
 	panic("implement me")
 }
-func (c VirtualMachineImageClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c VirtualMachineImageClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
-func (c VirtualMachineImageClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *harvesterv1.VirtualMachineImage, err error) {
+func (c VirtualMachineImageClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *harvesterv1.VirtualMachineImage, err error) {
 	panic("implement me")
 }
 
@@ -61,9 +61,9 @@ func (c VirtualMachineImageCache) List(namespace string, selector labels.Selecto
 	}
 	return result, err
 }
-func (c VirtualMachineImageCache) AddIndexer(indexName string, indexer ctlharvesterv1.VirtualMachineImageIndexer) {
+func (c VirtualMachineImageCache) AddIndexer(_ string, _ ctlharvesterv1.VirtualMachineImageIndexer) {
 	panic("implement me")
 }
-func (c VirtualMachineImageCache) GetByIndex(indexName, key string) ([]*harvesterv1.VirtualMachineImage, error) {
+func (c VirtualMachineImageCache) GetByIndex(_, _ string) ([]*harvesterv1.VirtualMachineImage, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/virtualmachineinstance.go
+++ b/pkg/util/fakeclients/virtualmachineinstance.go
@@ -20,18 +20,18 @@ func (c VirtualMachineInstanceClient) Update(vmi *kubevirtv1api.VirtualMachineIn
 }
 
 func (c VirtualMachineInstanceClient) Get(namespace, name string, options metav1.GetOptions) (*kubevirtv1api.VirtualMachineInstance, error) {
-	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	return c(namespace).Get(context.TODO(), name, options)
 }
 
 func (c VirtualMachineInstanceClient) Create(vmi *kubevirtv1api.VirtualMachineInstance) (*kubevirtv1api.VirtualMachineInstance, error) {
 	return c(vmi.Namespace).Create(context.TODO(), vmi, metav1.CreateOptions{})
 }
 
-func (c VirtualMachineInstanceClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+func (c VirtualMachineInstanceClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
 
-func (c VirtualMachineInstanceClient) List(namespace string, opts metav1.ListOptions) (*kubevirtv1api.VirtualMachineInstanceList, error) {
+func (c VirtualMachineInstanceClient) List(_ string, _ metav1.ListOptions) (*kubevirtv1api.VirtualMachineInstanceList, error) {
 	panic("implement me")
 }
 
@@ -39,11 +39,11 @@ func (c VirtualMachineInstanceClient) UpdateStatus(*kubevirtv1api.VirtualMachine
 	panic("implement me")
 }
 
-func (c VirtualMachineInstanceClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (c VirtualMachineInstanceClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (c VirtualMachineInstanceClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *kubevirtv1api.VirtualMachineInstance, err error) {
+func (c VirtualMachineInstanceClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *kubevirtv1api.VirtualMachineInstance, err error) {
 	panic("implement me")
 }
 
@@ -67,10 +67,10 @@ func (c VirtualMachineInstanceCache) List(namespace string, selector labels.Sele
 	return result, err
 }
 
-func (c VirtualMachineInstanceCache) AddIndexer(indexName string, indexer kubevirtctlv1.VirtualMachineInstanceIndexer) {
+func (c VirtualMachineInstanceCache) AddIndexer(_ string, _ kubevirtctlv1.VirtualMachineInstanceIndexer) {
 	panic("implement me")
 }
 
-func (c VirtualMachineInstanceCache) GetByIndex(indexName, key string) ([]*kubevirtv1api.VirtualMachineInstance, error) {
+func (c VirtualMachineInstanceCache) GetByIndex(_, _ string) ([]*kubevirtv1api.VirtualMachineInstance, error) {
 	panic("implement me")
 }

--- a/pkg/util/fakeclients/virtualmachineinstancemigration.go
+++ b/pkg/util/fakeclients/virtualmachineinstancemigration.go
@@ -33,11 +33,11 @@ func (c VirtualMachineInstanceMigrationCache) List(namespace string, selector la
 	return result, err
 }
 
-func (c VirtualMachineInstanceMigrationCache) AddIndexer(indexName string, indexer kubevirtctrl.VirtualMachineInstanceMigrationIndexer) {
+func (c VirtualMachineInstanceMigrationCache) AddIndexer(_ string, _ kubevirtctrl.VirtualMachineInstanceMigrationIndexer) {
 	panic("implement me")
 }
 
-func (c VirtualMachineInstanceMigrationCache) GetByIndex(indexName, key string) ([]*kubevirtv1.VirtualMachineInstanceMigration, error) {
+func (c VirtualMachineInstanceMigrationCache) GetByIndex(_, _ string) ([]*kubevirtv1.VirtualMachineInstanceMigration, error) {
 	panic("implement me")
 }
 

--- a/pkg/util/fakeclients/vmbackup.go
+++ b/pkg/util/fakeclients/vmbackup.go
@@ -25,7 +25,7 @@ func (c VMBackupClient) Update(volume *harvesterv1beta1.VirtualMachineBackup) (*
 	return c(volume.Namespace).Update(context.TODO(), volume, metav1.UpdateOptions{})
 }
 
-func (c VMBackupClient) UpdateStatus(volume *harvesterv1beta1.VirtualMachineBackup) (*harvesterv1beta1.VirtualMachineBackup, error) {
+func (c VMBackupClient) UpdateStatus(_ *harvesterv1beta1.VirtualMachineBackup) (*harvesterv1beta1.VirtualMachineBackup, error) {
 	panic("implement me")
 }
 
@@ -55,11 +55,11 @@ func (c VMBackupCache) Get(namespace, name string) (*harvesterv1beta1.VirtualMac
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c VMBackupCache) List(namespace string, selector labels.Selector) ([]*harvesterv1beta1.VirtualMachineBackup, error) {
+func (c VMBackupCache) List(_ string, _ labels.Selector) ([]*harvesterv1beta1.VirtualMachineBackup, error) {
 	panic("implement me")
 }
 
-func (c VMBackupCache) AddIndexer(indexName string, indexer harvesterv1ctl.VirtualMachineBackupIndexer) {
+func (c VMBackupCache) AddIndexer(_ string, _ harvesterv1ctl.VirtualMachineBackupIndexer) {
 	panic("implement me")
 }
 

--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -49,7 +49,7 @@ func (v *addonValidator) Resource() types.Resource {
 }
 
 // Do not allow one addon to be created twice
-func (v *addonValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *addonValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	newAddon := newObj.(*v1beta1.Addon)
 
 	addons, err := v.addons.List(metav1.NamespaceAll, labels.Everything())
@@ -61,7 +61,7 @@ func (v *addonValidator) Create(request *types.Request, newObj runtime.Object) e
 }
 
 // Do not allow some fields to be changed, or set to non-existing values
-func (v *addonValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *addonValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	newAddon := newObj.(*v1beta1.Addon)
 	oldAddon := oldObj.(*v1beta1.Addon)
 

--- a/pkg/webhook/resources/bundle/validator.go
+++ b/pkg/webhook/resources/bundle/validator.go
@@ -31,7 +31,7 @@ func (v *bundleValidator) Resource() types.Resource {
 		},
 	}
 }
-func (v *bundleValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+func (v *bundleValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	bundle := oldObj.(*fleetv1alpha1.Bundle)
 
 	// Template of Bundle name is "mcc-<managedchart>".

--- a/pkg/webhook/resources/bundledeployment/validator.go
+++ b/pkg/webhook/resources/bundledeployment/validator.go
@@ -35,7 +35,7 @@ func (v *bundleDeploymentValidator) Resource() types.Resource {
 		},
 	}
 }
-func (v *bundleDeploymentValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+func (v *bundleDeploymentValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	bundleDeployment := oldObj.(*fleetv1alpha1.BundleDeployment)
 
 	// BundleDeployment name is from Bundle.

--- a/pkg/webhook/resources/keypair/validator.go
+++ b/pkg/webhook/resources/keypair/validator.go
@@ -42,7 +42,7 @@ func (v *keyPairValidator) Resource() types.Resource {
 	}
 }
 
-func (v *keyPairValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *keyPairValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	keypair := newObj.(*v1beta1.KeyPair)
 
 	if err := v.checkPublicKey(keypair.Spec.PublicKey); err != nil {
@@ -51,7 +51,7 @@ func (v *keyPairValidator) Create(request *types.Request, newObj runtime.Object)
 	return nil
 }
 
-func (v *keyPairValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *keyPairValidator) Update(_ *types.Request, _ runtime.Object, newObj runtime.Object) error {
 	keypair := newObj.(*v1beta1.KeyPair)
 
 	if err := v.checkPublicKey(keypair.Spec.PublicKey); err != nil {

--- a/pkg/webhook/resources/managedchart/validator.go
+++ b/pkg/webhook/resources/managedchart/validator.go
@@ -31,7 +31,7 @@ func (v *managedChartValidator) Resource() types.Resource {
 		},
 	}
 }
-func (v *managedChartValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+func (v *managedChartValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	managedChart := oldObj.(*managementv3.ManagedChart)
 
 	// ManagedChart namespaces and names are from:

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -36,7 +36,7 @@ func (v *nodeValidator) Resource() types.Resource {
 	}
 }
 
-func (v *nodeValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *nodeValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldNode := oldObj.(*corev1.Node)
 	newNode := newObj.(*corev1.Node)
 

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -84,7 +84,7 @@ func (v *pvcValidator) Delete(request *types.Request, oldObj runtime.Object) err
 	return nil
 }
 
-func (v *pvcValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *pvcValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldPVC := oldObj.(*corev1.PersistentVolumeClaim)
 	newPVC := newObj.(*corev1.PersistentVolumeClaim)
 

--- a/pkg/webhook/resources/pod/mutator.go
+++ b/pkg/webhook/resources/pod/mutator.go
@@ -59,7 +59,7 @@ func (m *podMutator) Resource() types.Resource {
 	})
 }
 
-func (m *podMutator) Create(request *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+func (m *podMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
 	pod := newObj.(*corev1.Pod)
 
 	podLabels := labels.Set(pod.Labels)

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -166,15 +166,15 @@ func (v *settingValidator) Resource() types.Resource {
 	}
 }
 
-func (v *settingValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *settingValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	return validateSetting(newObj)
 }
 
-func (v *settingValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *settingValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	return validateUpdateSetting(oldObj, newObj)
 }
 
-func (v *settingValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+func (v *settingValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	return validateDeleteSetting(oldObj)
 }
 
@@ -220,7 +220,7 @@ func validateHTTPProxy(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateHTTPProxy(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateHTTPProxy(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateHTTPProxy(newSetting)
 }
 
@@ -248,7 +248,7 @@ func validateOvercommitConfig(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateOvercommitConfig(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateOvercommitConfig(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateOvercommitConfig(newSetting)
 }
 
@@ -264,7 +264,7 @@ func validateVMForceResetPolicy(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateVMForceResetPolicy(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateVMForceResetPolicy(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateVMForceResetPolicy(newSetting)
 }
 
@@ -278,11 +278,9 @@ func (v *settingValidator) isUpdatedS3BackupTarget(target *settings.BackupTarget
 		return false
 	} else if savedTarget, err := settings.DecodeBackupTarget(savedSetting.Value); err != nil {
 		return false
-	} else {
+	} else if savedTarget.Type != target.Type || savedTarget.BucketName != target.BucketName || savedTarget.BucketRegion != target.BucketRegion || savedTarget.Endpoint != target.Endpoint || savedTarget.VirtualHostedStyle != target.VirtualHostedStyle {
 		// when any of those fields is different, then it is from user input, not from internal re-config
-		if savedTarget.Type != target.Type || savedTarget.BucketName != target.BucketName || savedTarget.BucketRegion != target.BucketRegion || savedTarget.Endpoint != target.Endpoint || savedTarget.VirtualHostedStyle != target.VirtualHostedStyle {
-			return false
-		}
+		return false
 	}
 
 	return true
@@ -321,7 +319,7 @@ func (v *settingValidator) validateBackupTargetFields(target *settings.BackupTar
 	return nil
 }
 
-func (v *settingValidator) validateUpdateBackupTarget(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateBackupTarget(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateBackupTarget(newSetting)
 }
 
@@ -496,7 +494,7 @@ func validateNTPServer(server string, nameValidator, patternValidator *regexp.Re
 	return true
 }
 
-func validateUpdateNTPServers(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateNTPServers(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateNTPServers(newSetting)
 }
 
@@ -518,7 +516,7 @@ func validateVipPoolsConfig(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateVipPoolsConfig(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateVipPoolsConfig(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateVipPoolsConfig(newSetting)
 }
 
@@ -537,7 +535,7 @@ func validateSupportBundleTimeout(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSupportBundleTimeout(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSupportBundleTimeout(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleTimeout(newSetting)
 }
 
@@ -570,7 +568,7 @@ func validateSSLCertificates(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSSLCertificates(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSSLCertificates(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSSLCertificates(newSetting)
 }
 
@@ -598,7 +596,7 @@ func validateSSLParameters(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSSLParameters(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSSLParameters(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSSLParameters(newSetting)
 }
 
@@ -664,7 +662,7 @@ func validateSupportBundleImage(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSupportBundleImage(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSupportBundleImage(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleImage(newSetting)
 }
 
@@ -676,7 +674,7 @@ func (v *settingValidator) validateVolumeSnapshotClass(setting *v1beta1.Setting)
 	return err
 }
 
-func (v *settingValidator) validateUpdateVolumeSnapshotClass(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateVolumeSnapshotClass(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateVolumeSnapshotClass(newSetting)
 }
 
@@ -693,7 +691,7 @@ func validateContainerdRegistry(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateContainerdRegistry(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateContainerdRegistry(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateContainerdRegistry(newSetting)
 }
 
@@ -723,7 +721,7 @@ func (v *settingValidator) validateUpdateStorageNetwork(oldSetting *v1beta1.Sett
 	return v.checkStorageNetworkValueVaild(newSetting)
 }
 
-func (v *settingValidator) validateDeleteStorageNetwork(setting *v1beta1.Setting) error {
+func (v *settingValidator) validateDeleteStorageNetwork(_ *v1beta1.Setting) error {
 	return werror.NewMethodNotAllowed(fmt.Sprintf("Disallow delete setting name %s", settings.StorageNetworkName))
 }
 

--- a/pkg/webhook/resources/storageclass/validator.go
+++ b/pkg/webhook/resources/storageclass/validator.go
@@ -37,11 +37,11 @@ func (v *storageClassValidator) Resource() types.Resource {
 	}
 }
 
-func (v *storageClassValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *storageClassValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	return v.validateSetUniqueDefault(newObj)
 }
 
-func (v *storageClassValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *storageClassValidator) Update(_ *types.Request, _ runtime.Object, newObj runtime.Object) error {
 	return v.validateSetUniqueDefault(newObj)
 }
 

--- a/pkg/webhook/resources/templateversion/mutator.go
+++ b/pkg/webhook/resources/templateversion/mutator.go
@@ -37,7 +37,7 @@ func (m *templateVersionMutator) Resource() types.Resource {
 	})
 }
 
-func (m *templateVersionMutator) Create(request *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+func (m *templateVersionMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
 	vmTemplVersion := newObj.(*v1beta1.VirtualMachineTemplateVersion)
 
 	templateID := vmTemplVersion.Spec.TemplateID

--- a/pkg/webhook/resources/templateversion/validator.go
+++ b/pkg/webhook/resources/templateversion/validator.go
@@ -45,7 +45,7 @@ func (v *templateVersionValidator) Resource() types.Resource {
 	})
 }
 
-func (v *templateVersionValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *templateVersionValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	vmTemplVersion := newObj.(*v1beta1.VirtualMachineTemplateVersion)
 
 	templateID := vmTemplVersion.Spec.TemplateID
@@ -92,7 +92,7 @@ func (v *templateVersionValidator) Create(request *types.Request, newObj runtime
 	return nil
 }
 
-func (v *templateVersionValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *templateVersionValidator) Update(request *types.Request, _ runtime.Object, _ runtime.Object) error {
 	if request.IsFromController() {
 		return nil
 	}

--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -97,7 +97,7 @@ func (v *upgradeValidator) Resource() types.Resource {
 	}
 }
 
-func (v *upgradeValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *upgradeValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	newUpgrade := newObj.(*v1beta1.Upgrade)
 
 	if newUpgrade.Spec.Version == "" && newUpgrade.Spec.Image == "" {

--- a/pkg/webhook/resources/version/validator.go
+++ b/pkg/webhook/resources/version/validator.go
@@ -38,7 +38,7 @@ func (v *versionValidator) Resource() types.Resource {
 	}
 }
 
-func (v *versionValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *versionValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	newVersion := newObj.(*v1beta1.Version)
 	return v.checkAnnotations(newVersion)
 }
@@ -53,7 +53,7 @@ func (v *versionValidator) checkAnnotations(version *v1beta1.Version) error {
 	return nil
 }
 
-func (v *versionValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *versionValidator) Update(_ *types.Request, _ runtime.Object, newObj runtime.Object) error {
 	newVersion := newObj.(*v1beta1.Version)
 	return v.checkAnnotations(newVersion)
 }

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -55,7 +55,7 @@ func (m *vmMutator) Resource() types.Resource {
 	}
 }
 
-func (m *vmMutator) Create(request *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+func (m *vmMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
 	vm := newObj.(*kubevirtv1.VirtualMachine)
 
 	logrus.Debugf("create VM %s/%s", vm.Namespace, vm.Name)
@@ -78,7 +78,7 @@ func (m *vmMutator) Create(request *types.Request, newObj runtime.Object) (types
 	return patchOps, nil
 }
 
-func (m *vmMutator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) (types.PatchOps, error) {
+func (m *vmMutator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) (types.PatchOps, error) {
 	newVM := newObj.(*kubevirtv1.VirtualMachine)
 	oldVM := oldObj.(*kubevirtv1.VirtualMachine)
 

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -66,7 +66,7 @@ func (v *vmValidator) Resource() types.Resource {
 	}
 }
 
-func (v *vmValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *vmValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	vm := newObj.(*kubevirtv1.VirtualMachine)
 	if vm == nil {
 		return nil
@@ -78,7 +78,7 @@ func (v *vmValidator) Create(request *types.Request, newObj runtime.Object) erro
 	return nil
 }
 
-func (v *vmValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *vmValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	newVM := newObj.(*kubevirtv1.VirtualMachine)
 	if newVM == nil {
 		return nil

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -61,7 +61,7 @@ func (v *virtualMachineBackupValidator) Resource() types.Resource {
 	}
 }
 
-func (v *virtualMachineBackupValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *virtualMachineBackupValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	newVMBackup := newObj.(*v1beta1.VirtualMachineBackup)
 
 	if newVMBackup.Spec.Source.Name == "" {
@@ -155,7 +155,7 @@ func (v *virtualMachineBackupValidator) checkBackupTarget() error {
 	return nil
 }
 
-func (v *virtualMachineBackupValidator) Delete(request *types.Request, obj runtime.Object) error {
+func (v *virtualMachineBackupValidator) Delete(_ *types.Request, obj runtime.Object) error {
 	vmBackup := obj.(*v1beta1.VirtualMachineBackup)
 
 	vmRestores, err := v.vmrestores.GetByIndex(indexeres.VMRestoreByVMBackupNamespaceAndName, fmt.Sprintf("%s-%s", vmBackup.Namespace, vmBackup.Name))

--- a/pkg/webhook/resources/virtualmachineimage/mutator.go
+++ b/pkg/webhook/resources/virtualmachineimage/mutator.go
@@ -42,7 +42,7 @@ func (m *virtualMachineImageMutator) Resource() types.Resource {
 	}
 }
 
-func (m *virtualMachineImageMutator) Create(request *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+func (m *virtualMachineImageMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
 	newImage := newObj.(*harvesterv1.VirtualMachineImage)
 
 	return m.patchImageStorageClassParams(newImage)

--- a/pkg/webhook/resources/virtualmachineimage/validator.go
+++ b/pkg/webhook/resources/virtualmachineimage/validator.go
@@ -143,7 +143,7 @@ func (v *virtualMachineImageValidator) CheckImagePVC(request *types.Request, new
 	return nil
 }
 
-func (v *virtualMachineImageValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *virtualMachineImageValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	newImage := newObj.(*v1beta1.VirtualMachineImage)
 	oldImage := oldObj.(*v1beta1.VirtualMachineImage)
 
@@ -175,7 +175,7 @@ func (v *virtualMachineImageValidator) Update(request *types.Request, oldObj run
 	return v.CheckImageDisplayNameAndURL(newImage)
 }
 
-func (v *virtualMachineImageValidator) Delete(request *types.Request, oldObj runtime.Object) error {
+func (v *virtualMachineImageValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	image := oldObj.(*v1beta1.VirtualMachineImage)
 
 	if image.Status.StorageClassName == "" {

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -82,7 +82,7 @@ func (v *restoreValidator) Resource() types.Resource {
 	}
 }
 
-func (v *restoreValidator) Create(request *types.Request, newObj runtime.Object) error {
+func (v *restoreValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	newRestore := newObj.(*v1beta1.VirtualMachineRestore)
 
 	targetVM := newRestore.Spec.Target.Name
@@ -126,7 +126,7 @@ func (v *restoreValidator) Create(request *types.Request, newObj runtime.Object)
 	return v.handleExistVM(newVM, vm)
 }
 
-func (v *restoreValidator) Update(request *types.Request, oldObj, newObj runtime.Object) error {
+func (v *restoreValidator) Update(_ *types.Request, oldObj, newObj runtime.Object) error {
 	oldRestore := oldObj.(*v1beta1.VirtualMachineRestore)
 	newRestore := newObj.(*v1beta1.VirtualMachineRestore)
 	if !reflect.DeepEqual(oldRestore.Spec, newRestore.Spec) {

--- a/pkg/webhook/types/mutator.go
+++ b/pkg/webhook/types/mutator.go
@@ -10,18 +10,18 @@ type Mutator Admitter
 type DefaultMutator struct {
 }
 
-func (v *DefaultMutator) Create(request *Request, newObj runtime.Object) (PatchOps, error) {
+func (v *DefaultMutator) Create(_ *Request, _ runtime.Object) (PatchOps, error) {
 	return nil, nil
 }
 
-func (v *DefaultMutator) Update(request *Request, oldObj runtime.Object, newObj runtime.Object) (PatchOps, error) {
+func (v *DefaultMutator) Update(_ *Request, _ runtime.Object, _ runtime.Object) (PatchOps, error) {
 	return nil, nil
 }
 
-func (v *DefaultMutator) Delete(request *Request, oldObj runtime.Object) (PatchOps, error) {
+func (v *DefaultMutator) Delete(_ *Request, _ runtime.Object) (PatchOps, error) {
 	return nil, nil
 }
 
-func (v *DefaultMutator) Connect(request *Request, newObj runtime.Object) (PatchOps, error) {
+func (v *DefaultMutator) Connect(_ *Request, _ runtime.Object) (PatchOps, error) {
 	return nil, nil
 }

--- a/pkg/webhook/types/validator.go
+++ b/pkg/webhook/types/validator.go
@@ -54,18 +54,18 @@ func (c *ValidatorAdapter) Resource() Resource {
 type DefaultValidator struct {
 }
 
-func (v *DefaultValidator) Create(request *Request, newObj runtime.Object) error {
+func (v *DefaultValidator) Create(_ *Request, _ runtime.Object) error {
 	return nil
 }
 
-func (v *DefaultValidator) Update(request *Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *DefaultValidator) Update(_ *Request, _ runtime.Object, _ runtime.Object) error {
 	return nil
 }
 
-func (v *DefaultValidator) Delete(request *Request, oldObj runtime.Object) error {
+func (v *DefaultValidator) Delete(_ *Request, _ runtime.Object) error {
 	return nil
 }
 
-func (v *DefaultValidator) Connect(request *Request, newObj runtime.Object) error {
+func (v *DefaultValidator) Connect(_ *Request, _ runtime.Object) error {
 	return nil
 }

--- a/tests/integration/api/host_apis_test.go
+++ b/tests/integration/api/host_apis_test.go
@@ -5,14 +5,11 @@ import (
 	"net/http"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
 	nodeapi "github.com/harvester/harvester/pkg/api/node"
 	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/tests/framework/cluster"
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/helper"
 )
 

--- a/tests/integration/api/image_apis_test.go
+++ b/tests/integration/api/image_apis_test.go
@@ -5,13 +5,10 @@ import (
 	"net/http"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/util"
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 	"github.com/harvester/harvester/tests/framework/helper"
 )

--- a/tests/integration/api/keypair_apis_test.go
+++ b/tests/integration/api/keypair_apis_test.go
@@ -6,15 +6,12 @@ import (
 	"strings"
 
 	"github.com/guonaihong/gout"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/tidwall/gjson"
 	"golang.org/x/crypto/ssh"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/util"
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 	"github.com/harvester/harvester/tests/framework/helper"
 )

--- a/tests/integration/api/setting_apis_test.go
+++ b/tests/integration/api/setting_apis_test.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	. "github.com/onsi/ginkgo/v2"
 	"github.com/tidwall/gjson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/helper"
 )
 

--- a/tests/integration/api/suite_test.go
+++ b/tests/integration/api/suite_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	"github.com/rancher/dynamiclistener"
 	"github.com/sirupsen/logrus"
 	restclient "k8s.io/client-go/rest"
@@ -16,7 +16,7 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/server"
 	"github.com/harvester/harvester/tests/framework/cluster"
-	. "github.com/harvester/harvester/tests/framework/dsl"
+	"github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/helper"
 	"github.com/harvester/harvester/tests/integration/runtime"
 )
@@ -44,6 +44,54 @@ const (
 	harvesterStartTimeOut = 20
 )
 
+// Declarations for Ginkgo DSL
+var Fail = ginkgo.Fail
+var Describe = ginkgo.Describe
+var It = ginkgo.It
+var By = ginkgo.By
+var BeforeEach = ginkgo.BeforeEach
+var AfterEach = ginkgo.AfterEach
+var BeforeSuite = ginkgo.BeforeSuite
+var AfterSuite = ginkgo.AfterSuite
+var RunSpecs = ginkgo.RunSpecs
+var GinkgoWriter = ginkgo.GinkgoWriter
+var GinkgoRecover = ginkgo.GinkgoRecover
+var GinkgoT = ginkgo.GinkgoT
+var Context = ginkgo.Context
+var Specify = ginkgo.Specify
+
+// Declarations for Gomega Matchers
+var RegisterFailHandler = gomega.RegisterFailHandler
+var Equal = gomega.Equal
+var Expect = gomega.Expect
+var BeNil = gomega.BeNil
+var HaveOccurred = gomega.HaveOccurred
+var BeEmpty = gomega.BeEmpty
+var Eventually = gomega.Eventually
+var BeEquivalentTo = gomega.BeEquivalentTo
+var BeElementOf = gomega.BeElementOf
+var Consistently = gomega.Consistently
+var BeTrue = gomega.BeTrue
+
+// Declarations for DSL
+var MustNotError = dsl.MustNotError
+var MustFinallyBeTrue = dsl.MustFinallyBeTrue
+var MustRespCodeIs = dsl.MustRespCodeIs
+var MustRespCodeIn = dsl.MustRespCodeIn
+var MustEqual = dsl.MustEqual
+var MustNotEqual = dsl.MustNotEqual
+var Cleanup = dsl.Cleanup
+var CheckRespCodeIs = dsl.CheckRespCodeIs
+var HasNoneVMI = dsl.HasNoneVMI
+var AfterVMRunning = dsl.AfterVMRunning
+var AfterVMIRunning = dsl.AfterVMIRunning
+var AfterVMIRestarted = dsl.AfterVMIRestarted
+var MustVMPaused = dsl.MustVMPaused
+var MustVMRunning = dsl.MustVMRunning
+var MustVMDeleted = dsl.MustVMDeleted
+var MustVMIRunning = dsl.MustVMIRunning
+var MustPVCDeleted = dsl.MustPVCDeleted
+
 func TestAPI(t *testing.T) {
 	defer GinkgoRecover()
 
@@ -68,7 +116,7 @@ var _ = BeforeSuite(func() {
 	MustNotError(err)
 
 	By("set harvester config")
-	options, err = runtime.SetConfig(kubeConfig, testCluster)
+	options, err = runtime.SetConfig()
 	MustNotError(err)
 
 	By("new harvester server")

--- a/tests/integration/api/supportbundle_test.go
+++ b/tests/integration/api/supportbundle_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	ctlappsv1 "github.com/rancher/wrangler/pkg/generated/controllers/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests/integration/api/vm_apis_test.go
+++ b/tests/integration/api/vm_apis_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -18,7 +16,6 @@ import (
 	"github.com/harvester/harvester/pkg/builder"
 	"github.com/harvester/harvester/pkg/config"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 	"github.com/harvester/harvester/tests/framework/helper"
 )

--- a/tests/integration/api/vm_apis_utils_test.go
+++ b/tests/integration/api/vm_apis_utils_test.go
@@ -2,12 +2,9 @@ package api_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/onsi/ginkgo/v2"
 
 	"github.com/harvester/harvester/pkg/builder"
 )
@@ -119,15 +116,15 @@ func Exec(command string) error {
 	cmd := exec.Command("bash", "-c", command)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		ginkgo.GinkgoT().Errorf("failed to exec command %s, out: %s, err: %v", cmd, out, err)
+		GinkgoT().Errorf("failed to exec command %s, out: %s, err: %v", cmd, out, err)
 		return err
 	}
-	ginkgo.GinkgoT().Logf("exec command %s, out: %s", cmd, out)
+	GinkgoT().Logf("exec command %s, out: %s", cmd, out)
 	return nil
 }
 
 func CreateTmpFile(dir, pattern, content string, mode os.FileMode) (string, error) {
-	tmpFile, err := ioutil.TempFile(dir, pattern)
+	tmpFile, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return "", err
 	}

--- a/tests/integration/api/vm_backup_restore_test.go
+++ b/tests/integration/api/vm_backup_restore_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	. "github.com/onsi/ginkgo/v2"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +18,6 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/env"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 	"github.com/harvester/harvester/tests/framework/helper"

--- a/tests/integration/api/vm_template_apis_test.go
+++ b/tests/integration/api/vm_template_apis_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -12,7 +11,6 @@ import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 	"github.com/harvester/harvester/tests/framework/helper"
 )

--- a/tests/integration/api/volumes_apis_test.go
+++ b/tests/integration/api/volumes_apis_test.go
@@ -5,13 +5,10 @@ import (
 	"net/http"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/harvester/harvester/tests/framework/dsl"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 	"github.com/harvester/harvester/tests/framework/helper"
 )

--- a/tests/integration/controllers/addons_test.go
+++ b/tests/integration/controllers/addons_test.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	ctlhelmv1 "github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	ctlappsv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	ctlbatchv1 "github.com/rancher/wrangler/pkg/generated/controllers/batch/v1"
@@ -18,7 +18,7 @@ import (
 	"github.com/harvester/harvester/tests/integration/controllers/fake"
 )
 
-var _ = Describe("verify helm chart is create and addon gets to desired state", func() {
+var _ = ginkgo.Describe("verify helm chart is create and addon gets to desired state", func() {
 
 	var a *harvesterv1.Addon
 	var app *catalogv1.App
@@ -30,7 +30,7 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 	var jobName string
 
 	const managedChartKey = "catalog.cattle.io/managed"
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		a = &harvesterv1.Addon{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "demo-addon-create",
@@ -58,19 +58,19 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 				},
 			},
 		}
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			jobController = scaled.Management.BatchFactory.Batch().V1().Job()
 			appController = scaled.Management.CatalogFactory.Catalog().V1().App()
 			_, err := addonController.Create(a)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("checking helm and addon reconcile", func() {
-		By("helm chart exists and has same spec as addon", func() {
-			Eventually(func() error {
+	ginkgo.It("checking helm and addon reconcile", func() {
+		ginkgo.By("helm chart exists and has same spec as addon", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -89,11 +89,11 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check jobname is populated in helmchart", func() {
-			Eventually(func() error {
+		ginkgo.By("check jobname is populated in helmchart", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -101,31 +101,31 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 
 				if h.Status.JobName != "" {
 					jobName = h.Status.JobName
-					GinkgoWriter.Printf("found job name: %s\n", jobName)
+					ginkgo.GinkgoWriter.Printf("found job name: %s\n", jobName)
 					return nil
 				}
 
 				return fmt.Errorf("waiting for jobname to be populated in helmchart status")
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
-		By("check job has been updated", func() {
-			Eventually(func() error {
+		ginkgo.By("check job has been updated", func() {
+			gomega.Eventually(func() error {
 				j, err := jobController.Get(a.Namespace, jobName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if j.Status.CompletionTime != nil {
-					GinkgoWriter.Printf("job status: %v \n", j.Status)
+					ginkgo.GinkgoWriter.Printf("job status: %v \n", j.Status)
 					return nil
 				}
 
 				return fmt.Errorf("waiting for job to complete")
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check status of addon", func() {
-			Eventually(func() error {
+		ginkgo.By("check status of addon", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -134,11 +134,11 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 					return fmt.Errorf("waiting for addon to be deploy successfully. current status is %s", aObj.Status.Status)
 				}
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("watch status of addon to ensure it doesnt change", func() {
-			Eventually(func() error {
+		ginkgo.By("watch status of addon to ensure it doesnt change", func() {
+			gomega.Eventually(func() error {
 				i := 0
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
@@ -161,18 +161,18 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 					}
 				}
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("creating an app is created", func() {
-			Eventually(func() error {
+		ginkgo.By("creating an app is created", func() {
+			gomega.Eventually(func() error {
 				_, err := appController.Create(app)
 				return err
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("ensuring app is patched", func() {
-			Eventually(func() error {
+		ginkgo.By("ensuring app is patched", func() {
+			gomega.Eventually(func() error {
 				appObj, err := appController.Get(app.Namespace, app.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -183,19 +183,19 @@ var _ = Describe("verify helm chart is create and addon gets to desired state", 
 				}
 
 				return fmt.Errorf("waiting for key to be added to annotations on app")
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
 	})
 
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 })
 
-var _ = Describe("addon and helm chart deletion", func() {
+var _ = ginkgo.Describe("addon and helm chart deletion", func() {
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
 
@@ -215,18 +215,18 @@ var _ = Describe("addon and helm chart deletion", func() {
 		},
 	}
 
-	It("verify helm deletion tasks", func() {
-		By("create addon", func() {
-			Eventually(func() error {
+	ginkgo.It("verify helm deletion tasks", func() {
+		ginkgo.By("create addon", func() {
+			gomega.Eventually(func() error {
 				addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 				helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 				_, err := addonController.Create(a)
 				return err
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check helm chart object is created", func() {
-			Eventually(func() error {
+		ginkgo.By("check helm chart object is created", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -245,11 +245,11 @@ var _ = Describe("addon and helm chart deletion", func() {
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check addon status is successful", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon status is successful", func() {
+			gomega.Eventually(func() error {
 				a, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -258,17 +258,17 @@ var _ = Describe("addon and helm chart deletion", func() {
 					return fmt.Errorf("addon %s is not deployed successfully, status %v", a.Name, a.Status.Status)
 				}
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("delete addon object", func() {
-			Eventually(func() error {
+		ginkgo.By("delete addon object", func() {
+			gomega.Eventually(func() error {
 				return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("ensuring helm chart object is not found", func() {
-			Eventually(func() error {
+		ginkgo.By("ensuring helm chart object is not found", func() {
+			gomega.Eventually(func() error {
 				_, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
@@ -279,12 +279,12 @@ var _ = Describe("addon and helm chart deletion", func() {
 
 				// default scenario when hc is found
 				return fmt.Errorf("found a helm chart, waiting for gc")
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 	})
 })
 
-var _ = Describe("verify helm chart redeploy", func() {
+var _ = ginkgo.Describe("verify helm chart redeploy", func() {
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
 
@@ -304,18 +304,18 @@ var _ = Describe("verify helm chart redeploy", func() {
 		},
 	}
 
-	BeforeEach(func() {
-		Eventually(func() error {
+	ginkgo.BeforeEach(func() {
+		gomega.Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			_, err := addonController.Create(a)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("reconcile helm chart recreation", func() {
-		By("fetch helm chart and verify its spec", func() {
-			Eventually(func() error {
+	ginkgo.It("reconcile helm chart recreation", func() {
+		ginkgo.By("fetch helm chart and verify its spec", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -334,11 +334,11 @@ var _ = Describe("verify helm chart redeploy", func() {
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check addon status is successful", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon status is successful", func() {
+			gomega.Eventually(func() error {
 				a, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -347,17 +347,17 @@ var _ = Describe("verify helm chart redeploy", func() {
 					return fmt.Errorf("addon %s is not deployed successfully, status %v", a.Name, a.Status.Status)
 				}
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("delete helm chart object", func() {
-			Eventually(func() error {
+		ginkgo.By("delete helm chart object", func() {
+			gomega.Eventually(func() error {
 				return helmController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("verify helm chart is recreated", func() {
-			Eventually(func() error {
+		ginkgo.By("verify helm chart is recreated", func() {
+			gomega.Eventually(func() error {
 				hc, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -380,18 +380,18 @@ var _ = Describe("verify helm chart redeploy", func() {
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 	})
 
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 })
 
-var _ = Describe("perform addon upgrade", func() {
+var _ = ginkgo.Describe("perform addon upgrade", func() {
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
 
@@ -411,18 +411,18 @@ var _ = Describe("perform addon upgrade", func() {
 		},
 	}
 
-	BeforeEach(func() {
-		Eventually(func() error {
+	ginkgo.BeforeEach(func() {
+		gomega.Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			_, err := addonController.Create(a)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("reconcile helm chart upgrade", func() {
-		By("check helm chart object is created", func() {
-			Eventually(func() error {
+	ginkgo.It("reconcile helm chart upgrade", func() {
+		ginkgo.By("check helm chart object is created", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -441,11 +441,11 @@ var _ = Describe("perform addon upgrade", func() {
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check addon status is successful", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon status is successful", func() {
+			gomega.Eventually(func() error {
 				a, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -454,11 +454,11 @@ var _ = Describe("perform addon upgrade", func() {
 					return fmt.Errorf("addon %s is not deployed successfully, status %v", a.Name, a.Status.Status)
 				}
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("update addon", func() {
-			Eventually(func() error {
+		ginkgo.By("update addon", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -468,11 +468,11 @@ var _ = Describe("perform addon upgrade", func() {
 				aObj.Spec.Repo = "http://harvester-cluster-repo.cattle-system.svc.cluster.local"
 				_, err = addonController.Update(aObj)
 				return err
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check helm chart got updated", func() {
-			Eventually(func() error {
+		ginkgo.By("check helm chart got updated", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -496,26 +496,26 @@ var _ = Describe("perform addon upgrade", func() {
 				}
 
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 	})
 
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
 })
 
 // Failed Addon reconcile
-var _ = Describe("verify helm chart is create and addon gets to failed state", func() {
+var _ = ginkgo.Describe("verify helm chart is create and addon gets to failed state", func() {
 
 	var a *harvesterv1.Addon
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
 	var jobName string
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		a = &harvesterv1.Addon{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "demo-addon-fail",
@@ -532,17 +532,17 @@ var _ = Describe("verify helm chart is create and addon gets to failed state", f
 			},
 		}
 
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			_, err := addonController.Create(a)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("checking helm and addon reconcile", func() {
-		By("helm chart exists and has same spec as addon", func() {
-			Eventually(func() error {
+	ginkgo.It("checking helm and addon reconcile", func() {
+		ginkgo.By("helm chart exists and has same spec as addon", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -561,11 +561,11 @@ var _ = Describe("verify helm chart is create and addon gets to failed state", f
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check jobname is populated in helmchart", func() {
-			Eventually(func() error {
+		ginkgo.By("check jobname is populated in helmchart", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -573,17 +573,17 @@ var _ = Describe("verify helm chart is create and addon gets to failed state", f
 
 				if h.Status.JobName != "" {
 					jobName = h.Status.JobName
-					GinkgoWriter.Printf("found job name: %s\n", jobName)
+					ginkgo.GinkgoWriter.Printf("found job name: %s\n", jobName)
 					//fmt.Printf("found job name: %s\n", h.Status.JobName)
 					return nil
 				}
 
 				return fmt.Errorf("waiting for jobname to be populated in helmchart status")
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check status of addon", func() {
-			Eventually(func() error {
+		ginkgo.By("check status of addon", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -592,24 +592,24 @@ var _ = Describe("verify helm chart is create and addon gets to failed state", f
 					return nil
 				}
 				return fmt.Errorf("waiting for addon to be deploy failed. current status is %s", aObj.Status.Status)
-			}, "120s", "5s").ShouldNot(HaveOccurred())
+			}, "120s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
 	})
 
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 })
 
-var _ = Describe("enable and disable successful addon", func() {
+var _ = ginkgo.Describe("enable and disable successful addon", func() {
 
 	var a *harvesterv1.Addon
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		a = &harvesterv1.Addon{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "demo-disable-success",
@@ -627,18 +627,18 @@ var _ = Describe("enable and disable successful addon", func() {
 			},
 		}
 
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			_, err := addonController.Create(a)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("check and disable addon", func() {
+	ginkgo.It("check and disable addon", func() {
 
-		By("helm chart exists and has same spec as addon", func() {
-			Eventually(func() error {
+		ginkgo.By("helm chart exists and has same spec as addon", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -657,12 +657,12 @@ var _ = Describe("enable and disable successful addon", func() {
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
 		// only when successful, next operation is allowed
-		By("check addon status is successful", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon status is successful", func() {
+			gomega.Eventually(func() error {
 				a, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -671,11 +671,11 @@ var _ = Describe("enable and disable successful addon", func() {
 					return fmt.Errorf("addon %s is not deployed successfully, status %v", a.Name, a.Status.Status)
 				}
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("updating addon to disable", func() {
-			Eventually(func() error {
+		ginkgo.By("updating addon to disable", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return fmt.Errorf("error fetching addon: %v", err)
@@ -684,11 +684,11 @@ var _ = Describe("enable and disable successful addon", func() {
 				a.Spec.Enabled = false
 				_, err = addonController.Update(a)
 				return err
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("helm chart is removed", func() {
-			Eventually(func() error {
+		ginkgo.By("helm chart is removed", func() {
+			gomega.Eventually(func() error {
 				_, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
@@ -698,24 +698,24 @@ var _ = Describe("enable and disable successful addon", func() {
 				}
 
 				return fmt.Errorf("waiting for helm chart to be removed")
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
 	})
 
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 })
 
-var _ = Describe("enable and disable failed addon", func() {
+var _ = ginkgo.Describe("enable and disable failed addon", func() {
 
 	var a *harvesterv1.Addon
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		a = &harvesterv1.Addon{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "demo-disable-fail",
@@ -733,18 +733,18 @@ var _ = Describe("enable and disable failed addon", func() {
 			},
 		}
 
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			_, err := addonController.Create(a)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("check disable addon", func() {
+	ginkgo.It("check disable addon", func() {
 
-		By("helm chart exists and has same spec as addon", func() {
-			Eventually(func() error {
+		ginkgo.By("helm chart exists and has same spec as addon", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -763,11 +763,11 @@ var _ = Describe("enable and disable failed addon", func() {
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check addon status is failed", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon status is failed", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -776,11 +776,11 @@ var _ = Describe("enable and disable failed addon", func() {
 					return nil
 				}
 				return fmt.Errorf("waiting for addon to be deploy failed. current status is %s", aObj.Status.Status)
-			}, "120s", "5s").ShouldNot(HaveOccurred())
+			}, "120s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("updating addon to disable", func() {
-			Eventually(func() error {
+		ginkgo.By("updating addon to disable", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return fmt.Errorf("error fetching addon: %v", err)
@@ -792,11 +792,11 @@ var _ = Describe("enable and disable failed addon", func() {
 				a.Spec.Enabled = false
 				_, err = addonController.Update(a)
 				return err
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check addon disable status is failed", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon disable status is failed", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -805,11 +805,11 @@ var _ = Describe("enable and disable failed addon", func() {
 					return nil
 				}
 				return fmt.Errorf("waiting for addon to be disabled. current status is %s", aObj.Status.Status)
-			}, "120s", "5s").ShouldNot(HaveOccurred())
+			}, "120s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("helm chart is removed", func() {
-			Eventually(func() error {
+		ginkgo.By("helm chart is removed", func() {
+			gomega.Eventually(func() error {
 				_, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
@@ -819,19 +819,19 @@ var _ = Describe("enable and disable failed addon", func() {
 				}
 
 				return fmt.Errorf("waiting for helm chart to be removed")
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
 	})
 
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 })
 
-var _ = Describe("test addon upgrade fail", func() {
+var _ = ginkgo.Describe("test addon upgrade fail", func() {
 	var addonController ctlharvesterv1.AddonController
 	var helmController ctlhelmv1.HelmChartController
 
@@ -851,18 +851,18 @@ var _ = Describe("test addon upgrade fail", func() {
 		},
 	}
 
-	BeforeEach(func() {
-		Eventually(func() error {
+	ginkgo.BeforeEach(func() {
+		gomega.Eventually(func() error {
 			addonController = scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().Addon()
 			helmController = scaled.Management.HelmFactory.Helm().V1().HelmChart()
 			_, err := addonController.Create(a)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("reconcile helm chart upgrade", func() {
-		By("check helm chart object is created", func() {
-			Eventually(func() error {
+	ginkgo.It("reconcile helm chart upgrade", func() {
+		ginkgo.By("check helm chart object is created", func() {
+			gomega.Eventually(func() error {
 				h, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -885,11 +885,11 @@ var _ = Describe("test addon upgrade fail", func() {
 				}
 
 				return nil
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check addon status is successful", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon status is successful", func() {
+			gomega.Eventually(func() error {
 				a, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -898,11 +898,11 @@ var _ = Describe("test addon upgrade fail", func() {
 					return fmt.Errorf("addon %s is not deployed successfully, status %v", a.Name, a.Status.Status)
 				}
 				return nil
-			}, "90s", "5s").ShouldNot(HaveOccurred())
+			}, "90s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("patching helm chart to fail before upgrade", func() {
-			Eventually(func() error {
+		ginkgo.By("patching helm chart to fail before upgrade", func() {
+			gomega.Eventually(func() error {
 				hObj, err := helmController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -915,11 +915,11 @@ var _ = Describe("test addon upgrade fail", func() {
 				hObj.Annotations[fake.OverrideToFail] = "true"
 				_, err = helmController.Update(hObj)
 				return err
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("update addon", func() {
-			Eventually(func() error {
+		ginkgo.By("update addon", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -929,11 +929,11 @@ var _ = Describe("test addon upgrade fail", func() {
 				aObj.Spec.Repo = "http://harvester-cluster-repo.cattle-system.svc.cluster.local"
 				_, err = addonController.Update(aObj)
 				return err
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check helm chart got updated", func() {
-			Eventually(func() error {
+		ginkgo.By("check helm chart got updated", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -957,11 +957,11 @@ var _ = Describe("test addon upgrade fail", func() {
 				}
 
 				return nil
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("check addon upgrade failed", func() {
-			Eventually(func() error {
+		ginkgo.By("check addon upgrade failed", func() {
+			gomega.Eventually(func() error {
 				aObj, err := addonController.Get(a.Namespace, a.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -970,14 +970,14 @@ var _ = Describe("test addon upgrade fail", func() {
 					return nil
 				}
 				return fmt.Errorf("addon %s is not in correct state %v", aObj.Name, aObj.Status.Status)
-			}, "60s", "5s").ShouldNot(HaveOccurred())
+			}, "60s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 	})
 
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return addonController.Delete(a.Namespace, a.Name, &metav1.DeleteOptions{})
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
 })

--- a/tests/integration/controllers/clusterrepo_test.go
+++ b/tests/integration/controllers/clusterrepo_test.go
@@ -3,8 +3,8 @@ package controllers
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	ctlcatalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,11 +12,11 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/mcmsettings"
 )
 
-var _ = Describe("verify cluster repos are patched", func() {
+var _ = ginkgo.Describe("verify cluster repos are patched", func() {
 	var harvestercharts, partnercharts *catalogv1.ClusterRepo
 	var clusterRepoController ctlcatalogv1.ClusterRepoController
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		harvestercharts = &catalogv1.ClusterRepo{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "harvester-charts",
@@ -32,21 +32,21 @@ var _ = Describe("verify cluster repos are patched", func() {
 		}
 
 		clusterRepoController = scaled.Management.CatalogFactory.Catalog().V1().ClusterRepo()
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			_, err := clusterRepoController.Create(harvestercharts)
 			return err
-		}, "30s", "5s").ShouldNot(HaveOccurred())
+		}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			_, err := clusterRepoController.Create(partnercharts)
 			return err
-		}, "30s", "5s").ShouldNot(HaveOccurred())
+		}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 
 	})
 
-	It("verify cluster repo annotations", func() {
-		By("checking annotation on harvester-charts", func() {
-			Eventually(func() error {
+	ginkgo.It("verify cluster repo annotations", func() {
+		ginkgo.By("checking annotation on harvester-charts", func() {
+			gomega.Eventually(func() error {
 				obj, err := clusterRepoController.Get(harvestercharts.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -60,11 +60,11 @@ var _ = Describe("verify cluster repos are patched", func() {
 				}
 
 				return fmt.Errorf("waiting for hide key/value: %s/%s to be annotated on cluster repo", mcmsettings.HideClusterRepoKey, mcmsettings.HideClusterRepoValue)
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 
-		By("checking annotation on rancher-partner-charts", func() {
-			Consistently(func() error {
+		ginkgo.By("checking annotation on rancher-partner-charts", func() {
+			gomega.Consistently(func() error {
 				obj, err := clusterRepoController.Get(partnercharts.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
@@ -79,17 +79,17 @@ var _ = Describe("verify cluster repos are patched", func() {
 				}
 
 				return fmt.Errorf("key/value %s/%s should not have been annotated on cluster repo", mcmsettings.HideClusterRepoKey, mcmsettings.HideClusterRepoValue)
-			}, "30s", "5s").ShouldNot(HaveOccurred())
+			}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 		})
 	})
-	AfterEach(func() {
-		Eventually(func() error {
+	ginkgo.AfterEach(func() {
+		gomega.Eventually(func() error {
 			return clusterRepoController.Delete(harvestercharts.Name, &metav1.DeleteOptions{})
-		}, "30s", "5s").ShouldNot(HaveOccurred())
+		}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			return clusterRepoController.Delete(partnercharts.Name, &metav1.DeleteOptions{})
-		}, "30s", "5s").ShouldNot(HaveOccurred())
+		}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 	})
 
 })

--- a/tests/integration/controllers/fake/jobs_controller.go
+++ b/tests/integration/controllers/fake/jobs_controller.go
@@ -28,7 +28,7 @@ type handler struct {
 	helm ctlhelmv1.HelmChartController
 }
 
-func RegisterFakeControllers(ctx context.Context, management *config.Management, opts config.Options) error {
+func RegisterFakeControllers(ctx context.Context, management *config.Management, _ config.Options) error {
 	jc := management.BatchFactory.Batch().V1().Job()
 	hc := management.HelmFactory.Helm().V1().HelmChart()
 	h := &handler{
@@ -41,7 +41,7 @@ func RegisterFakeControllers(ctx context.Context, management *config.Management,
 	return nil
 }
 
-func (h *handler) OnHelmChartChange(key string, hc *helmv1.HelmChart) (*helmv1.HelmChart, error) {
+func (h *handler) OnHelmChartChange(_ string, hc *helmv1.HelmChart) (*helmv1.HelmChart, error) {
 	if hc == nil || hc.DeletionTimestamp != nil {
 		return hc, nil
 	}
@@ -74,7 +74,7 @@ func (h *handler) OnHelmChartChange(key string, hc *helmv1.HelmChart) (*helmv1.H
 	return h.helm.Update(hcCopy)
 }
 
-func (h *handler) OnHelmChartDelete(key string, hc *helmv1.HelmChart) (*helmv1.HelmChart, error) {
+func (h *handler) OnHelmChartDelete(_ string, hc *helmv1.HelmChart) (*helmv1.HelmChart, error) {
 	if hc == nil || hc.DeletionTimestamp == nil {
 		return nil, nil
 	}

--- a/tests/integration/controllers/node_drain_test.go
+++ b/tests/integration/controllers/node_drain_test.go
@@ -3,20 +3,20 @@ package controllers
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/harvester/pkg/util/drainhelper"
-	. "github.com/harvester/harvester/tests/framework/dsl"
+	"github.com/harvester/harvester/tests/framework/dsl"
 )
 
-var _ = Describe("verify node drain apis", func() {
+var _ = ginkgo.Describe("verify node drain apis", func() {
 	var node corev1.Node
 
-	BeforeEach(func() {
-		Eventually(func() error {
+	ginkgo.BeforeEach(func() {
+		gomega.Eventually(func() error {
 			nodeList, err := scaled.CoreFactory.Core().V1().Node().List(metav1.ListOptions{})
 			if err != nil {
 				return err
@@ -29,16 +29,16 @@ var _ = Describe("verify node drain apis", func() {
 				}
 			}
 			return fmt.Errorf("no worker node found in cluster")
-		}).ShouldNot(HaveOccurred())
+		}).ShouldNot(gomega.HaveOccurred())
 	})
 
-	It("drain node using drainhelper", func() {
-		By("draining nodes", func() {
+	ginkgo.It("drain node using drainhelper", func() {
+		ginkgo.By("draining nodes", func() {
 			err := drainhelper.DrainNode(testCtx, cfg, &node)
-			MustNotError(err)
+			dsl.MustNotError(err)
 		})
 
-		Eventually(func() error {
+		gomega.Eventually(func() error {
 			nodeObj, err := scaled.CoreFactory.Core().V1().Node().Get(node.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -58,7 +58,7 @@ var _ = Describe("verify node drain apis", func() {
 			}
 
 			return fmt.Errorf("expected to find taint for no schedule")
-		}, "30s", "5s").ShouldNot(HaveOccurred())
+		}, "30s", "5s").ShouldNot(gomega.HaveOccurred())
 
 	})
 })

--- a/tests/integration/runtime/runtime.go
+++ b/tests/integration/runtime/runtime.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/client-go/rest"
-
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/settings"
-	"github.com/harvester/harvester/tests/framework/cluster"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 )
 
@@ -46,7 +43,7 @@ var (
 )
 
 // SetConfig configures the public variables exported in github.com/harvester/harvester/pkg/config package.
-func SetConfig(kubeConfig *rest.Config, testCluster cluster.Cluster) (config.Options, error) {
+func SetConfig() (config.Options, error) {
 	var options config.Options
 
 	// generate two random ports


### PR DESCRIPTION
**Problem:**
The golangci-lint version before v1.51.0 may have OOM issue with golang v1.20.

**Solution:**
Bump golangci-lint to a version after v1.51.0.

**Related Issue:**
https://github.com/harvester/harvester/issues/4938
