### PR TITLE
Introduce the upgrade-config setting to control the behavior of image preloading during upgrades

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -249,7 +249,7 @@ func prepareCleanupPlan(upgrade *harvesterv1.Upgrade, imageList []string) *upgra
 	}
 }
 
-func preparePlan(upgrade *harvesterv1.Upgrade) *upgradev1.Plan {
+func preparePlan(upgrade *harvesterv1.Upgrade, concurrency int) *upgradev1.Plan {
 	planVersion := upgrade.Name
 
 	// Use current running version because new images are not preloaded yet.
@@ -264,7 +264,7 @@ func preparePlan(upgrade *harvesterv1.Upgrade) *upgradev1.Plan {
 			},
 		},
 		Spec: upgradev1.PlanSpec{
-			Concurrency:           int64(1),
+			Concurrency:           int64(concurrency),
 			JobActiveDeadlineSecs: defaultPrepareDeadlineSeconds,
 			Version:               planVersion,
 			NodeSelector: &metav1.LabelSelector{

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -725,6 +725,11 @@ func (p *planBuilder) WithLabel(key, value string) *planBuilder {
 	return p
 }
 
+func (p *planBuilder) Concurrency(concurrency int) *planBuilder {
+	p.plan.Spec.Concurrency = int64(concurrency)
+	return p
+}
+
 func (p *planBuilder) Version(version string) *planBuilder {
 	p.plan.Spec.Version = version
 	return p

--- a/pkg/controller/master/upgrade/plan_controller_test.go
+++ b/pkg/controller/master/upgrade/plan_controller_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func newTestPreparePlan() *upgradeapiv1.Plan {
-	plan := preparePlan(newTestUpgradeBuilder().Build())
+	plan := preparePlan(newTestUpgradeBuilder().Build(), defaultImagePreloadConcurrency)
 	plan.Status.LatestHash = testPlanHash
 	return plan
 }

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -46,7 +46,6 @@ func Register(ctx context.Context, management *config.Management, options config
 		jobCache:          jobs.Cache(),
 		nodeCache:         nodes.Cache(),
 		namespace:         options.Namespace,
-		settingCache:      settings.Cache(),
 		upgradeClient:     upgrades,
 		upgradeCache:      upgrades.Cache(),
 		upgradeController: upgrades,

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -46,6 +46,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		jobCache:          jobs.Cache(),
 		nodeCache:         nodes.Cache(),
 		namespace:         options.Namespace,
+		settingCache:      settings.Cache(),
 		upgradeClient:     upgrades,
 		upgradeCache:      upgrades.Cache(),
 		upgradeController: upgrades,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -57,6 +57,7 @@ var (
 	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.3.0","harvester-csi-provider":">=0.0.1 <0.3.0"}`)
 	NTPServers             = NewSetting(NTPServersSettingName, "")
 	WhiteListedSettings    = []string{"server-version", "default-storage-class", "harvester-csi-ccm-versions", "default-vm-termination-grace-period-seconds"}
+	ImagePreloadStrategy   = NewSetting(ImagePreloadStrategySettingName, SequentialImagePreload) // options are skip, sequential, and parallel
 )
 
 const (
@@ -88,6 +89,7 @@ const (
 	AutoRotateRKE2CertsSettingName                    = "auto-rotate-rke2-certs"
 	KubeconfigDefaultTokenTTLMinutesSettingName       = "kubeconfig-default-token-ttl-minutes"
 	SupportBundleNodeCollectionTimeoutName            = "support-bundle-node-collection-timeout"
+	ImagePreloadStrategySettingName                   = "image-preload-strategy"
 )
 
 func init() {
@@ -324,3 +326,9 @@ func GetCSIDriverInfo(provisioner string) (*CSIDriverInfo, error) {
 	}
 	return csiDriverInfo, nil
 }
+
+const (
+	SkipImagePreload       string = "skip"
+	SequentialImagePreload string = "sequential"
+	ParallelImagePreload   string = "parallel"
+)

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -91,6 +91,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.NTPServersSettingName:                             validateNTPServers,
 	settings.AutoRotateRKE2CertsSettingName:                    validateAutoRotateRKE2Certs,
 	settings.KubeconfigDefaultTokenTTLMinutesSettingName:       validateKubeConfigTTLSetting,
+	settings.ImagePreloadStrategySettingName:                   validateImagePreloadStrategy,
 }
 
 type validateSettingUpdateFunc func(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error
@@ -110,6 +111,7 @@ var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
 	settings.NTPServersSettingName:                             validateUpdateNTPServers,
 	settings.AutoRotateRKE2CertsSettingName:                    validateUpdateAutoRotateRKE2Certs,
 	settings.KubeconfigDefaultTokenTTLMinutesSettingName:       validateUpdateKubeConfigTTLSetting,
+	settings.ImagePreloadStrategySettingName:                   validateUpdateImagePreloadStrategy,
 }
 
 type validateSettingDeleteFunc func(setting *v1beta1.Setting) error
@@ -1262,4 +1264,21 @@ func validateKubeConfigTTLSetting(newSetting *v1beta1.Setting) error {
 
 func validateUpdateKubeConfigTTLSetting(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateKubeConfigTTLSetting(newSetting)
+}
+
+func validateImagePreloadStrategy(newSetting *v1beta1.Setting) error {
+	if newSetting.Value == "" {
+		return nil
+	}
+
+	switch newSetting.Value {
+	case settings.SkipImagePreload, settings.SequentialImagePreload, settings.ParallelImagePreload:
+		return nil
+	default:
+		return werror.NewInvalidError("Invalid image preload strategy", "value")
+	}
+}
+
+func validateUpdateImagePreloadStrategy(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	return validateImagePreloadStrategy(newSetting)
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -731,3 +731,51 @@ func Test_validateNTPServers(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateImagePreloadStrategy(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
+	}{
+		{
+			name: "invalid string",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
+				Value:      "random string",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "skip image preload",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
+				Value:      "skip",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload node by node",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
+				Value:      "sequential",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
+				Value:      "parallel",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateImagePreloadStrategy(tt.args)
+			assert.Equal(t, tt.expectedErr, err != nil)
+		})
+	}
+}

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -732,41 +732,153 @@ func Test_validateNTPServers(t *testing.T) {
 	}
 }
 
-func Test_validateImagePreloadStrategy(t *testing.T) {
+func Test_validateUpgradeConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        *v1beta1.Setting
 		expectedErr bool
 	}{
 		{
-			name: "invalid string",
+			name: "empty config - default",
 			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    "{}",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty config - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      "{}",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid string - default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    "random string",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid string - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
 				Value:      "random string",
 			},
 			expectedErr: true,
 		},
 		{
-			name: "skip image preload",
+			name: "skip image preload - default",
 			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
-				Value:      "skip",
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    `{"imagePreloadOption":{"strategy":{"type":"skip"}}}`,
 			},
 			expectedErr: false,
 		},
 		{
-			name: "do image preload node by node",
+			name: "skip image preload - value",
 			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
-				Value:      "sequential",
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      `{"imagePreloadOption":{"strategy":{"type":"skip"}}}`,
 			},
 			expectedErr: false,
 		},
 		{
-			name: "do image preload in parallel",
+			name: "do image preload node by node - default",
 			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.ImagePreloadStrategySettingName},
-				Value:      "parallel",
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    `{"imagePreloadOption":{"strategy":{"type":"sequential"}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload node by node - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      `{"imagePreloadOption":{"strategy":{"type":"sequential"}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel - default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    `{"imagePreloadOption":{"strategy":{"type":"parallel"}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel"}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel with negative value for concurrency - default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":-1}}}`,
+			},
+			expectedErr: true,
+		},
+		{
+			name: "do image preload in parallel with negative value for concurrency - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":-1}}}`,
+			},
+			expectedErr: true,
+		},
+		{
+			name: "do image preload in parallel (all nodes) - default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":0}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel (all nodes) - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":0}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel with concurrency set to 1 - default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":1}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel with concurrency set to 1 - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":1}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel with concurrency set to 2 - default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Default:    `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}}`,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "do image preload in parallel with concurrency set to 2 - value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
+				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}}`,
 			},
 			expectedErr: false,
 		},
@@ -774,7 +886,7 @@ func Test_validateImagePreloadStrategy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateImagePreloadStrategy(tt.args)
+			err := validateUpgradeConfig(tt.args)
 			assert.Equal(t, tt.expectedErr, err != nil)
 		})
 	}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

In the current Harvester upgrade implementation, image preloading will always happen (provided new container images are introduced) in a one-node-at-a-time fashion. It takes a significant portion of the upgrade time, no matter how powerful the given cluster nodes and network capacity. We shall provide the flexibility for users to customize the image preload strategy.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add a new Setting called `upgrade-config`. The upgrade controller will honor the setting value to decide whether to skip preload, preload sequentially, or preload in parallel for container images. This new Setting object will be where we store upgrade-relevant configs/options. For example:

```json
{
  "imagePreloadOption": {
    "strategy": {
      "type": "parallel",
      "concurrency": 2
    }
  }
}
```

This will allow the Harvester cluster to conduct future upgrades with parallel image preloading at a two-node-at-a-time pace. If the `.imagePreloadOption.strategy.concurrency` field is set to 0 (this is also the default value), all nodes will start preloading images simultaneously. Concurrency value is ignored when a strategy type other than "parallel" is chosen.

Available `.imagePreloadOption.strategy.type` field are:

- `skip`
- `sequential`
- `parallel`

**Related Issue:**

#3059 #6028

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

0. For reviewers, please use a custom-built ISO image that contains the PR; for QAs, please use the master ISO image.
1. Prepare a Harvester cluster consists of at lease two nodes
2. Configure the `upgrade-config` setting's `.imagePreloadOption.strategy.type` field to `skip`, `sequential`, or `parallel` respectively
   ```shell
   kubectl patch setting.harvesterhci upgrade-config --type=merge -p '{"value":"{\"imagePreloadOption\":{\"strategy\":{\"type\":\"skip\"}}}"}'
   kubectl patch setting.harvesterhci upgrade-config --type=merge -p '{"value":"{\"imagePreloadOption\":{\"strategy\":{\"type\":\"sequential\"}}}"}'
   kubectl patch setting.harvesterhci upgrade-config --type=merge -p '{"value":"{\"imagePreloadOption\":{\"strategy\":{\"type\":\"parallel\",\"concurrency\":2}}}"}'
   ```
4. Start the upgrade using the same ISO image
5. Observe the upgrade progress, when it enters the image-preload phase:
   - If `skip` is specified, there should be **no** `prepare` pods running in the cluster
   - If `sequential` is specified, there should be exact **one** `parepare` pod running at a time
   - If `parallel` is specified, there should be **two** (or other number depending on how many nodes are there) `prepare` pods running simultaneously
7. The upgrade ends successfully