### PR TITLE
fix: avoid apply-manifest job complete another upgrade

### DIFF
--- a/pkg/controller/master/upgrade/job_controller_test.go
+++ b/pkg/controller/master/upgrade/job_controller_test.go
@@ -115,6 +115,26 @@ func TestJobHandler_OnChanged(t *testing.T) {
 				err:     nil,
 			},
 		},
+		{
+			name: "a previous upgrading manifest job should not complete upgrade",
+			given: input{
+				key: testJobName,
+				job: newJobBuilder(testJobName).
+					WithLabel(harvesterUpgradeLabel, "test-upgrade-old").
+					WithLabel(harvesterUpgradeComponentLabel, manifestComponent).
+					Completed().Build(),
+				plan:    newTestPlanBuilder().Build(),
+				upgrade: newTestUpgradeBuilder().WithLabel(harvesterLatestUpgradeLabel, "true").ChartUpgradeStatus(v1.ConditionUnknown, "", "").Build(),
+			},
+			expected: output{
+				job: newJobBuilder(testJobName).
+					WithLabel(harvesterUpgradeLabel, "test-upgrade-old").
+					WithLabel(harvesterUpgradeComponentLabel, manifestComponent).
+					Completed().Build(),
+				upgrade: newTestUpgradeBuilder().WithLabel(harvesterLatestUpgradeLabel, "true").ChartUpgradeStatus(v1.ConditionUnknown, "", "").Build(),
+				err:     nil,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		var clientset = fake.NewSimpleClientset(tc.given.plan, tc.given.upgrade)

--- a/pkg/controller/master/upgrade/pod_controller.go
+++ b/pkg/controller/master/upgrade/pod_controller.go
@@ -1,12 +1,8 @@
 package upgrade
 
 import (
-	"reflect"
-
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
-	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	upgradev1 "github.com/harvester/harvester/pkg/generated/controllers/upgrade.cattle.io/v1"
 )
@@ -43,67 +39,6 @@ func (h *podHandler) OnChanged(_ string, pod *v1.Pod) (*v1.Pod, error) {
 				_, err = h.upgradeClient.Update(toUpdate)
 				return pod, err
 			}
-		}
-	}
-
-	return pod, nil
-}
-
-func (h *podHandler) syncHelmChartPod(pod *v1.Pod) (*v1.Pod, error) {
-	if pod.Status.Phase == v1.PodSucceeded {
-		return pod, nil
-	}
-
-	sets := labels.Set{
-		harvesterLatestUpgradeLabel: "true",
-	}
-	onGoingUpgrades, err := h.upgradeCache.List(h.namespace, sets.AsSelector())
-	if err != nil {
-		return pod, err
-	}
-	if len(onGoingUpgrades) == 0 {
-		return pod, nil
-	}
-	upgrade := onGoingUpgrades[0]
-	if !harvesterv1.SystemServicesUpgraded.IsUnknown(upgrade) {
-		return pod, nil
-	}
-	toUpdate := upgrade.DeepCopy()
-
-	reason, message := getPodWaitingStatus(pod)
-	setHelmChartUpgradeStatus(toUpdate, v1.ConditionUnknown, reason, message)
-
-	if !reflect.DeepEqual(upgrade, toUpdate) {
-		if _, err := h.upgradeClient.Update(toUpdate); err != nil {
-			return pod, err
-		}
-	}
-	return pod, nil
-}
-
-func (h *podHandler) syncNodeUpgradePod(pod *v1.Pod, planName string, nodeName string) (*v1.Pod, error) {
-	if pod.Status.Phase == v1.PodSucceeded {
-		return pod, nil
-	}
-	plan, err := h.planCache.Get(upgradeNamespace, planName)
-	if err != nil {
-		return pod, err
-	}
-	upgradeName, ok := plan.Labels[harvesterUpgradeLabel]
-	if !ok {
-		return pod, nil
-	}
-	upgrade, err := h.upgradeCache.Get(h.namespace, upgradeName)
-	if err != nil {
-		return pod, err
-	}
-	toUpdate := upgrade.DeepCopy()
-
-	reason, message := getPodWaitingStatus(pod)
-	setNodeUpgradeStatus(toUpdate, nodeName, StateUpgrading, reason, message)
-	if !reflect.DeepEqual(upgrade, toUpdate) {
-		if _, err := h.upgradeClient.Update(toUpdate); err != nil {
-			return pod, err
 		}
 	}
 

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -45,6 +45,7 @@ func newTestPlanBuilder() *planBuilder {
 
 func newTestChartJobBuilder() *jobBuilder {
 	return newJobBuilder(testJobName).
+		WithLabel(harvesterUpgradeLabel, testUpgradeName).
 		WithLabel(harvesterUpgradeComponentLabel, manifestComponent)
 }
 


### PR DESCRIPTION
Fix the problem that an apply-manifest job in a previous upgrade can set the SystemServicesUpgraded condition in another upgrade because we didn't check the relationship between the job and an upgrade.

**Related Issue:**

https://github.com/harvester/harvester/issues/5090

**Test plan:**
- Do Harvester upgrade. Wait until the upgrade succeeds.
- Do another upgrade immediately.
- When the second upgrade's apply_manifest job is running, its "Upgrade System Service" progress should not be completed.