### PR TITLE
fix: crash when setting backup status

### DIFF
--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -753,6 +753,10 @@ func (h *Handler) createVolumeSnapshotContent(
 
 func (h *Handler) setStatusError(vmBackup *harvesterv1.VirtualMachineBackup, err error) error {
 	vmBackupCpy := vmBackup.DeepCopy()
+	if vmBackupCpy.Status == nil {
+		vmBackupCpy.Status = &harvesterv1.VirtualMachineBackupStatus{}
+	}
+
 	vmBackupCpy.Status.Error = &harvesterv1.Error{
 		Time:    currentTime(),
 		Message: pointer.StringPtr(err.Error()),


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
harvester crashes when attempting to set an error status when no status exists yet.

**Solution:**
Set a status when it doesn't already exist to prevent nil pointer errors.

**Related Issue:**
Refs: #5805

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
