### PR TITLE
CI: fix chart length detection and publish artifacts on release branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,6 +58,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -104,6 +105,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -150,6 +152,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -247,6 +250,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -293,6 +297,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -339,6 +344,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -401,6 +407,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -441,6 +448,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -481,6 +489,7 @@ steps:
       ref:
         include:
           - "refs/heads/master"
+          - "refs/heads/release**"
           - "refs/heads/v*"
       event:
         - push
@@ -614,7 +623,7 @@ steps:
         - drone-publish.rancher.io
       ref:
         - refs/heads/master
-        - refs/heads/release-*
+        - refs/heads/release**
         - refs/heads/v*
       event:
         - push
@@ -635,7 +644,7 @@ steps:
         - drone-publish.rancher.io
       ref:
         - refs/heads/master
-        - refs/heads/release-*
+        - refs/heads/release**
         - refs/heads/v*
       event:
         - push
@@ -685,6 +694,7 @@ trigger:
     - push
   ref:
     - "refs/heads/master"
+    - "refs/heads/release**"
     - "refs/heads/v*"
     - "refs/tags/*"
 

--- a/scripts/version
+++ b/scripts/version
@@ -41,7 +41,7 @@ CHART_VERSION="$(echo ${CHART_VERSION} | sed -E 's/^v//')"
 # The length of metadata.label is no more than 63 characters.
 # We limit the CHART_VERSION less than or equal to 50 characters and it would be safe.
 CHART_VERSION_LEN=${#CHART_VERSION}
-if [[ $CHART_VERSION_LEN > 50 ]]; then
+if [ "$CHART_VERSION_LEN" -gt "50" ]; then
     echo "Please reduce the length of CHART_VERSION, it should less than or equal to 50 characters."
     echo "Current CHART_VERSION(${CHART_VERSION_LEN}): ${CHART_VERSION}"
     exit 1


### PR DESCRIPTION
A "forward port" from the [`release-1.3`](https://github.com/harvester/harvester/commits/release-1.3/) branch:
- Fix the length comparison on the chart name.
- Allow publishing images and ISO on `release**` branches:
  - Currently, we are doing a release on `release-<version>` branch. I extend the syntax to support `release/<version>` in the future too.