### PR TITLE
OpenAPI docs - change `exportParam()` to `actionParam()`

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -230,17 +230,17 @@
         "operationId": "readNamespacedPersistentVolumeClaim",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -969,17 +969,17 @@
         "operationId": "readNamespacedKeyPair",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -1472,17 +1472,17 @@
         "operationId": "readNamespacedSupportBundle",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -1975,17 +1975,17 @@
         "operationId": "readNamespacedUpgrade",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -2478,17 +2478,17 @@
         "operationId": "readNamespacedVirtualMachineBackup",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -2981,17 +2981,17 @@
         "operationId": "readNamespacedVirtualMachineImage",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -3484,17 +3484,17 @@
         "operationId": "readNamespacedVirtualMachineRestore",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -3987,17 +3987,17 @@
         "operationId": "readNamespacedVirtualMachineTemplate",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -4490,17 +4490,17 @@
         "operationId": "readNamespacedVirtualMachineTemplateVersion",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -5819,17 +5819,17 @@
         "operationId": "readNamespacedNetworkAttachmentDefinition",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -6440,17 +6440,17 @@
         "operationId": "readNamespacedVirtualMachineInstanceMigration",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -6899,17 +6899,17 @@
       },
       "parameters": [
         {
-          "name": "exact",
+          "name": "action",
           "in": "query",
-          "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+          "description": "Which action you'd like to take. Options include \"export\".",
           "schema": {
-            "type": "boolean"
+            "type": "string"
           }
         },
         {
-          "name": "export",
+          "name": "exact",
           "in": "query",
-          "description": "Should this value be exported. Export strips fields that a user can not specify.",
+          "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
           "schema": {
             "type": "boolean"
           }
@@ -7161,17 +7161,17 @@
         "operationId": "readNamespacedVirtualMachine",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -8028,17 +8028,17 @@
         "operationId": "readNamespacedClusterNetwork",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }
@@ -8541,17 +8541,17 @@
         "operationId": "readNamespacedNodeNetwork",
         "parameters": [
           {
-            "name": "exact",
+            "name": "action",
             "in": "query",
-            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
+            "description": "Which action you'd like to take. Options include \"export\".",
             "schema": {
-              "type": "boolean"
+              "type": "string"
             }
           },
           {
-            "name": "export",
+            "name": "exact",
             "in": "query",
-            "description": "Should this value be exported. Export strips fields that a user can not specify.",
+            "description": "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.",
             "schema": {
               "type": "boolean"
             }

--- a/pkg/genswagger/rest/webservices.go
+++ b/pkg/genswagger/rest/webservices.go
@@ -21,6 +21,8 @@ import (
 
 var defaultActions = []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
 
+var actionParamPossibleValues = []string{"export"}
+
 func AggregatedWebServices() []*restful.WebService {
 	harvesterv1beta1API := NewGroupVersionWebService(v1beta1.SchemeGroupVersion)
 	AddGenericNamespacedResourceRoutes(harvesterv1beta1API, "virtualmachinebackups", &v1beta1.VirtualMachineBackup{}, "VirtualMachineBackup", &v1beta1.VirtualMachineBackupList{})
@@ -195,7 +197,7 @@ func addGetParams(builder *restful.RouteBuilder, ws *restful.WebService) *restfu
 	return builder.Param(NameParam(ws)).
 		Param(NamespaceParam(ws)).
 		Param(exactParam(ws)).
-		Param(exportParam(ws))
+		Param(actionParam(ws))
 }
 
 func addGetNamespacedListParams(builder *restful.RouteBuilder, ws *restful.WebService) *restful.RouteBuilder {
@@ -269,8 +271,10 @@ func exactParam(ws *restful.WebService) *restful.Parameter {
 	return ws.QueryParameter("exact", "Should the export be exact. Exact export maintains cluster-specific fields like 'Namespace'.").DataType("boolean")
 }
 
-func exportParam(ws *restful.WebService) *restful.Parameter {
-	return ws.QueryParameter("export", "Should this value be exported. Export strips fields that a user can not specify.").DataType("boolean")
+func actionParam(ws *restful.WebService) *restful.Parameter {
+	return ws.QueryParameter("action", "Which action you'd like to take. Options include \"export\".").
+		PossibleValues(actionParamPossibleValues)
+
 }
 
 func gracePeriodSecondsParam(ws *restful.WebService) *restful.Parameter {


### PR DESCRIPTION
**Problem:**

A very basic attempt to fix: https://github.com/harvester/harvester/issues/5576

Unfortunately the `exportParam` function is shared across many api endpoints... This should **not be merged**  unless **ALL** of these endpoints should be updated to remove `export` and add `action`:

- readNamespacedPersistentVolumeClaim
- readNamespacedKeyPair
- readNamespacedSupportBundle
- readNamespacedUpgrade
- readNamespacedVirtualMachineBackup
- readNamespacedVirtualMachineImage
- readNamespacedVirtualMachineRestore
- readNamespacedVirtualMachineTemplate
- readNamespacedVirtualMachineTemplateVersion
- readNamespacedNetworkAttachmentDefinition
- readNamespacedVirtualMachineInstanceMigration

A couple other questions:
- If all of these shouldn't be updated. Can you please provide me with a list of which do require the change.
- Are other actions possible besides `export`?


**Solution:**

Update genswagger function to use new param 

**Related Issue:**
https://github.com/harvester/harvester/issues/5576
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
