### PR TITLE
fix(upgrade): add harvester-upgrade into the retain list

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -781,6 +781,16 @@ func upgradeReference(upgrade *harvesterv1.Upgrade) metav1.OwnerReference {
 	}
 }
 
+// removeItemFromSlice removes one element at index i from the slice. By
+// removing the element, it simply copies the last element in the slice to the
+// slot at index i and returns the same slice but excluding the last element.
+// That is to say, the order of elements in the slice might change, depending
+// on what element is going to be removed.
+func removeItemFromSlice(slice []string, i int) []string {
+	slice[i] = slice[len(slice)-1]
+	return slice[:len(slice)-1]
+}
+
 func difference(setA, setB map[string]bool) []string {
 	var diff []string
 	for key := range setA {


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

If an upgrade goes well and ends successfully, the old `harvester-upgrade` container image is gone. The upgrade log download request afterward will inevitably fail to be complete because the log packager Job depends on that container image.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

After the upgrade ends, the `harvester-upgrade` container image is immune to the image pruning procedure.

**Related Issue:**

#5230 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster in v1.2.1
2. Upgrade to master-head
3. After the upgrade ends successfully, try to download the upgrade log from the dashboard
4. The upgrade log archive should be generated and downloaded successfully