### PR TITLE
Fix storage overcommit default not applied to Longhorn

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -37,6 +37,9 @@ var (
 	bootstrapSettings = []string{
 		settings.SSLCertificatesSettingName,
 		settings.KubeconfigDefaultTokenTTLMinutesSettingName,
+		// The Longhorn storage over-provisioning percentage is set to 100, whereas Harvester uses 200.
+		// This needs to be synchronized when Harvester starts.
+		settings.OvercommitConfigSettingName,
 	}
 	skipHashCheckSettings = []string{
 		settings.AutoRotateRKE2CertsSettingName,

--- a/pkg/controller/master/setting/overcommit_config.go
+++ b/pkg/controller/master/setting/overcommit_config.go
@@ -14,7 +14,13 @@ import (
 
 func (h *Handler) syncOvercommitConfig(setting *harvesterv1.Setting) error {
 	overcommit := &settings.Overcommit{}
-	if err := json.Unmarshal([]byte(setting.Value), overcommit); err != nil {
+	var value string
+	if setting.Value != "" {
+		value = setting.Value
+	} else {
+		value = setting.Default
+	}
+	if err := json.Unmarshal([]byte(value), overcommit); err != nil {
 		return fmt.Errorf("Invalid JSON `%s`: %s", setting.Value, err.Error())
 	}
 


### PR DESCRIPTION
**Problem:**
Harvester storage overcommit-config is set to 200% while the value not applied to Longhorn  `StorageOverProvisioningPercentage` which is still 100%.

**Solution:**
Take care `Default` value in  https://github.com/harvester/harvester/blob/6b79086f42d005c19070b760a877fe27ccb4767a/pkg/controller/master/setting/overcommit_config.go#L17
And sync storage overcommit-config during harvester bootstrap.

**Related Issue:**
https://github.com/harvester/harvester/issues/5695

**Test plan:**
1. Setup harvester with one node (easy for testing), and go to longhorn dashboard > setting tab, check `Storage Over Provisioning Percentage` is 200 instead of 100.
2. Setup harvester 1.3.1 with one node (easy for testing), upgrade to the harvester version contains this fix, and go to longhorn dashboard > setting tab, check `Storage Over Provisioning Percentage` is 200 instead of 100.
![image](https://github.com/harvester/harvester/assets/4344302/d2cf7bc6-b825-4af0-b179-dcb6dd475c4d)

