### PR TITLE
feat: add new storage class name format

### DIFF
--- a/pkg/controller/master/image/register.go
+++ b/pkg/controller/master/image/register.go
@@ -22,6 +22,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		backingImages:     backingImages,
 		backingImageCache: backingImages.Cache(),
 		storageClasses:    storageClasses,
+		storageClassCache: storageClasses.Cache(),
 		images:            images,
 		imageController:   images,
 		httpClient: http.Client{

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -7,6 +7,8 @@ import (
 	"github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	lhutil "github.com/longhorn/longhorn-manager/util"
+	ctlstoragev1 "github.com/rancher/wrangler/pkg/generated/controllers/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -49,8 +51,41 @@ func GetBackingImageDataSourceName(backingImageCache ctllhv1.BackingImageCache, 
 	return GetBackingImageName(backingImageCache, image)
 }
 
-func GetImageStorageClassName(imageName string) string {
+func storageClassLegacyName(imageName string) string {
 	return fmt.Sprintf("longhorn-%s", imageName)
+}
+
+func GenerateStorageClassName(imageUID string) string {
+	return lhutil.AutoCorrectName(fmt.Sprintf("longhorn-%s", imageUID), lhdatastore.NameMaximumLength)
+}
+
+func GetStorageClass(storageClassCache ctlstoragev1.StorageClassCache, image *harvesterv1.VirtualMachineImage) (*storagev1.StorageClass, error) {
+	// For backward compatibility, try to get the storage class with legacy name first.
+	// If it exists, return it directly.
+	// If not, return a new format based on the image namespace and UID which can avoid name conflict.
+	sc, err := storageClassCache.Get(storageClassLegacyName(image.Name))
+	if err == nil {
+		return sc, nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	return storageClassCache.Get(GenerateStorageClassName(string(image.UID)))
+}
+
+func GetImageStorageClassName(storageClassCache ctlstoragev1.StorageClassCache, image *harvesterv1.VirtualMachineImage) (string, error) {
+	sc, err := GetStorageClass(storageClassCache, image)
+	if err == nil {
+		return sc.Name, nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return "", err
+	}
+
+	return GenerateStorageClassName(string(image.UID)), nil
 }
 
 func GetImageStorageClassParameters(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (map[string]string, error) {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We use `longhorn-<vmimage name>` as storage class name. The StorageClass doesn't have namesapce, but vmimage has. If there are same vmimage name in different namespace, storage class name will be conflicts.

https://github.com/harvester/harvester/blob/1e8c677c49005dfd312c7143f23a2632b83c42e5/pkg/controller/master/image/vm_image_controller.go#L214-L217

**Solution:**
Use `namespace` and image `UID` as name format.

**Related Issue:**
https://github.com/harvester/harvester/issues/5165

**Additional content:**
~Dashboard doesn't use `vmimage.status.storageClassName` to construct value in `harvesterhci.io/volumeClaimTemplates` annotation. It uses format like `longhorn-<vmimage-name>` as storage class name, so we can't create VM by dashboard with this PR.~ Already fixed by https://github.com/harvester/dashboard/pull/986.

**Test plan:**
### Case 1: VM basic operations (create / backup /restore) without error.

1. Create a VMImage.
2. Create a VM without error.
3.. Write some data.
4. Setup backup-target.
5. Backup the VM.
6. Restore a new VM. New VM can start without error.

### Case 2: VMImage with a same name in different namespaces can work
1. Create a VMImage `thisistest` in `default` and `harvester-public` namespaces.
2. Both images can be created without error.

### Case 3: An old VMImage can work without error.
1. Create a Harvester cluster v1.3.0.
2. Create a VMImage.
3. Replace harvester and harvester-webhook deployment with this PR.
4. The VMImage can work without error.

### Case 4: Create VM Template without error
1. Follow case 1.
2. Generate Template with data.
3. After template is ready, launch a new VM and we can see default image name starts with `templateversion-`. New VM can start without error and data is in the new VM.
![Screenshot 2024-04-10 at 3 36 17 PM](https://github.com/harvester/harvester/assets/4927361/4d801157-8139-4a73-af15-5c2730416ef6)
