### PR TITLE
update resource overcommit during GPU updates

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -173,6 +173,12 @@ func needUpdateResourceOvercommit(oldVM, newVM *kubevirtv1.VirtualMachine) bool 
 	if newReservedMemory != oldReservedMemory {
 		return true
 	}
+
+	// if host devices or GPUs are added or removed then resource update is needed
+	if len(newVM.Spec.Template.Spec.Domain.Devices.HostDevices) != len(oldVM.Spec.Template.Spec.Domain.Devices.HostDevices) || len(newVM.Spec.Template.Spec.Domain.Devices.GPUs) != len(oldVM.Spec.Template.Spec.Domain.Devices.GPUs) {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION


**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
for host devices and vGPU to work with kubevirt v1.1.1 the resource overcommit needs to be disabled.

There is already a change in v1.3.0-rc2 which performs this action when a VM is created with host device / GPU devices defined. 

However the check for VM updates when host devices or GPU's are added to existing VM's does not take into account that a resource overcommit change is needed. 

As a result of this VM's where GPU is added after a VM has been created can not boot.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The fix adds an extra check in the VM resource mutation to check if a memory patch is needed if host devices or GPUs are added.

**Related Issue:**
https://github.com/harvester/harvester/issues/5121
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
