### PR TITLE
chore: fix image branch name with dot

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -10,7 +10,7 @@ fi
 
 COMMIT=$(git rev-parse --short=8 HEAD)
 COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-COMMIT_BRANCH_FORMATTED=$(echo "${COMMIT_BRANCH}" | sed -E 's/[^a-zA-Z0-9]+/-/g')
+COMMIT_BRANCH_FORMATTED=$(echo "${COMMIT_BRANCH}" | sed -E 's/[^a-zA-Z0-9.]+/-/g')
 GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then


### PR DESCRIPTION
The change a42d9cc83d29249797d02105ab3295aa16c4a644 replace dot `.` to `-` in image tags (e.g., `v1.3-xxxx-head` to `v1-3-xxxx-head`), ignore the dot because we publish branch images with tags like `v1.3-xxx-head`.

supposed to fix: https://github.com/harvester/harvester/actions/runs/9345571254/job/25727308736