### PR TITLE
Expose virtual size of VM images

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9547,6 +9547,10 @@
           },
           "storageClassName": {
             "type": "string"
+          },
+          "virtualSize": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },

--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachineimages.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachineimages.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.size
       name: SIZE
       type: integer
+    - jsonPath: .status.virtualSize
+      name: VIRTUALSIZE
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
@@ -123,6 +126,9 @@ spec:
                 type: integer
               storageClassName:
                 type: string
+              virtualSize:
+                format: int64
+                type: integer
             type: object
         required:
         - spec

--- a/pkg/apis/harvesterhci.io/v1beta1/image.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/image.go
@@ -10,6 +10,7 @@ var (
 	ImageInitialized        condition.Cond = "Initialized"
 	ImageImported           condition.Cond = "Imported"
 	ImageRetryLimitExceeded condition.Cond = "RetryLimitExceeded"
+	BackingImageMissing     condition.Cond = "BackingImageMissing"
 )
 
 // +genclient

--- a/pkg/apis/harvesterhci.io/v1beta1/image.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/image.go
@@ -17,6 +17,7 @@ var (
 // +kubebuilder:resource:shortName=vmimage;vmimages,scope=Namespaced
 // +kubebuilder:printcolumn:name="DISPLAY-NAME",type=string,JSONPath=`.spec.displayName`
 // +kubebuilder:printcolumn:name="SIZE",type=integer,JSONPath=`.status.size`
+// +kubebuilder:printcolumn:name="VIRTUALSIZE",type=integer,JSONPath=`.status.virtualSize`
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=`.metadata.creationTimestamp`
 
 type VirtualMachineImage struct {
@@ -79,6 +80,9 @@ type VirtualMachineImageStatus struct {
 
 	// +optional
 	Size int64 `json:"size,omitempty"`
+
+	// +optional
+	VirtualSize int64 `json:"virtualSize,omitempty"`
 
 	// +optional
 	StorageClassName string `json:"storageClassName,omitempty"`

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -3967,6 +3967,12 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineImageStatus(ref common
 							Format: "int64",
 						},
 					},
+					"virtualSize": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
 					"storageClassName": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},


### PR DESCRIPTION
This requires:

- https://github.com/longhorn/backing-image-manager/pull/208
- https://github.com/longhorn/longhorn-manager/pull/2680

With this change, we can do this:

```
# kubectl get vmimages
NAME          DISPLAY-NAME                                         SIZE          VIRTUALSIZE   AGE
image-26r4s   sles15-sp5-minimal-vm.x86_64-kvm-and-xen-qu1.qcow2   267845632     25769803776   6m36s
image-bgnhb   sle-micro.x86_64-5.5.0-default-qcow-gm.qcow2         1001652224    21474836480   20m
image-nmmvj   sle-15-sp5-full-x86_64-gm-media1.iso                 14548992000   14548992000   19m
```

Related issue: https://github.com/harvester/harvester/issues/4905