### PR TITLE
Upgrade rancher-monitoring and rancher-logging addons

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1188,28 +1188,18 @@ EOF
 upgrade_addon_rancher_monitoring()
 {
   echo "upgrade addon rancher_monitoring"
-  if [[ $(is_formal_release $UPGRADE_PREVIOUS_VERSION) = "true" ]]; then
-    if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
-      echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
-    fi
-  else
-    # the addon may be existing in v1.2.0 master-head release and the chart version is bumped, then the addon is upgraded to new version
-    upgrade_addon_try_patch_version_only "rancher-monitoring" "cattle-monitoring-system" $REPO_MONITORING_CHART_VERSION
-  fi
+  # .spec.valuesContent has dynamic fields, cannot merge simply, review in each release
+  # in v1.3.0, patch version is OK
+  upgrade_addon_try_patch_version_only "rancher-monitoring" "cattle-monitoring-system" $REPO_MONITORING_CHART_VERSION
 }
 
 # NOTE: review in each release, add corresponding process
 upgrade_addon_rancher_logging()
 {
   echo "upgrade addon rancher_logging"
-  if [[ $(is_formal_release $UPGRADE_PREVIOUS_VERSION) = "true" ]]; then
-    if [[ "$UPGRADE_PREVIOUS_VERSION" = "v1.2.0" ]] || [[ "$UPGRADE_PREVIOUS_VERSION" > "v1.2.0" ]]; then
-      echo ".spec.valuesContent has dynamic fields, cannot merge simply, review in each release"
-    fi
-  else
-    # the addon may be existing in v1.2.0 master-head release and the chart version is bumped, then the addon is upgraded to new version
-    upgrade_addon_try_patch_version_only "rancher-logging" "cattle-logging-system" $REPO_LOGGING_CHART_VERSION
-  fi
+  # .spec.valuesContent has dynamic fields, cannot merge simply, review in each release
+  # in v1.3.0, patch version is OK
+  upgrade_addon_try_patch_version_only "rancher-logging" "cattle-logging-system" $REPO_LOGGING_CHART_VERSION
 }
 
 upgrade_addons()


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Rancher-monitoring and rancher-logging charts are bumped in v1.3.0, the related addons are not processed in upgrade path

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add related processing in upgrade path.

**Related Issue:**
https://github.com/harvester/harvester/issues/5003

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install v1.2.1 cluster
2. Upgrade to v1.3.0