### PR TITLE
fix: add images which are needed post-upgrade into retaining list

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -46,6 +46,10 @@ var (
 	// the end of an upgrade.
 	imageRetainList = []string{
 		"rancher/harvester-upgrade",
+		"longhornio/longhorn-engine",
+		"longhornio/longhorn-instance-manager",
+		"rancher/mirrored-banzaicloud-fluentd",
+		"rancher/mirrored-fluent-fluent-bit",
 	}
 )
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Some of the pods like LH instance-manager will continue to use the old container image after the upgrade ended, such images should not be cleaned up. Otherwise, it could break the service especially for air-gapped environment.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Find out those critical images and adding them into the retaining list so that they won't get purged.

**Related Issue:**

#5749

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Build an ISO image containing this fix
2. Prepare a Harvester cluster (v1.3.0) in air-gapped environment
3. Start the upgrade
4. After the upgrade ends, check for the following images. Both the old and new versions should exist on the node
   - `rancher/harvester-upgrade`
   - `longhornio/longhorn-engine`
   - `longhornio/longhorn-instance-manager`
   - `rancher/mirrored-banzaicloud-fluentd`
   - `rancher/mirrored-fluent-fluent-bit`
5. Check if any pod fails to run