### PR TITLE
feat: migrate harvester action API to subresource

### DIFF
--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -105,14 +105,17 @@ func (h Handler) do(rw http.ResponseWriter, req *http.Request) error {
 	}
 
 	// Need to convert the link and action to subresource
-	if req.Method == http.MethodGet {
+	switch req.Method {
+	case http.MethodGet:
 		resource.SubResource = vars["link"]
-	} else if req.Method == http.MethodPost {
+	case http.MethodPost:
 		resource.SubResource = vars["action"]
+	default:
+		return apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported method %s", req.Method))
 	}
 
 	if !h.IsMatchedResource(resource, req.Method) {
-		return apierror.NewAPIError(validation.InvalidAction, "Invalid resource handler")
+		return apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported %s action %s", req.Method, resource.SubResource))
 	}
 
 	return h.SubResourceHandler(rw, req, resource)

--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -29,7 +29,6 @@ import (
 const (
 	actionUpload   = "upload"
 	actionDownload = "download"
-	imagesResource = "virtualmachineimages"
 )
 
 func Formatter(request *types.APIRequest, resource *types.RawResource) {
@@ -56,7 +55,7 @@ type Handler struct {
 }
 
 func (h Handler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != imagesResource {
+	if resource.Name != subresource.VirtualMachineImages.Resource {
 		return false
 	}
 
@@ -99,7 +98,7 @@ func (h Handler) do(rw http.ResponseWriter, req *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(req))
 
 	resource := subresource.Resource{
-		Name:       imagesResource,
+		Name:       subresource.VirtualMachineImages.Resource,
 		ObjectName: vars["name"],
 		Namespace:  vars["namespace"],
 	}

--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -118,24 +118,6 @@ func (h Handler) do(rw http.ResponseWriter, req *http.Request) error {
 	return h.SubResourceHandler(rw, req, resource)
 }
 
-func (h Handler) doGet(link string, rw http.ResponseWriter, req *http.Request) error {
-	switch link {
-	case actionDownload:
-		return h.downloadImage(rw, req)
-	default:
-		return apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported GET action %s", link))
-	}
-}
-
-func (h Handler) doPost(action string, rw http.ResponseWriter, req *http.Request) error {
-	switch action {
-	case actionUpload:
-		return h.uploadImage(rw, req)
-	default:
-		return apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported POST action %s", action))
-	}
-}
-
 func (h Handler) downloadImage(rw http.ResponseWriter, req *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(req))
 	namespace := vars["namespace"]

--- a/pkg/api/image/schema.go
+++ b/pkg/api/image/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/wrangler/pkg/schemas"
 
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/server/subresource"
 )
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
@@ -50,5 +51,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		},
 	}
 	server.SchemaFactory.AddTemplate(t)
+
+	subresource.RegisterSubResourceHandler(&imgHandler)
+
 	return nil
 }

--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -53,7 +53,6 @@ const (
 var (
 	seederGVR            = schema.GroupVersionResource{Group: "metal.harvesterhci.io", Version: "v1alpha1", Resource: "inventories"}
 	possiblePowerActions = []string{"shutdown", "poweron", "reboot"}
-	nodeResource         = "nodes"
 	subResources         = []string{
 		enableMaintenanceModeAction,
 		disableMaintenanceModeAction,
@@ -115,7 +114,7 @@ func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h ActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != nodeResource && method != http.MethodPost {
+	if resource.Name != subresource.Node.Resource && method != http.MethodPost {
 		return false
 	}
 
@@ -177,7 +176,7 @@ func (h ActionHandler) do(rw http.ResponseWriter, req *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(req))
 
 	resource := subresource.Resource{
-		Name:        nodeResource,
+		Name:        subresource.Node.Resource,
 		ObjectName:  vars["name"],
 		Namespace:   "",
 		SubResource: vars["action"],

--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -114,7 +114,7 @@ func (h ActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h ActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != subresource.Node.Resource && method != http.MethodPost {
+	if resource.Name != subresource.Node.Resource || method != http.MethodPost {
 		return false
 	}
 

--- a/pkg/api/node/schema.go
+++ b/pkg/api/node/schema.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/server/subresource"
 )
 
 type MaintenanceModeInput struct {
@@ -76,5 +77,6 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		},
 	}
 	server.SchemaFactory.AddTemplate(t)
+	subresource.RegisterSubResourceHandler(&nodeHandler)
 	return nil
 }

--- a/pkg/api/upgradelog/handler.go
+++ b/pkg/api/upgradelog/handler.go
@@ -27,7 +27,6 @@ import (
 )
 
 const (
-	upgradelogsResource          = "upgradelogs"
 	archiveSuffix                = ".zip"
 	defaultJobBackoffLimit int32 = 5
 	logPackagingScript           = `
@@ -85,7 +84,7 @@ type Handler struct {
 }
 
 func (h Handler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != upgradelogsResource {
+	if resource.Name != subresource.UpgradeLogs.Resource {
 		return false
 	}
 
@@ -127,7 +126,7 @@ func (h Handler) doAction(rw http.ResponseWriter, req *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(req))
 
 	resource := subresource.Resource{
-		Name:       upgradelogsResource,
+		Name:       subresource.UpgradeLogs.Resource,
 		ObjectName: vars["name"],
 		Namespace:  vars["namespace"],
 	}

--- a/pkg/api/upgradelog/schema.go
+++ b/pkg/api/upgradelog/schema.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/wrangler/pkg/schemas"
 
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/server/subresource"
 )
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
@@ -40,5 +41,6 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		Formatter: Formatter,
 	}
 	server.SchemaFactory.AddTemplate(t)
+	subresource.RegisterSubResourceHandler(&upgradeLogHandler)
 	return nil
 }

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -57,31 +57,30 @@ var (
 )
 
 type vmActionHandler struct {
-	namespace                  string
-	vms                        ctlkubevirtv1.VirtualMachineClient
-	vmis                       ctlkubevirtv1.VirtualMachineInstanceClient
-	vmCache                    ctlkubevirtv1.VirtualMachineCache
-	vmiCache                   ctlkubevirtv1.VirtualMachineInstanceCache
-	vmims                      ctlkubevirtv1.VirtualMachineInstanceMigrationClient
-	vmTemplateClient           ctlharvesterv1.VirtualMachineTemplateClient
-	vmTemplateVersionClient    ctlharvesterv1.VirtualMachineTemplateVersionClient
-	vmimCache                  ctlkubevirtv1.VirtualMachineInstanceMigrationCache
-	backups                    ctlharvesterv1.VirtualMachineBackupClient
-	backupCache                ctlharvesterv1.VirtualMachineBackupCache
-	restores                   ctlharvesterv1.VirtualMachineRestoreClient
-	settingCache               ctlharvesterv1.SettingCache
-	nadCache                   ctlcniv1.NetworkAttachmentDefinitionCache
-	nodeCache                  ctlcorev1.NodeCache
-	pvcCache                   ctlcorev1.PersistentVolumeClaimCache
-	pvCache                    ctlcorev1.PersistentVolumeCache
-	secretClient               ctlcorev1.SecretClient
-	secretCache                ctlcorev1.SecretCache
-	virtSubresourceRestClient  rest.Interface
-	virtRestClient             rest.Interface
-	harvesterSubresourceClient rest.Interface
-	vmImages                   ctlharvesterv1.VirtualMachineImageClient
-	vmImageCache               ctlharvesterv1.VirtualMachineImageCache
-	storageClassCache          ctlstoragev1.StorageClassCache
+	namespace                 string
+	vms                       ctlkubevirtv1.VirtualMachineClient
+	vmis                      ctlkubevirtv1.VirtualMachineInstanceClient
+	vmCache                   ctlkubevirtv1.VirtualMachineCache
+	vmiCache                  ctlkubevirtv1.VirtualMachineInstanceCache
+	vmims                     ctlkubevirtv1.VirtualMachineInstanceMigrationClient
+	vmTemplateClient          ctlharvesterv1.VirtualMachineTemplateClient
+	vmTemplateVersionClient   ctlharvesterv1.VirtualMachineTemplateVersionClient
+	vmimCache                 ctlkubevirtv1.VirtualMachineInstanceMigrationCache
+	backups                   ctlharvesterv1.VirtualMachineBackupClient
+	backupCache               ctlharvesterv1.VirtualMachineBackupCache
+	restores                  ctlharvesterv1.VirtualMachineRestoreClient
+	settingCache              ctlharvesterv1.SettingCache
+	nadCache                  ctlcniv1.NetworkAttachmentDefinitionCache
+	nodeCache                 ctlcorev1.NodeCache
+	pvcCache                  ctlcorev1.PersistentVolumeClaimCache
+	pvCache                   ctlcorev1.PersistentVolumeCache
+	secretClient              ctlcorev1.SecretClient
+	secretCache               ctlcorev1.SecretCache
+	virtSubresourceRestClient rest.Interface
+	virtRestClient            rest.Interface
+	vmImages                  ctlharvesterv1.VirtualMachineImageClient
+	vmImageCache              ctlharvesterv1.VirtualMachineImageCache
+	storageClassCache         ctlstoragev1.StorageClassCache
 }
 
 func (h *vmActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -117,7 +117,7 @@ func (h *vmActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *vmActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != vmResource && method != http.MethodPost {
+	if resource.Name != subresource.VirtualMachines.Resource && method != http.MethodPost {
 		return false
 	}
 
@@ -272,7 +272,7 @@ func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) erro
 	vars := util.EncodeVars(mux.Vars(r))
 
 	resource := subresource.Resource{
-		Name:        vmResource,
+		Name:        subresource.VirtualMachines.Resource,
 		ObjectName:  vars["name"],
 		Namespace:   vars["namespace"],
 		SubResource: vars["action"],

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -60,12 +60,6 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	copyConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 	virtSubresourceClient, err := rest.RESTClientFor(copyConfig)
 
-	harvesterCopyConfig := rest.CopyConfig(server.RESTConfig)
-	harvesterCopyConfig.GroupVersion = &k8sschema.GroupVersion{Group: "subresources.harvester.io", Version: "v1"}
-	harvesterCopyConfig.APIPath = "/apis"
-	harvesterCopyConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-	harvesterSubresourceClient, err := rest.RESTClientFor(harvesterCopyConfig)
-
 	if err != nil {
 		return err
 	}
@@ -74,31 +68,30 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		return err
 	}
 	actionHandler := vmActionHandler{
-		namespace:                  options.Namespace,
-		vms:                        vms,
-		vmCache:                    vms.Cache(),
-		vmis:                       vmis,
-		vmiCache:                   vmis.Cache(),
-		vmims:                      vmims,
-		vmimCache:                  vmims.Cache(),
-		vmTemplateClient:           vmt,
-		vmTemplateVersionClient:    vmtv,
-		backups:                    backups,
-		backupCache:                backups.Cache(),
-		restores:                   restores,
-		settingCache:               settings.Cache(),
-		nadCache:                   nads.Cache(),
-		nodeCache:                  nodes.Cache(),
-		pvcCache:                   pvcs.Cache(),
-		pvCache:                    pvs.Cache(),
-		secretClient:               secrets,
-		secretCache:                secrets.Cache(),
-		virtSubresourceRestClient:  virtSubresourceClient,
-		harvesterSubresourceClient: harvesterSubresourceClient,
-		virtRestClient:             virtv1Client.RESTClient(),
-		vmImages:                   vmImages,
-		vmImageCache:               vmImages.Cache(),
-		storageClassCache:          storageClasses.Cache(),
+		namespace:                 options.Namespace,
+		vms:                       vms,
+		vmCache:                   vms.Cache(),
+		vmis:                      vmis,
+		vmiCache:                  vmis.Cache(),
+		vmims:                     vmims,
+		vmimCache:                 vmims.Cache(),
+		vmTemplateClient:          vmt,
+		vmTemplateVersionClient:   vmtv,
+		backups:                   backups,
+		backupCache:               backups.Cache(),
+		restores:                  restores,
+		settingCache:              settings.Cache(),
+		nadCache:                  nads.Cache(),
+		nodeCache:                 nodes.Cache(),
+		pvcCache:                  pvcs.Cache(),
+		pvCache:                   pvs.Cache(),
+		secretClient:              secrets,
+		secretCache:               secrets.Cache(),
+		virtSubresourceRestClient: virtSubresourceClient,
+		virtRestClient:            virtv1Client.RESTClient(),
+		vmImages:                  vmImages,
+		vmImageCache:              vmImages.Cache(),
+		storageClassCache:         storageClasses.Cache(),
 	}
 
 	vmformatter := vmformatter{

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
 	virtv1 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/server/subresource"
 )
 
 const (
@@ -58,6 +59,13 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	copyConfig.APIPath = "/apis"
 	copyConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 	virtSubresourceClient, err := rest.RESTClientFor(copyConfig)
+
+	harvesterCopyConfig := rest.CopyConfig(server.RESTConfig)
+	harvesterCopyConfig.GroupVersion = &k8sschema.GroupVersion{Group: "subresources.harvester.io", Version: "v1"}
+	harvesterCopyConfig.APIPath = "/apis"
+	harvesterCopyConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	harvesterSubresourceClient, err := rest.RESTClientFor(harvesterCopyConfig)
+
 	if err != nil {
 		return err
 	}
@@ -66,30 +74,31 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		return err
 	}
 	actionHandler := vmActionHandler{
-		namespace:                 options.Namespace,
-		vms:                       vms,
-		vmCache:                   vms.Cache(),
-		vmis:                      vmis,
-		vmiCache:                  vmis.Cache(),
-		vmims:                     vmims,
-		vmimCache:                 vmims.Cache(),
-		vmTemplateClient:          vmt,
-		vmTemplateVersionClient:   vmtv,
-		backups:                   backups,
-		backupCache:               backups.Cache(),
-		restores:                  restores,
-		settingCache:              settings.Cache(),
-		nadCache:                  nads.Cache(),
-		nodeCache:                 nodes.Cache(),
-		pvcCache:                  pvcs.Cache(),
-		pvCache:                   pvs.Cache(),
-		secretClient:              secrets,
-		secretCache:               secrets.Cache(),
-		virtSubresourceRestClient: virtSubresourceClient,
-		virtRestClient:            virtv1Client.RESTClient(),
-		vmImages:                  vmImages,
-		vmImageCache:              vmImages.Cache(),
-		storageClassCache:         storageClasses.Cache(),
+		namespace:                  options.Namespace,
+		vms:                        vms,
+		vmCache:                    vms.Cache(),
+		vmis:                       vmis,
+		vmiCache:                   vmis.Cache(),
+		vmims:                      vmims,
+		vmimCache:                  vmims.Cache(),
+		vmTemplateClient:           vmt,
+		vmTemplateVersionClient:    vmtv,
+		backups:                    backups,
+		backupCache:                backups.Cache(),
+		restores:                   restores,
+		settingCache:               settings.Cache(),
+		nadCache:                   nads.Cache(),
+		nodeCache:                  nodes.Cache(),
+		pvcCache:                   pvcs.Cache(),
+		pvCache:                    pvs.Cache(),
+		secretClient:               secrets,
+		secretCache:                secrets.Cache(),
+		virtSubresourceRestClient:  virtSubresourceClient,
+		harvesterSubresourceClient: harvesterSubresourceClient,
+		virtRestClient:             virtv1Client.RESTClient(),
+		vmImages:                   vmImages,
+		vmImageCache:               vmImages.Cache(),
+		storageClassCache:          storageClasses.Cache(),
 	}
 
 	vmformatter := vmformatter{
@@ -170,5 +179,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	}
 
 	server.SchemaFactory.AddTemplate(t)
+
+	subresource.RegisterSubResourceHandler(&actionHandler)
+
 	return nil
 }

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -32,10 +32,6 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 )
 
-const (
-	pvcResource = "persistentvolumeclaims"
-)
-
 var (
 	subResources = []string{
 		actionExport,
@@ -57,7 +53,7 @@ type ActionHandler struct {
 }
 
 func (h *ActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != pvcResource && method != http.MethodPost {
+	if resource.Name != subresource.PersistentVolumeClaims.Resource && method != http.MethodPost {
 		return false
 	}
 
@@ -131,7 +127,7 @@ func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(r))
 
 	resource := subresource.Resource{
-		Name:        pvcResource,
+		Name:        subresource.PersistentVolumeClaims.Resource,
 		ObjectName:  vars["name"],
 		Namespace:   vars["namespace"],
 		SubResource: vars["action"],

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -53,7 +53,7 @@ type ActionHandler struct {
 }
 
 func (h *ActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != subresource.PersistentVolumeClaims.Resource && method != http.MethodPost {
+	if resource.Name != subresource.PersistentVolumeClaims.Resource || method != http.MethodPost {
 		return false
 	}
 

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -32,6 +32,10 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 )
 
+const (
+	pvcResource = "persistentvolumeclaims"
+)
+
 var (
 	subResources = []string{
 		actionExport,
@@ -53,7 +57,7 @@ type ActionHandler struct {
 }
 
 func (h *ActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != pvcSchemaID && method != http.MethodPost {
+	if resource.Name != pvcResource && method != http.MethodPost {
 		return false
 	}
 
@@ -66,7 +70,7 @@ func (h *ActionHandler) IsMatchedResource(resource subresource.Resource, method 
 	return false
 }
 
-func (h *ActionHandler) SubResourceHandler(rw http.ResponseWriter, r *http.Request, resource subresource.Resource) error {
+func (h *ActionHandler) SubResourceHandler(_ http.ResponseWriter, r *http.Request, resource subresource.Resource) error {
 	action := resource.SubResource
 	pvcNamespace := resource.Namespace
 	pvcName := resource.ObjectName
@@ -127,7 +131,7 @@ func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(r))
 
 	resource := subresource.Resource{
-		Name:        pvcSchemaID,
+		Name:        pvcResource,
 		ObjectName:  vars["name"],
 		Namespace:   vars["namespace"],
 		SubResource: vars["action"],

--- a/pkg/api/volume/schema.go
+++ b/pkg/api/volume/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/wrangler/pkg/schemas"
 
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/server/subresource"
 )
 
 const (
@@ -55,5 +56,6 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		Formatter: Formatter,
 	}
 	server.SchemaFactory.AddTemplate(t)
+	subresource.RegisterSubResourceHandler(&actionHandler)
 	return nil
 }

--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -36,7 +36,7 @@ type ActionHandler struct {
 }
 
 func (h *ActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != subresource.VolumeSnapshots.Resource && method != http.MethodPost {
+	if resource.Name != subresource.VolumeSnapshots.Resource || method != http.MethodPost {
 		return false
 	}
 

--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -36,7 +36,7 @@ type ActionHandler struct {
 }
 
 func (h *ActionHandler) IsMatchedResource(resource subresource.Resource, method string) bool {
-	if resource.Name != volumesnapshotSchemaID && method != http.MethodPost {
+	if resource.Name != subresource.VolumeSnapshots.Resource && method != http.MethodPost {
 		return false
 	}
 
@@ -86,7 +86,7 @@ func (h *ActionHandler) do(rw http.ResponseWriter, r *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(r))
 
 	resource := subresource.Resource{
-		Name:        volumesnapshotSchemaID,
+		Name:        subresource.VolumeSnapshots.Resource,
 		ObjectName:  vars["name"],
 		Namespace:   vars["namespace"],
 		SubResource: vars["action"],

--- a/pkg/api/volumesnapshot/handler.go
+++ b/pkg/api/volumesnapshot/handler.go
@@ -49,7 +49,7 @@ func (h *ActionHandler) IsMatchedResource(resource subresource.Resource, method 
 	return false
 }
 
-func (h *ActionHandler) SubResourceHandler(rw http.ResponseWriter, r *http.Request, resource subresource.Resource) error {
+func (h *ActionHandler) SubResourceHandler(_ http.ResponseWriter, r *http.Request, resource subresource.Resource) error {
 	action := resource.SubResource
 	snapshotNamespace := resource.Namespace
 	snapshotName := resource.ObjectName

--- a/pkg/api/volumesnapshot/schema.go
+++ b/pkg/api/volumesnapshot/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/wrangler/pkg/schemas"
 
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/server/subresource"
 )
 
 const (
@@ -40,5 +41,6 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		Formatter: Formatter,
 	}
 	server.SchemaFactory.AddTemplate(t)
+	subresource.RegisterSubResourceHandler(&actionHandler)
 	return nil
 }

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harvester/harvester/pkg/api/supportbundle"
 	"github.com/harvester/harvester/pkg/api/uiinfo"
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/server/subresource"
 	"github.com/harvester/harvester/pkg/server/ui"
 )
 
@@ -81,6 +82,12 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	m.Path("/v1/harvester/{type}/{namespace}/{name}").Queries("link", "{link}").Handler(h.K8sResource)
 	m.Path("/v1/harvester/{type}/{namespace}/{name}").Handler(h.K8sResource)
 	m.Path("/v1/harvester/{type}/{namespace}/{name}/{link}").Handler(h.K8sResource)
+
+	subHealthHandler := &subresource.HealthHandler{}
+	m.Path("/apis/subresources.harvester.io/v1").Handler(subHealthHandler)
+
+	subHandler := &subresource.Handler{}
+	m.Path("/apis/subresources.harvester.io/v1/namespaces/{namespace}/{resource}/{name}/{subresource}").Handler(subHandler)
 
 	vueUI := ui.Vue
 	m.Handle("/dashboard/", vueUI.IndexFile())

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -83,11 +83,7 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	m.Path("/v1/harvester/{type}/{namespace}/{name}").Handler(h.K8sResource)
 	m.Path("/v1/harvester/{type}/{namespace}/{name}/{link}").Handler(h.K8sResource)
 
-	subHealthHandler := &subresource.HealthHandler{}
-	m.Path("/apis/subresources.harvester.io/v1").Handler(subHealthHandler)
-
-	subHandler := &subresource.Handler{}
-	m.Path("/apis/subresources.harvester.io/v1/namespaces/{namespace}/{resource}/{name}/{subresource}").Handler(subHandler)
+	subresource.NewSubResourceHandler(m)
 
 	vueUI := ui.Vue
 	m.Handle("/dashboard/", vueUI.IndexFile())

--- a/pkg/server/subresource/subresource.go
+++ b/pkg/server/subresource/subresource.go
@@ -1,0 +1,93 @@
+package subresource
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/rancher/apiserver/pkg/apierror"
+)
+
+type Resource struct {
+	Name        string
+	ObjectName  string
+	SubResource string
+	Namespace   string
+}
+
+type Handler struct{}
+
+type HealthHandler struct{}
+
+type ResourceHandler interface {
+	Matched(resource string) bool
+	SubResourceHandler(rw http.ResponseWriter, r *http.Request, resource Resource) error
+}
+
+var (
+	handlers []ResourceHandler
+)
+
+func RegisterSubResourceHandler(handler ResourceHandler) {
+	handlers = append(handlers, handler)
+}
+
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+
+	namespace := vars["namespace"]
+	resource := vars["resource"]
+	name := vars["name"]
+	subresource := vars["subresource"]
+
+	fmt.Println("namespace: ", namespace)
+	fmt.Println("resource: ", resource)
+	fmt.Println("name: ", name)
+	fmt.Println("subresource: ", subresource)
+
+	var (
+		err   error
+		found bool
+	)
+
+	for _, handler := range handlers {
+		if handler.Matched(resource) {
+			fmt.Println("==== handler matched ====")
+			fmt.Println("namespace: ", namespace)
+			fmt.Println("resource: ", resource)
+			fmt.Println("name: ", name)
+			fmt.Println("subresource: ", subresource)
+			fmt.Println("==== handler matched ====")
+			err = handler.SubResourceHandler(rw, req, Resource{
+				Name:        name,
+				ObjectName:  name,
+				SubResource: subresource,
+				Namespace:   namespace,
+			})
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		rw.WriteHeader(http.StatusNotFound)
+		_, _ = rw.Write([]byte("Not found subresource handler"))
+		return
+	}
+
+	if err != nil {
+		status := http.StatusInternalServerError
+		if e, ok := err.(*apierror.APIError); ok {
+			status = e.Code.Status
+		}
+		rw.WriteHeader(status)
+		_, _ = rw.Write([]byte(err.Error()))
+		return
+	}
+
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+func (h *HealthHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	rw.WriteHeader(http.StatusOK)
+}

--- a/pkg/server/subresource/subresource.go
+++ b/pkg/server/subresource/subresource.go
@@ -35,7 +35,8 @@ type Resource struct {
 }
 
 type ResourceHandler interface {
-	// IsMatchedResource checks if the resource, subresource and http method are matched
+	// IsMatchedResource checks if the path, resource, subresource and http method are matched.
+	// This only check new API schema, old API schema have verified the path and method in rancher/steve.
 	IsMatchedResource(resource Resource, method string) bool
 
 	// SubResourceHandler handles the request if `IsMatchedResource` is true.
@@ -77,12 +78,9 @@ func healthCheck(rw http.ResponseWriter, _ *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
-// Execute processes the request from old API schema
+// Execute processes the request from old API schema.
+// Old API have verified the path and method, so we can directly call the handler.
 func Execute(handler ResourceHandler, rw http.ResponseWriter, r *http.Request, resource Resource) error {
-	if !handler.IsMatchedResource(resource, r.Method) {
-		return apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
-	}
-
 	return handler.SubResourceHandler(rw, r, resource)
 }
 

--- a/pkg/server/subresource/subresource.go
+++ b/pkg/server/subresource/subresource.go
@@ -30,7 +30,7 @@ var (
 	handlers        []ResourceHandler
 	apiPath         = "/apis/subresources.harvester.io/v1"
 	healthCheckPath = apiPath
-	subResourcePath = apiPath + "/{namespace}/{resource}/{name}/{subresource}"
+	subResourcePath = apiPath + "/namespaces/{namespace}/{resource}/{name}/{subresource}"
 )
 
 func NewSubResourceHandler(mux *mux.Router) {

--- a/pkg/server/subresource/subresource.go
+++ b/pkg/server/subresource/subresource.go
@@ -90,7 +90,7 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if !found {
-		err = apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported %s/%s resource/subresource", resource.Name, resource.SubResource))
+		err = apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported %s/%s", resource.Name, resource.SubResource))
 	}
 
 	if err != nil {
@@ -101,6 +101,7 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			status = http.StatusNotFound
 		}
 		rw.WriteHeader(status)
+		fmt.Println(err)
 		_, _ = rw.Write([]byte(err.Error()))
 		return
 	}

--- a/pkg/server/subresource/subresource.go
+++ b/pkg/server/subresource/subresource.go
@@ -21,9 +21,6 @@ var (
 	VirtualMachines        = schema.GroupVersionResource{Group: apiService.Group, Version: apiService.Version, Resource: "virtualmachines"}
 	PersistentVolumeClaims = schema.GroupVersionResource{Group: apiService.Group, Version: apiService.Version, Resource: "persistentvolumeclaims"}
 	VolumeSnapshots        = schema.GroupVersionResource{Group: apiService.Group, Version: apiService.Version, Resource: "snapshot.storage.k8s.io.volumesnapshot"}
-
-	namespacedSubResources    = []schema.GroupVersionResource{VirtualMachineImages, UpgradeLogs, VirtualMachines, PersistentVolumeClaims, VolumeSnapshots}
-	nonNamespacedSubResources = []schema.GroupVersionResource{Node}
 )
 
 type Resource struct {
@@ -52,23 +49,9 @@ var (
 )
 
 func NewSubResourceHandler(mux *mux.Router) {
-	var paths []string
-
-	for _, resource := range namespacedSubResources {
-		path := fmt.Sprintf("/apis/%s/%s/namespaces/{namespace}/%s/{name}/{subresource}", resource.Group, resource.Version, resource.Resource)
-		paths = append(paths, path)
-	}
-
-	for _, resource := range nonNamespacedSubResources {
-		path := fmt.Sprintf("/apis/%s/%s/%s/{name}/{subresource}", resource.Group, resource.Version, resource.Resource)
-		paths = append(paths, path)
-	}
-
-	for _, path := range paths {
-		mux.Path(path).Handler(&handler{})
-	}
-
 	mux.Path(healthCheckPath).Handler(&healthHandler{})
+	mux.Path(fmt.Sprintf("/apis/%s/%s/namespaces/{namespace}/{resource}/{name}/{subresource}", apiService.Group, apiService.Version)).Handler(&handler{})
+	mux.Path(fmt.Sprintf("/apis/%s/%s/{resource}/{name}/{subresource}", apiService.Group, apiService.Version)).Handler(&handler{})
 }
 
 func RegisterSubResourceHandler(handler ResourceHandler) {

--- a/pkg/server/subresource/subresource.go
+++ b/pkg/server/subresource/subresource.go
@@ -77,6 +77,16 @@ func healthCheck(rw http.ResponseWriter, _ *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
+// Execute processes the request from old API schema
+func Execute(handler ResourceHandler, rw http.ResponseWriter, r *http.Request, resource Resource) error {
+	if !handler.IsMatchedResource(resource, r.Method) {
+		return apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
+	}
+
+	return handler.SubResourceHandler(rw, r, resource)
+}
+
+// serveSubResource processes the request from new API schema
 func serveSubResource(rw http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 

--- a/pkg/server/subresource/subresource.go
+++ b/pkg/server/subresource/subresource.go
@@ -28,7 +28,7 @@ type ResourceHandler interface {
 
 var (
 	handlers        []ResourceHandler
-	apiPath         = "/apis/subresources.harvester.io/v1"
+	apiPath         = "/apis/subresources.harvesterhci.io/v1beta1"
 	healthCheckPath = apiPath
 	subResourcePath = apiPath + "/namespaces/{namespace}/{resource}/{name}/{subresource}"
 )


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Currently, there are fews APIs don't follow kubernetes rules. In order to make use of kubernetes API format, we should migrate those APIs.

**Solution:**
HEP https://github.com/harvester/harvester/pull/5885

We could use Aggregated API Server (API Service) to solve this issue. Need to define a `subresources.harvesterhci.io` to proxy request to our harvester server. It's similar with [kubevirt subresource](https://kubevirt.io/api-reference/v1.2.0/operations.html#_v1start).

Create another common interface to deal with two different sources, this is a simple visual flow of objects.

![image](https://github.com/harvester/harvester/assets/6960289/1988ee73-518e-4816-bf75-7dc05b4819b4)




**Related Issue:**
https://github.com/harvester/harvester/issues/1078

**Test plan:**

Before testing, should check there is a harvester apiservice:

```yaml
apiVersion: apiregistration.k8s.io/v1
kind: APIService
metadata:
  name: v1beta1.subresources.harvesterhci.io
spec:
  group: subresources.harvesterhci.io
  groupPriorityMinimum: 1000
  service:
    name: harvester
    namespace: harvester-system
    port: 8443
  version: v1beta1
  versionPriority: 15
  insecureSkipTLSVerify: true
```

Before testing, these are example action API lists we currently use:
- GET `/v1/harvester/harvesterhci.io.virtualmachineimages/default/image-g88lp/download`
- POST `/v1/harvester/kubevirt.io.virtualmachines/default/test?action=stop`
- POST `/v1/harvester/nodes/jacknode?action=cordon`
- GET `/v1/harvester/upgradeslogs/default/test/download`
- POST `/v1/harvester/persistentvolumeclaims/default/test-disk-0-rlnlk?action=snapshot`

We should test those APIs by using subresource APIs, for example:

- GET `/apis/subresources.harvesterhci.io/v1beta1/namespaces/default/virtualmachineimages/ubuntu-focal/download`
- POST `/apis/subresources.harvesterhci.io/v1beta1/namespaces/default/virtualmachines/test/stop`
- POST `/apis/subresources.harvesterhci.io/v1beta1/nodes/jacknode/uncordon`
- GET `/apis/subresources.harvesterhci.io/v1beta1/namespaces/default/upgradelogs/test/download`
- POST `/apis/subresources.harvesterhci.io/v1beta1/namespaces/default/persistentvolumeclaims/test/snapshot`
- `/apis/subresources.harvesterhci.io/v1beta1/namespaces/default/snapshot.storage.k8s.io.volumesnapshots/test/restore`

Then you could also use following REST config to invoke subresource:

```go
harvesterCopyConfig := rest.CopyConfig(server.RESTConfig)
harvesterCopyConfig.GroupVersion = &k8sschema.GroupVersion{Group: "subresources.harvesterhci.io", Version: "v1beta1"}
harvesterCopyConfig.APIPath = "/apis"
harvesterCopyConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
harvesterSubresourceClient, err := rest.RESTClientFor(harvesterCopyConfig)

h.harvesterSubresourceClient.Post().Resource("nodes").SubResource("uncordon").Name(node.Name).Do(context.Background())
h.harvesterSubresourceClient.Post().Namespace("default").Resource("virtualmachines").SubResource("stop").Name("test").Do(context.Background())
```

When testing with wrong resource/name/subresource, will get different status code and message like:

- 422 - `InvalidAction 422: Unsupported virtualmachines/stopa`
- 422 - `InvalidAction 422: Unsupported virtualmachinessss/stop`
- 404 - `NotFound 404: Virtual machine default/testa not found`

Currently, I use rancher/apiserver to generate apierror like we did in action part. But, I think it's still discussable which ways we'd like to respond.

**Actions should migrate**

- [x] image
- [x] node
- [x] upgradelog
- [x] vm
- [x] volume
- [x] volumesnapshot
