### PR TITLE
style: reformat generate-openapi script

### DIFF
--- a/scripts/generate-openapi
+++ b/scripts/generate-openapi
@@ -2,12 +2,37 @@
 set -e
 
 # Add +k8s:openapi-gen=true to pkg/apis/harvesterhci.io/v1beta1/doc.go
-files=("pkg/apis/harvesterhci.io/v1beta1/doc.go" "vendor/github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1/doc.go" "vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/doc.go")
+files=(
+    "pkg/apis/harvesterhci.io/v1beta1/doc.go"
+    "vendor/github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1/doc.go"
+    "vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/doc.go"
+)
 for file in "${files[@]}"; do
-awk '/package v1/ { print "// +k8s:openapi-gen=true"; print;  next }1' $file > tmp && mv tmp $file;
+    awk '/package v1/ { print "// +k8s:openapi-gen=true"; print;  next }1' "$file" > tmp && mv tmp "$file";
 done
+input_dirs=(
+    k8s.io/apimachinery/pkg/util/intstr
+    k8s.io/apimachinery/pkg/api/resource
+    k8s.io/apimachinery/pkg/apis/meta/v1
+    k8s.io/apimachinery/pkg/runtime
+    k8s.io/api/core/v1
+    k8s.io/apimachinery/pkg/api/errors
+    github.com/openshift/api/operator/v1
+    kubevirt.io/api/core/v1
+    kubevirt.io/client-go/apis/snapshot/v1alpha1
+    kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1
+    kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1
+    github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
+    github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1
+    github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1
+)
 
-GO111MODULE=auto openapi-gen --input-dirs k8s.io/apimachinery/pkg/util/intstr,k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/runtime,k8s.io/api/core/v1,k8s.io/apimachinery/pkg/api/errors,github.com/openshift/api/operator/v1,kubevirt.io/api/core/v1,kubevirt.io/client-go/apis/snapshot/v1alpha1,kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1,kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1alpha1,github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1,github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1,github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1 \
+comma_join() {
+    local IFS=","
+    echo "$*"
+}
+
+GO111MODULE=auto openapi-gen --input-dirs "$(comma_join "${input_dirs[@]}")" \
     --output-package github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1 \
     --go-header-file scripts/boilerplate.go.txt > scripts/known-api-rule-violations.txt
 


### PR DESCRIPTION

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
While investigating #5500, I was having a hard time reading the files and directories used in `./scripts/generate-openapi` since they were concatenated into a single line.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
I split the files and directories involved in OpenAPI generation into multiple lines. 

**Related Issue:**
#5500

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
```sh
./scripts/generate-openapi
git diff # there should be no diffs to the generated code
```