### PR TITLE
expose kubeconfig ttl setting in harvester

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -36,7 +36,7 @@ var (
 	// bootstrapSettings are the setting that syncs on bootstrap
 	bootstrapSettings = []string{
 		settings.SSLCertificatesSettingName,
-		settings.KubeconfigTTLSettingName,
+		settings.KubeconfigDefaultTokenTTLMinutesSettingName,
 	}
 	skipHashCheckSettings = []string{
 		settings.AutoRotateRKE2CertsSettingName,

--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -36,6 +36,7 @@ var (
 	// bootstrapSettings are the setting that syncs on bootstrap
 	bootstrapSettings = []string{
 		settings.SSLCertificatesSettingName,
+		settings.KubeconfigTTLSettingName,
 	}
 	skipHashCheckSettings = []string{
 		settings.AutoRotateRKE2CertsSettingName,
@@ -72,6 +73,8 @@ type Handler struct {
 	nodeConfigs          ctlnodev1.NodeConfigClient
 	nodeConfigsCache     ctlnodev1.NodeConfigCache
 	rkeControlPlaneCache ctlrkev1.RKEControlPlaneCache
+	rancherSettings      ctlmgmtv3.SettingClient
+	rancherSettingsCache ctlmgmtv3.SettingCache
 }
 
 func (h *Handler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {

--- a/pkg/controller/master/setting/kubeconfigttl.go
+++ b/pkg/controller/master/setting/kubeconfigttl.go
@@ -7,18 +7,35 @@ import (
 	harvSettings "github.com/harvester/harvester/pkg/settings"
 )
 
+const (
+	AuthTokenMaxTTLSettinName = "auth-token-max-ttl-minutes"
+)
+
 func (h *Handler) syncKubeconfigTTL(setting *harvesterv1.Setting) error {
 	rancherKubeconfigTTLSetting, err := h.rancherSettingsCache.Get(harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName)
 	if err != nil {
 		return fmt.Errorf("error fetching setting %s: %v", harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName, err)
 	}
+	rancherAuthTokenMaxTTLSetting, err := h.rancherSettingsCache.Get(AuthTokenMaxTTLSettinName)
+	if err != nil {
+		return fmt.Errorf("error fetching setting %s: %v", AuthTokenMaxTTLSettinName, err)
+	}
 
 	// if a custom ttl is set in harvester
 	if len(setting.Value) > 0 {
 		rancherKubeconfigTTLSetting.Value = setting.Value
+		rancherAuthTokenMaxTTLSetting.Value = setting.Value
 	} else { // apply default setting
 		rancherKubeconfigTTLSetting.Value = setting.Default
+		rancherAuthTokenMaxTTLSetting.Value = setting.Default
 	}
-	_, err = h.rancherSettings.Update(rancherKubeconfigTTLSetting)
-	return err
+
+	if _, err := h.rancherSettings.Update(rancherKubeconfigTTLSetting); err != nil {
+		return fmt.Errorf("unable to update rancher setting %s: %v", rancherKubeconfigTTLSetting.Name, err)
+	}
+
+	if _, err := h.rancherSettings.Update(rancherAuthTokenMaxTTLSetting); err != nil {
+		return fmt.Errorf("unable to update rancher setting %s: %v", rancherAuthTokenMaxTTLSetting.Name, err)
+	}
+	return nil
 }

--- a/pkg/controller/master/setting/kubeconfigttl.go
+++ b/pkg/controller/master/setting/kubeconfigttl.go
@@ -8,9 +8,9 @@ import (
 )
 
 func (h *Handler) syncKubeconfigTTL(setting *harvesterv1.Setting) error {
-	rancherKubeconfigTTLSetting, err := h.rancherSettingsCache.Get(harvSettings.KubeconfigTTLSettingName)
+	rancherKubeconfigTTLSetting, err := h.rancherSettingsCache.Get(harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName)
 	if err != nil {
-		return fmt.Errorf("error fetching setting %s: %v", harvSettings.KubeconfigTTLSettingName, err)
+		return fmt.Errorf("error fetching setting %s: %v", harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName, err)
 	}
 
 	// if a custom ttl is set in harvester

--- a/pkg/controller/master/setting/kubeconfigttl.go
+++ b/pkg/controller/master/setting/kubeconfigttl.go
@@ -1,0 +1,24 @@
+package setting
+
+import (
+	"fmt"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harvSettings "github.com/harvester/harvester/pkg/settings"
+)
+
+func (h *Handler) syncKubeconfigTTL(setting *harvesterv1.Setting) error {
+	rancherKubeconfigTTLSetting, err := h.rancherSettingsCache.Get(harvSettings.KubeconfigTTLSettingName)
+	if err != nil {
+		return fmt.Errorf("error fetching setting %s: %v", harvSettings.KubeconfigTTLSettingName, err)
+	}
+
+	// if a custom ttl is set in harvester
+	if len(setting.Value) > 0 {
+		rancherKubeconfigTTLSetting.Value = setting.Value
+	} else { // apply default setting
+		rancherKubeconfigTTLSetting.Value = setting.Default
+	}
+	_, err = h.rancherSettings.Update(rancherKubeconfigTTLSetting)
+	return err
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -74,19 +74,19 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 
 	syncers = map[string]syncerFunc{
-		"additional-ca":                       controller.syncAdditionalTrustedCAs,
-		"cluster-registration-url":            controller.registerCluster,
-		"http-proxy":                          controller.syncHTTPProxy,
-		"log-level":                           controller.setLogLevel,
-		"overcommit-config":                   controller.syncOvercommitConfig,
-		"vip-pools":                           controller.syncVipPoolsConfig,
-		"auto-disk-provision-paths":           controller.syncNDMAutoProvisionPaths,
-		"ssl-certificates":                    controller.syncSSLCertificate,
-		"ssl-parameters":                      controller.syncSSLParameters,
-		"containerd-registry":                 controller.syncContainerdRegistry,
-		"ntp-servers":                         controller.syncNTPServer,
-		"auto-rotate-rke2-certs":              controller.syncAutoRotateRKE2Certs,
-		harvSettings.KubeconfigTTLSettingName: controller.syncKubeconfigTTL,
+		"additional-ca":             controller.syncAdditionalTrustedCAs,
+		"cluster-registration-url":  controller.registerCluster,
+		"http-proxy":                controller.syncHTTPProxy,
+		"log-level":                 controller.setLogLevel,
+		"overcommit-config":         controller.syncOvercommitConfig,
+		"vip-pools":                 controller.syncVipPoolsConfig,
+		"auto-disk-provision-paths": controller.syncNDMAutoProvisionPaths,
+		"ssl-certificates":          controller.syncSSLCertificate,
+		"ssl-parameters":            controller.syncSSLParameters,
+		"containerd-registry":       controller.syncContainerdRegistry,
+		"ntp-servers":               controller.syncNTPServer,
+		"auto-rotate-rke2-certs":    controller.syncAutoRotateRKE2Certs,
+		harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName: controller.syncKubeconfigTTL,
 		// for "backup-target" syncer, please check harvester-backup-target-controller
 		// for "storage-network" syncer, please check harvester-storage-network-controller
 	}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -52,7 +52,7 @@ var (
 	StorageNetwork                         = NewSetting(StorageNetworkName, "")
 	DefaultVMTerminationGracePeriodSeconds = NewSetting(DefaultVMTerminationGracePeriodSecondsSettingName, "120")
 	AutoRotateRKE2CertsSet                 = NewSetting(AutoRotateRKE2CertsSettingName, InitAutoRotateRKE2Certs())
-
+	KubeconfigTTL                          = NewSetting(KubeconfigDefaultTokenTTLMinutesSettingName, "0") // "0" is default value to ensure token does not expire
 	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
 	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.3.0","harvester-csi-provider":">=0.0.1 <0.3.0"}`)
 	NTPServers             = NewSetting(NTPServersSettingName, "")
@@ -86,7 +86,7 @@ const (
 	SupportBundleExpirationSettingName                = "support-bundle-expiration"
 	NTPServersSettingName                             = "ntp-servers"
 	AutoRotateRKE2CertsSettingName                    = "auto-rotate-rke2-certs"
-	KubeconfigTTLSettingName                          = "kubeconfig-default-token-ttl-minutes"
+	KubeconfigDefaultTokenTTLMinutesSettingName       = "kubeconfig-default-token-ttl-minutes"
 	SupportBundleNodeCollectionTimeoutName            = "support-bundle-node-collection-timeout"
 )
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -86,6 +86,7 @@ const (
 	SupportBundleExpirationSettingName                = "support-bundle-expiration"
 	NTPServersSettingName                             = "ntp-servers"
 	AutoRotateRKE2CertsSettingName                    = "auto-rotate-rke2-certs"
+	KubeconfigTTLSettingName                          = "kubeconfig-default-token-ttl-minutes"
 	SupportBundleNodeCollectionTimeoutName            = "support-bundle-node-collection-timeout"
 )
 

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -88,6 +88,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.DefaultVMTerminationGracePeriodSecondsSettingName: validateDefaultVMTerminationGracePeriodSeconds,
 	settings.NTPServersSettingName:                             validateNTPServers,
 	settings.AutoRotateRKE2CertsSettingName:                    validateAutoRotateRKE2Certs,
+	settings.KubeconfigDefaultTokenTTLMinutesSettingName:       validateKubeConfigTTLSetting,
 }
 
 type validateSettingUpdateFunc func(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error
@@ -105,6 +106,7 @@ var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
 	settings.DefaultVMTerminationGracePeriodSecondsSettingName: validateUpdateDefaultVMTerminationGracePeriodSeconds,
 	settings.NTPServersSettingName:                             validateUpdateNTPServers,
 	settings.AutoRotateRKE2CertsSettingName:                    validateUpdateAutoRotateRKE2Certs,
+	settings.KubeconfigDefaultTokenTTLMinutesSettingName:       validateUpdateKubeConfigTTLSetting,
 }
 
 type validateSettingDeleteFunc func(setting *v1beta1.Setting) error
@@ -1032,4 +1034,24 @@ func validateAutoRotateRKE2Certs(setting *v1beta1.Setting) error {
 
 func validateUpdateAutoRotateRKE2Certs(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateAutoRotateRKE2Certs(newSetting)
+}
+
+func validateKubeConfigTTLSetting(newSetting *v1beta1.Setting) error {
+	if newSetting.Value == "" {
+		return nil
+	}
+
+	num, err := strconv.Atoi(newSetting.Value)
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), "value")
+	}
+
+	if num < 0 {
+		return werror.NewInvalidError("kubeconfig-default-token-ttl-minutes cannot be negative", "value")
+	}
+	return nil
+}
+
+func validateUpdateKubeConfigTTLSetting(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	return validateKubeConfigTTLSetting(newSetting)
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -446,3 +446,51 @@ func Test_validateNoProxy_2(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateKubeconfigTTLSetting(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
+	}{
+		{
+			name: "invalid int",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.KubeconfigDefaultTokenTTLMinutesSettingName},
+				Value:      "not int",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "negative int",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.KubeconfigDefaultTokenTTLMinutesSettingName},
+				Value:      "-1",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty input",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.KubeconfigDefaultTokenTTLMinutesSettingName},
+				Value:      "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "positive int",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.KubeconfigDefaultTokenTTLMinutesSettingName},
+				Value:      "10",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSupportBundleNodeCollectionTimeout(tt.args)
+			assert.Equal(t, tt.expectedErr, err != nil)
+		})
+	}
+}

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -489,7 +489,7 @@ func Test_validateKubeconfigTTLSetting(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSupportBundleNodeCollectionTimeout(tt.args)
+			err := validateKubeConfigTTLSetting(tt.args)
 			assert.Equal(t, tt.expectedErr, err != nil)
 		})
 	}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Rancher 2.8.x introduced a new setting for kubeconfig ttl. The default value for the setting is 30 days. As a result admin kubeconfig generated from Harvester expires in 30 days since this leverages the embedded rancher.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR exposes the same kubeconfig ttl setting via harvester, with the harvester value taking precedence over rancher setting.

**Related Issue:**
https://github.com/harvester/harvester/issues/5874
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
