### PR TITLE
enhancement: remove useless namespace word in cluster scope resouce

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7798,9 +7798,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "List Namespaced Cluster Networks",
-        "description": "Get a list of ClusterNetwork objects in a namespace.",
-        "operationId": "listNamespacedClusterNetwork",
+        "summary": "List Cluster Networks",
+        "description": "Get a list of all ClusterNetwork objects.",
+        "operationId": "listClusterNetwork",
         "parameters": [
           {
             "name": "continue",
@@ -7840,16 +7840,6 @@
             "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
             "schema": {
               "type": "integer"
-            }
-          },
-          {
-            "name": "namespace",
-            "in": "path",
-            "description": "Object name and auth scope, such as for teams and projects",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "[a-z0-9][a-z0-9\\-]*"
             }
           },
           {
@@ -7924,21 +7914,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Create a Namespaced Cluster Network",
+        "summary": "Create a Cluster Network",
         "description": "Create a ClusterNetwork object.",
-        "operationId": "createNamespacedClusterNetwork",
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "description": "Object name and auth scope, such as for teams and projects",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "[a-z0-9][a-z0-9\\-]*"
-            }
-          }
-        ],
+        "operationId": "createClusterNetwork",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8023,9 +8001,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Read a Namespaced Cluster Network",
+        "summary": "Read a Cluster Network",
         "description": "Get a ClusterNetwork object.",
-        "operationId": "readNamespacedClusterNetwork",
+        "operationId": "readClusterNetwork",
         "parameters": [
           {
             "name": "exact",
@@ -8091,9 +8069,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Replace a Namespaced Cluster Network",
+        "summary": "Replace a Cluster Network",
         "description": "Update a ClusterNetwork object.",
-        "operationId": "replaceNamespacedClusterNetwork",
+        "operationId": "replaceClusterNetwork",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8161,9 +8139,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Delete a Namespaced Cluster Network",
+        "summary": "Delete a Cluster Network",
         "description": "Delete a ClusterNetwork object.",
-        "operationId": "deleteNamespacedClusterNetwork",
+        "operationId": "deleteClusterNetwork",
         "parameters": [
           {
             "name": "gracePeriodSeconds",
@@ -8242,9 +8220,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Patch a Namespaced Cluster Network",
+        "summary": "Patch a Cluster Network",
         "description": "Patch a ClusterNetwork object.",
-        "operationId": "patchNamespacedClusterNetwork",
+        "operationId": "patchClusterNetwork",
         "requestBody": {
           "content": {
             "application/json-patch+json": {
@@ -8293,16 +8271,6 @@
             "type": "string",
             "pattern": "[a-z0-9][a-z0-9\\-]*"
           }
-        },
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "Object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "pattern": "[a-z0-9][a-z0-9\\-]*"
-          }
         }
       ]
     },
@@ -8311,9 +8279,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "List Namespaced Node Networks",
-        "description": "Get a list of NodeNetwork objects in a namespace.",
-        "operationId": "listNamespacedNodeNetwork",
+        "summary": "List Node Networks",
+        "description": "Get a list of all NodeNetwork objects.",
+        "operationId": "listNodeNetwork",
         "parameters": [
           {
             "name": "continue",
@@ -8353,16 +8321,6 @@
             "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
             "schema": {
               "type": "integer"
-            }
-          },
-          {
-            "name": "namespace",
-            "in": "path",
-            "description": "Object name and auth scope, such as for teams and projects",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "[a-z0-9][a-z0-9\\-]*"
             }
           },
           {
@@ -8437,21 +8395,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Create a Namespaced Node Network",
+        "summary": "Create a Node Network",
         "description": "Create a NodeNetwork object.",
-        "operationId": "createNamespacedNodeNetwork",
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "description": "Object name and auth scope, such as for teams and projects",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "[a-z0-9][a-z0-9\\-]*"
-            }
-          }
-        ],
+        "operationId": "createNodeNetwork",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8536,9 +8482,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Read a Namespaced Node Network",
+        "summary": "Read a Node Network",
         "description": "Get a NodeNetwork object.",
-        "operationId": "readNamespacedNodeNetwork",
+        "operationId": "readNodeNetwork",
         "parameters": [
           {
             "name": "exact",
@@ -8604,9 +8550,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Replace a Namespaced Node Network",
+        "summary": "Replace a Node Network",
         "description": "Update a NodeNetwork object.",
-        "operationId": "replaceNamespacedNodeNetwork",
+        "operationId": "replaceNodeNetwork",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8674,9 +8620,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Delete a Namespaced Node Network",
+        "summary": "Delete a Node Network",
         "description": "Delete a NodeNetwork object.",
-        "operationId": "deleteNamespacedNodeNetwork",
+        "operationId": "deleteNodeNetwork",
         "parameters": [
           {
             "name": "gracePeriodSeconds",
@@ -8755,9 +8701,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Patch a Namespaced Node Network",
+        "summary": "Patch a Node Network",
         "description": "Patch a NodeNetwork object.",
-        "operationId": "patchNamespacedNodeNetwork",
+        "operationId": "patchNodeNetwork",
         "requestBody": {
           "content": {
             "application/json-patch+json": {
@@ -8801,16 +8747,6 @@
           "name": "name",
           "in": "path",
           "description": "Name of the resource",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "pattern": "[a-z0-9][a-z0-9\\-]*"
-          }
-        },
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "Object name and auth scope, such as for teams and projects",
           "required": true,
           "schema": {
             "type": "string",

--- a/pkg/genswagger/rest/genericresource.go
+++ b/pkg/genswagger/rest/genericresource.go
@@ -1,0 +1,221 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"github.com/emicklei/go-restful/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	mime "kubevirt.io/kubevirt/pkg/rest"
+)
+
+var defaultActions = []Action{
+	GetAction,
+	GetAll,
+	GetNamespacedAll,
+	PostAction,
+	PutAction,
+	PatchAction,
+	DeleteAction,
+}
+
+var defaultGetActions = []Action{
+	GetAction,
+	GetAll,
+	GetNamespacedAll,
+}
+
+type GenericResource struct {
+	ws             *restful.WebService
+	resource       string
+	objPointer     runtime.Object
+	objKind        string
+	objListPointer runtime.Object
+	actions        []Action
+	namespaced     bool
+	objExample     any
+	listExample    any
+}
+
+func NewGenericResource(ws *restful.WebService, resource string, objPointer runtime.Object, objKind string, objListPointer runtime.Object, namespaced bool, actions []Action) {
+	objExample := reflect.ValueOf(objPointer).Elem().Interface()
+	listExample := reflect.ValueOf(objListPointer).Elem().Interface()
+
+	gr := &GenericResource{
+		ws:             ws,
+		resource:       resource,
+		objPointer:     objPointer,
+		objKind:        objKind,
+		actions:        actions,
+		objListPointer: objListPointer,
+		namespaced:     namespaced,
+		objExample:     objExample,
+		listExample:    listExample,
+	}
+
+	gr.Build()
+}
+
+func (gr *GenericResource) Build() {
+	for _, action := range gr.actions {
+		builder := action(gr, gr.ws)
+
+		gr.ws.Route(builder)
+	}
+}
+
+func (gr *GenericResource) addNamespaceParam(builder *restful.RouteBuilder) *restful.RouteBuilder {
+	if gr.namespaced {
+		builder.Param(NamespaceParam(gr.ws))
+	}
+
+	return builder
+}
+
+type Action func(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder
+
+func GetAction(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder {
+	operation := "read" + gr.objKind
+
+	if gr.namespaced {
+		operation = "readNamespaced" + gr.objKind
+	}
+
+	builder := ws.GET(ResourcePath(gr.resource, gr.namespaced)).
+		Produces(mime.MIME_JSON, mime.MIME_YAML, mime.MIME_JSON_STREAM).
+		Operation(operation).
+		To(Noop).Writes(gr.objExample).
+		Doc("Get a "+gr.objKind+" object.").
+		Metadata("kind", gr.objKind).
+		Returns(http.StatusOK, "OK", gr.objExample).
+		Returns(http.StatusUnauthorized, "Unauthorized", "")
+
+	return gr.addNamespaceParam(builder).Param(NameParam(ws)).
+		Param(exactParam(ws)).
+		Param(exportParam(ws))
+}
+
+func GetAll(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder {
+	builder := ws.GET(gr.resource).
+		Produces(mime.MIME_JSON, mime.MIME_YAML, mime.MIME_JSON_STREAM).
+		Operation("list"+gr.objKind+"ForAllNamespaces").
+		To(Noop).Writes(gr.listExample).
+		Doc("Get a list of all "+gr.objKind+" objects.").
+		Metadata("kind", gr.objKind).
+		Returns(http.StatusOK, "OK", gr.listExample).
+		Returns(http.StatusUnauthorized, "Unauthorized", "")
+
+	return addCollectionParams(builder, ws)
+}
+
+func GetNamespacedAll(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder {
+	operation := "list" + gr.objKind
+	doc := fmt.Sprintf("Get a list of all %s objects.", gr.objKind)
+
+	if gr.namespaced {
+		doc = fmt.Sprintf("Get a list of %s objects in a namespace.", gr.objKind)
+		operation = "listNamespaced" + gr.objKind
+	}
+
+	builder := ws.GET(ResourceBasePath(gr.resource, gr.namespaced)).
+		Produces(mime.MIME_JSON, mime.MIME_YAML, mime.MIME_JSON_STREAM).
+		Operation(operation).
+		Writes(gr.listExample).
+		To(Noop).
+		Doc(doc).
+		Metadata("kind", gr.objKind).
+		Returns(http.StatusOK, "OK", gr.listExample).
+		Returns(http.StatusUnauthorized, "Unauthorized", "")
+
+	return addCollectionParams(gr.addNamespaceParam(builder), ws)
+}
+
+func PostAction(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder {
+	operation := "create" + gr.objKind
+
+	if gr.namespaced {
+		operation = "createNamespaced" + gr.objKind
+	}
+
+	builder := ws.POST(ResourceBasePath(gr.resource, gr.namespaced)).
+		Produces(mime.MIME_JSON, mime.MIME_YAML).
+		Consumes(mime.MIME_JSON, mime.MIME_YAML).
+		Operation(operation).
+		To(Noop).Reads(gr.objExample).Writes(gr.objExample).
+		Doc("Create a "+gr.objKind+" object.").
+		Metadata("kind", gr.objKind).
+		Returns(http.StatusOK, "OK", gr.objExample).
+		Returns(http.StatusCreated, "Created", gr.objExample).
+		Returns(http.StatusAccepted, "Accepted", gr.objExample).
+		Returns(http.StatusUnauthorized, "Unauthorized", "")
+
+	return gr.addNamespaceParam(builder)
+}
+
+func PutAction(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder {
+	operation := "replace" + gr.objKind
+
+	if gr.namespaced {
+		operation = "replaceNamespaced" + gr.objKind
+	}
+
+	builder := ws.PUT(ResourcePath(gr.resource, gr.namespaced)).
+		Produces(mime.MIME_JSON, mime.MIME_YAML).
+		Consumes(mime.MIME_JSON, mime.MIME_YAML).
+		Operation(operation).
+		To(Noop).Reads(gr.objExample).Writes(gr.objExample).
+		Doc("Update a "+gr.objKind+" object.").
+		Metadata("kind", gr.objKind).
+		Returns(http.StatusOK, "OK", gr.objExample).
+		Returns(http.StatusCreated, "Create", gr.objExample).
+		Returns(http.StatusUnauthorized, "Unauthorized", "")
+
+	return gr.addNamespaceParam(builder).Param(NameParam(ws))
+}
+
+func PatchAction(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder {
+	operation := "patch" + gr.objKind
+
+	if gr.namespaced {
+		operation = "patchNamespaced" + gr.objKind
+	}
+
+	builder := ws.PATCH(ResourcePath(gr.resource, gr.namespaced)).
+		Consumes(mime.MIME_JSON_PATCH, mime.MIME_MERGE_PATCH).
+		Produces(mime.MIME_JSON).
+		Operation(operation).
+		To(Noop).
+		Writes(gr.objExample).Reads(metav1.Patch{}).
+		Doc("Patch a "+gr.objKind+" object.").
+		Metadata("kind", gr.objKind).
+		Returns(http.StatusOK, "OK", gr.objExample).
+		Returns(http.StatusUnauthorized, "Unauthorized", "")
+
+	return gr.addNamespaceParam(builder).Param(NameParam(ws))
+}
+
+func DeleteAction(gr *GenericResource, ws *restful.WebService) *restful.RouteBuilder {
+	operation := "delete" + gr.objKind
+
+	if gr.namespaced {
+		operation = "deleteNamespaced" + gr.objKind
+	}
+
+	builder := ws.DELETE(ResourcePath(gr.resource, gr.namespaced)).
+		Produces(mime.MIME_JSON, mime.MIME_YAML).
+		Consumes(mime.MIME_JSON, mime.MIME_YAML).
+		Operation(operation).
+		To(Noop).
+		Reads(metav1.DeleteOptions{}).Writes(metav1.Status{}).
+		Doc("Delete a "+gr.objKind+" object.").
+		Metadata("kind", gr.objKind).
+		Returns(http.StatusOK, "OK", gr.objExample).
+		Returns(http.StatusUnauthorized, "Unauthorized", "")
+
+	return gr.addNamespaceParam(builder).Param(NameParam(ws)).
+		Param(gracePeriodSecondsParam(ws)).
+		Param(orphanDependentsParam(ws)).
+		Param(propagationPolicyParam(ws))
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Generators displayed useless namespace parameters for those cluster scope resources in swagger.json.

**Solution:**
Remove namespace parameters documentation for cluster scope resources. I also refactored some codes, made they more easily be modified.

**Related Issue:**
https://github.com/harvester/harvester/issues/5497

**Test plan:**
Just use this swagger.json to check it. Here is a documentation https://github.com/harvester/docs/pull/568.
