### PR TITLE
controller/promote: fix multiple witness nodes promotion

### DIFF
--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -339,6 +339,10 @@ func selectPromoteNode(nodeList []*corev1.Node) *corev1.Node {
 			return nil
 		}
 	}
+	// make sure the witness preferred is empty if witness node has been promoted
+	if witnessPromoted {
+		witnessPreferred = nil
+	}
 
 	// return if there are no enough zones
 	hasZones := len(managementZones) > 0

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -689,6 +689,13 @@ func Test_selectPromoteNode(t *testing.T) {
 			want: w3,
 		},
 		{
+			name: "one management one witness one promoted witness one worker order testing",
+			args: args{
+				nodeList: []*corev1.Node{m1, w2rw, witnc1, w3},
+			},
+			want: w3,
+		},
+		{
 			name: "one management one running witness one witness one worker",
 			args: args{
 				nodeList: []*corev1.Node{m1, witnr1, w2rw, w3},


### PR DESCRIPTION
 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
When we delete the management node, sometimes the witness node will be promoted again even if we already have one in the cluster.

**Solution:**
Ensure the promote controller do not promote another witness node if we already have one.

**Related Issue:**
https://github.com/harvester/harvester/issues/5163

**Test plan:**
See the steps from https://github.com/harvester/harvester/issues/5163