### PR TITLE
Fix README of vm-live-migrate-detector

### DIFF
--- a/cmd/upgradehelper/README.md
+++ b/cmd/upgradehelper/README.md
@@ -33,7 +33,7 @@ Flags:
   -h, --help                 help for vm-live-migrate-detector
       --kubeconfig string    Path to the kubeconfig file (default "/home/rancher/.kube/config")
       --kubecontext string   Context name
-      --shutdown             Do not shutdown non-migratable VMs
+      --shutdown             Shutdown non-migratable VMs
       --trace                set logging level to trace
   -v, --version              version for vm-live-migrate-detector
 ```


### PR DESCRIPTION
**Problem:**
The description of the `--shutdown` option is exactly the opposite of what the option actually does.

**Solution:**
Fix the README.

**Related Issue:**
https://github.com/harvester/harvester/pull/4984

**Test plan:**
n/a
