### PR TITLE
The `AddBuiltInNoProxy` function does not handle whitespace

### DIFF
--- a/pkg/util/proxy.go
+++ b/pkg/util/proxy.go
@@ -3,6 +3,7 @@ package util
 import (
 	"strings"
 
+	gocommon "github.com/harvester/go-common"
 	"github.com/rancher/wrangler/pkg/slice"
 )
 
@@ -26,7 +27,8 @@ type HTTPProxyConfig struct {
 }
 
 func AddBuiltInNoProxy(noProxy string) string {
-	noProxySlice := strings.Split(noProxy, ",")
+	noProxySlice := gocommon.SliceMapFunc(strings.Split(noProxy, ","),
+		func(v string, _ int) string { return strings.TrimSpace(v) })
 	for _, item := range builtInNoProxy {
 		if !slice.ContainsString(noProxySlice, item) {
 			noProxySlice = append(noProxySlice, item)

--- a/pkg/util/proxy_test.go
+++ b/pkg/util/proxy_test.go
@@ -27,6 +27,11 @@ func Test_AddBuiltInNoProxy(t *testing.T) {
 			input:  "10.0.0.0/8,127.0.0.1",
 			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
 		},
+		{
+			name:   "overlapped items, with whitespace",
+			input:  " 10.0.0.0/8  ,  127.0.0.1 ",
+			output: "10.0.0.0/8,127.0.0.1,localhost,0.0.0.0,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
**Problem:**
When a user enters a noProxy setting like ` 10.0.0.0/8  ,  127.0.0.1 `, the [built-in noProxy configuration](https://github.com/harvester/harvester/blob/5ee0329f1a6acef48e52758d3caf1d19e3bac1aa/pkg/util/proxy.go#L9) will add duplicates, in this case `127.0.0.1`.

**Solution:**
Trim the parts of the split-ed `noProxy` string.

**Related Issue:**
https://github.com/harvester/harvester/issues/5900

**Test plan:**
The internal test cases have been adapted. 

It is not possible to test that from within the UI directly. You can only check it indirectly. See:

- https://github.com/harvester/harvester/issues/5900#issuecomment-2257951768
- https://github.com/harvester/harvester/issues/5900#issuecomment-2295886250
