### PR TITLE
feat(upgradelog): add fleet-controller and local agent's log

### DIFF
--- a/pkg/controller/master/upgradelog/common.go
+++ b/pkg/controller/master/upgradelog/common.go
@@ -238,6 +238,22 @@ func prepareClusterFlow(upgradeLog *harvesterv1.UpgradeLog) *loggingv1.ClusterFl
 						ContainerNames: []string{"upgrade"},
 					},
 				},
+				{
+					ClusterSelect: &loggingv1.ClusterSelect{
+						Labels: map[string]string{
+							"app": "fleet-controller",
+						},
+						Namespaces: []string{"cattle-fleet-system"},
+					},
+				},
+				{
+					ClusterSelect: &loggingv1.ClusterSelect{
+						Labels: map[string]string{
+							"app": "fleet-agent",
+						},
+						Namespaces: []string{"cattle-fleet-local-system"},
+					},
+				},
 			},
 			GlobalOutputRefs: []string{name.SafeConcatName(upgradeLog.Name, util.UpgradeLogOutputComponent)},
 		},


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

We want to examine Fleet relevant logs output during upgrades.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add `cattle-fleet-system/fleet-controller` and `cattle-fleet-local-system/fleet-agent` into ClusterFlow's match filter

**Related Issue:**

#5335 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster with a custom build containing the fix
2. Upgrade the cluster using the same ISO image
3. Download the upgrade log archive from the dashboard
4. Check if the downloaded and extracted archive contains fleet-related logs