### PR TITLE
feat(upgrade): support skipping upgrade eligibility check

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -122,6 +122,11 @@ detect_repo()
 
 check_version()
 {
+  if [ "$SKIP_VERSION_CHECK" = "true" ]; then
+    echo "Skip minimum upgradable version check."
+    return
+  fi
+
   local current_version="${UPGRADE_PREVIOUS_VERSION#v}"
   local min_upgradable_version="${REPO_HARVESTER_MIN_UPGRADABLE_VERSION#v}"
 
@@ -243,6 +248,7 @@ detect_upgrade()
   upgrade_obj=$(kubectl get upgrades.harvesterhci.io $HARVESTER_UPGRADE_NAME -n $UPGRADE_NAMESPACE -o yaml)
 
   UPGRADE_PREVIOUS_VERSION=$(echo "$upgrade_obj" | yq e .status.previousVersion -)
+  SKIP_VERSION_CHECK=$(echo "$upgrade_obj" | yq e '.metadata.annotations."harvesterhci.io/skip-version-check"' -)
 }
 
 # refer https://github.com/harvester/harvester/issues/3098

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1259,7 +1259,6 @@ patch_local_cluster_details() {
 wait_repo
 detect_repo
 detect_upgrade
-check_version
 pre_upgrade_manifest
 pause_all_charts
 skip_restart_rancher_system_agent

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -64,6 +64,7 @@ const (
 	extendedReplicaReplenishmentWaitInterval = 1800
 
 	imageCleanupPlanCompletedAnnotation = "harvesterhci.io/image-cleanup-plan-completed"
+	skipVersionCheckAnnotation          = "harvesterhci.io/skip-version-check"
 )
 
 // upgradeHandler Creates Plan CRDs to trigger upgrades
@@ -263,9 +264,10 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 			return h.upgradeClient.Update(toUpdate)
 		}
 
-		logrus.Info("Check minimum upgradable version")
-		if err := isVersionUpgradable(toUpdate.Status.PreviousVersion, repoInfo.Release.MinUpgradableVersion); err != nil {
-			setUpgradeCompletedCondition(toUpdate, StateFailed, corev1.ConditionFalse, err.Error(), "")
+		isEligible, reason := upgradeEligibilityCheck(upgrade, repoInfo)
+
+		if !isEligible {
+			setUpgradeCompletedCondition(toUpdate, StateFailed, corev1.ConditionFalse, reason, "")
 			return h.upgradeClient.Update(toUpdate)
 		}
 
@@ -606,6 +608,24 @@ func isVersionUpgradable(currentVersion, minUpgradableVersion string) error {
 	}
 
 	return nil
+}
+
+func upgradeEligibilityCheck(upgrade *harvesterv1.Upgrade, repoInfo *RepoInfo) (bool, string) {
+	skipVersionCheckStr, ok := upgrade.Annotations[skipVersionCheckAnnotation]
+	if ok {
+		skipVersionCheck, err := strconv.ParseBool(skipVersionCheckStr)
+		if err == nil && skipVersionCheck {
+			logrus.Info("Skip minimum upgradable version check")
+			return true, ""
+		}
+	}
+
+	logrus.Info("Check minimum upgradable version")
+	if err := isVersionUpgradable(upgrade.Status.PreviousVersion, repoInfo.Release.MinUpgradableVersion); err != nil {
+		return false, err.Error()
+	}
+
+	return true, ""
 }
 
 func (h *upgradeHandler) getReplicaReplenishmentValue() (int, error) {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

When users install Harvester clusters with informal versions, e.g. `master`, `v1.3-head`, or any other custom-built artifacts, the Harvester version string is like `[<branch>-]<commit-hash>[-dirty][-head]`. They're not semantic versions, so the upgrade will fail when users try to upgrade such clusters to a **formal** release version. Here **formal** means the artifacts are built based on tagged commits. In the Harvester release workflow, we update the upgraded matrix with a minimum upgradable version string. This also applies to release candidates (RCs). That implies there will be upgrade eligibility checking during the upgrade procedure. Since the procedure is basically comparing two **semantic version** strings, it will fail.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Now the upgrade controller will honor the `harvesterhci.io/skip-version-check` annotation in Upgrade objects. It will pass the regular checking procedure if the annoation exists and is set to "true". the same logic also applies to the upgrade-node script especially for the preparing node phase.

**Related Issue:**

#5203 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. For developers reviewing the PR, please build a custom ISO image containing the fix and use the image to provision a Harvester cluster; for QA engineers, please prepare a Harvester cluster installed with the master ISO image (this PR should be merged by then).
2. Initiate the upgrade with the `v1.3.0-rc*` ISO image
3. Annotate the Upgrade CR with the following command (**must be done before the upgrade repo VM running**):
   ```
   kubectl -n harvester-system annotate upgrades hvst-upgrade-dgd6q harvesterhci.io/skip-version-check=true
   ```
4. (Optional) Check the logs in the `harvester` Pod. After the upgrade repo VM started, you should see a message "Skip minimum upgradable version check" pops up.
   ```
   time="2024-02-23T05:24:35Z" level=info msg="Starting upgrade repo VM"
   time="2024-02-23T05:24:35Z" level=info msg="handle upgrade harvester-system/hvst-upgrade-dgd6q with labels map[harvesterhci.io/latestUpgrade:true harvesterhci.io/upgradeState:PreparingRepo]"
   time="2024-02-23T05:25:49Z" level=info msg="handle upgrade harvester-system/hvst-upgrade-dgd6q with labels map[harvesterhci.io/latestUpgrade:true harvesterhci.io/upgradeState:RepoPrepared]"
   time="2024-02-23T05:25:49Z" level=warning msg="Repo info retrieval failed with: Get \"http://upgrade-repo-hvst-upgrade-dgd6q.harvester-system/harvester-iso/harvester-release.yaml\": dial tcp 10.53.178.182:80: connect: connection refused"
   time="2024-02-23T05:26:00Z" level=info msg="Skip minimum upgradable version check"
   time="2024-02-23T05:26:00Z" level=info msg="handle upgrade harvester-system/hvst-upgrade-dgd6q with labels map[harvesterhci.io/latestUpgrade:true harvesterhci.io/upgradeState:PreparingNodes]"
   ```
5. (Optional) Check the logs in the `prepare` Jobs
6. Upgrade ends up successfully