### PR TITLE
VM Image Supports LH Data Locality

### DIFF
--- a/pkg/util/volume.go
+++ b/pkg/util/volume.go
@@ -14,6 +14,7 @@ import (
 const (
 	AnnStorageProvisioner     = "volume.kubernetes.io/storage-provisioner"
 	AnnBetaStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+	LonghornDataLocality      = "dataLocality"
 )
 
 var (

--- a/pkg/webhook/resources/virtualmachineimage/mutator.go
+++ b/pkg/webhook/resources/virtualmachineimage/mutator.go
@@ -112,7 +112,9 @@ func mergeStorageClassParams(image *harvesterv1.VirtualMachineImage, storageClas
 	}
 	var allowPatchParams = []string{
 		longhorntypes.OptionNodeSelector, longhorntypes.OptionDiskSelector,
-		longhorntypes.OptionNumberOfReplicas, longhorntypes.OptionStaleReplicaTimeout}
+		longhorntypes.OptionNumberOfReplicas, longhorntypes.OptionStaleReplicaTimeout,
+		util.LonghornDataLocality,
+	}
 	for k, v := range mergeParams {
 		if slice.ContainsString(allowPatchParams, k) {
 			params[k] = v


### PR DESCRIPTION
**Problem:**
Support LH data locality

**Solution:**
1. Support LH data locality `disable` and `best-effort` for image-backed volume
2. Reject data locality as `strict-local` since this blocks VM migration and node drain

**Related Issue:**
#4101 

**Test plan:**

**Setup:**
- Build a Harvester cluster with the master-head branch
- Update harvester-webhook deployment from this branch

**Case1: Best-Effort Data Locality**
- Creating storage class with this yaml 
  ```
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    name: best-effort
  allowVolumeExpansion: true
  parameters:
    numberOfReplicas: '2'
    staleReplicaTimeout: '30'
    migratable: 'true'
    dataLocality: "best-effort"
  provisioner: driver.longhorn.io
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
  ```
- Creating a VM Image `best-effort.img` with storage class `best-effort`
- Creating a VM with disk from image `best-effort.img`
- Checking the related LH volume data locality is `best-effort` (from `.spec.dataLocality`)

**Case2: Data Locality Disable**
- Creating storage class with this yaml 
  ```
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    name: data-locality-disable
  allowVolumeExpansion: true
  parameters:
    numberOfReplicas: '2'
    staleReplicaTimeout: '30'
    migratable: 'true'
  provisioner: driver.longhorn.io
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
  ```
- Creating a VM Image `data-locality-disable.img` with storage class `data-locality-disable`
- Creating a VM with disk from image `data-locality-disable.img`
- Checking the related LH volume data locality is `disabled` (from `.spec.dataLocality`)

**Case3: Strict Local Data Locality**
- Creating storage class with this yaml 
  ```
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    name: strict-local
  allowVolumeExpansion: true
  parameters:
    numberOfReplicas: '1'
    staleReplicaTimeout: '30'
    migratable: 'true'
    dataLocality: "strict-local"
  provisioner: driver.longhorn.io
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
  ```
- Receive error as `storage class with strict-local data locality is not allowed`

**Case4: Invalid Data Locality**
- Creating storage class with this yaml 
  ```
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    name: strict-invalid
  allowVolumeExpansion: true
  parameters:
    numberOfReplicas: '2'
    staleReplicaTimeout: '30'
    migratable: 'true'
    dataLocality: "testing"
  provisioner: driver.longhorn.io
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
  ```
- Receive error as `storage class with invalid data locality testing, valid values: "disabled", "best-effort"`

