### PR TITLE
[v1.2] Upgrade eventrouter image to v0.1.2

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1217,9 +1217,9 @@ upgrade_addon_rancher_logging()
 {
   echo "upgrade addon rancher_logging"
   # .spec.valuesContent has dynamic fields, cannot merge simply, review in each release
-  # in v1.2.2, the fluentbit image needs to be patched
+  # in v1.2.2, the fluentbit and eventrouter image needs to be patched
   if [ "$REPO_LOGGING_CHART_VERSION" = "103.0.0+up3.17.10" ]; then
-    upgrade_addon_rancher_logging_with_patch_fluentbit_image $REPO_LOGGING_CHART_VERSION
+    upgrade_addon_rancher_logging_with_patch_fluentbit_eventrouter_image $REPO_LOGGING_CHART_VERSION
   else
     upgrade_addon_try_patch_version_only "rancher-logging" "cattle-logging-system" $REPO_LOGGING_CHART_VERSION
   fi


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
https://github.com/harvester/harvester/issues/5412


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#5412 has been verified by @albinsun https://github.com/harvester/harvester/issues/5412#issuecomment-2043089552, and the only left issue is:
` the eventrouter image tag was not upgraded`, this PR will fix it.

Add upgrade processing of eventrouter image

**Related Issue:**
https://github.com/harvester/harvester/issues/5412

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Per https://github.com/harvester/harvester/issues/5412

**NOTE:**
This PR is only needed in Harvester v1.2;  master-head doesn't need it as the eventrouter image tag in Harvester v1.3.0 has already been v0.1.2