### PR TITLE
minor change for patch_local_cluster_details

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1245,7 +1245,7 @@ sync_containerd_registry_to_rancher() {
 # for new installs this is already patched by rancherd during bootstrap of cluster however rancherd logic is not
 # re-run in the upgrade path as a result this needs to be handled out of band
 patch_local_cluster_details() {
-  kubectl label -n fleet-local cluster.provisioning local "provisioning.cattle.io/management-cluster-name=local"
+  kubectl label -n fleet-local cluster.provisioning local "provisioning.cattle.io/management-cluster-name=local" --overwrite=true
   kubectl patch -n fleet-local cluster.provisioning local --subresource=status --type=merge --patch '{"status":{"fleetWorkspaceName": "fleet-local"}}'
 }
 


### PR DESCRIPTION
minor change to patch_local_cluster_details in upgrade path to overwrite labels if they exist.

this is needed to ensure update manifests does no error during upgrade from v1.2-head to v1.3-head

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
