### PR TITLE
controller/promote: refine the promote mechanism with witness nodes

### DIFF
--- a/enhancements/20231113-witness-node-support.md
+++ b/enhancements/20231113-witness-node-support.md
@@ -58,7 +58,7 @@ We need to document the following limitations and requirements for the witness n
 
 - The replica number of the default StorageClass is `3`, but in the two master nodes + one witness node scenario, the replica number should be `2`. Users could manually create a new StorageClass and set it as default or use the installation configuration to change the replica number of the default StorageClass [link](https://docs.harvesterhci.io/v1.2/install/harvester-configuration#installharvesterstorage_classreplica_count).
 
-- Only allow one witness node in the cluster.
+- Only allow one witness node in the cluster. If we have more than one witness node, promote controller will not count the other witness nodes into the management node number.
 
 #### Requirements
 

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -113,7 +113,10 @@ var (
 	m2 = NewDefaultNodeBuilder().Name("m-2").Harvester().Management()
 	m3 = NewDefaultNodeBuilder().Name("m-3").Harvester().Management()
 
-	e1 = NewDefaultNodeBuilder().Name("e-1").Harvester().Witness()
+	witnc1 = NewDefaultNodeBuilder().Name("witness-c-1").Harvester().Complete().RoleWitness().Witness()
+	witnr1 = NewDefaultNodeBuilder().Name("witness-r-1").Harvester().Running().Witness()
+	witnf1 = NewDefaultNodeBuilder().Name("witness-f-1").Harvester().Failed().Witness()
+	witnu1 = NewDefaultNodeBuilder().Name("witness-u-1").Harvester().Unknown().Witness()
 
 	mc1 = NewDefaultNodeBuilder().Name("m-complete-1").Harvester().Complete().Management()
 
@@ -134,6 +137,7 @@ var (
 	w1rm  = NewDefaultNodeBuilder().Name("w-1-r-mgmt").Harvester().RoleMgmt().Worker()
 	w1rwk = NewDefaultNodeBuilder().Name("w-1-r-worker").Harvester().RoleWorker().Worker()
 	w1rw  = NewDefaultNodeBuilder().Name("w-1-r-witness").Harvester().RoleWitness().Worker()
+	w2rw  = NewDefaultNodeBuilder().Name("w-2-r-witness").Harvester().RoleWitness().Worker()
 
 	// zone aware nodes
 	mu1z2 = NewDefaultNodeBuilder().Name("m-unmanaged-1-z2").Zone("zone2").Management()
@@ -659,7 +663,49 @@ func Test_selectPromoteNode(t *testing.T) {
 		{
 			name: "two management one witness",
 			args: args{
-				nodeList: []*corev1.Node{m1, m2, e1},
+				nodeList: []*corev1.Node{m1, m2, witnc1},
+			},
+			want: nil,
+		},
+		{
+			name: "one management two witness",
+			args: args{
+				nodeList: []*corev1.Node{m1, w1rw, w2rw},
+			},
+			want: nil,
+		},
+		{
+			name: "one management one witness one worker",
+			args: args{
+				nodeList: []*corev1.Node{m1, w1rw, w2rw, w3},
+			},
+			want: w1rw,
+		},
+		{
+			name: "one management one witness promoted one witness one worker",
+			args: args{
+				nodeList: []*corev1.Node{m1, witnc1, w2rw, w3},
+			},
+			want: w3,
+		},
+		{
+			name: "one management one running witness one witness one worker",
+			args: args{
+				nodeList: []*corev1.Node{m1, witnr1, w2rw, w3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management one failed witness one witness one worker",
+			args: args{
+				nodeList: []*corev1.Node{m1, witnf1, w2rw, w3},
+			},
+			want: nil,
+		},
+		{
+			name: "one management one unknown witness one witness one worker",
+			args: args{
+				nodeList: []*corev1.Node{m1, witnu1, w2rw, w3},
 			},
 			want: nil,
 		},


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We only support one witness node in the cluster.
If we have more than one witness node, other witness nodes will not be calculated into the management node number.

**Solution:**
Update the promotion mechanism.

**Related Issue:**
https://github.com/harvester/harvester/issues/5070
https://github.com/harvester/harvester/issues/3266

**Test plan:**
1. Create 3 nodes cluster
2. 1st node as default, 2nd and 3rd node select the witness role.
3. Should not promote 2nd/3rd nodes, which means we only have one management node
The should should be 1 management node (1st node) and 2 worker node (2nd and 3rd nodes)
