### PR TITLE
ci: add daily build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
     tags:
     - v*
   pull_request:
+  schedule:
+    - cron: "10 0,12 * * *"
 jobs:
   build-binaries:
     name: Build binaries


### PR DESCRIPTION
We no longer publish ISOs from the harvester-installer repo, so we do daily builds here.
Build ISOs twice a day to catch up the installer change earlier (in case there is no merge event in the harvester repo).
