### PR TITLE
chore: fix node-manager pullPolicy and add webhook image in chart values

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -488,9 +488,14 @@ whereabouts:
 
 harvester-node-manager:
   image:
-    imagePullPolicy: IfNotPresent
+    pullPolicy: IfNotPresent
     repository: rancher/harvester-node-manager
     tag: master-head
+  webhook:
+    image:
+      pullPolicy: IfNotPresent
+      repository: rancher/harvester-node-manager-webhook
+      tag: master-head
 
 snapshot-validation-webhook:
   enabled: true


### PR DESCRIPTION
- Fix pullPolicy: The field should be `pullPolicy` according to https://github.com/harvester/charts/blob/master/charts/harvester-node-manager/values.yaml
- Add webhook image to values.
