### PR TITLE
fix(upgrade): add quotes around the plan version

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1160,7 +1160,7 @@ spec:
     - sh
     - -c
     - set -x && mkdir -p /run/systemd/system/rancher-system-agent.service.d && echo -e '[Service]\nEnvironmentFile=-/run/systemd/system/rancher-system-agent.service.d/10-harvester-upgrade.env' | tee /run/systemd/system/rancher-system-agent.service.d/override.conf && echo 'INSTALL_RKE2_SKIP_ENABLE=true' | tee /run/systemd/system/rancher-system-agent.service.d/10-harvester-upgrade.env && systemctl daemon-reload && systemctl restart rancher-system-agent.service
-  version: $plan_version
+  version: "$plan_version"
 EOF
 
   echo "Creating plan $plan_name to make rancher-system-agent temporarily skip restarting RKE2 server..."


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

There's a chance that the randomly generated plan version consists of all numeric characters.

```shell
harvester-node-0:~ # openssl rand -hex 4
35964120
harvester-node-0:~ # openssl rand -hex 4
7cdd6c6e
```

And the variable is not surrounded by quotes:

```yaml
  ...
  version: $plan_version
  ...
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The Plan version `.spec.version` must be of type string. To prevent the randomly generated version consists of all numeric characters, quotes are added around the `plan_version` variable to force it to be parsed as string type.

**Related Issue:**

#5263

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster with master-head
2. Upgrade to a new version which contains the fix
3. The upgrade should end successfully