### PR TITLE
bump: support-bundle-kit to v0.0.36

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -483,7 +483,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.28
+    tag: v0.0.36
 
 generalJob:
   image:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Old support bundle kit doesn't collect containerd.log in v1.2 harvester.

**Solution:**
Bump support bundle kit.

**Related Issue:**
https://github.com/harvester/harvester/issues/4427

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
