### PR TITLE
chore: switch UI version to release-harvester-v1.2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,12 +10,12 @@ RUN zypper -n rm container-suseconnect && \
 
 WORKDIR /var/lib/harvester/harvester
 
-ENV HARVESTER_UI_VERSION v1.2.0-rc2
+ENV HARVESTER_UI_VERSION release-harvester-v1.2
 ENV HARVESTER_UI_PATH /usr/share/harvester/harvester
 # Please update the api-ui-version in pkg/settings/settings.go when updating the version here.
 ENV HARVESTER_API_UI_VERSION 1.1.9
 
-ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION v1.2.0-rc2
+ENV HARVESTER_UI_PLUGIN_BUNDLED_VERSION release-harvester-v1.2
 
 ARG ARCH=amd64
 ARG VERSION=dev


### PR DESCRIPTION
We should use the release branch from UI, not a tag release.