### PR TITLE
Revert "feat: add new storage class name format"

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -621,46 +621,32 @@ func getMigrationUID(vmi *kubevirtv1.VirtualMachineInstance) string {
 }
 
 // createTemplate creates a template and version that are derived from the given virtual machine.
-func (h *vmActionHandler) createTemplate(namespace, name string, input CreateTemplateInput) (err error) {
-	var (
-		vm         *kubevirtv1.VirtualMachine
-		keyPairIDs []string
-		vmt        *harvesterv1.VirtualMachineTemplate
-		vmtv       *harvesterv1.VirtualMachineTemplateVersion
-	)
-	defer func() {
-		if err != nil {
-			logrus.WithError(err).WithFields(logrus.Fields{
-				"namespace": namespace,
-				"name":      name,
-			}).Error("Failed to create template")
-
-			if vmtv != nil {
-				// other resources have owner reference to vmtv, so we only need to delete vmtv
-				if cleanupErr := h.vmTemplateVersionClient.Delete(vmtv.Namespace, vmtv.Name, &metav1.DeleteOptions{}); cleanupErr != nil {
-					logrus.WithError(cleanupErr).WithFields(logrus.Fields{
-						"namespace": vmtv.Namespace,
-						"name":      vmtv.Name,
-					}).Error("Failed to delete vm template version")
-					err = fmt.Errorf("failed to delete vm template version, cleanup error: %s, original error: %w", cleanupErr.Error(), err)
-				}
-			}
-		}
-	}()
-	vm, err = h.vmCache.Get(namespace, name)
+func (h *vmActionHandler) createTemplate(namespace, name string, input CreateTemplateInput) error {
+	vm, err := h.vmCache.Get(namespace, name)
 	if err != nil {
 		return err
 	}
 
-	keyPairIDs, err = getSSHKeysFromVMITemplateSpec(vm.Spec.Template)
+	keyPairIDs, err := getSSHKeysFromVMITemplateSpec(vm.Spec.Template)
 	if err != nil {
 		return err
 	}
 
 	vmtvName := fmt.Sprintf("%s-%s", input.Name, rand.String(5))
-	vmSourceSpec := h.sanitizeVirtualMachineForTemplateVersion(vmtvName, vm)
+	vmSourceSpec, err := h.sanitizeVirtualMachineForTemplateVersion(vmtvName, vm, input.WithData)
+	if err != nil {
+		return err
+	}
 
-	vmt, err = h.vmTemplateClient.Create(
+	var pvcStorageClassMap map[string]string
+	if input.WithData {
+		pvcStorageClassMap, err = h.getPVCStorageClassMap(vm)
+		if err != nil {
+			return err
+		}
+	}
+
+	vmt, err := h.vmTemplateClient.Create(
 		&harvesterv1.VirtualMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      input.Name,
@@ -676,7 +662,7 @@ func (h *vmActionHandler) createTemplate(namespace, name string, input CreateTem
 
 	vmID := fmt.Sprintf("%s/%s", vmt.Namespace, vmt.Name)
 
-	vmtv, err = h.vmTemplateVersionClient.Create(
+	vmtv, err := h.vmTemplateVersionClient.Create(
 		&harvesterv1.VirtualMachineTemplateVersion{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      vmtvName,
@@ -694,27 +680,7 @@ func (h *vmActionHandler) createTemplate(namespace, name string, input CreateTem
 	}
 
 	if input.WithData {
-		var (
-			pvcMap             map[string]corev1.PersistentVolumeClaim
-			pvcStorageClassMap map[string]string
-			vmImageMap         map[string]harvesterv1.VirtualMachineImage
-		)
-		pvcMap, pvcStorageClassMap, err = h.getPVCStorageClassMap(vm)
-		if err != nil {
-			return err
-		}
-		vmImageMap, err = h.createVMImages(vmtv, vm, pvcStorageClassMap)
-		if err != nil {
-			return err
-		}
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			vmtv, err = h.vmTemplateVersionClient.Get(vmtv.Namespace, vmtv.Name, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			return h.sanitizeVolumes(vmtv, pvcMap, vmImageMap)
-		})
-		if err != nil {
+		if err := h.createVMImages(vmtv, vm, pvcStorageClassMap); err != nil {
 			return err
 		}
 	}
@@ -760,11 +726,6 @@ func (h *vmActionHandler) createSecrets(templateVersion *harvesterv1.VirtualMach
 func (h *vmActionHandler) copySecret(sourceName, targetName string, templateVersion *harvesterv1.VirtualMachineTemplateVersion) error {
 	secret, err := h.secretCache.Get(templateVersion.Namespace, sourceName)
 	if err != nil {
-		logrus.WithError(err).WithFields(logrus.Fields{
-			"namespace":       templateVersion.Namespace,
-			"templateVersion": templateVersion.Name,
-			"secret":          sourceName,
-		}).Error("Failed to get secret")
 		return err
 	}
 	toCreate := &corev1.Secret{
@@ -817,8 +778,7 @@ func (h *vmActionHandler) updateVMVolumeClaimTemplate(vm *kubevirtv1.VirtualMach
 	return nil
 }
 
-func (h *vmActionHandler) getPVCStorageClassMap(vm *kubevirtv1.VirtualMachine) (map[string]corev1.PersistentVolumeClaim, map[string]string, error) {
-	pvcMap := map[string]corev1.PersistentVolumeClaim{}
+func (h *vmActionHandler) getPVCStorageClassMap(vm *kubevirtv1.VirtualMachine) (map[string]string, error) {
 	pvcStorageClassMap := map[string]string{}
 	for _, volume := range vm.Spec.Template.Spec.Volumes {
 		if volume.PersistentVolumeClaim == nil {
@@ -827,13 +787,11 @@ func (h *vmActionHandler) getPVCStorageClassMap(vm *kubevirtv1.VirtualMachine) (
 
 		pvc, err := h.pvcCache.Get(vm.Namespace, volume.PersistentVolumeClaim.ClaimName)
 		if err != nil {
-			return pvcMap, pvcStorageClassMap, err
+			return pvcStorageClassMap, err
 		}
-		pvcMap[pvc.Name] = *pvc
-
 		pvcStorageClass, err := h.storageClassCache.Get(*pvc.Spec.StorageClassName)
 		if err != nil {
-			return pvcMap, pvcStorageClassMap, err
+			return pvcStorageClassMap, err
 		}
 		var sc *storagev1.StorageClass
 		if _, ok := pvcStorageClass.Parameters["backingImage"]; ok {
@@ -844,12 +802,12 @@ func (h *vmActionHandler) getPVCStorageClassMap(vm *kubevirtv1.VirtualMachine) (
 				if len(imageIDSplit) == 2 {
 					vmImage, err := h.vmImageCache.Get(imageIDSplit[0], imageIDSplit[1])
 					if err != nil {
-						return pvcMap, pvcStorageClassMap, err
+						return pvcStorageClassMap, err
 					}
 					if storageClassName, ok := vmImage.Annotations[util.AnnotationStorageClassName]; ok {
 						sc, err = h.storageClassCache.Get(storageClassName)
 						if err != nil {
-							return pvcMap, pvcStorageClassMap, err
+							return pvcStorageClassMap, err
 						}
 					}
 				}
@@ -863,16 +821,14 @@ func (h *vmActionHandler) getPVCStorageClassMap(vm *kubevirtv1.VirtualMachine) (
 			continue
 		}
 		if sc.Provisioner != longhorntypes.LonghornDriverName {
-			return pvcMap, pvcStorageClassMap, fmt.Errorf("VMTemplate with data only supports driver.longhorn.io provisioner, PVC %s/%s can't be exported as VMImage", pvc.Namespace, pvc.Name)
+			return pvcStorageClassMap, fmt.Errorf("VMTemplate with data only supports driver.longhorn.io provisioner, PVC %s/%s can't be exported as VMImage", pvc.Namespace, pvc.Name)
 		}
 		pvcStorageClassMap[pvc.Name] = sc.Name
 	}
-	return pvcMap, pvcStorageClassMap, nil
+	return pvcStorageClassMap, nil
 }
 
-func (h *vmActionHandler) createVMImages(templateVersion *harvesterv1.VirtualMachineTemplateVersion, vm *kubevirtv1.VirtualMachine, pvcStorageClassMap map[string]string) (map[string]harvesterv1.VirtualMachineImage, error) {
-	var err error
-	vmImageMap := map[string]harvesterv1.VirtualMachineImage{}
+func (h *vmActionHandler) createVMImages(templateVersion *harvesterv1.VirtualMachineTemplateVersion, vm *kubevirtv1.VirtualMachine, pvcStorageClassMap map[string]string) error {
 	for index, volume := range vm.Spec.Template.Spec.Volumes {
 		if volume.PersistentVolumeClaim == nil {
 			continue
@@ -902,18 +858,11 @@ func (h *vmActionHandler) createVMImages(templateVersion *harvesterv1.VirtualMac
 			},
 		}
 
-		vmImage, err = h.vmImages.Create(vmImage)
-		if err != nil {
-			logrus.WithError(err).WithFields(logrus.Fields{
-				"namespace":       templateVersion.Namespace,
-				"templateVersion": templateVersion.Name,
-				"pvc":             volume.PersistentVolumeClaim.ClaimName,
-			}).Error("Failed to create VM image")
-			return nil, err
+		if _, err := h.vmImages.Create(vmImage); err != nil {
+			return err
 		}
-		vmImageMap[vmImage.Name] = *vmImage
 	}
-	return vmImageMap, nil
+	return nil
 }
 
 // Since the LH volume creation and replica scheduling are asynchronous
@@ -1222,17 +1171,21 @@ func (h *vmActionHandler) cloneVolumes(newVM *kubevirtv1.VirtualMachine) ([]core
 	return newPVCs, secretNameMap, nil
 }
 
-// sanitizeVirtualMachineForTemplateVersion removes mac addresses and changes secrets names.
-// The PVCs are not sanitized in the function because users may want to create template with data.
-// This will change storage class name in PVCs, so we handle it with VMImages.
-func (h *vmActionHandler) sanitizeVirtualMachineForTemplateVersion(templateVersionName string, vm *kubevirtv1.VirtualMachine) harvesterv1.VirtualMachineSourceSpec {
+func (h *vmActionHandler) sanitizeVirtualMachineForTemplateVersion(templateVersionName string, vm *kubevirtv1.VirtualMachine, withData bool) (harvesterv1.VirtualMachineSourceSpec, error) {
+	var err error
 	sanitizedVM := removeMacAddresses(vm)
 	sanitizedVM = replaceSecrets(templateVersionName, sanitizedVM)
+	if withData {
+		sanitizedVM, err = h.replaceVolumes(templateVersionName, sanitizedVM)
+		if err != nil {
+			return harvesterv1.VirtualMachineSourceSpec{}, err
+		}
+	}
 
 	return harvesterv1.VirtualMachineSourceSpec{
 		ObjectMeta: sanitizedVM.ObjectMeta,
 		Spec:       sanitizedVM.Spec,
-	}
+	}, nil
 }
 
 func replaceSecrets(templateVersionName string, vm *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine {
@@ -1259,55 +1212,48 @@ func replaceSecrets(templateVersionName string, vm *kubevirtv1.VirtualMachine) *
 	return sanitizedVM
 }
 
-func (h *vmActionHandler) sanitizeVolumes(templateVersion *harvesterv1.VirtualMachineTemplateVersion, pvcMap map[string]corev1.PersistentVolumeClaim, vmImageMap map[string]harvesterv1.VirtualMachineImage) error {
-	templateVersionCopy := templateVersion.DeepCopy()
-	vmSource := &templateVersionCopy.Spec.VM
+func (h *vmActionHandler) replaceVolumes(templateVersionName string, vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+	sanitizedVM := vm.DeepCopy()
 	volumeClaimTemplates := []corev1.PersistentVolumeClaim{}
-	for index, volume := range vmSource.Spec.Template.Spec.Volumes {
+	for index, volume := range sanitizedVM.Spec.Template.Spec.Volumes {
 		if volume.PersistentVolumeClaim == nil {
 			continue
 		}
 
-		vmImageName := getTemplateVersionVMImageName(templateVersion.Name, index)
-		vmImage := vmImageMap[vmImageName]
+		pvc, err := h.pvcCache.Get(vm.Namespace, volume.PersistentVolumeClaim.ClaimName)
+		if err != nil {
+			return nil, err
+		}
 
-		pvc := pvcMap[volume.PersistentVolumeClaim.ClaimName]
-		pvcName := getTemplateVersionPvcName(templateVersion.Name, index)
+		vmImageName := getTemplateVersionVMImageName(templateVersionName, index)
+		pvcName := getTemplateVersionPvcName(templateVersionName, index)
 		volumeClaimTemplates = append(volumeClaimTemplates, corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: pvcName,
 				Annotations: map[string]string{
-					util.AnnotationImageID: fmt.Sprintf("%s/%s", templateVersion.Namespace, vmImageName),
+					util.AnnotationImageID: fmt.Sprintf("%s/%s", vm.Namespace, vmImageName),
 				},
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes:      pvc.Spec.AccessModes,
 				Resources:        pvc.Spec.Resources,
 				VolumeMode:       pvc.Spec.VolumeMode,
-				StorageClassName: pointer.String(util.GenerateStorageClassName(string(vmImage.UID))),
+				StorageClassName: pointer.String(util.GetImageStorageClassName(vmImageName)),
 			},
 		})
-		vmSource.Spec.Template.Spec.Volumes[index].PersistentVolumeClaim.ClaimName = pvcName
+		sanitizedVM.Spec.Template.Spec.Volumes[index].PersistentVolumeClaim.ClaimName = pvcName
 	}
 
 	volumeCliamTemplatesJSON, err := json.Marshal(volumeClaimTemplates)
 	if err != nil {
-		logrus.WithError(err).WithFields(logrus.Fields{
-			"namespace":       templateVersion.Namespace,
-			"templateVersion": templateVersion.Name,
-			"volumeClaim":     volumeClaimTemplates,
-		}).Error("Failed to json.Marshal volume claim templates")
-		return err
+		return nil, err
 	}
 
-	if vmSource.ObjectMeta.Annotations == nil {
-		vmSource.ObjectMeta.Annotations = map[string]string{}
+	if sanitizedVM.Annotations == nil {
+		sanitizedVM.Annotations = map[string]string{}
 	}
-	vmSource.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = string(volumeCliamTemplatesJSON)
-	if _, err := h.vmTemplateVersionClient.Update(templateVersionCopy); err != nil {
-		return err
-	}
-	return nil
+	sanitizedVM.Annotations[util.AnnotationVolumeClaimTemplates] = string(volumeCliamTemplatesJSON)
+	return sanitizedVM, nil
 }
 
 func (h *vmActionHandler) dismissInsufficientResourceQuota(name, namespace string) error {

--- a/pkg/controller/master/image/register.go
+++ b/pkg/controller/master/image/register.go
@@ -22,7 +22,6 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		backingImages:     backingImages,
 		backingImageCache: backingImages.Cache(),
 		storageClasses:    storageClasses,
-		storageClassCache: storageClasses.Cache(),
 		images:            images,
 		imageController:   images,
 		httpClient: http.Client{


### PR DESCRIPTION
Reverts harvester/harvester#5459

issue: https://github.com/harvester/harvester/issues/5165

We found several issues after 5459 was merged.
- terraform provider can't create VM. A [fix](https://github.com/harvester/terraform-provider-harvester/pull/94) is ongoing, but users with the older provider can't create a VM until upgrade the terraform provider.
- Rancher manager can't create VM. This means users using Ranchers can't create guest clusters unless we [update the node driver.](https://github.com/harvester/docker-machine-driver-harvester/pull/56/files)

Temporarily revert it before figuring out the best solution.