### PR TITLE
upgrade: remove redundant elemental binary

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,7 +1,3 @@
-# source reference: https://github.com/rancher/elemental-cli/commits/v0.3.1
-# ***NOTE*** Deprecated, we need to use the new elemental-cli in the next release.
-FROM registry.suse.com/rancher/elemental-builder-image/5.3:0.3.1 AS temp_elemental
-
 FROM registry.suse.com/bci/bci-base:15.5
 
 ARG ARCH=amd64
@@ -17,8 +13,6 @@ RUN curl -sfL https://storage.googleapis.com/kubernetes-release/release/${KUBECT
 RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.1.0/virtctl-v1.1.0-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.5/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
-
-COPY --from=temp_elemental /usr/bin/elemental /usr/local/bin/elemental
 
 COPY do_upgrade_node.sh /usr/local/bin/
 COPY upgrade_node.sh /usr/local/bin/

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -39,10 +39,6 @@ clean_up_tmp_files()
     echo "Try to unmount $tmp_rootfs_mount..."
     umount $tmp_rootfs_mount || echo "Umount $tmp_rootfs_mount failed with return code: $?"
   fi
-  if [ -n "$target_elemental_cli" ] && is_mounted "$target_elemental_cli"; then
-    echo "Try to unmount $target_elemental_cli..."
-    umount $target_elemental_cli || echo "Umount $target_elemental_cli failed with return code: $?"
-  fi
   echo "Clean up tmp files..."
   if [ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]; then
     echo "Try to remove $NEW_OS_SQUASHFS_IMAGE_FILE..."
@@ -520,12 +516,8 @@ EOF
   # we would like to clean up the incomplete state.yaml to avoid the issue of https://github.com/harvester/harvester/issues/4526
   cleanup_incomplete_state_file
 
-  # replace the fixed elemental CLI for fix elemental upgrade issues
-  new_elemental_cli=$SCRIPT_DIR/elemental
-  target_elemental_cli=$HOST_DIR/usr/bin/elemental
   elemental_upgrade_log="${UPGRADE_TMP_DIR#"$HOST_DIR"}/elemental-upgrade-$(date +%Y%m%d%H%M%S).log"
   local ret=0
-  mount --bind $new_elemental_cli $target_elemental_cli
   chroot $HOST_DIR elemental upgrade \
     --logfile "$elemental_upgrade_log" \
     --directory ${tmp_rootfs_mount#"$HOST_DIR"} \
@@ -553,7 +545,6 @@ EOF
   GRUBENV_FILE="/oem/grubcustom"
   chroot $HOST_DIR /bin/bash -c "if ! [ -f ${GRUBENV_FILE} ]; then touch ${GRUBENV_FILE}; fi" 
 
-  umount $target_elemental_cli
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The `elemental` on the upgrade image is too old.

**Solution:**
We can use the elemental binary directly because we already use the latest elemental on the host image.

**Related Issue:**

**Test plan:**
Make sure the upgrade works as well.
