### PR TITLE
Remove redundant TODO comment

### DIFF
--- a/pkg/genswagger/main.go
+++ b/pkg/genswagger/main.go
@@ -34,7 +34,7 @@ const (
 	defTimeValue = ""
 )
 
-var outputFile = flag.String("output", "api/openapi-spec/swagger.json", "Output file.") // TODO: rename to openapi.json
+var outputFile = flag.String("output", "api/openapi-spec/swagger.json", "Output file.")
 
 var vowels = map[rune]bool{
 	'a': true,


### PR DESCRIPTION
**Problem:**
The comment `// TODO: rename to openapi.json` seems incorrect, 
the file should be named swagger.json instead of openapi.json. This naming is intentional. For more information, please refer to the discussion at https://github.com/harvester/harvester/pull/889#discussion_r636701432

**Solution:**
Remove the redundant TODO comment in  `pkg/genswagger/main.go`

**Related Issue:**
Not sure if this one need an issue since it is dev-related.

**Test plan:**
only remove comment here, no test required