### PR TITLE
feat: bump harvester-node-manager to v0.1.9

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -505,7 +505,7 @@ harvester-node-manager:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/harvester-node-manager
-    tag: v0.1.7
+    tag: v0.1.9
 
 snapshot-validation-webhook:
   enabled: true


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
SLE 15 SP4 general ends on 31 Dec 2023.

**Solution:**
Update it to SP5.

**Related Issue:**
https://github.com/harvester/harvester/issues/4761

**Test plan:**
1. Create a harvester cluster. 
2. In node-manager, run `cat /etc/os-release` and check the version is SP5.
