### PR TITLE
fix(upgrade): skip residual vmis during pre-draining

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -132,7 +132,7 @@ get_running_vm_count()
 {
   local count
 
-  count=$(kubectl get vmi -A -l kubevirt.io/nodeName=$HARVESTER_UPGRADE_NODE_NAME -ojson | jq '.items | length' || true)
+  count=$(kubectl get vmi -A -l kubevirt.io/nodeName=$HARVESTER_UPGRADE_NODE_NAME -o yaml | yq e '.items[] | [select(.status.phase!="Succeeded")] | length' || true)
   echo $count
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Residual VMIs, i.e., VMIs with phase equals "Succeeded" and their corresponding launcher Pods in a "Completed" state, will cause the waiting of live migrating VMs much longer.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Skip the VMIs with the phase in "Succeeded" when counting the number of running VMs.

**Related Issue:**

#4725

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster in version 1.2.1
2. Create a VM and shut it down from within the OS (do not shut down the VM via dashboard)
![SCR-20240122-ithh](https://github.com/harvester/harvester/assets/1827717/539435ee-1134-4a20-bb50-518b0b5f24bb)
3. Upgrade the cluster with the master build or custom-built ISO image containing the fix
4. The stopped VM should not not stall the upgrade