### PR TITLE
fix: should return not found

### DIFF
--- a/pkg/api/vm/store.go
+++ b/pkg/api/vm/store.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/schemas/validation"
 	"github.com/rancher/wrangler/pkg/slice"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
@@ -28,6 +29,9 @@ func (s *vmStore) Delete(request *types.APIRequest, _ *types.APISchema, id strin
 	removedDisks := request.Query["removedDisks"]
 	vm, err := s.vmCache.Get(request.Namespace, request.Name)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return types.APIObject{}, apierror.NewAPIError(validation.NotFound, fmt.Sprintf("VirtualMachine %s/%s not found", request.Namespace, request.Name))
+		}
 		return types.APIObject{}, apierror.NewAPIError(validation.ServerError, fmt.Sprintf("Failed to get vm %s/%s, %v", request.Namespace, request.Name, err))
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Although we use steven to proxy all k8s resource, but we can still customize some logic with store of schema. In our custom logic, we didn't check not found error, we just returned any error with 500 error code.

**Solution:**
Return not found if vm doesn't exist.

**Related Issue:**
https://github.com/harvester/harvester/issues/4388

**Test plan:**
Delete a non-existing vm with this endpoint `/v1/harvester/kubevirt.io.virtualmachines/{namespace}/{name}`, it will return 404 not found http status code back.

![image](https://github.com/harvester/harvester/assets/6960289/736762d8-3f0b-4a0b-8430-d466d120de6f)

