### PR TITLE
fix: enhance wording on insufficient space message

### DIFF
--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -290,11 +290,12 @@ func (v *upgradeValidator) checkDiskSpace(node *corev1.Node, minFreeDiskSpace ui
 		imageGCHighThresholdPercent = float64(*kubeletConfiguration.ImageGCHighThresholdPercent)
 	}
 	usedPercent := (float64(*summary.Node.Fs.UsedBytes+defaultNewImageSize) / float64(*summary.Node.Fs.CapacityBytes)) * 100.0
-	logrus.Debugf("node %s uses %3f%% storage space, kubelet image garbage collection threshold is %3f%%", node.Name, usedPercent, imageGCHighThresholdPercent)
+	logrus.Debugf("node %s uses %.3f%% storage space, kubelet image garbage collection threshold is %.3f%%", node.Name, usedPercent, imageGCHighThresholdPercent)
 
 	if usedPercent > imageGCHighThresholdPercent {
-		return werror.NewBadRequest(fmt.Sprintf("Node %q uses %3f%% storage space. It's higher than kubelet image garbage collection threshold %3f%%.",
-			node.Name, usedPercent, imageGCHighThresholdPercent))
+		// Using strconv.FormatFloat to show imageGCHighThresholdPercent to trim zeros, because the default value is 0.85.
+		return werror.NewBadRequest(fmt.Sprintf("Node %q will reach %.2f%% storage space after loading new images. It's higher than kubelet image garbage collection threshold %s%%.",
+			node.Name, usedPercent, strconv.FormatFloat(imageGCHighThresholdPercent, 'f', -1, 64)))
 	}
 
 	if *summary.Node.Fs.AvailableBytes < minFreeDiskSpace {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Original error message is not clear.

![image](https://github.com/user-attachments/assets/6c6ca717-e517-4595-88c2-6405d4421902)


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

![Screenshot 2024-07-15 at 4 30 09 PM](https://github.com/user-attachments/assets/f626cc3b-8169-4a6a-848c-83f8c09b315b)


**Related Issue:**
https://github.com/harvester/harvester/issues/6155

**Test plan:**
### Setup

1. Use this branch to build a new ISO.

### Case 1: a node without enough disk spaces can't upgrade

1. Create a new Harvester cluster. Each node's disk space should be 250G.
2. If every node's `/usr/local` free space is more than 15%, you can use `dd` to write files to make sure one of the node's free disk space is lower than 15%. For example: `dd if=/dev/zero of=/usr/local/test.img bs=1G count=93`.
3. Create a test version.
```yaml
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master-head
  namespace: harvester-system
spec:
  isoURL: http://192.168.0.181:8000/harvester-master-head-amd64.iso
  minUpgradableVersion: 1.3.1
  releaseDate: "20231210"
  tags:
  - dev
  - test
```
4. Click upgrade on the dashboard. We should get an error message.

![Screenshot 2024-07-15 at 4 30 09 PM](https://github.com/user-attachments/assets/f626cc3b-8169-4a6a-848c-83f8c09b315b)

### Case 2: a node with enough disk spaces can upgrade

1. Remove the `dd` file.
2. Click the upgrade again. There is no error message.
