### PR TITLE
chore: bump harvester-seeder to v0.1.2

### DIFF
--- a/package/upgrade/addons/harvester-seeder.yaml
+++ b/package/upgrade/addons/harvester-seeder.yaml
@@ -12,5 +12,5 @@ spec:
   enabled: false
   valuesContent: |
     image:
-      tag: v0.1.1
+      tag: v0.1.2
     fullnameOverride: harvester-seeder


### PR DESCRIPTION
This PR bumps the harvester-seeder image tag from v0.1.2; the chart is untouched.