### PR TITLE
fix: Harvester ManagedChart is modified after an upgrade

### DIFF
--- a/package/upgrade/migrations/managed_charts/v1.2.1.sh
+++ b/package/upgrade/migrations/managed_charts/v1.2.1.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_ignoring_resource()
+{
+	# add ignoring resources ()
+	yq e '.spec.diff.comparePatches += [{"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition", "name": "settings.longhorn.io", "jsonPointers":["/status/acceptedNames", "/status/conditions", "/status/storedVersions"]}]' $CHART_MANIFEST -i
+	yq e '.spec.diff.comparePatches += [{"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition", "name": "replicas.longhorn.io", "jsonPointers":["/status/acceptedNames", "/status/conditions", "/status/storedVersions"]}]' $CHART_MANIFEST -i
+	yq e '.spec.diff.comparePatches += [{"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition", "name": "instancemanagers.longhorn.io", "jsonPointers":["/status/acceptedNames", "/status/conditions", "/status/storedVersions"]}]' $CHART_MANIFEST -i
+	yq e '.spec.diff.comparePatches += [{"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition", "name": "engines.longhorn.io", "jsonPointers":["/status/acceptedNames", "/status/conditions", "/status/storedVersions"]}]' $CHART_MANIFEST -i
+}
+
+case $CHART_NAME in
+  harvester)
+    patch_ignoring_resource
+    ;;
+esac


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
 Harvester ManagedChart is modified after an upgrade.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Ignore the status fields in some post-modified CRDs in the upgrade path.


**Related Issue:**

https://github.com/harvester/harvester/issues/5566

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Upgrade from v1.2.1
- apply-manifest job should not block.
- After the upgrade finishes, run `kubectl get bundles -n fleet-local mcc-harvester`, the `BUNDLEDEPLOYMENTS-READY` should be `1/1` and `STATUS` should be empty. For example:

      ```
      NAME            BUNDLEDEPLOYMENTS-READY   STATUS
      mcc-harvester   1/1 
      ```