### PR TITLE
feat: add KeepMacAddress to VMRestore.Spec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7031,6 +7031,9 @@
         "deletionPolicy": {
           "type": "string"
         },
+        "keepMacAddress": {
+          "type": "boolean"
+        },
         "newVM": {
           "type": "boolean"
         },

--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinerestores.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinerestores.yaml
@@ -59,6 +59,10 @@ spec:
                 description: DeletionPolicy defines that to do with resources when
                   VirtualMachineRestore is deleted
                 type: string
+              keepMacAddress:
+                description: KeepMacAddress only works when NewVM is true. For replacing
+                  original VM, the macaddress will be the same.
+                type: boolean
               newVM:
                 type: boolean
               target:

--- a/pkg/apis/harvesterhci.io/v1beta1/backup.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/backup.go
@@ -208,6 +208,11 @@ type VirtualMachineRestoreSpec struct {
 
 	// +optional
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
+
+	// +optional
+	// KeepMacAddress only works when NewVM is true.
+	// For replacing original VM, the macaddress will be the same.
+	KeepMacAddress bool `json:"keepMacAddress,omitempty"`
 }
 
 // VirtualMachineRestoreStatus is the spec for a VirtualMachineRestore resource

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -4137,6 +4137,13 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineRestoreSpec(ref common
 							Format: "",
 						},
 					},
+					"keepMacAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "KeepMacAddress only works when NewVM is true. For replacing original VM, the macaddress will be the same.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"target", "virtualMachineBackupName", "virtualMachineBackupNamespace"},
 			},

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -696,9 +696,11 @@ func (h *RestoreHandler) createNewVM(restore *harvesterv1.VirtualMachineRestore,
 	}
 	vm.Spec.Template.Spec.Volumes = newVolumes
 
-	for i := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
-		// remove the copied mac address of the new VM
-		vm.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = ""
+	if !restore.Spec.KeepMacAddress {
+		for i := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
+			// remove the copied mac address of the new VM
+			vm.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = ""
+		}
 	}
 
 	newVM, err := h.vms.Create(vm)


### PR DESCRIPTION
**Problem:**
The system removes macaddress by default when users restore a new VM.

**Solution:**
Add a option to support keeping macaddress.

**Related Issue:**
https://github.com/harvester/harvester/issues/3541

**Test plan:**
1. Create a VM.
2. Create a VMBackup.
3. Restore the VMBackup to a new VM with `keepMacAddress=true`. The webhook should deny the request because the source VM is still existent.
4. Remove the source VM.
5. Restore the VMBackup to a new VM with `keepMacAddress=true`. The new VM should have same macaddress as source VM.
6. Restore the VMBackup to a new VM with `keepMacAddress=true` again. The webhook should deny the request because the another VMRestore with `keepMacAddress=true` is existent.
