### PR TITLE
fix: change go from 1.21.8-bookworm to 1.21-bookworm

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
 FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 as grub2-mbr
 FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 as grub2-efi
 
-FROM golang:1.21.8-bookworm
+FROM golang:1.21-bookworm
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Solution:**
Remove patch version, so we can get latest update in golang.

**Related Issue:**
https://github.com/harvester/harvester/issues/5310

