### PR TITLE
check timestamps before waiting for agent rollout

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1303,7 +1303,7 @@ wait_for_deployment() {
 }
 
 fleet_agent_timestamp(){
-  wait_for_deployment cattle-fleet-local-system fleet-agent
+  wait_for_deployment cattle-fleet-local-system fleet-agent &> /dev/null
   time=$(kubectl get deploy -n cattle-fleet-local-system fleet-agent -o json | jq -r .metadata.creationTimestamp)
   date -u -d $time +'%s' 
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR attempts to address random upgrade fails where the upgrade fails due to the following error:

```
Wait for cluster settling down...
CAPI cluster fleet-local/local is provisioned (current generation: 838).
cluster.fleet.cattle.io/local patched
Error from server (NotFound): deployments.apps "fleet-agent" not found
```

This is caused by a delay in rollout of fleet-agent, where the rollout happens when the check for fleet-agent rollout status is running, and deployment gets recreated.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The fix attempts to use original fleet-agent creation timestamp before fleet cluster object is patched, and ensures new fleet-agent deployment has a newer creation timestamp before rollout status is checked.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
