### PR TITLE
Improve tracking of device allocation

### DIFF
--- a/pkg/api/cluster/formatter.go
+++ b/pkg/api/cluster/formatter.go
@@ -1,0 +1,93 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/rancher/apiserver/pkg/apierror"
+	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+)
+
+type Handler struct {
+	vmCache   ctlkubevirtv1.VirtualMachineCache
+	nodeCache ctlcorev1.NodeCache
+}
+
+func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if err := h.do(rw, req); err != nil {
+		status := http.StatusInternalServerError
+		if e, ok := err.(*apierror.APIError); ok {
+			status = e.Code.Status
+		}
+		rw.WriteHeader(status)
+		_, _ = rw.Write([]byte(err.Error()))
+		return
+	}
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+func (h Handler) do(rw http.ResponseWriter, _ *http.Request) error {
+
+	nodeDeviceAvailability, err := h.generateDeviceAvailability()
+	if err != nil {
+		return err
+	}
+	result, err := json.Marshal(nodeDeviceAvailability)
+	if err != nil {
+		return fmt.Errorf("unable to marshal node device capacity: %v", err)
+	}
+	_, err = rw.Write(result)
+	return err
+}
+
+func (h Handler) generateDeviceAvailability() (map[string]resource.Quantity, error) {
+	nodes, err := h.nodeCache.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error looking up nodes from nodeCache: %v", err)
+	}
+
+	vmList, err := h.vmCache.List(corev1.NamespaceAll, labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error looking up vms from vmCache: %v", err)
+	}
+
+	return calculateAllocation(nodes, vmList), nil
+}
+
+func calculateAllocation(nodes []*corev1.Node, vms []*kubevirtv1.VirtualMachine) map[string]resource.Quantity {
+	nodeDeviceAvailability := make(map[string]resource.Quantity)
+	for _, node := range nodes {
+		for resourceName, quantity := range node.Status.Allocatable {
+			existingQuantity := nodeDeviceAvailability[resourceName.String()]
+			existingQuantity.Add(quantity)
+			nodeDeviceAvailability[resourceName.String()] = existingQuantity
+		}
+	}
+	for _, vm := range vms {
+		for _, hostDevice := range vm.Spec.Template.Spec.Domain.Devices.HostDevices {
+			currentAvailability, ok := nodeDeviceAvailability[hostDevice.DeviceName]
+			if ok {
+				currentAvailability.Sub(*resource.NewQuantity(1, resource.DecimalSI))
+				nodeDeviceAvailability[hostDevice.DeviceName] = currentAvailability
+			}
+		}
+
+		for _, gpuDevice := range vm.Spec.Template.Spec.Domain.Devices.GPUs {
+			currentAvailability, ok := nodeDeviceAvailability[gpuDevice.DeviceName]
+			if ok {
+				currentAvailability.Sub(*resource.NewQuantity(1, resource.DecimalSI))
+				nodeDeviceAvailability[gpuDevice.DeviceName] = currentAvailability
+			}
+		}
+	}
+	return nodeDeviceAvailability
+}

--- a/pkg/api/cluster/formatter_test.go
+++ b/pkg/api/cluster/formatter_test.go
@@ -1,0 +1,118 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+var (
+	vm1 = &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							HostDevices: []kubevirtv1.HostDevice{
+								{
+									Name:       "sample-vf1",
+									DeviceName: "intel.com/X540_ETHERNET_CONTROLLER_VIRTUAL_FUNCTION",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vm2 = &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							HostDevices: []kubevirtv1.HostDevice{
+								{
+									Name:       "sample-vf1",
+									DeviceName: "intel.com/X540_ETHERNET_CONTROLLER_VIRTUAL_FUNCTION",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vm3 = &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							GPUs: []kubevirtv1.GPU{
+								{
+									Name:       "sample-vgpu",
+									DeviceName: "nvidia.com/GRID_A100-20C",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vm4 = &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							GPUs: []kubevirtv1.GPU{
+								{
+									Name:       "sample-vgpu",
+									DeviceName: "nvidia.com/GRID_A100-10C",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	node1 = &corev1.Node{
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				"nvidia.com/GRID_A100-20C":                            *resource.NewQuantity(2, resource.DecimalSI),
+				"intel.com/X540_ETHERNET_CONTROLLER_VIRTUAL_FUNCTION": *resource.NewQuantity(16, resource.DecimalSI),
+			},
+		},
+	}
+
+	node2 = &corev1.Node{
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				"nvidia.com/GRID_A100-10C":                            *resource.NewQuantity(4, resource.DecimalSI),
+				"intel.com/X540_ETHERNET_CONTROLLER_VIRTUAL_FUNCTION": *resource.NewQuantity(16, resource.DecimalSI),
+			},
+		},
+	}
+
+	nodes = []*corev1.Node{node1, node2}
+	vms   = []*kubevirtv1.VirtualMachine{vm1, vm2, vm3, vm4}
+)
+
+func Test_calculateAllocation(t *testing.T) {
+	assert := require.New(t)
+	nodeDeviceAvailability := calculateAllocation(nodes, vms)
+	assert.Equal(nodeDeviceAvailability["nvidia.com/GRID_A100-20C"], *resource.NewQuantity(1, resource.DecimalSI), "expect to find 1 A100-20C device")
+	assert.Equal(nodeDeviceAvailability["nvidia.com/GRID_A100-10C"], *resource.NewQuantity(3, resource.DecimalSI), "expect to find 3 A100-10C device")
+	assert.Equal(nodeDeviceAvailability["intel.com/X540_ETHERNET_CONTROLLER_VIRTUAL_FUNCTION"], *resource.NewQuantity(30, resource.DecimalSI), "expect to find 30 X540_ETHERNET_CONTROLLER_VIRTUAL_FUNCTION VF's")
+}

--- a/pkg/api/cluster/schema.go
+++ b/pkg/api/cluster/schema.go
@@ -1,0 +1,46 @@
+package cluster
+
+import (
+	"net/http"
+
+	"github.com/rancher/apiserver/pkg/store/empty"
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/server"
+
+	"github.com/harvester/harvester/pkg/config"
+)
+
+const (
+	deviceCapacity   = "deviceCapacity"
+	localClusterName = "local"
+)
+
+type Cluster struct {
+	Name string
+}
+
+// RegisterSchema returns a fake cluster schema, based on examples in
+// github.com/rancher/apiserver which serves as a store to expose a cluster object
+// this cluster object is not backed by an actual CRD and is only needed to
+// satisfy ability to define actions or linkHandlers
+// The cluster link handlers allow querying details of device allocation
+// from all nodes in the cluster
+func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
+	handler := Handler{
+		nodeCache: scaled.CoreFactory.Core().V1().Node().Cache(),
+		vmCache:   scaled.VirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
+	}
+
+	fakeClusterStore := &Store{
+		&empty.Store{},
+	}
+	server.BaseSchemas.MustImportAndCustomize(Cluster{}, func(schema *types.APISchema) {
+		schema.Store = fakeClusterStore
+		schema.ResourceMethods = []string{"GET"}
+		schema.CollectionMethods = []string{"GET"}
+		schema.LinkHandlers = map[string]http.Handler{
+			deviceCapacity: handler,
+		}
+	})
+	return nil
+}

--- a/pkg/api/cluster/store.go
+++ b/pkg/api/cluster/store.go
@@ -1,0 +1,38 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/rancher/apiserver/pkg/types"
+)
+
+type Store struct {
+	types.Store
+}
+
+func (f *Store) ByID(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
+	if id != localClusterName {
+		return types.APIObject{}, fmt.Errorf("only supported cluster id is local")
+	}
+	return types.APIObject{
+		Type: "cluster",
+		ID:   "local",
+		Object: Cluster{
+			Name: "local",
+		},
+	}, nil
+}
+
+func (f *Store) List(_ *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
+	return types.APIObjectList{
+		Objects: []types.APIObject{
+			{
+				Type: "cluster",
+				ID:   "local",
+				Object: Cluster{
+					Name: "local",
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rancher/steve/pkg/server"
 
+	"github.com/harvester/harvester/pkg/api/cluster"
 	"github.com/harvester/harvester/pkg/api/image"
 	"github.com/harvester/harvester/pkg/api/keypair"
 	"github.com/harvester/harvester/pkg/api/node"
@@ -37,5 +38,6 @@ func Setup(ctx context.Context, server *server.Server, _ *server.Controllers, op
 		node.RegisterSchema,
 		upgradelog.RegisterSchema,
 		volume.RegisterSchema,
-		volumesnapshot.RegisterSchema)
+		volumesnapshot.RegisterSchema,
+		cluster.RegisterSchema)
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently there is no way to track the device allocation across VM's in a cluster since the device plugin only reports the allocatable count based on health of devices and is not responsible for tracking the allocation.

Harvester v1.3.x introduced support for vgpu devices and the associated rancher release allows end users to define vGPU's directly during downstream cluster provisioning. However there is no easy way to track current device allocation on the underlying cluster. As a result end user may be able to create VMs with vGPU device requests which can no longer be satisfied by the cluster. As a result the VM is unschedulable, and eventually rancher keeps reprovisioning the VM.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces a new api endpoint for `/v1/harvester/cluster` which allows rancher to query the current device free list across all nodes from the cluster, and results the response as a json. This can then be used by the UI to filter on devices to gate creation of VM's

A sample json response from harvester looks as follows:

```
(⎈|local:harvester-system)➜  ~ curl -sk -u $APITOKEN "${URL}/v1/harvester/cluster/local?link=deviceCapacity"  | jq .
{
  "cpu": "32",
  "devices.kubevirt.io/kvm": "1k",
  "devices.kubevirt.io/tun": "1k",
  "devices.kubevirt.io/vhost-net": "1k",
  "ephemeral-storage": "573222064908",
  "hugepages-1Gi": "0",
  "hugepages-2Mi": "0",
  "intel.com/X540_ETHERNET_CONTROLLER_VIRTUAL_FUNCTION": "2",
  "memory": "263873540Ki",
  "nvidia.com/GA100_A100_PCIE_40GB": "0",
  "nvidia.com/GRID_A100-10C": "0",
  "nvidia.com/GRID_A100-20C": "-1",
  "nvidia.com/GRID_A100-40C": "0",
  "nvidia.com/GRID_A100-4C": "0",
  "pods": "200"
}
```
**Related Issue:**
https://github.com/harvester/harvester/issues/5774
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
