### PR TITLE
Bump harvester-load-balancer to v0.2.5

### DIFF
--- a/deploy/charts/harvester/Chart.lock
+++ b/deploy/charts/harvester/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.4.2
 - name: harvester-load-balancer
   repository: https://charts.harvesterhci.io
-  version: 0.2.0
+  version: 0.2.5
 - name: whereabouts
   repository: file://dependency_charts/whereabouts
   version: 0.1.1

--- a/deploy/charts/harvester/Chart.yaml
+++ b/deploy/charts/harvester/Chart.yaml
@@ -46,7 +46,7 @@ dependencies:
     version: 0.4.2
     repository: https://kube-vip.github.io/helm-charts
   - name: harvester-load-balancer
-    version: 0.2.0
+    version: 0.2.5
     repository: https://charts.harvesterhci.io
   - name: whereabouts
     version: 0.1.1


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

MUST wait https://github.com/harvester/charts/pull/234 is merge at first.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Fix issue https://github.com/harvester/harvester/issues/5137

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

After https://github.com/harvester/charts/pull/234, we also need to sync it to harvester deployment

**BUT**, it seems harvester uses the `master-head` image tag, such sync looks not necessary when only bump image tag.

**Related Issue:**
https://github.com/harvester/harvester/issues/5137

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
