### PR TITLE
enhancement: prohibit users from resizing volume when vm is stopping

### DIFF
--- a/pkg/util/virtualmachine/virtualmachine.go
+++ b/pkg/util/virtualmachine/virtualmachine.go
@@ -23,13 +23,13 @@ func IsVMStopped(
 		return false, fmt.Errorf("error getting run strategy for vm %s in namespace %s: %v", vm.Name, vm.Namespace, err)
 	}
 
+	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
+		return false, nil
+	}
+
 	// VM is stopped from GUI
 	if strategy == kubevirtv1.RunStrategyHalted {
 		return true, nil
-	}
-
-	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
-		return false, nil
 	}
 
 	// When vm is stopped inside VM, the vmi will not be deleted.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Users could resize the volume when vm is stopping, it should be forbidden.

**Solution:**
Change condition order.

**Related Issue:**
https://github.com/harvester/harvester/issues/5407

**Test plan:**

1. Create VM
2. Stop VM from GUI button
3. When VM is stopping, edit VM config to resize volume
4. It should show the admission webhook message

#### Reproduce
https://github.com/harvester/harvester/assets/6960289/9fb97d2d-b3df-411f-be9f-22fdc7245202

#### Resolved
https://github.com/harvester/harvester/assets/6960289/e56e6038-4092-4da1-965b-3bfa9e03c7e2


