### PR TITLE
fix(upgrade): remove version check for rancher-system-agent workaround

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1126,12 +1126,6 @@ skip_restart_rancher_system_agent() {
   # by adding an env var to temporarily make rancher-system-agent on each node skip restarting rke2-server/agent.
   # issue link: https://github.com/rancher/rancher/issues/41965
 
-  # only versions before v1.2.0 that upgrading to v1.2.0 need this workaround
-  if [[ ! "${UPGRADE_PREVIOUS_VERSION%%-rc*}" < "v1.2.0" ]]; then
-    echo "Only versions before v1.2.0 need this patch."
-    return
-  fi
-
   plan_manifest="$(mktemp --suffix=.yaml)"
   plan_name="$HARVESTER_UPGRADE_NAME"-skip-restart-rancher-system-agent
   plan_version="$(openssl rand -hex 4)"

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -272,14 +272,6 @@ wait_evacuation_pdb_gone()
 }
 
 recover_rancher_system_agent() {
-  # only versions before v1.2.0 that upgrading to v1.2.0 need to recover the workaround
-  if [ -z "$UPGRADE_PREVIOUS_VERSION" ]; then
-    detect_upgrade
-  fi
-  if [[ ! "${UPGRADE_PREVIOUS_VERSION%%-rc*}" < "v1.2.0" ]]; then
-    echo "Only versions before v1.2.0 need to recover this patch."
-    return
-  fi
   chroot "$HOST_DIR" /bin/bash -c "rm -rf /run/systemd/system/rancher-system-agent.service.d && systemctl daemon-reload && systemctl restart rancher-system-agent.service"
 }
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Previously, the workaround applied to `rancher-system-agent` for not restarting RKE2 server/agent remains on the nodes if an upgrade failed after upgrading Harvester charts (in phase 3). This is problematic if an upgrade from v1.1.x to v1.2.x failed, and the user want to start over the upgrade again. This will effectively become an upgrade from v1.2.x to v1.2.x, and the workaround will not be removed in the pre-drain phase because of the version checking.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

We need RKE2 server/agent to not restart during Rancher upgrade. This is true no matter what version we're upgrading from/to, so changing the workaround applied to rancher-system-agent to be a part of the regular upgrade flow by removing the version checking.

**Related Issue:**

#4965 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install Harvester v1.1.2
2. Upgrade to v1.2.1
3. Monitor the upgrade progress, when the Harvester version becomes v1.2.1, remove the Upgrade CR (to break the upgrade)
4. Clean up the mess (if any)
5. Start the upgrade again (upgrade from v1.2.1 to v1.2.1)
6. The upgrade ends up successfully
7. There should be **no** `/run/systemd/system/rancher-system-agent.service.d/` directory on the nodes

---

For QA engineers, the test plan would be:

1. Install Harvester v1.3-head
2. Upgrade to v1.3.0-rc3
3. Intentionally break the upgrade when the Harvester version becomes the new version (by removing the Upgrade CR)
4. Clean up the mess if there are any unsettled bundles
5. Start the upgrade again
6. The upgrade should end successfully
7. There should be **no** `/run/systemd/system/rancher-system-agent.service.d/` directory on the nodes