### PR TITLE
ci: name upload ISO with tag step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,7 +366,7 @@ jobs:
         headers: |-
           cache-control: public,no-cache,proxy-revalidate
 
-    - id: upload-iso-with-tag
+    - name: upload-iso-with-tag
       uses: 'google-github-actions/upload-cloud-storage@v2'
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:


### PR DESCRIPTION
Name the step with a name.
ref: https://github.com/harvester/harvester/actions/runs/9810466712/job/27091964735

<img width="486" alt="截圖 2024-07-10 下午5 49 24" src="https://github.com/harvester/harvester/assets/1691518/64a02517-0bf6-4de9-af5f-5f18d054af0a">


It's clearer the step is run if it has a name.