### PR TITLE
Fix get fleet-agent deployment failed

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1304,8 +1304,13 @@ wait_for_deployment() {
 
 fleet_agent_timestamp(){
   wait_for_deployment cattle-fleet-local-system fleet-agent &> /dev/null
-  time=$(kubectl get deploy -n cattle-fleet-local-system fleet-agent -o json | jq -r .metadata.creationTimestamp)
-  date -u -d $time +'%s' 
+  local temptime=$(kubectl get deploy -n cattle-fleet-local-system fleet-agent -o json | jq -r .metadata.creationTimestamp)
+  if [ -z "$temptime" ]; then
+    # if kubectl happens to fail due to deployment is just deleted, echo 0 to continue
+    echo "0"
+  else
+    date -u -d $temptime +'%s'
+  fi
 }
 
 wait_for_fleet_agent(){


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

There is a chance the the old deployment is just deleted and the code failed to get it.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Return 0 in that case to continue

**Related Issue:**
https://github.com/harvester/harvester/issues/5712

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->


simulte to continue
```
cat > testdep.sh << 'EOF'
fleet_agent_timestamp(){
  wait_for_deployment cattle-fleet-local-system fleet-agent1 &> /dev/null
  local timetemp=$(kubectl get deploy -n cattle-fleet-local-system fleet-agent1 -o json | jq -r .metadata.creationTimestamp)
  if [ -z "$timetemp" ]; then
    # if kubectl happens to fail due to deployment is just deleted, echo 0 to continue
    echo "0"
  else
    date -u -d $timetemp +'%s'
  fi
}

wait_for_fleet_agent(){
  local timestamp=$1
  local newtimestamp=$(fleet_agent_timestamp)
  echo $timestamp $newtimestamp
  while [ $timestamp -ge $newtimestamp ]
  do
    echo "waiting for fleet-agent creation timestamp to be updated"
    sleep 10
    newtimestamp=$(fleet_agent_timestamp)
  done
}

wait_for_fleet_agent 100

EOF
chmod +x testdep.sh
./testdep.sh


harv41:/home/rancher # ./testdep.sh
Error from server (NotFound): deployments.apps "fleet-agent1" not found
100 0
waiting for fleet-agent creation timestamp to be updated
Error from server (NotFound): deployments.apps "fleet-agent1" not found
waiting for fleet-agent creation timestamp to be updated

...
```