### PR TITLE
ci: fix upload target folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,7 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/heads/') }}
       with:
         path: dist/artifacts
+        parent: false
         destination: releases.rancher.com/harvester/${{ env.branch }}
         predefinedAcl: publicRead
         headers: |-
@@ -364,6 +365,7 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
         path: dist/artifacts
+        parent: false
         destination: releases.rancher.com/harvester/${{ github.ref_name }}
         predefinedAcl: publicRead
         headers: |-


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**

`Uploading /home/runner/_work/harvester/harvester/dist/artifacts/harvester-v1.3-rootfs-amd64.squashfs to gs://releases.rancher.com/harvester/v1.3/artifacts/harvester-v1.3-rootfs-amd64.squashfs`

**Solution:**

Should be `gs://releases.rancher.com/harvester/v1.3/harvester-v1.3-rootfs-amd64.squashfs` without `artifacts. 

Original drone setting https://github.com/harvester/harvester/pull/5674/files#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7L701-L715

Reference of Google action: https://github.com/google-github-actions/upload-cloud-storage?tab=readme-ov-file#destination-filenames

**Related Issue:**
https://github.com/harvester/harvester/pull/5674

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
