### PR TITLE
Renaming the download image file with appropriate suffix

### DIFF
--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -106,7 +106,7 @@ func (h Handler) downloadImage(rw http.ResponseWriter, req *http.Request) error 
 		return fmt.Errorf("failed to get backing image name for VMImage %s/%s, error: %w", namespace, name, err)
 	}
 
-	targetFileName := vmImage.Spec.DisplayName
+	targetFileName := fmt.Sprintf("%s.gz", vmImage.Spec.DisplayName)
 	downloadURL := fmt.Sprintf("%s/backingimages/%s/download", util.LonghornDefaultManagerURL, biName)
 	downloadReq, err := http.NewRequestWithContext(req.Context(), http.MethodGet, downloadURL, nil)
 	if err != nil {


### PR DESCRIPTION
**Problem:**
Described in https://github.com/harvester/harvester/issues/5044#issue-2105104769

**Solution:**
Renaming the download image file with the appropriate suffix

**Related Issue:**
#5044 

**Test plan:**
- Creating a virtual machine image that is uploaded from local
- Downloading the image just uploaded
  -  The downloaded image should be named with `.gz` suffix by default
- Decompress the downloaded image with `$ gzip -d <image name>`
- Creating another virtual image by uploading the newly downloaded image
- The image should be uploaded successfully
