### PR TITLE
Add error message to upgrade and vm image CR on retry failure

### DIFF
--- a/pkg/controller/master/image/backing_image_controller.go
+++ b/pkg/controller/master/image/backing_image_controller.go
@@ -71,6 +71,12 @@ func (h *backingImageHandler) OnChanged(_ string, backingImage *lhv1beta2.Backin
 			harvesterv1beta1.ImageImported.True(toUpdate)
 			harvesterv1beta1.ImageImported.Reason(toUpdate, "Imported")
 			harvesterv1beta1.ImageImported.Message(toUpdate, status.Message)
+			// Clear the ImageRetryLimitExceeded reason and message to prevent the error message
+			// from lingering in the Harvester dashboard after multiple image import retries
+			// have failed but eventually succeeded.
+			harvesterv1beta1.ImageRetryLimitExceeded.False(toUpdate)
+			harvesterv1beta1.ImageRetryLimitExceeded.Reason(toUpdate, "")
+			harvesterv1beta1.ImageRetryLimitExceeded.Message(toUpdate, "")
 			toUpdate.Status.Progress = status.Progress
 			toUpdate.Status.Size = backingImage.Status.Size
 			toUpdate.Status.VirtualSize = backingImage.Status.VirtualSize

--- a/pkg/controller/master/image/vm_image_controller.go
+++ b/pkg/controller/master/image/vm_image_controller.go
@@ -347,11 +347,18 @@ func (h *vmImageHandler) handleRetry(image *harvesterv1.VirtualMachineImage) (*h
 func handleFail(image *harvesterv1.VirtualMachineImage, cond condition.Cond, err error) *harvesterv1.VirtualMachineImage {
 	image.Status.Failed++
 	image.Status.LastFailedTime = time.Now().Format(time.RFC3339)
+	errMsg := fmt.Sprintf("failed due to error: %s", err.Error())
+	if image.Status.Failed > 1 {
+		errMsg = fmt.Sprintf("retry attempted %d/%d %s", image.Status.Failed-1, image.Spec.Retry, errMsg)
+	}
 	if image.Status.Failed > image.Spec.Retry {
 		harvesterv1.ImageRetryLimitExceeded.True(image)
-		harvesterv1.ImageRetryLimitExceeded.Message(image, "VMImage has reached the specified retry limit")
+		harvesterv1.ImageRetryLimitExceeded.Message(image, errMsg)
 		cond.False(image)
-		cond.Message(image, err.Error())
+		cond.Message(image, errMsg)
+	} else {
+		harvesterv1.ImageRetryLimitExceeded.False(image)
+		harvesterv1.ImageRetryLimitExceeded.Message(image, errMsg)
 	}
 	return image
 }

--- a/pkg/controller/master/upgrade/image_controller.go
+++ b/pkg/controller/master/upgrade/image_controller.go
@@ -42,6 +42,8 @@ func (h *vmImageHandler) OnChanged(_ string, image *harvesterv1.VirtualMachineIm
 		setImageReadyCondition(toUpdate, corev1.ConditionFalse, harvesterv1.ImageImported.GetReason(image), harvesterv1.ImageImported.GetMessage(image))
 	case harvesterv1.ImageRetryLimitExceeded.IsTrue(image):
 		setImageReadyCondition(toUpdate, corev1.ConditionFalse, harvesterv1.ImageRetryLimitExceeded.GetReason(image), harvesterv1.ImageRetryLimitExceeded.GetMessage(image))
+	case isUponRetryFailure(image, upgrade):
+		setImageReadyCondition(toUpdate, corev1.ConditionUnknown, harvesterv1.ImageRetryLimitExceeded.GetReason(image), harvesterv1.ImageRetryLimitExceeded.GetMessage(image))
 	default:
 		return image, nil
 	}
@@ -52,4 +54,10 @@ func (h *vmImageHandler) OnChanged(_ string, image *harvesterv1.VirtualMachineIm
 	}
 
 	return image, nil
+}
+
+func isUponRetryFailure(image *harvesterv1.VirtualMachineImage, upgrade *harvesterv1.Upgrade) bool {
+	return harvesterv1.ImageRetryLimitExceeded.IsFalse(image) &&
+		(harvesterv1.ImageRetryLimitExceeded.GetReason(image) != harvesterv1.ImageReady.GetReason(upgrade) ||
+			harvesterv1.ImageRetryLimitExceeded.GetMessage(image) != harvesterv1.ImageReady.GetMessage(upgrade))
 }


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
During each iteration of virtual machine image retry process, it does not update the error message and status on the upgrade custom resource unless the number of retries surpasses the maximum limit. Consequently, users will not observe any error notifications in the UI until all retries have been exhausted and failed.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
This comes into two parts:
- Update error message in upgrade CR upon vm image retry failure in this pr
- Make web ui pop up error message upon each retry failure https://github.com/harvester/dashboard/pull/973

**Related Issue:**
https://github.com/harvester/harvester/issues/5288.

**Test plan:**
### Test Upgrade
<!-- Make sure tests pass on the Circle CI. -->
- Provide a Version CR with the incorrect isoChecksum
- Upgrade the cluster
- Verify whether the error message with type `ImageReady` in the upgrade Custom Resource (CR) is correctly updated after each retry attempt fails
![image](https://github.com/harvester/harvester/assets/4344302/5abe7d93-1617-4cf4-beee-14bba23b0cae)

### Test Images
- goto tab Images
- click create and fill in URL and **incorrect** checksum
- Verify whether the error message with type `Imported` in the VirtualMachineImage Custom Resource (CR) is correctly updated after each retry attempt fails
![image](https://github.com/harvester/harvester/assets/4344302/8b7e5778-913f-4298-8183-aeafd9674e64)
