### PR TITLE
feat: add cluster.x-k8s.io/control-plane label

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -106,6 +106,7 @@ data:
 
     # For how to promote nodes, see: https://github.com/rancher/rancher/issues/36480#issuecomment-1039253499
     $KUBECTL label --overwrite -n fleet-local machines.cluster.x-k8s.io $CUSTOM_MACHINE $ROLE_LABELS
+    $KUBECTL label --overwrite -n fleet-local machines.cluster.x-k8s.io $CUSTOM_MACHINE cluster.x-k8s.io/control-plane=true
     $KUBECTL label --overwrite -n fleet-local secret $PLAN_SECRET $ROLE_LABELS
     $KUBECTL label --overwrite -n fleet-local rkebootstraps.rke.cattle.io $CUSTOM_MACHINE $ROLE_LABELS
 

--- a/pkg/apis/harvesterhci.io/v1beta1/doc.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/doc.go
@@ -18,5 +18,4 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=harvesterhci.io
-// +k8s:openapi-gen=true
 package v1beta1

--- a/pkg/controller/master/machine/machine_control_plane_controller.go
+++ b/pkg/controller/master/machine/machine_control_plane_controller.go
@@ -1,0 +1,49 @@
+package machine
+
+import (
+	"context"
+
+	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/harvester/harvester/pkg/config"
+	ctlclusterv1 "github.com/harvester/harvester/pkg/generated/controllers/cluster.x-k8s.io/v1alpha4"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	machineControlPlaneControllerName = "machine-control-plane-controller"
+)
+
+// machineControlPlaneHandler add cluster.x-k8s.io/control-plane to machine
+// if rke.cattle.io/control-plane-role label is true
+type machineControlPlaneHandler struct {
+	machineClient ctlclusterv1.MachineClient
+}
+
+// machineControlPlaneHandler registers a controller to sync labels
+func ControlPlaneRegister(ctx context.Context, management *config.Management, _ config.Options) error {
+	machines := management.ClusterFactory.Cluster().V1alpha4().Machine()
+	handler := &machineControlPlaneHandler{
+		machineClient: machines,
+	}
+
+	machines.OnChange(ctx, machineControlPlaneControllerName, handler.OnMachineChanged)
+
+	return nil
+}
+
+func (h *machineControlPlaneHandler) OnMachineChanged(_ string, machine *clusterv1alpha4.Machine) (*clusterv1alpha4.Machine, error) {
+	if machine == nil || machine.DeletionTimestamp != nil || machine.Labels == nil {
+		return machine, nil
+	}
+
+	if v1, ok := machine.Labels[util.RKEControlPlaneRoleLabel]; ok && v1 == "true" {
+		if v2, ok := machine.Labels[clusterv1beta1.MachineControlPlaneLabel]; !ok || v2 != "true" {
+			machineCopy := machine.DeepCopy()
+			machineCopy.Labels[clusterv1beta1.MachineControlPlaneLabel] = "true"
+			return h.machineClient.Update(machineCopy)
+		}
+	}
+	return nil, nil
+}

--- a/pkg/controller/master/node/node_remove_controller.go
+++ b/pkg/controller/master/node/node_remove_controller.go
@@ -1,0 +1,68 @@
+package node
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+
+	"github.com/harvester/harvester/pkg/config"
+	ctlclusterv1 "github.com/harvester/harvester/pkg/generated/controllers/cluster.x-k8s.io/v1alpha4"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	nodeRemoveControllerName = "node-remove-controller"
+)
+
+// nodeRemoveHandler force remove machine
+type nodeRemoveHandler struct {
+	machineClient ctlclusterv1.MachineClient
+}
+
+// RemoveRegister registers a controller to remove machine when node is removed
+func RemoveRegister(ctx context.Context, management *config.Management, _ config.Options) error {
+	nodes := management.CoreFactory.Core().V1().Node()
+	machineClient := management.ClusterFactory.Cluster().V1alpha4().Machine()
+	handler := &nodeRemoveHandler{
+		machineClient: machineClient,
+	}
+
+	nodes.OnRemove(ctx, nodeRemoveControllerName, handler.OnNodeRemoved)
+
+	return nil
+}
+
+func (h *nodeRemoveHandler) OnNodeRemoved(_ string, node *corev1.Node) (*corev1.Node, error) {
+	if node == nil || node.DeletionTimestamp == nil || node.Annotations == nil || node.Annotations[clusterv1.MachineAnnotation] == "" {
+		return node, nil
+	}
+
+	_, err := h.machineClient.Get(util.FleetLocalNamespaceName, node.Annotations[clusterv1.MachineAnnotation], metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"node":    node.Name,
+			"machine": node.Annotations[clusterv1.MachineAnnotation],
+		}).Error("Can't get machine")
+		return nil, err
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"node":    node.Name,
+		"machine": node.Annotations[clusterv1.MachineAnnotation],
+	}).Info("Attempting to delete machine")
+	if err := h.machineClient.Delete(util.FleetLocalNamespaceName, node.Annotations[clusterv1.MachineAnnotation], &metav1.DeleteOptions{}); err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"node":    node.Name,
+			"machine": node.Annotations[clusterv1.MachineAnnotation],
+		}).Error("failed to delete machine")
+		return nil, err
+	}
+	return nil, nil
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/backup"
 	"github.com/harvester/harvester/pkg/controller/master/image"
 	"github.com/harvester/harvester/pkg/controller/master/keypair"
+	"github.com/harvester/harvester/pkg/controller/master/machine"
 	"github.com/harvester/harvester/pkg/controller/master/mcmsettings"
 	"github.com/harvester/harvester/pkg/controller/master/migration"
 	"github.com/harvester/harvester/pkg/controller/master/node"
@@ -34,7 +35,9 @@ var registerFuncs = []registerFunc{
 	node.PromoteRegister,
 	node.MaintainRegister,
 	node.DownRegister,
+	node.RemoveRegister,
 	node.VolumeDetachRegister,
+	machine.ControlPlaneRegister,
 	setting.Register,
 	template.Register,
 	virtualmachine.Register,

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -101,4 +101,6 @@ const (
 	RancherInternalServerURLSetting          = "internal-server-url"
 	APIServerURLKey                          = "apiServerURL"
 	APIServerCAKey                           = "apiServerCA"
+
+	RKEControlPlaneRoleLabel = "rke.cattle.io/control-plane-role"
 )


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
A new node can't be promoted to control plane if the first node is removed.

**Solution:**
1. Add `cluster.x-k8s.io/control-plane` label to all control plane nodes, so CAPI doesn't fail in [reconcileDelete](https://github.com/kubernetes-sigs/cluster-api/blob/00dbf7b9f6322d7ebd06ae2efa703b23354dd37d/internal/controllers/machine/machine_controller.go#L306-L453) function.
2. Remove machine when users remove node, so Rancher doesn't use the first node as joining URL.

* https://github.com/rancher/rancher/blob/e8447834f3f5840c0a4dc0c7b9bd85787a082790/pkg/capr/planner/config.go#L120
* https://github.com/rancher/rancher/blob/e8447834f3f5840c0a4dc0c7b9bd85787a082790/pkg/capr/planner/planner.go#L899

**Related Issue:**
https://github.com/harvester/harvester/issues/5158

**Test plan:**

Case 1: Make sure all control plane nodes has `cluster.x-k8s.io/control-plane: "true"` label
1. Create a 3-node harvester cluster.
2. Run following command and it should output 3 nodes.
```
kubectl get machine -n fleet-local -l cluster.x-k8s.io/control-plane=true
```

Case 2: Remove the first node and a new node can be promoted to control plane
1. Create a 4-node harvester cluster.
2. After all nodes are ready, make the first node into maintenance mode.
3. After the first node is in maintenance mode, remove the first node.
4. Check a new node can be promoted to control plane.
5. Check the first node related machine is removed.