### PR TITLE
Feat: exporting volume returns the image data in response body

### DIFF
--- a/pkg/api/volume/schema.go
+++ b/pkg/api/volume/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/schemas"
 
 	"github.com/harvester/harvester/pkg/config"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 const (
@@ -19,7 +20,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 	server.BaseSchemas.MustImportAndCustomize(ExportVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(CloneVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(SnapshotVolumeInput{}, nil)
-	actionHandler := ActionHandler{
+	actionHandler := &ActionHandler{
 		images:      scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage(),
 		pvcs:        scaled.CoreFactory.Core().V1().PersistentVolumeClaim(),
 		pvcCache:    scaled.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),
@@ -30,6 +31,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		volumeCache: scaled.LonghornFactory.Longhorn().V1beta2().Volume().Cache(),
 		vmCache:     scaled.VirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 	}
+
+	handler := harvesterServer.NewHandler(actionHandler)
 
 	t := schema.Template{
 		ID: pvcSchemaID,
@@ -47,10 +50,10 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 				},
 			}
 			s.ActionHandlers = map[string]http.Handler{
-				actionExport:       &actionHandler,
-				actionCancelExpand: &actionHandler,
-				actionClone:        &actionHandler,
-				actionSnapshot:     &actionHandler,
+				actionExport:       handler,
+				actionCancelExpand: handler,
+				actionClone:        handler,
+				actionSnapshot:     handler,
 			}
 		},
 		Formatter: Formatter,

--- a/pkg/server/http/ctx.go
+++ b/pkg/server/http/ctx.go
@@ -1,0 +1,24 @@
+package http
+
+import "net/http"
+
+type Ctx struct {
+	statusCode int
+	rw         http.ResponseWriter
+	req        *http.Request
+}
+
+func newDefaultHarvesterServerCtx(rw http.ResponseWriter, req *http.Request) *Ctx {
+	return &Ctx{
+		statusCode: http.StatusNoContent, // default is 204
+		rw:         rw,
+		req:        req,
+	}
+}
+
+func (ctx *Ctx) SetStatus(statusCode int) { ctx.statusCode = statusCode }
+func (ctx *Ctx) StatusCode() int          { return ctx.statusCode }
+func (ctx *Ctx) Req() *http.Request       { return ctx.req }
+func (ctx *Ctx) RespWriter() http.ResponseWriter {
+	return ctx.rw
+}

--- a/pkg/server/http/handler.go
+++ b/pkg/server/http/handler.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/rancher/apiserver/pkg/apierror"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+type HarvesterServerHandler interface {
+	Do(ctx *Ctx) (interface{}, error)
+}
+
+type harvesterServerHandler struct {
+	httpHandler HarvesterServerHandler
+}
+
+func NewHandler(httpHandler HarvesterServerHandler) http.Handler {
+	return &harvesterServerHandler{
+		httpHandler: httpHandler,
+	}
+}
+
+func (handler *harvesterServerHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	ctx := newDefaultHarvesterServerCtx(rw, req)
+	resp, err := handler.httpHandler.Do(ctx)
+	if err != nil {
+		status := http.StatusInternalServerError
+		var e *apierror.APIError
+		if errors.As(err, &e) {
+			status = e.Code.Status
+		}
+		rw.WriteHeader(status)
+		_, _ = rw.Write([]byte(err.Error()))
+		return
+	}
+
+	if resp == nil {
+		rw.WriteHeader(ctx.StatusCode())
+		return
+	}
+
+	util.ResponseOKWithBody(rw, resp)
+}


### PR DESCRIPTION
## Problem
Some APIs doesn't return the response body, but some do L476 in example. In current design, we need to customize the logic to write the response body in the business logic.

https://github.com/harvester/harvester/blob/026d49fa55d465c43818068240c2ea8c2a48ea88/pkg/api/vm/handler.go#L458-L478

 It breaks the architecture consistency, and writes header twice. I think we need a consistent way to serve those APIs.

## Solution

### Proposal 1 - This PR

Create a new interface and common function to serve all APIs like below.

```go
// 204 case
func businessLogic(w http.ResponseWriter, r *http.Request) (interface{}, error) {
	return nil, nil // -> 204
}

// 200 case-1
func businessLogic(w http.ResponseWriter, r *http.Request) (interface{}, error) {
	return obj1, nil // -> 200 with content
}

// 200 case-2
func businessLogic(w http.ResponseWriter, r *http.Request) (interface{}, error) {
	return struct{}{}, nil // -> 200 without content
}

// error case
func businessLogic(w http.ResponseWriter, r *http.Request) (interface{}, error) {
	return apierror.NewAPIError(validation.NotFound, "Not found resource: {resource name} ") // -> 404
}
```

If we'd like to return 200 status code with a empty response, we could return `struct{}{}`, then handle it, let it return status 200 with empty response body. (This one is for current `healthy_handler.go`.)

---

### Proposal 2 - https://github.com/Yu-Jack/harvester/commit/96e7cd3dd684e6d1e99a1047bc664681556bc000

Use simple ctx to wrap everything, inspired some Golang http framework.

```go
type harvesterCutomCtx struct {
	body       interface{}
	statusCode int
	rw         http.ResponseWriter
	req        *http.Request
}

// 204 case
func businessLogic(ctx *harvesterCutomCtx) (error) {
	ctx.SetStatus(204) -> return 204
	return nil
}

// 200 case-1
func businessLogic(ctx *harvesterCutomCtx) (error) {
	ctx.SetBody("hi") -> return 200 with content
	return nil
}

// 200 case-2
func businessLogic(ctx *harvesterCutomCtx) (error) {
	ctx.SetStatus(200) -> return 200 without content
	return nil
}

// error case
func businessLogic(ctx *harvesterCutomCtx) (error) {
	return apierror.NewAPIError(validation.NotFound, "Not found resource: {resource name} ") // -> 404
}
```

This one would be more flexible if we want more control.

---

## Discussion
Not sure we should change all APIs in this time, or we change it over time?

## Related Issue
https://github.com/harvester/harvester/issues/5618

## Test plan
Current all test cases should be successful like https://github.com/harvester/harvester/pull/6138#issuecomment-2219519324, including api and integration tests.
