### PR TITLE
Bump support bundle kit to v0.0.36

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -485,7 +485,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.34
+    tag: v0.0.36
 
 generalJob:
   image:


### PR DESCRIPTION
Speed up support bundle generation.

https://github.com/rancher/support-bundle-kit/releases/tag/v0.0.36


**Related issue**
https://github.com/harvester/harvester/issues/5323

