### PR TITLE
Add addons dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ api.test
 package/harvester
 package/harvester-webhook
 package/upgrade/upgrade-helper
+package/upgrade/addons


### PR DESCRIPTION
**Problem:**
addons dir should be added to .gitignore since it is generated every time we build harvester.

**Solution:**
add addons to gitignore

**Related Issue:**
N/A

**Test plan:**
N/A
