### PR TITLE
feat: add support bundle node collection timeout

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -54,8 +54,8 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string, pullPolicy
 	deployName = m.getManagerName(sb)
 	logrus.Debugf("creating deployment %s with image %s", deployName, image)
 
-	if expiration := settings.SupportBundleNodeTimeout.GetInt(); expiration == 0 {
-		nodeTimeout = time.Duration(supportBundleUtil.SupportBundleNodeTimeoutDefault) * time.Minute
+	if expiration := settings.SupportBundleNodeCollectionTimeout.GetInt(); expiration == 0 {
+		nodeTimeout = time.Duration(supportBundleUtil.SupportBundleNodeCollectionTimeoutDefault) * time.Minute
 	} else {
 		nodeTimeout = time.Duration(expiration) * time.Minute
 	}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -38,9 +38,9 @@ var (
 	SSLParameters                          = NewSetting(SSLParametersName, "{}")
 	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
 	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
-	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")                                                   // Unit is minute. 0 means disable timeout.
-	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, supportBundleUtil.SupportBundleExpirationDefaultStr) // Unit is minute.
-	SupportBundleNodeTimeout               = NewSetting(SupportBundleNodeTimeoutName, supportBundleUtil.SupportBundleNodeTimeoutDefaultStr)      // Unit is minute.
+	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")                                                                  // Unit is minute. 0 means disable timeout.
+	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, supportBundleUtil.SupportBundleExpirationDefaultStr)                // Unit is minute.
+	SupportBundleNodeCollectionTimeout     = NewSetting(SupportBundleNodeCollectionTimeoutName, supportBundleUtil.SupportBundleNodeCollectionTimeoutDefaultStr) // Unit is minute.
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
@@ -86,7 +86,7 @@ const (
 	SupportBundleExpirationSettingName                = "support-bundle-expiration"
 	NTPServersSettingName                             = "ntp-servers"
 	AutoRotateRKE2CertsSettingName                    = "auto-rotate-rke2-certs"
-	SupportBundleNodeTimeoutName                      = "support-bundle-node-timeout"
+	SupportBundleNodeCollectionTimeoutName            = "support-bundle-node-collection-timeout"
 )
 
 func init() {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -40,6 +40,7 @@ var (
 	SupportBundleNamespaces                = NewSetting("support-bundle-namespaces", "")
 	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, "10")                                                   // Unit is minute. 0 means disable timeout.
 	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, supportBundleUtil.SupportBundleExpirationDefaultStr) // Unit is minute.
+	SupportBundleNodeTimeout               = NewSetting(SupportBundleNodeTimeoutName, supportBundleUtil.SupportBundleNodeTimeoutDefaultStr)      // Unit is minute.
 	DefaultStorageClass                    = NewSetting("default-storage-class", "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
@@ -85,6 +86,7 @@ const (
 	SupportBundleExpirationSettingName                = "support-bundle-expiration"
 	NTPServersSettingName                             = "ntp-servers"
 	AutoRotateRKE2CertsSettingName                    = "auto-rotate-rke2-certs"
+	SupportBundleNodeTimeoutName                      = "support-bundle-node-timeout"
 )
 
 func init() {

--- a/pkg/util/supportbundle/constants.go
+++ b/pkg/util/supportbundle/constants.go
@@ -5,7 +5,7 @@ const (
 	SupportBundleExpirationDefault    = 30
 	SupportBundleExpirationDefaultStr = "30"
 
-	// SupportBundleNodeTimeoutDefault and SupportBundleNodeTimeoutDefaultStr these two value should be changed together.
-	SupportBundleNodeTimeoutDefault    = 30
-	SupportBundleNodeTimeoutDefaultStr = "30"
+	// SupportBundleNodeCollectionTimeoutDefault and SupportBundleNodeCollectionTimeoutDefaultStr these two value should be changed together.
+	SupportBundleNodeCollectionTimeoutDefault    = 30
+	SupportBundleNodeCollectionTimeoutDefaultStr = "30"
 )

--- a/pkg/util/supportbundle/constants.go
+++ b/pkg/util/supportbundle/constants.go
@@ -4,4 +4,8 @@ const (
 	// SupportBundleExpirationDefault and SupportBundleExpirationDefaultStr these two value should be changed together.
 	SupportBundleExpirationDefault    = 30
 	SupportBundleExpirationDefaultStr = "30"
+
+	// SupportBundleNodeTimeoutDefault and SupportBundleNodeTimeoutDefaultStr these two value should be changed together.
+	SupportBundleNodeTimeoutDefault    = 30
+	SupportBundleNodeTimeoutDefaultStr = "30"
 )

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -76,6 +76,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.SupportBundleImageName:                            validateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName:                   validateSupportBundleTimeout,
 	settings.SupportBundleExpirationSettingName:                validateSupportBundleExpiration,
+	settings.SupportBundleNodeTimeoutName:                      validateSupportBundleNodeTimeout,
 	settings.OvercommitConfigSettingName:                       validateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateSSLCertificates,
@@ -544,6 +545,21 @@ func validateUpdateSupportBundleTimeout(_ *v1beta1.Setting, newSetting *v1beta1.
 }
 
 func validateSupportBundleExpiration(setting *v1beta1.Setting) error {
+	if setting.Value == "" {
+		return nil
+	}
+
+	i, err := strconv.Atoi(setting.Value)
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), "value")
+	}
+	if i < 0 {
+		return werror.NewInvalidError("expiration can't be negative", "value")
+	}
+	return nil
+}
+
+func validateSupportBundleNodeTimeout(setting *v1beta1.Setting) error {
 	if setting.Value == "" {
 		return nil
 	}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -76,7 +76,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.SupportBundleImageName:                            validateSupportBundleImage,
 	settings.SupportBundleTimeoutSettingName:                   validateSupportBundleTimeout,
 	settings.SupportBundleExpirationSettingName:                validateSupportBundleExpiration,
-	settings.SupportBundleNodeTimeoutName:                      validateSupportBundleNodeTimeout,
+	settings.SupportBundleNodeCollectionTimeoutName:            validateSupportBundleNodeCollectionTimeout,
 	settings.OvercommitConfigSettingName:                       validateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateSSLCertificates,
@@ -559,7 +559,7 @@ func validateSupportBundleExpiration(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateSupportBundleNodeTimeout(setting *v1beta1.Setting) error {
+func validateSupportBundleNodeCollectionTimeout(setting *v1beta1.Setting) error {
 	if setting.Value == "" {
 		return nil
 	}

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -169,7 +169,7 @@ func Test_validateSupportBundleExpiration(t *testing.T) {
 	}
 }
 
-func Test_validateSupportBundleNodeTimeout(t *testing.T) {
+func Test_validateSupportBundleNodeCollectionTimeout(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        *v1beta1.Setting
@@ -178,7 +178,7 @@ func Test_validateSupportBundleNodeTimeout(t *testing.T) {
 		{
 			name: "invalid int",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeCollectionTimeoutName},
 				Value:      "not int",
 			},
 			expectedErr: true,
@@ -186,7 +186,7 @@ func Test_validateSupportBundleNodeTimeout(t *testing.T) {
 		{
 			name: "negative int",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeCollectionTimeoutName},
 				Value:      "-1",
 			},
 			expectedErr: true,
@@ -194,7 +194,7 @@ func Test_validateSupportBundleNodeTimeout(t *testing.T) {
 		{
 			name: "empty input",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeCollectionTimeoutName},
 				Value:      "",
 			},
 			expectedErr: false,
@@ -202,7 +202,7 @@ func Test_validateSupportBundleNodeTimeout(t *testing.T) {
 		{
 			name: "positive int",
 			args: &v1beta1.Setting{
-				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeCollectionTimeoutName},
 				Value:      "10",
 			},
 			expectedErr: false,
@@ -211,7 +211,7 @@ func Test_validateSupportBundleNodeTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSupportBundleNodeTimeout(tt.args)
+			err := validateSupportBundleNodeCollectionTimeout(tt.args)
 			assert.Equal(t, tt.expectedErr, err != nil)
 		})
 	}

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -169,6 +169,54 @@ func Test_validateSupportBundleExpiration(t *testing.T) {
 	}
 }
 
+func Test_validateSupportBundleNodeTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
+	}{
+		{
+			name: "invalid int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				Value:      "not int",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "negative int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				Value:      "-1",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty input",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				Value:      "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "positive int",
+			args: &v1beta1.Setting{
+				ObjectMeta: v1.ObjectMeta{Name: settings.SupportBundleNodeTimeoutName},
+				Value:      "10",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSupportBundleNodeTimeout(tt.args)
+			assert.Equal(t, tt.expectedErr, err != nil)
+		})
+	}
+}
+
 func Test_validateSSLProtocols(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**

Currently, there is no timeout for nodes when creating support bundle files, resulting in infinite waiting for node collection. That means we can't download support bundle file.

**Solution:**

- First, support node timeout in support-bundle-kit https://github.com/rancher/support-bundle-kit/pull/109.
- Second, provide custom setting of node timeout in harvester (this PR).

By this, we could still download support bundle file even node is timeout.

**Related Issue:**

https://github.com/harvester/harvester/issues/1646

**Test plan:**

Prepare:

1. Use new harvester with new support bundle kit image
2. Define `settings > support-bundle-node-collection-timeout` (unit is minute)
3. Create support bundle 
4. Check env fields of support bundle manager deployment

Two different cases:

- Case A: define large and enough minutes, it should get nodes folder successfully.
- Case B: define a small minute, like `"1"`. This one depends how long your environment takes. Just define a very small minute to make timeout happen. Although It won't get nodes folder, but It will get the support bundle file zip.