### PR TITLE
[v1.3] Bump node-manager chart to v0.2.1

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -507,12 +507,12 @@ harvester-node-manager:
   image:
     pullPolicy: IfNotPresent
     repository: rancher/harvester-node-manager
-    tag: v0.2.0
+    tag: v0.2.1
   webhook:
     image:
       pullPolicy: IfNotPresent
       repository: rancher/harvester-node-manager-webhook
-      tag: v0.2.0
+      tag: v0.2.1
 
 snapshot-validation-webhook:
   enabled: true


### PR DESCRIPTION
Changes:

* 0e0dadd "Require CloudInit .spec.contents to be valid YAML"

**Related Issue:** https://github.com/harvester/harvester/issues/5119

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->


Deploy a build of the harvester-node-manager-webhook image from this PR to the Harvester cluster, then use this file to `kubectl create -f` and reboot, then expect:

1. The node comes back up
2. The node is Ready on the dashboard
3. The management URL is Ready on the dashboard
4. You can SSH in to the node
5. You can log in at the node's console
6. The last entry in the list below, `consolelogoverwrite` is rejected by the webhook for not being valid YAML

```
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: ssh-access
spec:
  matchSelector: {}
  filename: 99_ssh.yaml
  contents: |
    stages:
      network:
        - authorized_keys:
            rancher:
              - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBzZT+yXkr28BJzki4WdisefgyR1hKMXWlJCd9KfajEm michael.russell@suse.com
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: grubcustom
spec:
  matchSelector: {}
  filename: grubcustom
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: 99settings
spec:
  matchSelector: {}
  filename: 99_settings.yaml
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: 90custom
spec:
  matchSelector: {}
  filename: 90_custom.yaml
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: elemental.config
spec:
  matchSelector: {}
  filename: elemental.config
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: grubenv
spec:
  matchSelector: {}
  filename: grubenv
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: harvesterconfig
spec:
  matchSelector: {}
  filename: harvester.config
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: install
spec:
  matchSelector: {}
  filename: install
  contents: |
    hello: there
---
apiVersion: node.harvesterhci.io/v1beta1
kind: CloudInit
metadata:
  name: consolelogoverwrite
spec:
  matchSelector: {}
  filename: install/console.log
  contents: |
    hello  there
```
