### PR TITLE
Fix upgrade stuck when using incorrect isoChecksum in version CR

### DIFF
--- a/pkg/controller/master/image/register.go
+++ b/pkg/controller/master/image/register.go
@@ -22,6 +22,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		backingImages:     backingImages,
 		backingImageCache: backingImages.Cache(),
 		storageClasses:    storageClasses,
+		storageClassCache: storageClasses.Cache(),
 		images:            images,
 		imageController:   images,
 		httpClient: http.Client{


### PR DESCRIPTION
**Problem:**
The upgrade stuck when isoChecksum isn't in SHA512 format in Version CR. The root cause is in `createBackingImageAndStorageClass` we missed to invoke `handleFail` thus the max retry never reached to maximum count and lead to the infinite loop of vm_image_controller.go#onChanged

**Solution:**
Applied two things here.
1. Add Version isoChecksum validation, make it fail fast if the checksum isn't in SHA512 format.
2. Invoke handleFail when BackingImage, StorageClass creation fails.
  though 1. could avoid invalid isoChecksum passed to BackingImage, the VMImage required two things, StorageClass and BackingImage, and there might have other potential failures in BackingImage/StorageClass creation other than invalid isoChecksum.

**Related Issue:**
related to #5480

**Test plan:**
1. **Test version with incorrect isoChecksum** 
After applying the following version.yaml, the console should return error message like `admission webhook "validator.harvesterhci.io" denied the request: invalid isoChecksum asdf` since asdf isn't in sha512 format.
    ```yaml
    apiVersion: harvesterhci.io/v1beta1
    kind: Version
    metadata:
      name: master
      namespace: harvester-system
    spec:
      isoURL: http://192.168.100.1:8000/harvester-v1.3.0-amd64.iso
      isoChecksum: asdf
    ```
2. **Test version with correct isoChecksum and run upgrade** 
  - Apply the correct version.yaml to K8s
  - Click the upgrade button in harvester dashboard
  - Everything should works fine
3. **Test vm image**
  - Go to harvester UI `images` and create image with mismatch SHA512 checksum
  - The vm image should download 4 times and then failed with error message like `Failed to process sync file: the expected checksum ... doesn't match the file actual checksum ...`