### PR TITLE
feat(rbac): add guestosinfo to harvesterhci.io:cloudprovider

### DIFF
--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -131,6 +131,7 @@ rules:
       - virtualmachines/removevolume
       - virtualmachineinstances/addvolume
       - virtualmachineinstances/removevolume
+      - virtualmachineinstances/guestosinfo
     verbs:
       - get
       - update


### PR DESCRIPTION
**Solution:**
Add getting virtualmachineinstances guestosinfo permission to `harvesterhci.io:cloudprovider`.

**Related Issue:**
https://github.com/harvester/harvester/issues/4947

**Test plan:**
Check https://github.com/harvester/cloud-provider-harvester/pull/38.
