### PR TITLE
HEP: Add migration harvester to standardized k8s API [CI SKIP]

### DIFF
--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -230,6 +230,8 @@ But, each subresource might contain different HTTP method. It depends on the beh
 - If it's not idempotent, use `POST` or more matched HTTP method.
 - For list API, should use `GET` method. For example, `findMigratableNodes` action, it should be `GET` cause it doesn't change anything.
 
+We should also check which action is not used anymore, and remove it on new APIs. 
+
 #### Related Documentation Issue
 
 Currently, we didn't have any documentation for the action APIs, we only have k8s resource API instead.
@@ -244,7 +246,7 @@ Please check [api list](#api-list), and we need to test old and new APIs.
 There are two ways to test it:
 
 1. Test Entry Point
-   - The server shouldn't return 404 not found error for old and new APIs.
+   - The server shouldn't return 404 not found error for old and new endpoints.
 2. Test Functionality
    - The server should correctly handle the request.
 
@@ -258,12 +260,12 @@ However, it's an effort to maintain two different APIs, so eventually we need to
 
 1. (v1.4.0) Introduce the new APIs, and still support old APIs. Here, we could also introduce the new feature flag of setting resource to enable/disable old APIs. By default, it should be enabled at this moment. 
 2. (v1.5.0) Encourage the users to use the new APIs, and internal services/tools should use the new APIs.
-3. (v1.6.0)Old APIs are disabled by default, and we could turn it on by feature flag of setting resource.
+3. (v1.6.0) Old APIs are disabled by default, and we could turn it on by feature flag of setting resource.
 4. (v1.7.0) After a period of time, we could remove the old APIs and feature flag. Only keep new APIs.
 
 Those releases are just for reference, we could adjust it based on the progress of the migration.
 
-> Thanks @m-ildefons for the suggestion.
+> Thanks @m-ildefons for the milestone suggestion.
 
 In v1.4.0 harvester, we should accomplish first step at least.
 
@@ -271,8 +273,23 @@ About the second step, we need to request each project owner to check whether th
 
 For the third step and the last step, it depends on the progress of the second step. So, we will keep tracking it in the future release.
 
-***NOTE: if we have new action APIs, we should add them into both APIs at the same time ***
+***NOTE: if we have new action APIs, we should add them into both APIs at the same time.***
 
 ## Note
 
 Because kube api server will proxying request to the harvester api server, it may increase latency and pressure of kube api server if there are some huge usages with our subresource APIs.
+
+## Overall TODO
+
+- [ ] Check which action is not used anymore, remove it on new APIs.
+- [ ] Create new APIs for each action, check [api list](#api-list).
+  - [ ] Define the `APIService`
+  - [ ] New interface to fulfill two different API sources
+- [ ] Feature flag to enabled/disable old APIs
+- [ ] Internal services/tools convert old APIs to new APIs
+  - [ ] QA Tools
+  - [ ] Harvester Dashboard
+  - [ ] Other internal services
+- [ ] Release note to encourage users to use new APIs
+- [ ] Document for new APIs
+- [ ] Document for old APIs (Tracked in other issue)

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -256,19 +256,22 @@ We won't remove old APIs format immediately, we will support both old and new AP
 
 However, it's an effort to maintain two different APIs, so eventually we need to remove old one. So, the road map will be:
 
-1. Introduce the new APIs, and still support old APIs. Here, we could also introduce the new feature flag of setting resource to enable/disable old APIs. By default, it should be enabled at this moment. 
-2. Encourage the users to use the new APIs, and internal services/tools should use the new APIs.
-3. Old APIs are disabled by default, and we could turn it on by feature flag of setting resource.
-4. After a period of time, we could remove the old APIs and feature flag. Remain only new APIs.
+1. (v1.4.0) Introduce the new APIs, and still support old APIs. Here, we could also introduce the new feature flag of setting resource to enable/disable old APIs. By default, it should be enabled at this moment. 
+2. (v1.5.0) Encourage the users to use the new APIs, and internal services/tools should use the new APIs.
+3. (v1.6.0)Old APIs are disabled by default, and we could turn it on by feature flag of setting resource.
+4. (v1.7.0) After a period of time, we could remove the old APIs and feature flag. Only keep new APIs.
 
-***NOTE: we should add it into both APIs at the same time if we have new action APIs.***
+Those releases are just for reference, we could adjust it based on the progress of the migration.
 
-In v1.4 harvester, we should accomplish first step. 
+> Thanks @m-ildefons for the suggestion.
+
+In v1.4.0 harvester, we should accomplish first step at least.
 
 About the second step, we need to request each project owner to check whether they are using the old APIs or not. Then, open a new issue to track the progress. For the external users, because we didn't have any metrics to track all usages, so we can only note this in our release note. They could also use feature flag to test their application which is being used old APIs or not.
 
 For the third step and the last step, it depends on the progress of the second step. So, we will keep tracking it in the future release.
 
+***NOTE: if we have new action APIs, we should add them into both APIs at the same time ***
 
 ## Note
 

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -1,0 +1,159 @@
+# Migrate harvester API actions to standardized k8s API
+
+
+## Summary
+
+Harvester currently use rancher/steve to build custom api actions, such as stop vm with `?action=stop` which is not standard k8s API. 
+
+We will leverage the Kubernetes API Aggregation Layer, which proxies client requests to a specified API server defined with a custom resource `APIService`.
+
+This allows us to use the native Kubernetes client to invoke subresource APIs. 
+
+```go
+harvesterSubresourceClient.
+	Post().
+	Namespace("default").
+	Resource("virtualmachines").
+	SubResource("stop").
+	Name("test").Do(context.Background())
+```
+
+### Related Issue
+
+- https://github.com/harvester/harvester/issues/1078
+  - This is root issue.
+- https://github.com/harvester/harvester/issues/5627
+  - This is sub-issue about we need to add documentation for the action APIs. 
+
+
+## Motivation
+
+### Goals
+
+- Ensure the API format aligns with Kubernetes conventions for better consistency and security.
+- Support old and new API actions at the same time for backward compatibility.
+
+### Non-Goals
+
+- Remove old API actions immediately.
+- Migrate current non action APIs to k8s standardized APIs.
+
+## Proposal
+
+### Use Case 1 - API Usage
+
+In real usecase, the old api looks like this:
+
+```
+POST /v1/harvester/kubevirt.io.virtualmachines/default/test?action=stop
+POST /v1/harvester/nodes/jacknode?action=cordon
+GET  /v1/harvester/upgradeslogs/default/test/download
+POST /v1/harvester/persistentvolumeclaims/default/test-disk-0-rlnlk?action=snapshot
+```
+
+The new api will be like this:
+
+```yaml
+POST /apis/subresources.harvesterhci.io/v1beta1/namespaces/default/virtualmachines/test/stop
+POST /apis/subresources.harvesterhci.io/v1beta1/nodes/jacknode/uncordon
+GET  /apis/subresources.harvesterhci.io/v1beta1/namespaces/default/upgradelogs/test/download
+POST /apis/subresources.harvesterhci.io/v1beta1/namespaces/default/persistentvolumeclaims/test/snapshot
+```
+
+That means we can use k8s client to access the subresource API as well.
+
+```go
+harvesterCopyConfig := rest.CopyConfig(server.RESTConfig)
+harvesterCopyConfig.GroupVersion = &k8sschema.GroupVersion{Group: "subresources.harvesterhci.io", Version: "v1beta1"}
+harvesterCopyConfig.APIPath = "/apis"
+harvesterCopyConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+harvesterSubresourceClient, err := rest.RESTClientFor(harvesterCopyConfig)
+
+h.harvesterSubresourceClient.Post().Resource("nodes").SubResource("uncordon").Name(node.Name).Do(context.Background())
+h.harvesterSubresourceClient.Post().Namespace("default").Resource("virtualmachines").SubResource("stop").Name("test").Do(context.Background())
+```
+
+Or a pure native k8s API.
+
+```
+https://{server}/apis/subresources.harvesterhci.io/v1beta1/namespaces/default/virtualmachines/test2/stop
+```
+
+### Use Case 2 - Security
+
+When using subresource API, we can leverage the Kubernetes RBAC to control the access to the subresource API. For example, if we create a role like below, the user can only GET and POST the subresource.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: subresource-test
+  namespace: default
+rules:
+- apiGroups:
+  - subresources.harvesterhci.io
+  resources:
+  - virtualmachines/stop
+  verbs:
+  - get
+  - create
+```
+
+It will get the 403 forbidden error if the user tries to access the subresource without the permission.
+
+```json
+{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "metadata": {},
+  "status": "Failure",
+  "message": "virtualmachines.subresources.harvesterhci.io \"test2\" is forbidden: User \"system:serviceaccount:default:test-subresource\" cannot create resource \"virtualmachines/start\" in API group \"subresources.harvesterhci.io\" in the namespace \"default\"",
+  "reason": "Forbidden",
+  "details": {
+    "name": "test2",
+    "group": "subresources.harvesterhci.io",
+    "kind": "virtualmachines"
+  },
+  "code": 403
+}
+```
+
+### Design
+
+In order to implement this proposal, we need to take the following steps:
+
+1. Define the `APIService` to proxy requests to Harvester API server.
+    ```yaml
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      name: v1beta1.subresources.harvesterhci.io
+    spec:
+      group: subresources.harvesterhci.io
+      groupPriorityMinimum: 1000
+      insecureSkipTLSVerify: true
+      service:
+        name: harvester
+        namespace: harvester-system
+        port: 8443
+      version: v1beta1
+      versionPriority: 15
+    ```
+2. Define the new routes path to accept following request path formats:
+   - `/apis/subresources.harvesterhci.io/v1beta1/namespaces/{namespace}/{resource}/{name}/{subresource}` 
+   - `/apis/subresources.harvesterhci.io/v1beta1/{resource}/{name}/{subresource}`
+
+It's basically done because we've had the action business logic in the controller, we just need to create a new interface to fulfill two different API sources, which one is from steve and the other is from subresource api.
+
+### Test Plan
+
+Should test old and new APIs path formats, both should work as expected.
+
+### Upgrade strategy
+
+We won't remove old APIs format immediately, we will support both old and new APIs at the same time for backward compatibility.
+
+
+## Note
+
+Because kube api server will proxying request to the harvester api server, it may increase latency and pressure of kube api server if there are some huge usages with our subresource APIs.

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -35,7 +35,6 @@ harvesterSubresourceClient.
 
 ### Non-Goals
 
-- Remove old API actions immediately.
 - Migrate current non action APIs to k8s standardized APIs.
 
 ## Proposal
@@ -233,9 +232,10 @@ But, each subresource might contain different HTTP method. It depends on the beh
 
 #### Related Documentation Issue
 
-Currently, we didn't have any document for the action APIs, there is already an issue for tracking this. After migration, we also need to document the new APIs.
+Currently, we didn't have any documentation for the action APIs, we only have k8s resource API instead.
 
-[[Doc] Add document for action APIs · Issue #5627 · harvester/harvester](https://github.com/harvester/harvester/issues/5627)
+There is already an issue [[Doc] Add document for action APIs](https://github.com/harvester/harvester/issues/5627) for tracking this. After migration, we also need to document the new APIs. This documentation upgrade strategy will follow below `Upgrade Strategy` section.
+
 
 ### Test Plan
 
@@ -244,6 +244,21 @@ Should test old and new APIs path formats, both should work as expected.
 ### Upgrade strategy
 
 We won't remove old APIs format immediately, we will support both old and new APIs at the same time for backward compatibility.
+
+However, it's an effort to maintain two different APIs, so eventually we need to remove old one. So, the road map will be:
+
+1. Introduce the new APIs, and still support old APIs. Here, we could also introduce the new feature flag of setting resource to enable/disable old APIs. By default, it should be enabled at this moment. 
+2. Encourage the users to use the new APIs, and internal services/tools should use the new APIs.
+3. Old APIs are disabled by default, and we could turn it on by feature flag of setting resource.
+4. After a period of time, we could remove the old APIs and feature flag. Remain only new APIs.
+
+***NOTE: we should add it into both APIs at the same time if we have new action APIs.***
+
+In v1.4 harvester, we should accomplish first step. 
+
+About the second step, we need to request each project owner to check whether they are using the old APIs or not. Then, open a new issue to track the progress. For the external users, because we didn't have any metrics to track all usages, so we can only note this in our release note. They could also use feature flag to test their application which is being used old APIs or not.
+
+For the third step and the last step, it depends on the progress of the second step. So, we will keep tracking it in the future release.
 
 
 ## Note

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -227,10 +227,10 @@ After migration, the new APIs will be like this:
 
 But, each subresource might contain different HTTP method. It depends on the behavior is idempotent or not. 
 - If it's idempotent, use `PUT` method.
-- If it's not idempotent, use `POST` or more matched HTTP method.
+- If it's not idempotent, use `POST` or more matched HTTP method. **However, there shouldn't be `POST` or more matched HTTP method because most APIs aim to handle existing resource instead of creating new one.**
 - For list API, should use `GET` method. For example, `findMigratableNodes` action, it should be `GET` cause it doesn't change anything.
 
-We should also check which action is not used anymore, and remove it on new APIs. 
+In short words, **there should be only `GET` or `PUT` method for subresource APIs**. And We should also check which action is not used anymore, and remove it on new APIs. 
 
 #### Related Documentation Issue
 

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -239,7 +239,16 @@ There is already an issue [[Doc] Add document for action APIs](https://github.co
 
 ### Test Plan
 
-Should test old and new APIs path formats, both should work as expected.
+Please check [api list](#api-list), and we need to test old and new APIs. 
+
+There are two ways to test it:
+
+1. Test Entry Point
+   - The server shouldn't return 404 not found error for old and new APIs.
+2. Test Functionality
+   - The server should correctly handle the request.
+
+For first one, just make sure the endpoint is accessible. For the second one, we could copy existing test cases and modify the request path to new APIs. But, it might increase the time of testing, so we might pick some important APIs to test first. If time is enough, we could test it all.
 
 ### Upgrade strategy
 

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -183,7 +183,7 @@ However, if we plan to change the HTTP method to suitable one, which might be fr
 So, there are two options for this:
 
 1. Don't change HTTP method, keep both same.
-2. Only change new API schema HTTP method, keep old API original.
+2. Don't migrate, create new API schema with new HTTP method and still keep old API original.
 
 Migration will be easier with first decision than second one. Since in second one, we need to create a way to sync endpoint and HTTP method between GUI and backend.
 

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -189,6 +189,8 @@ resource.Actions["start"] = fmt.Sprintf("%s/%s", link, "start")
 // "start": https://192.168.1.122/.../v1/harvester/kubevirt.io.virtualmachines/{namespace}/{name}/start
 ```
 
+However, we plan to change the HTTP method to suitable one, which might be from `POST` to `PUT` or from `POST` to `GET`. There will be some effort for GUI because GUI need to support two different API schema, even different HTTP method.
+
 
 ### Complete API List need migration
 
@@ -340,3 +342,7 @@ Because kube api server will proxying request to the harvester api server, it ma
 - [ ] Release note to encourage users to use new APIs
 - [ ] Document for new APIs
 - [ ] Document for old APIs (Tracked in other issue)
+
+## Open Discussion
+
+Since we highly couple with rancher/steve, it might not be a good option to change the way how we use rancher/steve. So, I'm thinking we could just only support new API schema instead of migration.

--- a/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
+++ b/enhancements/20240528-migrate-harvester-api-to-standardized-k8s-api.md
@@ -231,6 +231,12 @@ But, each subresource might contain different HTTP method. It depends on the beh
 - If it's not idempotent, use `POST` or more matched HTTP method.
 - For list API, should use `GET` method. For example, `findMigratableNodes` action, it should be `GET` cause it doesn't change anything.
 
+#### Related Documentation Issue
+
+Currently, we didn't have any document for the action APIs, there is already an issue for tracking this. After migration, we also need to document the new APIs.
+
+[[Doc] Add document for action APIs · Issue #5627 · harvester/harvester](https://github.com/harvester/harvester/issues/5627)
+
 ### Test Plan
 
 Should test old and new APIs path formats, both should work as expected.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**

Harvester currently use rancher/steve to build custom api actions, such as stop vm with `?action=stop` which is not standard k8s API. It's not convenient practice to use custom actions in k8s API.

**Solution:**

We will leverage the Kubernetes API Aggregation Layer, which proxies client requests to a specified API server defined with a custom resource `APIService`. This allows us to use the native Kubernetes client to invoke subresource APIs. 

Please take a look at HEP for more details.

**Related Issue:**
https://github.com/harvester/harvester/issues/1078

**Processing implementation PR**
- https://github.com/harvester/harvester/pull/5704 

**TODO after 1st review**

- [x] Complete List APIs
- [x] More details about upgrade strategy
- [x] More details about test plan
