### PR TITLE
fix: ignore pvc checking when vmrestore to a new vm

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -404,7 +404,7 @@ func (h *RestoreHandler) initVolumesStatus(vmRestore *harvesterv1.VirtualMachine
 		restoreCpy.Status.VolumeRestores = volumeRestores
 	}
 
-	if !isNewVMOrHasRetainPolicy(vmRestore) && vmRestore.Status.DeletedVolumes == nil {
+	if !IsNewVMOrHasRetainPolicy(vmRestore) && vmRestore.Status.DeletedVolumes == nil {
 		var deletedVolumes []string
 		for _, vol := range backup.Status.VolumeBackups {
 			deletedVolumes = append(deletedVolumes, vol.PersistentVolumeClaim.ObjectMeta.Name)
@@ -891,7 +891,7 @@ func (h *RestoreHandler) getOrCreateVolumeSnapshot(
 }
 
 func (h *RestoreHandler) deleteOldPVC(vmRestore *harvesterv1.VirtualMachineRestore, vm *kubevirtv1.VirtualMachine) error {
-	if isNewVMOrHasRetainPolicy(vmRestore) {
+	if IsNewVMOrHasRetainPolicy(vmRestore) {
 		logrus.Infof("skip deleting old PVC of vm %s/%s", vm.Name, vm.Namespace)
 		return nil
 	}

--- a/pkg/controller/master/backup/util.go
+++ b/pkg/controller/master/backup/util.go
@@ -53,10 +53,10 @@ func isVMRestoreProgressing(vmRestore *harvesterv1.VirtualMachineRestore) bool {
 
 func isVMRestoreMissingVolumes(vmRestore *harvesterv1.VirtualMachineRestore) bool {
 	return len(vmRestore.Status.VolumeRestores) == 0 ||
-		(!isNewVMOrHasRetainPolicy(vmRestore) && len(vmRestore.Status.DeletedVolumes) == 0)
+		(!IsNewVMOrHasRetainPolicy(vmRestore) && len(vmRestore.Status.DeletedVolumes) == 0)
 }
 
-func isNewVMOrHasRetainPolicy(vmRestore *harvesterv1.VirtualMachineRestore) bool {
+func IsNewVMOrHasRetainPolicy(vmRestore *harvesterv1.VirtualMachineRestore) bool {
 	return vmRestore.Spec.NewVM || vmRestore.Spec.DeletionPolicy == harvesterv1.VirtualMachineRestoreRetain
 }
 

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -206,7 +206,7 @@ func (v *restoreValidator) checkBackup(vmRestore *v1beta1.VirtualMachineRestore,
 		return err
 	}
 
-	if vmRestore.Spec.DeletionPolicy == v1beta1.VirtualMachineRestoreRetain {
+	if ctlbackup.IsNewVMOrHasRetainPolicy(vmRestore) {
 		return nil
 	}
 


### PR DESCRIPTION
**Problem:**
After https://github.com/harvester/harvester/issues/4604, we deny VMRestore request with deletion policy if there is a VMSnapshot. It introduces a new issue - if we don't specify DeletionPolicy, the VMRestore can't work when there is a VMSnapshot. The root cause is that we only check whether deletion policy is retain, but not empty.

**Solution:**
Check whether it's restored to a new VM.

**Related Issue:**
https://github.com/harvester/harvester/issues/4954

**Test plan:**
1. Create a VM.
2. Create a VMBackup and VMSnapshot.
3. Stop the VM.
4. Restore VMBackup to a new VM.
5. Restore VMRestore to a new VM.
