### PR TITLE
feat: bump node-disk-manager to v0.5.3

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -388,7 +388,7 @@ harvester-node-disk-manager:
     repository: rancher/harvester-node-disk-manager
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.5.1
+    tag: v0.5.3
 
 csi-snapshotter:
   ## Specify whether to install the csi-snapshotter


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
SLE 15 SP4 general ends on 31 Dec 2023.

**Solution:**
Update it to SP5.

**Related Issue:**
https://github.com/harvester/harvester/issues/4761

**Test plan:**
1. Create a harvester cluster. 
2. In node-disk-manager, run `cat /etc/os-release` and check the version is SP5.
