### PR TITLE
support etcd taints in upgrade plans

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -308,6 +308,11 @@ func preparePlan(upgrade *harvesterv1.Upgrade) *upgradev1.Plan {
 					Effect:   corev1.TaintEffectNoSchedule,
 					Value:    "arm",
 				},
+				{
+					Key:      node.KubeEtcdNodeLabelKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
 			},
 			Upgrade: &upgradev1.ContainerSpec{
 				Image:   fmt.Sprintf("%s:%s", upgradeImageRepository, imageVersion),


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently upgrade from v1.3.0-rc2 to v1.3.0-rc3 fails if one of the nodes is etcd.

This is because the prepare plan which loads images cannot be scheduled on the etcd node due to missing taints.

The job eventually times out since the pod cannot be scheduled.
```
Events:
  Type     Reason            Age   From               Message
  ----     ------            ----  ----               -------
  Warning  FailedScheduling  14s   default-scheduler  0/3 nodes are available: 1 node(s) had untolerated taint {node-role.kubernetes.io/etcd: true}, 2 node(s) didn't match Pod's node
 affinity/selector. preemption: 0/3 nodes are available: 3 Preemption is not helpful for scheduling..
```


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add additional taints for etcd only nodes in the prepare and clean up plans.

**Related Issue:**
https://github.com/harvester/harvester/issues/3266
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
To easily test the upgrade path without an RC the following can be done:

1. Install a HA cluster with v1.3.0-rc2
2. The cluster should have atleast one etcd role
3. Patch the harvester managedchart in fleet-local namespace as follows
```
values:
    containers:
      apiserver:
        env:
        # Use this to mock a source version to trigger an upgrade if needed
        - name: HARVESTER_SERVER_VERSION
          value: v1.3.0-rc2
        hciMode: true
        image:
          imagePullPolicy: Always
          repository: gmehta3/harvester 
          tag: upgrade-node-taints-head
```
4. Trigger upgrade to v1.3.0-rc3
5. Upgrade should be successful
