### PR TITLE
patch local cluster during upgrade path to support v2.8.1

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1241,6 +1241,14 @@ sync_containerd_registry_to_rancher() {
   kubectl annotate --overwrite=true setting.harvesterhci.io containerd-registry "harvesterhci.io/upgrade-patched=$REPO_HARVESTER_VERSION"
 }
 
+# rancher v2.8.1 introduced a new field fleetWorkspaceName in the cluster.provisioning CRD.
+# for new installs this is already patched by rancherd during bootstrap of cluster however rancherd logic is not
+# re-run in the upgrade path as a result this needs to be handled out of band
+patch_local_cluster_details() {
+  kubectl label -n fleet-local cluster.provisioning local "provisioning.cattle.io/management-cluster-name=local"
+  kubectl patch -n fleet-local cluster.provisioning local --subresource=status --type=merge --patch '{"status":{"fleetWorkspaceName": "fleet-local"}}'
+}
+
 wait_repo
 detect_repo
 detect_upgrade
@@ -1249,6 +1257,7 @@ pre_upgrade_manifest
 pause_all_charts
 skip_restart_rancher_system_agent
 upgrade_rancher
+patch_local_cluster_details
 update_local_rke_state_secret
 upgrade_harvester_cluster_repo
 upgrade_network


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Post upgrade to v1.2-head and v1.3-head, rancher still complains about `fleetWorkspaceName` not being setup.

For new installs this is already being setup by rancherd during the initialisation phase.

Currently the upgrade still completes successfully as the old fleet agent completes the updates to the bundles.

The fleet agent itself does not get updated as a result, and this is likely to cause issues in future upgrades.

This is visible as seen here: https://github.com/harvester/harvester-installer/pull/646#issuecomment-1925792176

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
An extra step is available in the upgrade_manifests step which will perform the same annotation and status subresource updates as rancherd.


**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
