### PR TITLE
(v1.3) bump: support-bundle-kit to v0.0.38

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -485,7 +485,7 @@ support-bundle-kit:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/support-bundle-kit
-    tag: v0.0.36
+    tag: v0.0.38
 
 generalJob:
   image:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
`None`, just a bump.

**Solution:**
bump support-bundle-kit to v0.0.38

**Related Issue:**
https://github.com/harvester/harvester/issues/1646

**Test plan:**
Should be able to create support bundle.
