### PR TITLE
Harvester is flooded with Terminating VMs if namespace is out of storage quota

### DIFF
--- a/pkg/util/resourcequota/calculator.go
+++ b/pkg/util/resourcequota/calculator.go
@@ -21,8 +21,9 @@ import (
 )
 
 var resourceQuotaConversion = map[string]string{
-	"limitsCpu":    "limits.cpu",
-	"limitsMemory": "limits.memory",
+	"limitsCpu":       string(corev1.ResourceLimitsCPU),
+	"limitsMemory":    string(corev1.ResourceLimitsMemory),
+	"requestsStorage": string(corev1.ResourceRequestsStorage),
 }
 
 type Calculator struct {
@@ -92,8 +93,7 @@ func (c *Calculator) CheckIfVMCanStartByResourceQuota(vm *kubevirtv1.VirtualMach
 	}
 
 	// get resource quota limits from ResourceQuota
-	selector := labels.Set{util.LabelManagementDefaultResourceQuota: "true"}.AsSelector()
-	rqs, err := c.rqCache.List(vm.Namespace, selector)
+	rqs, err := c.getResourceQuota(vm)
 	if err != nil {
 		return err
 	} else if len(rqs) == 0 {
@@ -119,11 +119,20 @@ func (c *Calculator) getNamespaceResourceQuota(vm *kubevirtv1.VirtualMachine) (*
 		return nil, err
 	}
 
-	if resourceQuota.Limit.LimitsCPU == "" && resourceQuota.Limit.LimitsMemory == "" {
+	if resourceQuota.Limit.LimitsCPU == "" && resourceQuota.Limit.LimitsMemory == "" && resourceQuota.Limit.RequestsStorage == "" {
 		return nil, nil
 	}
 
 	return resourceQuota, nil
+}
+
+func (c *Calculator) getResourceQuota(vm *kubevirtv1.VirtualMachine) ([]*corev1.ResourceQuota, error) {
+	selector := labels.Set{util.LabelManagementDefaultResourceQuota: "true"}.AsSelector()
+	rqs, err := c.rqCache.List(vm.Namespace, selector)
+	if err != nil {
+		return nil, err
+	}
+	return rqs, nil
 }
 
 // containsEnoughResourceQuotaToStartVM checks if the VM can be started based on the namespace resource quota limits
@@ -132,7 +141,7 @@ func (c *Calculator) containsEnoughResourceQuotaToStartVM(
 	namespaceResourceQuota *v3.NamespaceResourceQuota,
 	rq *corev1.ResourceQuota) error {
 	// get running migrations' used resource
-	vmimsCPU, vmimsMem, err := c.getRunningVMIMResources(rq)
+	vmimsCPU, vmimsMem, _, err := c.getRunningVMIMResources(rq)
 	if err != nil {
 		return err
 	}
@@ -192,15 +201,16 @@ func (c *Calculator) calculateVMActualOverhead(vm *kubevirtv1.VirtualMachine) *r
 	return &memoryOverhead
 }
 
-func (c *Calculator) getRunningVMIMResources(rq *corev1.ResourceQuota) (cpu, mem resource.Quantity, err error) {
+func (c *Calculator) getRunningVMIMResources(rq *corev1.ResourceQuota) (cpu, mem, storage resource.Quantity, err error) {
 	vms, err := GetResourceListFromMigratingVMs(rq)
 	if err != nil {
-		return cpu, mem, err
+		return cpu, mem, storage, err
 	}
 
 	for _, rl := range vms {
 		cpu.Add(*rl.Name(corev1.ResourceLimitsCPU, resource.DecimalSI))
 		mem.Add(*rl.Name(corev1.ResourceLimitsMemory, resource.BinarySI))
+		storage.Add(*rl.Name(corev1.ResourceRequestsStorage, resource.BinarySI))
 	}
 
 	return
@@ -208,6 +218,76 @@ func (c *Calculator) getRunningVMIMResources(rq *corev1.ResourceQuota) (cpu, mem
 
 func (c *Calculator) getVMPods(namespace, vmName string) ([]*corev1.Pod, error) {
 	return c.podCache.GetByIndex(indexeres.PodByVMNameIndex, fmt.Sprintf("%s/%s", namespace, vmName))
+}
+
+func (c *Calculator) CheckStorageResourceQuota(vm *kubevirtv1.VirtualMachine, oldVM *kubevirtv1.VirtualMachine) error {
+	nrq, err := c.getNamespaceResourceQuota(vm)
+	if err != nil {
+		return err
+	} else if nrq == nil {
+		logrus.Debugf("CheckStorageResourceQuota: skipping check, resource quota not found in the namespace %s", vm.Namespace)
+		return nil
+	}
+
+	rqs, err := c.getResourceQuota(vm)
+	if err != nil {
+		return err
+	} else if len(rqs) == 0 {
+		logrus.Debugf("CheckStorageResourceQuota: not found any default resource quota in the namespace %s", vm.Namespace)
+		return nil
+	}
+
+	rq := rqs[0]
+
+	_, _, vmimsStorage, err := c.getRunningVMIMResources(rq)
+	if err != nil {
+		return err
+	}
+
+	usedStorage := rq.Status.Used.Name(corev1.ResourceRequestsStorage, resource.BinarySI)
+	usedStorage.Sub(vmimsStorage)
+
+	// Calculate the storage quantity of the VM.
+	vmStorage, err := calculateVMStorageQuantity(vm)
+	if err != nil {
+		return err
+	}
+
+	// Calculate the storage quantity of the old VM.
+	// Then compare both storage quantity to assess whether the namespace
+	// resource quota can be exceeded at all. This is only the case when the
+	// storage requirements of the new VM is greater than those of the old
+	// one.
+	if oldVM != nil {
+		oldVMStorage, err := calculateVMStorageQuantity(oldVM)
+		if err != nil {
+			return err
+		}
+		// If the storage quantity of the VM is smaller than the old
+		// one, then exit immediately because the namespace resource
+		// quota cannot be exceeded in this case.
+		if vmStorage.Cmp(oldVMStorage) != 1 {
+			return nil
+		}
+		// Use the difference of the storage quantities as only this value
+		// is decisive for the further assessment.
+		vmStorage.Sub(oldVMStorage)
+	}
+
+	actualRq, err := convertNamespaceResourceLimitToResourceList(&nrq.Limit)
+	if err != nil {
+		return err
+	}
+	actualStorage := actualRq.Name(corev1.ResourceRequestsStorage, resource.BinarySI)
+
+	if !actualStorage.IsZero() {
+		actualStorage.Sub(*usedStorage)
+		if actualStorage.Cmp(vmStorage) == -1 {
+			return storageInsufficientResourceError()
+		}
+	}
+
+	return nil
 }
 
 func convertNamespaceResourceLimitToResourceList(limit *v3.ResourceQuotaLimit) (corev1.ResourceList, error) {
@@ -319,4 +399,25 @@ func isEmptyQuota(rq *corev1.ResourceQuota) bool {
 		return true
 	}
 	return false
+}
+
+func calculateVMStorageQuantity(vm *kubevirtv1.VirtualMachine) (resource.Quantity, error) {
+	storage := *resource.NewQuantity(0, resource.BinarySI)
+
+	volumeClaimTemplates, ok := vm.Annotations[util.AnnotationVolumeClaimTemplates]
+	if !ok || volumeClaimTemplates == "" {
+		return storage, nil
+	}
+
+	var pvcs []*corev1.PersistentVolumeClaim
+	err := json.Unmarshal([]byte(volumeClaimTemplates), &pvcs)
+	if err != nil {
+		return storage, fmt.Errorf("failed to unmarshal the volumeClaimTemplates annotation: %w", err)
+	}
+
+	for _, pvc := range pvcs {
+		storage.Add(*pvc.Spec.Resources.Requests.Storage())
+	}
+
+	return storage, nil
 }

--- a/pkg/util/resourcequota/error.go
+++ b/pkg/util/resourcequota/error.go
@@ -3,7 +3,7 @@ package resourcequota
 import "fmt"
 
 const (
-	ErrInsufficientResourcesFMT = "%s insufficient resources"
+	ErrInsufficientResourcesFMT = "%s insufficient resources due to resource quota"
 )
 
 type InsufficientResourceError struct {
@@ -26,6 +26,10 @@ func cpuInsufficientResourceError() error {
 
 func memInsufficientResourceError() error {
 	return newInsufficientResourceError("memory")
+}
+
+func storageInsufficientResourceError() error {
+	return newInsufficientResourceError("storage")
 }
 
 func IsInsufficientResourceError(err error) bool {

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -75,6 +75,11 @@ func (v *vmValidator) Create(_ *types.Request, newObj runtime.Object) error {
 	if err := v.checkVMSpec(vm); err != nil {
 		return err
 	}
+
+	if err := v.checkStorageResourceQuota(vm, nil); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -91,6 +96,10 @@ func (v *vmValidator) Update(_ *types.Request, oldObj runtime.Object, newObj run
 	oldVM := oldObj.(*kubevirtv1.VirtualMachine)
 	if oldVM == nil {
 		return nil
+	}
+
+	if err := v.checkStorageResourceQuota(newVM, oldVM); err != nil {
+		return err
 	}
 
 	// Prevent users to stop/restart VM when there is VMBackup in progress.
@@ -289,4 +298,8 @@ func (v *vmValidator) checkReservedMemoryAnnotation(vm *kubevirtv1.VirtualMachin
 		return werror.NewInvalidError("reservedMemory cannot be less than 0", field)
 	}
 	return nil
+}
+
+func (v *vmValidator) checkStorageResourceQuota(vm *kubevirtv1.VirtualMachine, oldVM *kubevirtv1.VirtualMachine) error {
+	return v.rqCalculator.CheckStorageResourceQuota(vm, oldVM)
 }


### PR DESCRIPTION
Improve the resource quota handling when creating VMs.

Check resource quotas when the VM is created via webhook. Prevent the VM from being created if the storage resource quotas are exceeded.

[Bildschirmaufzeichnung vom 2024-05-14, 16-20-08.webm](https://github.com/harvester/harvester/assets/1897962/1052944c-dfa8-4b60-93a8-74ef95c7d462)

[Bildschirmaufzeichnung vom 2024-05-14, 16-36-10.webm](https://github.com/harvester/harvester/assets/1897962/d9747a19-3b99-4798-8a19-5df21e9666cd)

**Related Issue:**
https://github.com/harvester/harvester/issues/5433

**Test plan:**

## Case 1:
1. Go to the UI of your Rancher standalone installation (NOT the embedded one in Harvester).
2. Make sure your cluster is imported in the `Virtualization Management`.
3. Click the Harvester cluster on the `Name` field of the datatable.
4. Go to `Projects/Namespaces` and create a new project by clicking `Create Project`.
5. In the `Resource Quotas` tab, add `Storage Reservation` and use `20000 MiB` as project limit and `12000 MiB` as namespace default limit.
6. Create a new namespace named `quota-test` in the previously created project. Take over the suggested resource quota of `12 GiB`.
7. In the Harvester UI, create a new VM with the namespace `quota-test`. In `Volumes`, make sure the volume occupies `10 GiB`.
8. Press `Create`. The VM should be created and started. All should be fine.
9. Create a second VM with the same parameters and press `Create`.
10. This time the VM shouldn't be created and a warning message should be displayed at the top of the form.
![grafik](https://github.com/harvester/harvester/assets/1897962/001abaee-9815-4989-af23-0013134dc9f8)

## Case 2:
1. Go to the UI of your Rancher standalone installation (NOT the embedded one in Harvester).
2. Make sure your cluster is imported in the `Virtualization Management`.
3. Click the Harvester cluster on the `Name` field of the datatable.
4. Go to `Projects/Namespaces` and create a new project by clicking `Create Project`.
5. In the `Resource Quotas` tab, add `Storage Reservation` and use `20000 MiB` as project limit and `12000 MiB` as namespace default limit.
6. Create a new namespace named `quota-test` in the previously created project. Take over the suggested resource quota of `12 GiB`.
7. In the Harvester UI, create a new VM named `test01` with the namespace `quota-test`. In `Volumes`, make sure the volume occupies `5 GiB`.
8. Press `Create`. The VM should be created and started. All should be fine.
9. Create a second VM named `test02` by cloning `test01`. Check the `clone volume data` checkbox. Press `Create`. The VM should be created and started. All should be fine.
10. Edit VM `test02` by choosing `Edit Config` in the action menu.
11. Go to the `Volumes` tab and change the `Size` field from `5 GiB` to `7 GiB`. Press `Save` An admission webhook error should be displayed at the top saying `admission webhook "validator.harvesterhci.io" denied the request: storage insufficient resources due to resource quota`. This is because the storage quota of `12 GiB` has been exceeded.
12. Change the `Size` to `6 GiB` and press `Save`. An error message `please stop the VM before resizing volumes` should be displayed at the top.
13. Press `Cancel` to switch back to the VM table. Stop VM `test02`.
14. Edit the VM `test02` again. Go to the `Volumes` tab and change `Size` to `6 GiB`. Press `Save`. This time the modification should be applied without an error.

## Case 3:
1. Go to the UI of your Rancher standalone installation (NOT the embedded one in Harvester).
2. Make sure your cluster is imported in the `Virtualization Management`.
3. Click the Harvester cluster on the `Name` field of the datatable.
4. Go to `Projects/Namespaces` and create a new project by clicking `Create Project`.
5. In the `Resource Quotas` tab, add `Storage Reservation` and use `20000 MiB` as project limit and `12000 MiB` as namespace default limit.
6. Create a new namespace named `quota-test` in the previously created project. Take over the suggested resource quota of `12 GiB`.
7. In the Harvester UI, create a new VM named `test01` with the namespace `quota-test`. In `Volumes`, make sure the volume occupies `7 GiB`.
8. Press `Create`. The VM should be created and started. All should be fine.
9. Stop the `test01`VM.
10. Select the `Clone` action menu on VM `test01`.
11. Enter `test02` as new VM name. Check the `clone volume data` checkbox in the displayed dialog. Press `Create`.
12. An error message should be displayed: `admission webhook "validator.harvesterhci.io" denied the request: storage insufficient resources due to resource quota`. This is because the storage quota of `12 GiB` has been exceeded (2 x 7GiB = 14 GiB).

![grafik](https://github.com/harvester/harvester/assets/1897962/24096337-b686-414a-95d3-02608fce1fbc)