### PR TITLE
Set default EvictionStrategy to LiveMigrateIfPossible

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -160,7 +160,7 @@ func (v *VMBuilder) CPU(cores int) *VMBuilder {
 
 func (v *VMBuilder) EvictionStrategy(liveMigrate bool) *VMBuilder {
 	if liveMigrate {
-		evictionStrategy := kubevirtv1.EvictionStrategyLiveMigrate
+		evictionStrategy := kubevirtv1.EvictionStrategyLiveMigrateIfPossible
 		v.VirtualMachine.Spec.Template.Spec.EvictionStrategy = &evictionStrategy
 	}
 	return v

--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -162,7 +162,7 @@ func (r *Repo) createVM(image *harvesterv1.VirtualMachineImage) (*kubevirtv1.Vir
 	vmName := r.getVMName()
 	vmRun := true
 	var bootOrder uint = 1
-	evictionStrategy := kubevirtv1.EvictionStrategyLiveMigrate
+	evictionStrategy := kubevirtv1.EvictionStrategyLiveMigrateIfPossible
 
 	disk0Claim := fmt.Sprintf("%s-disk-0", vmName)
 	volumeMode := corev1.PersistentVolumeBlock

--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -242,7 +242,7 @@ spec:
       runStrategy: RerunOnFailure
       template:
         spec:
-          evictionStrategy: LiveMigrate
+          evictionStrategy: LiveMigrateIfPossible
           domain:
             features:
               acpi:
@@ -317,7 +317,7 @@ spec:
       runStrategy: RerunOnFailure
       template:
         spec:
-          evictionStrategy: LiveMigrate
+          evictionStrategy: LiveMigrateIfPossible
           domain:
             features:
               acpi:
@@ -385,7 +385,7 @@ spec:
       runStrategy: RerunOnFailure
       template:
         spec:
-          evictionStrategy: LiveMigrate
+          evictionStrategy: LiveMigrateIfPossible
           domain:
             features:
               acpi:
@@ -463,7 +463,7 @@ spec:
       runStrategy: RerunOnFailure
       template:
         spec:
-          evictionStrategy: LiveMigrate
+          evictionStrategy: LiveMigrateIfPossible
           domain:
             features:
               acpi:


### PR DESCRIPTION
Depends on: https://github.com/harvester/dashboard/pull/980

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The original value, LiveMigrate, will emit events at the Warn level, which causes alerts to fire. For VMs with PCI Passthrough, alerts will fire for innocuous things, like the VM starting. Best not to fire off anything that can cause someone to get paged when it's well understood that PCI Passthrough is incompatible with live migration

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The version of KubeVirt in 1.2-head, 1.3-head, and master all have a new eviction strategy called LiveMigrateIfPossible, which does not fire spurious warnings for VMs with PCI passthrough.

**Related Issue:** https://github.com/harvester/harvester/issues/5049

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Enable PCI devices controller
2. Enable a device for passthrough (I used an NVMe SSD)
3. Create a VM, pass through the device
4. Assert that a Warning event does not fire with text similar to "EvictionStrategy is set but vmi is not migratable; VMI uses a PCI host devices "
