### PR TITLE
api: make VirtualMachineImageSourceType an enum

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9556,7 +9556,12 @@
           },
           "sourceType": {
             "type": "string",
-            "default": ""
+            "default": "",
+            "enum": [
+              "download",
+              "export-from-volume",
+              "upload"
+            ]
           },
           "storageClassParameters": {
             "type": "object",

--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -36,7 +36,10 @@ func Formatter(request *types.APIRequest, resource *types.RawResource) {
 		return
 	}
 
-	if resource.APIObject.Data().String("spec", "sourceType") == apisv1beta1.VirtualMachineImageSourceTypeUpload {
+	sourceTypeStr := resource.APIObject.Data().String("spec", "sourceType")
+	sourceType := apisv1beta1.VirtualMachineImageSourceType(sourceTypeStr)
+
+	if sourceType == apisv1beta1.VirtualMachineImageSourceTypeUpload {
 		resource.AddAction(request, actionUpload)
 	}
 }

--- a/pkg/apis/harvesterhci.io/v1beta1/image.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/image.go
@@ -12,12 +12,6 @@ var (
 	ImageRetryLimitExceeded condition.Cond = "RetryLimitExceeded"
 )
 
-const (
-	VirtualMachineImageSourceTypeDownload     = "download"
-	VirtualMachineImageSourceTypeUpload       = "upload"
-	VirtualMachineImageSourceTypeExportVolume = "export-from-volume"
-)
-
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=vmimage;vmimages,scope=Namespaced
@@ -42,7 +36,7 @@ type VirtualMachineImageSpec struct {
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=download;upload;export-from-volume
-	SourceType string `json:"sourceType"`
+	SourceType VirtualMachineImageSourceType `json:"sourceType"`
 
 	// +optional
 	PVCName string `json:"pvcName"`
@@ -66,6 +60,15 @@ type VirtualMachineImageSpec struct {
 	// +kubebuilder:validation:Optional
 	Retry int `json:"retry" default:"3"`
 }
+
+// +enum
+type VirtualMachineImageSourceType string
+
+const (
+	VirtualMachineImageSourceTypeDownload     VirtualMachineImageSourceType = "download"
+	VirtualMachineImageSourceTypeUpload       VirtualMachineImageSourceType = "upload"
+	VirtualMachineImageSourceTypeExportVolume VirtualMachineImageSourceType = "export-from-volume"
+)
 
 type VirtualMachineImageStatus struct {
 	// +optional

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -3876,10 +3876,11 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineImageSpec(ref common.R
 					},
 					"sourceType": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
+							Description: "\n\nPossible enum values:\n - `\"download\"`\n - `\"export-from-volume\"`\n - `\"upload\"`",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+							Enum:        []interface{}{"download", "export-from-volume", "upload"}},
 					},
 					"pvcName": {
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
**Problem:**
VirtualMachineImageSourceType is implemented as string, but it actually is an enum. This results in inaccurate API specs and incomplete documentation

**Solution:**
Implement VirtualMachineImageSourceType as enum analogous to other enums in K8s APIs.

**Related Issue:**

- https://github.com/harvester/harvester/issues/5510

**Test plan:**
No behavior changes expected.

Api documentation for VirtualMachineImage should name the possible values for the enum type.