### PR TITLE
[V1.3] chore: sync upgrade matrix from the release branch [CI SKIP]

### DIFF
--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,4 +1,6 @@
 versions:
+- name: v1.3.0
+  minUpgradableVersion: v1.2.2
 - name: v1.2.1
   minUpgradableVersion: v1.1.2
 - name: v1.2.0


### PR DESCRIPTION
Sync from https://github.com/harvester/harvester/blob/release-1.3/package/upgrade-matrix.yaml#L2-L3