### PR TITLE
webhook: validate owned-by annotation on create, update, delete

### DIFF
--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -44,10 +44,20 @@ func (v *pvcValidator) Resource() types.Resource {
 		APIVersion: corev1.SchemeGroupVersion.Version,
 		ObjectType: &corev1.PersistentVolumeClaim{},
 		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
 			admissionregv1.Delete,
 			admissionregv1.Update,
 		},
 	}
+}
+
+func (v *pvcValidator) Create(_ *types.Request, obj runtime.Object) error {
+	pvc := obj.(*corev1.PersistentVolumeClaim)
+	if _, err := ref.GetSchemaOwnersFromAnnotation(pvc); err != nil {
+		return fmt.Errorf("failed to get schema owners from annotation: %v", err)
+
+	}
+	return nil
 }
 
 func (v *pvcValidator) Delete(request *types.Request, oldObj runtime.Object) error {
@@ -108,6 +118,10 @@ func (v *pvcValidator) Delete(request *types.Request, oldObj runtime.Object) err
 func (v *pvcValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldPVC := oldObj.(*corev1.PersistentVolumeClaim)
 	newPVC := newObj.(*corev1.PersistentVolumeClaim)
+
+	if _, err := ref.GetSchemaOwnersFromAnnotation(newPVC); err != nil {
+		return fmt.Errorf("failed to get schema owners from annotation: %v", err)
+	}
 
 	newQuantity := newPVC.Spec.Resources.Requests.Storage()
 	oldQuantity := oldPVC.Spec.Resources.Requests.Storage()


### PR DESCRIPTION
This annotation is already validated on the PVC current object in the Delete handler, but to be more consistent, also check the new object in the Update and Create handlers.
