### PR TITLE
limit kubeconfig-default-token-ttl-minutes value to 100 years

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -59,6 +59,7 @@ const (
 	labelAppNameValueAlertManager     = "alertmanager"
 	labelAppNameValueGrafana          = "grafana"
 	labelAppNameValueImportController = "harvester-vm-import-controller"
+	maxTTLDurationMinutes             = 52560000 //specifies max duration allowed for kubeconfig TTL setting, and corresponds to 100 years
 )
 
 var certs = getSystemCerts()
@@ -1256,6 +1257,10 @@ func validateKubeConfigTTLSettingHelper(value string) error {
 
 	if num < 0 {
 		return fmt.Errorf("kubeconfig-default-token-ttl-minutes can't be negative")
+	}
+
+	if num > maxTTLDurationMinutes {
+		return fmt.Errorf("kubeconfig-default-token-ttl-minutes exceeds 100 years")
 	}
 	return nil
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -589,6 +589,15 @@ func Test_validateKubeconfigTTLSetting(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		{
+			name: "exceeds 100 years",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.KubeconfigDefaultTokenTTLMinutesSettingName},
+				Default:    "10",
+				Value:      "52560001",
+			},
+			expectedErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
harvester setting `kubeconfig-default-token-ttl-limit` is represented as a string, and there is no defined upper limit on the value passed. The string is eventually parsed as time.Duration, which has an upper limit of about 290 years.
As a result a value like `99999999999999` causes the duration parsing in rancher to break.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR adds a simple check in the setting validator to limit max setting to 100 years or `52560000` minutes.

**Related Issue:**
https://github.com/harvester/harvester/issues/6011

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
