### PR TITLE
Use strategic merge patch when upgrade harvester-cluster-repo

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -337,7 +337,7 @@ spec:
         - name: httpd
           image: rancher/harvester-cluster-repo:$REPO_OS_VERSION
 EOF
-  kubectl patch deployment harvester-cluster-repo -n cattle-system --patch-file ./cluster_repo.yaml --type merge
+  kubectl patch deployment harvester-cluster-repo -n cattle-system --patch-file ./cluster_repo.yaml --type strategic
 
   until kubectl -n cattle-system rollout status -w deployment/harvester-cluster-repo; do
     echo "Waiting for harvester-cluster-repo deployment ready..."


### PR DESCRIPTION
**Problem:**
this is a follow up from https://github.com/harvester/harvester/pull/5941#issuecomment-2182357156

Sine we use `--type merge` 
https://github.com/harvester/harvester/blob/226f72aa58532071232ad548e27970c1cec55733/package/upgrade/upgrade_manifests.sh#L340

it will erase the port settings

https://github.com/harvester/harvester-installer/blob/1e7572e3822c70adf5730d71ef94f071a15dde82/package/harvester-os/templates/91-harvester-bootstrap-repo.yaml#L20-L21

Would be better if we only change the image version during upgrade instead of replacing the entire settings in the httpd container.

**Solution:**
Use `strategic` instead of `merge` in `kubectl patch deployment harvester-cluster-repo`

**Related Issue:**
https://github.com/harvester/harvester/issues/6073

**Test plan:**
One easy way to test this pr is preparing a one harvester node and execute the cmd as follows. (note that you need to replace $REPO_OS_VERSION with the correct version)
```
  cat >cluster_repo.yaml <<EOF
spec:
  template:
    spec:
      containers:
        - name: httpd
          image: rancher/harvester-cluster-repo:$REPO_OS_VERSION
EOF
  kubectl patch deployment harvester-cluster-repo -n cattle-system --patch-file ./cluster_repo.yaml --type strategic
```
And check the ports settings is still
```yaml
ports:                                                 
- containerPort: 80
   protocol: TCP
```
instead of empty in `cattle-system/harvester-cluster-repo` 

**Addition Context**:

Added more context here. In fact, whether or not the container port is specified in the deployment, the harvester-cluster-repo still expose port 80.

quoted from https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/
> Not specifying a port here DOES NOT prevent that port from being exposed.
![image](https://github.com/harvester/harvester/assets/4344302/51c86777-33cd-4289-80fb-c8d3064caa5f)

So that's why even if we erase the ports setting during upgrade, harvester-cluster-repo still works.