### PR TITLE
[v1.2] Upgrade some grafana related metrics

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1205,7 +1205,10 @@ upgrade_addon_rancher_monitoring()
 {
   echo "upgrade addon rancher_monitoring"
   # .spec.valuesContent has dynamic fields, cannot merge simply, review in each release
-  # in v1.2.2, patch version is OK
+  if [ "$REPO_MONITORING_CHART_VERSION" = "103.0.3+up45.31.1" ]; then
+    patch_grafana_dashboard_harvester_vm_detail
+    patch_grafana_dashboard_harvester_vm
+  fi
   upgrade_addon_try_patch_version_only "rancher-monitoring" "cattle-monitoring-system" $REPO_MONITORING_CHART_VERSION
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

`No data` is found in VM metrics. Upstream kubevirt has renamed some metrics.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Besides https://github.com/harvester/harvester-installer/pull/693, add processing in upgrade path.

**Related Issue:**
backport issue in v1.2.2 https://github.com/harvester/harvester/issues/5499
original issue: https://github.com/harvester/harvester/issues/5442

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install harvester v1.2.1
2. Upgrade to v1.2.2

The related upgrade log will be like:
```
...
patch_grafana_dashboard_harvester_vm_detail
341c341
<           "format": "ms",
---
>           "format": "s",
configmap/harvester-vm-detail-dashboard patched
patch_grafana_dashboard_harvester_vm
need not patch configmap harvester-vm-dashboard, it is up-to-date

// if already upgraded and upgrade again:

patch_grafana_dashboard_harvester_vm_detail
need not patch configmap harvester-vm-detail-dashboard, it is up-to-date
patch_grafana_dashboard_harvester_vm
need not patch configmap harvester-vm-dashboard, it is up-to-date
```
