### PR TITLE
Switch installer branch to v1.3

### DIFF
--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO image"
 
-HARVESTER_INSTALLER_VERSION=master
+HARVESTER_INSTALLER_VERSION=v1.3
 
 git clone --branch ${HARVESTER_INSTALLER_VERSION} --single-branch --depth 1 https://github.com/harvester/harvester-installer.git ../harvester-installer
 


### PR DESCRIPTION
We created a [v1.3 branch](https://github.com/harvester/harvester-installer/tree/v1.3) from master and should use it on v1.3 branch.


