### PR TITLE
Add processing of fluentbit image in logging upgrade

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -425,7 +425,7 @@ upgrade_addon_try_patch_version_only()
   local name=$1
   local namespace=$2
   local newversion=$3
-  echo "try to patch addon $name in $namespace $newversion"
+  echo "try to patch addon $name in $namespace to $newversion"
 
   # check if addon is there
   local version=$(kubectl get addons.harvesterhci.io $name -n $namespace -o=jsonpath='{.spec.version}' || true)
@@ -460,6 +460,16 @@ EOF
   rm -f ./$patchfile
 
   # wait status only when enabled and already AddonDeploySuccessful
+  wait_for_addon_upgrade_deployment $name $namespace $enabled $curstatus
+}
+
+wait_for_addon_upgrade_deployment() {
+  local name=$1
+  local namespace=$2
+  local enabled=$3
+  local curstatus=$4
+
+  # wait status only when enabled and already AddonDeploySuccessful
   if [[ $enabled = "true" ]]; then
     if [[ "$curstatus" = "AddonDeploySuccessful" ]]; then
       echo "wait addon status to be AddonDeploySuccessful"
@@ -490,3 +500,70 @@ EOF
   fi
 }
 
+# upgrade rancher-logging with the patch of fluentbit image
+upgrade_addon_rancher_logging_with_patch_fluentbit_image()
+{
+  local name=rancher-logging
+  local namespace=cattle-logging-system
+  local newversion=$1
+  echo "try to patch addon $name in $namespace to $newversion, with patch of fluentbit image"
+
+  # check if addon is there
+  local version=$(kubectl get addons.harvesterhci.io $name -n $namespace -o=jsonpath='{.spec.version}' || true)
+  if [[ -z "$version" ]]; then
+    echo "addon is not found, nothing to do"
+    return 0
+  fi
+
+  local valuesfile="logging-values-temp.yaml"
+  rm -f $valuesfile
+  kubectl get addons.harvesterhci.io $name -n $namespace -ojsonpath="{.spec.valuesContent}" > $valuesfile
+
+  local EXIT_CODE=0
+  # yq shows `Error: no matches found` if it is not existing and returns 1
+  echo "check fluentbit image tag 1.9.5"
+  yq -e '(.images | select(.fluentbit.tag == "1.9.5"))' $valuesfile || EXIT_CODE=$?
+
+  if [ $EXIT_CODE != 0 ]; then
+    # fluentbit image is not 1.9.5
+    echo "fluentbit image is not 1.9.5, fallback to the normal addon $name upgrade"
+    rm -f $valuesfile
+    upgrade_addon_try_patch_version_only $name $namespace $newversion
+    return 0
+  fi
+
+  echo "current valuesContent of the addon $name:"
+  cat $valuesfile
+  # remove fluentbit related images tags
+  yq -e 'del(.images.fluentbit*)' -i $valuesfile
+  # add 4 spaces to each line
+  sed -i -e 's/^/    /' $valuesfile
+  local newvalues=$(<$valuesfile)
+  rm -f $valuesfile
+
+  local patchfile="addon-patch-temp.yaml"
+  rm -f $patchfile
+
+cat > $patchfile <<EOF
+spec:
+  version: $newversion
+  valuesContent: |
+$newvalues
+EOF
+
+  local enabled=""
+  local curstatus=""
+  enabled=$(kubectl get addons.harvesterhci.io $name -n $namespace -o=jsonpath='{.spec.enabled}' || true)
+  if [[ $enabled = "true" ]]; then
+    curstatus=$(kubectl get addons.harvesterhci.io $name -n $namespace -o=jsonpath='{.status.status}' || true)
+  fi
+
+  echo "new patch of addon $name:"
+  cat $patchfile
+
+  kubectl patch addons.harvesterhci.io $name -n $namespace --patch-file ./$patchfile --type merge
+  rm -f ./$patchfile
+
+  # wait status only when enabled and already AddonDeploySuccessful
+  wait_for_addon_upgrade_deployment $name $namespace $enabled $curstatus
+}

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1205,8 +1205,12 @@ upgrade_addon_rancher_logging()
 {
   echo "upgrade addon rancher_logging"
   # .spec.valuesContent has dynamic fields, cannot merge simply, review in each release
-  # in v1.3.0, patch version is OK
-  upgrade_addon_try_patch_version_only "rancher-logging" "cattle-logging-system" $REPO_LOGGING_CHART_VERSION
+  # in v1.3.0, the fluentbit image needs to be patched
+  if [ "$REPO_LOGGING_CHART_VERSION" = "103.0.0+up3.17.10" ]; then
+    upgrade_addon_rancher_logging_with_patch_fluentbit_image $REPO_LOGGING_CHART_VERSION
+  else
+    upgrade_addon_try_patch_version_only "rancher-logging" "cattle-logging-system" $REPO_LOGGING_CHART_VERSION
+  fi
 }
 
 upgrade_addons()


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

After PR https://github.com/harvester/harvester-installer/pull/658, the fluentbit image is v2.2.0, but in old version of Harvester, it is v1.9.5 and was recorded in addon CRD object.

We need to add related process in upgrade path, remove the fluentbit image setting from CRD object, then it will use the default image tag (v2.2.0) from  the rancher-logging new chart "103.0.0+up3.17.10". (Specially patched by Harvester)

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

In rancher-logging addon upgrade, amend the `fluentbit` image tag from rancher-logging addon.

**Related Issue:**
https://github.com/harvester/security/issues/44

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Prepare a Harvester v1.2.1 cluster
2. Enable rancher-logging
3. Upgrade to v130
4. Check rancher-logging addon is deployed successful
5. Check the POD image tag like:
```
$kubectl get pods -n $cattle-logging-system rancher-logging-root-fluentbit-gh2xn -oyaml | grep image -2

  containers:
  - image: rancher/mirrored-fluent-fluent-bit:2.2.0  // new image in new chart
    imagePullPolicy: IfNotPresent
    name: fluent-bit
    resources:
```

In upgrade logs it has:
Normal upgrade log:
```
...
try to patch addon rancher-logging in cattle-logging-system 103.0.0+up3.17.10, with path of fluentbit image
check fluentbit image tag 1.9.5
fluentbit:
  tag: 1.9.5 # replace the default 1.9.3, which has bug in systemd log
fluentbit_debug:
  tag: 1.9.5-debug
current valuesContent of the rancher-logging
images:
  fluentbit:
    tag: 1.9.5 # replace the default 1.9.3, which has bug in systemd log
  fluentbit_debug:
    tag: 1.9.5-debug
...
```

or:
Re-upgrade; or upgrade from v130 -> v130, when `v1.9.5` image tag is not found:
```

try to patch addon rancher-logging in cattle-logging-system to 103.0.0+up3.17.10, with patch of fluentbit image
check fluentbit image tag 1.9.5
Error: no matches found
fluentbit image is not 1.9.5, fallback to original rancher-logging addon upgrade
try to patch addon rancher-logging in cattle-logging-system to 103.0.0+up3.17.10
addon has already been 103.0.0+up3.17.10, nothing to do
...
```

The addon upgrade wait is changed from infinite loop to max 300 seconds.
```
addon.harvesterhci.io/rancher-logging patched
Tue Feb 20 15:00:42 UTC 2024
wait addon status to be AddonDeploySuccessful
current status is AddonUpdating, continue wait: 1
Tue Feb 20 15:00:53 UTC 2024
addon status is AddonDeploySuccessful
```