### PR TITLE
feat(webhook): add single-replica volume check for upgrade

### DIFF
--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -2,6 +2,9 @@ package indexeres
 
 import (
 	"fmt"
+	"strconv"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/indexeres"
@@ -13,6 +16,7 @@ const (
 	VMRestoreByTargetNamespaceAndName     = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
 	VMRestoreByVMBackupNamespaceAndName   = "harvesterhci.io/vmrestore-by-vmbackup-namespace-and-name"
 	VMBackupSnapshotByPVCNamespaceAndName = "harvesterhci.io/vmbackup-snapshot-by-pvc-namespace-and-name"
+	VolumeByReplicaCountIndex             = "harvesterhci.io/volume-by-replica-count"
 )
 
 func RegisterIndexers(clients *clients.Clients) {
@@ -26,6 +30,9 @@ func RegisterIndexers(clients *clients.Clients) {
 
 	podCache := clients.CoreFactory.Core().V1().Pod().Cache()
 	podCache.AddIndexer(indexeres.PodByVMNameIndex, indexeres.PodByVMName)
+
+	volumeCache := clients.LonghornFactory.Longhorn().V1beta2().Volume().Cache()
+	volumeCache.AddIndexer(VolumeByReplicaCountIndex, VolumeByReplicaCount)
 }
 
 func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
@@ -60,4 +67,9 @@ func vmRestoreByVMBackupNamespaceAndName(obj *harvesterv1.VirtualMachineRestore)
 		return []string{}, nil
 	}
 	return []string{fmt.Sprintf("%s-%s", obj.Spec.VirtualMachineBackupNamespace, obj.Spec.VirtualMachineBackupName)}, nil
+}
+
+func VolumeByReplicaCount(obj *lhv1beta2.Volume) ([]string, error) {
+	replicaCount := strconv.Itoa(obj.Spec.NumberOfReplicas)
+	return []string{replicaCount}, nil
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

An LH volume's `.spec.numberOfReplicas` is sometimes configured as `1`. Either intentionally by the user or derived from a StorageClass with replicas set to 1. In such cases, the volumes are in a `healthy` state but are fragile, especially for the Harvester upgrade. Harvester upgrade will try to drain each node in the cluster in a later step. The replica instance manager Pod cannot be drained if the volume it manages has one and only one replica. The recommended way is to shut down the workload of those using the volume and try to start the upgrade again.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add the single-replica volume check in the validating admission webhook. If such circumstances are detected, reject the creation of the Upgrade object.

**Related Issue:**

#4467 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster with 2+ nodes (installed with the version including the commit of this PR)
2. Create a new VM, say, `test-vm`
3. Shutdown the newly created VM
4. Find the LH volume of the VM and adjust its replica count in the field `.spec.numberOfReplicas` to `1`
5. Start the VM
6. Create the Version CR for upgrade (to whatever Harvester version, it does not matter)
7. When kick off the upgrade by clicking the "Upgrade" button, a webhook error message should show up like below:

<img width="1624" alt="image" src="https://github.com/harvester/harvester/assets/1827717/c7716504-971a-486f-9004-c5976cdd6d2a">

The error message should specify the relevant PVCs' namespace and name.