### PR TITLE
change controlplane filter to look for etcd presence

### DIFF
--- a/pkg/util/drainhelper/helper_test.go
+++ b/pkg/util/drainhelper/helper_test.go
@@ -32,6 +32,7 @@ var (
 			Name: "harvester-cp-2",
 			Labels: map[string]string{
 				"node-role.kubernetes.io/control-plane": "true",
+				"node-role.kubernetes.io/etcd":          "true",
 			},
 			Annotations: make(map[string]string),
 		},
@@ -41,7 +42,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "harvester-cp-3",
 			Labels: map[string]string{
-				"node-role.kubernetes.io/control-plane": "true",
+				"node-role.kubernetes.io/etcd": "true",
 			},
 			Annotations: make(map[string]string),
 		},
@@ -110,4 +111,12 @@ func Test_failsControlPlaneRequirementsSingleNode(t *testing.T) {
 	err := DrainPossible(nodeCache, cpNode1)
 	assert.Error(err, "expected error while trying to place cpNode1 in maintenance mode")
 	assert.True(errors.Is(err, errSingleControlPlaneNode), "expected error singleControlPlaneNodeError")
+}
+
+func Test_meetsWorkerRequirement(t *testing.T) {
+	assert := require.New(t)
+	k8sclientset := k8sfake.NewSimpleClientset(testNode, cpNode1, cpNode2, cpNode3)
+	nodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
+	err := DrainPossible(nodeCache, testNode)
+	assert.NoError(err, "expected no error while place worker node in drain")
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
With the introduction of witness role for worker nodes, we have nodes with only etcd running and no other controlplane / workload components.
This breaks the current calculation logic when trying to place controlplane nodes into maintenance mode.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The node role for etcd is labelled on all controlplane / witness nodes. As a result this would be a more effective label to filter for controlplane nodes.

**Related Issue:**
https://github.com/harvester/harvester/issues/5248
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
