### PR TITLE
feat(upgrade): unneeded image cleanup after upgrade

### DIFF
--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,4 +1,14 @@
 versions:
+- name: v1.2.1
+  minUpgradableVersion: v1.1.2
+- name: v1.2.0
+  minUpgradableVersion: v1.1.2
+- name: v1.1.3
+  minUpgradableVersion: v1.1.1
+- name: v1.1.2
+  minUpgradableVersion: v1.1.0
+- name: v1.1.1
+  minUpgradableVersion: v1.0.3
 - name: v1.1.0
   minUpgradableVersion: v1.0.3
 - name: v1.0.3

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"fmt"
+	"strings"
 
 	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/name"
@@ -17,12 +18,36 @@ import (
 const (
 	nodeComponent     = "node"
 	manifestComponent = "manifest"
+	cleanupComponent  = "cleanup"
 
 	labelArch               = "kubernetes.io/arch"
 	labelCriticalAddonsOnly = "CriticalAddonsOnly"
 
 	// keep jobs for 7 days
 	defaultTTLSecondsAfterFinished = 604800
+	imageCleanupScript             = `
+#!/usr/bin/env sh
+set -e
+
+HOST_DIR="${HOST_DIR:-/host}"
+
+export CONTAINER_RUNTIME_ENDPOINT=unix:///$HOST_DIR/run/k3s/containerd/containerd.sock
+export CONTAINERD_ADDRESS=$HOST_DIR/run/k3s/containerd/containerd.sock
+
+CTR="$HOST_DIR/$(readlink $HOST_DIR/var/lib/rancher/rke2/bin)/ctr"
+if [ -z "$CTR" ];then
+	echo "Fail to get host ctr binary."
+	exit 0
+fi
+
+ret=0
+"$CTR" -n k8s.io i rm $IMAGES || ret=$?
+
+if [ "$ret" -ne 0 ]; then
+	echo "Fail to remove images"
+	exit 0
+fi
+`
 )
 
 func setNodeUpgradeStatus(upgrade *harvesterv1.Upgrade, nodeName string, state, reason, message string) {
@@ -140,6 +165,79 @@ func prepareUpgradeLog(upgrade *harvesterv1.Upgrade) *harvesterv1.UpgradeLog {
 		},
 		Spec: harvesterv1.UpgradeLogSpec{
 			UpgradeName: upgrade.Name,
+		},
+	}
+}
+
+func prepareCleanupPlan(upgrade *harvesterv1.Upgrade, imageList []string) *upgradev1.Plan {
+	concurrency := len(upgrade.Status.NodeStatuses)
+	planVersion := upgrade.Name
+	imageVersion := upgrade.Status.PreviousVersion
+
+	return &upgradev1.Plan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-cleanup", upgrade.Name),
+			Namespace: sucNamespace,
+			Labels: map[string]string{
+				harvesterUpgradeLabel:          upgrade.Name,
+				harvesterUpgradeComponentLabel: cleanupComponent,
+			},
+		},
+		Spec: upgradev1.PlanSpec{
+			Concurrency: int64(concurrency),
+			Version:     planVersion,
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					harvesterManagedLabel: "true",
+				},
+			},
+			ServiceAccountName: upgradeServiceAccount,
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      labelCriticalAddonsOnly,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "kubevirt.io/drain",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      node.KubeControlPlaneNodeLabelKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      labelArch,
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+					Value:    "amd64",
+				},
+				{
+					Key:      labelArch,
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+					Value:    "arm64",
+				},
+				{
+					Key:      labelArch,
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+					Value:    "arm",
+				},
+			},
+			Upgrade: &upgradev1.ContainerSpec{
+				Image: fmt.Sprintf("%s:%s", upgradeImageRepository, imageVersion),
+				Command: []string{
+					"sh", "-c", imageCleanupScript,
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "IMAGES",
+						Value: strings.Join(imageList, " "),
+					},
+				},
+			},
 		},
 	}
 }
@@ -666,4 +764,14 @@ func upgradeReference(upgrade *harvesterv1.Upgrade) metav1.OwnerReference {
 		UID:        upgrade.UID,
 		APIVersion: upgrade.APIVersion,
 	}
+}
+
+func difference(setA, setB map[string]bool) []string {
+	var diff []string
+	for key := range setA {
+		if !setB[key] {
+			diff = append(diff, key)
+		}
+	}
+	return diff
 }

--- a/pkg/controller/master/upgrade/plan_controller.go
+++ b/pkg/controller/master/upgrade/plan_controller.go
@@ -1,6 +1,8 @@
 package upgrade
 
 import (
+	"strconv"
+
 	"github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
 	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
@@ -67,6 +69,16 @@ func (h *planHandler) OnChanged(_ string, plan *upgradev1.Plan) (*upgradev1.Plan
 	}
 
 	component := plan.Labels[harvesterUpgradeComponentLabel]
+	if component == cleanupComponent {
+		toUpdate := upgrade.DeepCopy()
+		if toUpdate.Annotations == nil {
+			toUpdate.Annotations = make(map[string]string)
+		}
+		toUpdate.Annotations[imageCleanupPlanCompletedAnnotation] = strconv.FormatBool(true)
+		if _, err := h.upgradeClient.Update(toUpdate); err != nil {
+			return plan, err
+		}
+	}
 	if !harvesterv1.NodesPrepared.IsTrue(upgrade) && component == nodeComponent {
 		toUpdate := upgrade.DeepCopy()
 		setNodesPreparedCondition(toUpdate, corev1.ConditionTrue, "", "")

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -190,9 +190,16 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 
 	// clean upgrade repo VMs and images if a upgrade succeeds.
 	if harvesterv1.UpgradeCompleted.IsTrue(upgrade) {
+		// try to clean up images before purging the repo VM
 		_, exists := upgrade.Annotations[imageCleanupPlanCompletedAnnotation]
 		if exists {
 			return nil, h.cleanup(upgrade, harvesterv1.UpgradeCompleted.IsTrue(upgrade))
+		}
+
+		// repo VM is required for the image cleaning procedure, bring it up if it's down
+		logrus.Info("Try to start repo VM for image pruning")
+		if err := repo.startVM(); err != nil {
+			return upgrade, err
 		}
 
 		if err := h.cleanupImages(upgrade, repo); err != nil {

--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -538,7 +538,7 @@ func (r *Repo) getImagesDiffList() ([]string, error) {
 	}
 
 	diffList := difference(previousImageList, currentImageList)
-	logrus.Debugf("Diff: %v", diffList)
+	logrus.Infof("Diff: %v", diffList)
 
 	return diffList, nil
 }

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"syscall"
@@ -37,6 +38,8 @@ func NewStillExists(qualifiedResource schema.GroupResource, name string) *apierr
 }
 
 func IsRetriableNetworkError(err error) bool {
+	var dnsError *net.DNSError
+
 	if os.IsTimeout(err) {
 		return true
 	} else if errors.Is(err, syscall.ENETDOWN) {
@@ -50,6 +53,8 @@ func IsRetriableNetworkError(err error) bool {
 	} else if errors.Is(err, syscall.ECONNREFUSED) {
 		return true
 	} else if errors.Is(err, syscall.EHOSTUNREACH) {
+		return true
+	} else if errors.As(err, &dnsError) && dnsError.IsTemporary {
 		return true
 	}
 	return false


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

As each upgrade progresses, the container image occupies more and more disk space, and occasionally the image garbage collection mechanism may mistakenly delete container images that should be retained.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

After upgrade was completed successfully and before tearing down the repo VM, create a image cleanup Plan to purge the unneeded container images on each node. The to-be-removed image list is calculated from the image lists of the current version and previous version.

**Related Issue:**

#4425 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Please reference https://github.com/harvester/harvester/issues/4425#issuecomment-1900566020