### PR TITLE
Add `harvesterhci.io/force-preload-import` to force import images in upgrade preload phase

### DIFF
--- a/pkg/webhook/resources/upgrade/validator_test.go
+++ b/pkg/webhook/resources/upgrade/validator_test.go
@@ -1,0 +1,61 @@
+package upgrade
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+)
+
+func Test_checkForcePreloadImportAnnotation(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		upgrade   *v1beta1.Upgrade
+		errString string
+	}{
+		{
+			name:      "annotation is nil",
+			upgrade:   &v1beta1.Upgrade{},
+			errString: "",
+		},
+		{
+			name: "annotation is true",
+			upgrade: &v1beta1.Upgrade{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{forcePreloadImportAnnotation: "true"},
+				},
+			},
+			errString: "",
+		},
+		{
+			name: "annotation is false",
+			upgrade: &v1beta1.Upgrade{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{forcePreloadImportAnnotation: "false"},
+				},
+			},
+			errString: "",
+		},
+		{
+			name: "annotation is something else",
+			upgrade: &v1beta1.Upgrade{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{forcePreloadImportAnnotation: "True"},
+				},
+			},
+			errString: fmt.Sprintf("annotation %s should be either 'true' or 'false'", forcePreloadImportAnnotation),
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := checkForcePreloadImportAnnotation(testCase.upgrade)
+		if testCase.errString != "" {
+			assert.Equal(t, testCase.errString, err.Error())
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+}


### PR DESCRIPTION
**Problem:**
The upgrade preload script will not preload the already displayed images again, e.g. the second upgrade uses the same image tag like rancher/harvester-cluster-repo:master

**Solution:**
Introduce a new annotation `harvesterhci.io/force-preload-import`, set it to true to force all images loaded during upgrade pre-load phase. 

**Related Issue:**
https://github.com/harvester/harvester/issues/2108

**Test plan:**
1. Build harvester iso from local dev branch. e.g. `branch-foobar` and create harvester cluster with one node.
2. Use the following yaml to upgrade to a lastest version in master branch.
```yaml
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master
  namespace: harvester-system
spec:
  isoURL: https://releases.rancher.com/harvester/master/harvester-master-amd64.iso
```

```yaml
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  annotations:
    harvesterhci.io/skip-version-check: "true"
    harvesterhci.io/skipWebhook: "true"
    harvesterhci.io/force-preload-import: "true"
  generateName: hvst-upgrade-
  namespace: harvester-system
spec:
  version: "master"
```
3. Check the upgrade complete without any error.