### PR TITLE
Support CPU Pinning

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -145,3 +145,94 @@ data:
       sleep 2
     done
     `}}
+  cpu-manager.sh: |-
+    function cleanup_cpu_manager_state() {
+      if [ -f "$CPU_MANAGER_STATE_FILE" ]; then
+        mv "$CPU_MANAGER_STATE_FILE" "${CPU_MANAGER_STATE_FILE}.old"
+        echo "File $CPU_MANAGER_STATE_FILE has been renamed to ${CPU_MANAGER_STATE_FILE}.old"
+      else
+        echo "File $CPU_MANAGER_STATE_FILE does not exist."
+      fi
+    }
+
+    function manage_service() {
+      local service=$1
+
+      echo "Stopping ${service}."
+      if ! chroot $HOST_DIR systemctl stop $service; then
+        echo "Error: failed to stop ${service}."
+        exit 1
+      fi
+      echo "Stopped ${service}."
+
+      cleanup_cpu_manager_state
+
+      echo "Starting ${service}."
+      if ! chroot $HOST_DIR systemctl start $service; then
+        echo "Error: failed to start ${service}."
+        exit 1
+      fi
+      echo "Started ${service}."
+    }
+
+    function wait_for_label() {
+      local node_name=$1
+      local expect_label_value=$2
+      local interval=5
+      local elapsed=0
+
+      while [ $elapsed -lt $WAIT_LABEL_TIMEOUT ]; do
+        if ! labels=$($KUBECTL get node "$node_name" --show-labels); then
+          echo "Error: failed to get labels in $node_name"
+          exit 1
+        fi
+        if echo "$labels" | grep -q "cpumanager=$expect_label_value"; then
+          echo "End update cpu-manager-policy"
+          exit 0
+        fi
+        echo "Value in label cpumanager is not $expect_label_value, wait ${interval}s..."
+        sleep $interval
+        elapsed=$((elapsed + interval))
+      done
+      echo "Error: timeout, elapsed ${elapsed}s"
+      exit 1
+    }
+
+    echo "Start update cpu-manager-policy option..."
+    KUBECTL="$HOST_DIR/$(readlink $HOST_DIR/var/lib/rancher/rke2/bin)/kubectl"
+    CPU_MANAGER_CONFIG_FILE="$HOST_DIR/etc/rancher/rke2/config.yaml.d/99-z01-harvester-cpu-manager.yaml"
+    STATIC_POLICY="static"
+    NONE_POLICY="none"
+    CPU_MANAGER_STATE_FILE="$HOST_DIR/var/lib/kubelet/cpu_manager_state"
+    NODE_NAME="$1"
+    NODE_POLICY="$2"
+    EXIT_CODE=0
+
+    if [ "$NODE_POLICY" != "$STATIC_POLICY" ] && [ "$NODE_POLICY" != "$NONE_POLICY" ]; then
+      echo "Error: invalid cpu-manager-policy $NODE_POLICY"
+      exit 1
+    fi
+
+    if ! $KUBECTL get node "$NODE_NAME" --show-labels | grep -q "cpumanager="; then
+      echo "Error: There is no label cpumanager in node $NODE_NAME."
+      exit 1
+    fi
+
+    printf 'kubelet-arg+:\n- "cpu-manager-policy=%s"' "$NODE_POLICY" > $CPU_MANAGER_CONFIG_FILE
+
+    if chroot $HOST_DIR systemctl is-active --quiet rke2-server; then
+      manage_service "rke2-server"
+    elif chroot $HOST_DIR systemctl is-active --quiet rke2-agent; then
+      manage_service "rke2-agent"
+    else
+      echo "Error: Neither rke2-server nor rke2-agent are running."
+      exit 1
+    fi
+
+    if [ "$NODE_POLICY" = "$STATIC_POLICY" ]; then
+      EXPECT_LABEL_VALUE="true"
+    else
+      EXPECT_LABEL_VALUE="false"
+    fi
+
+    wait_for_label "$NODE_NAME" "$EXPECT_LABEL_VALUE"

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -61,7 +61,7 @@ kubevirt:
     configuration:
       ## Specify kubevirt feature gates
       developerConfiguration:
-        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU"]
+        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager"]
 
       ## Specify the network configuration of VirtualMachineInstance.
       ##

--- a/pkg/api/node/schema.go
+++ b/pkg/api/node/schema.go
@@ -46,6 +46,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 	}
 
 	nodeHandler := ActionHandler{
+		jobCache:                    scaled.Management.BatchFactory.Batch().V1().Job().Cache(),
 		nodeClient:                  scaled.Management.CoreFactory.Core().V1().Node(),
 		nodeCache:                   scaled.Management.CoreFactory.Core().V1().Node().Cache(),
 		longhornReplicaCache:        scaled.Management.LonghornFactory.Longhorn().V1beta2().Replica().Cache(),
@@ -78,6 +79,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 					Input: "powerActionInput",
 				},
 				powerActionPossible: {},
+				enableCPUManager:    {},
+				disableCPUManager:   {},
 			}
 			s.ActionHandlers = map[string]http.Handler{
 				enableMaintenanceModeAction:  nodeHandler,
@@ -88,6 +91,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 				maintenancePossible:          nodeHandler,
 				powerAction:                  nodeHandler,
 				powerActionPossible:          nodeHandler,
+				enableCPUManager:             nodeHandler,
+				disableCPUManager:            nodeHandler,
 			}
 		},
 	}

--- a/pkg/controller/master/node/cpu_manager_controller.go
+++ b/pkg/controller/master/node/cpu_manager_controller.go
@@ -1,0 +1,322 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/go-errors/errors"
+	catalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
+	"github.com/rancher/wrangler/pkg/condition"
+	"github.com/rancher/wrangler/pkg/name"
+	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
+
+	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/catalog"
+)
+
+const (
+	CPUManagerControllerName = "cpu-manager-controller"
+	// policy
+	CPUManagerStaticPolicy CPUManagerPolicy = "static"
+	CPUManagerNonePolicy   CPUManagerPolicy = "none"
+	// status
+	CPUManagerRequestedStatus CPUManagerStatus = "requested"
+	CPUManagerRunningStatus   CPUManagerStatus = "running"
+	CPUManagerSuccessStatus   CPUManagerStatus = "success"
+	CPUManagerFailedStatus    CPUManagerStatus = "failed"
+
+	CPUManagerRootMountPath         string = "/host"
+	CPUManagerScriptMountPath       string = "/harvester-helpers"
+	CPUManagerScriptPath            string = CPUManagerScriptMountPath + "/cpu-manager.sh"
+	CPUManagerWaitLabelTimeoutInSec int64  = 300 // 5 min
+	CPUManagerJobTimeoutInSec       int64  = CPUManagerWaitLabelTimeoutInSec * 2
+	CPUManagerJobTTLInSec           int32  = 86400 * 7 // 7 day
+)
+
+type CPUManagerPolicy string
+type CPUManagerStatus string
+
+type CPUManagerUpdateStatus struct {
+	Policy  CPUManagerPolicy `json:"policy"`
+	Status  CPUManagerStatus `json:"status"`
+	JobName string           `json:"jobName,omitempty"`
+}
+
+// cpuManagerNodeHandler updates cpu manager status of a node in its annotations, so that
+// we can tell whether the node is under modifing cpu manager policy or not and its current policy.
+type cpuManagerNodeHandler struct {
+	appCache   catalogv1.AppCache
+	nodeCache  ctlcorev1.NodeCache
+	nodeClient ctlcorev1.NodeClient
+	jobClient  ctlbatchv1.JobClient
+	namespace  string
+}
+
+// CPUManagerRegister registers the node controller
+func CPUManagerRegister(ctx context.Context, management *config.Management, options config.Options) error {
+	app := management.CatalogFactory.Catalog().V1().App()
+	job := management.BatchFactory.Batch().V1().Job()
+	node := management.CoreFactory.Core().V1().Node()
+
+	cpuManagerNodeHandler := &cpuManagerNodeHandler{
+		appCache:   app.Cache(),
+		jobClient:  job,
+		nodeCache:  node.Cache(),
+		nodeClient: node,
+		namespace:  options.Namespace,
+	}
+
+	node.OnChange(ctx, CPUManagerControllerName, cpuManagerNodeHandler.OnNodeChanged)
+	job.OnChange(ctx, CPUManagerControllerName, cpuManagerNodeHandler.OnJobChanged)
+
+	return nil
+}
+
+func (h *cpuManagerNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
+	if node == nil || node.Annotations == nil || node.DeletionTimestamp != nil {
+		return node, nil
+	}
+
+	annot, found := node.Annotations[util.AnnotationCPUManagerUpdateStatus]
+	if !found {
+		return node, nil
+	}
+
+	// do nothing if the node is in witness role
+	if _, found := node.Labels[HarvesterWitnessNodeLabelKey]; found {
+		return node, nil
+	}
+
+	cpuManagerStatus, err := GetCPUManagerUpdateStatus(annot)
+	if err != nil {
+		logrus.WithField("node_name", node.Name).WithError(err).Error("Skip update cpu manager policy, failed to retrieve cpu-manager-update-status from annotation")
+		return node, nil
+	}
+	// do nothing if status is not requested
+	if cpuManagerStatus.Status != CPUManagerRequestedStatus {
+		return node, nil
+	}
+
+	newNode := node.DeepCopy()
+	job, err := h.submitJob(cpuManagerStatus, node)
+	logrus.WithFields(logrus.Fields{
+		"node_name": node.Name,
+		"job_name":  job.Name,
+		"policy":    cpuManagerStatus.Policy,
+	}).Info("Submit cpu manager job")
+	if err != nil {
+		logrus.WithField("node_name", node.Name).WithError(err).Error("Submit cpu manager job failed")
+		setUpdateStatus(newNode, toFailedStatus(cpuManagerStatus))
+	} else {
+		setUpdateStatus(newNode, toRunningStatus(cpuManagerStatus, job))
+	}
+
+	if reflect.DeepEqual(newNode, node) {
+		return node, nil
+	}
+	return h.nodeClient.Update(newNode)
+}
+
+func (h *cpuManagerNodeHandler) OnJobChanged(_ string, job *batchv1.Job) (*batchv1.Job, error) {
+	if job == nil || job.Labels == nil || job.DeletionTimestamp != nil {
+		return job, nil
+	}
+
+	nodeName, ok := job.Labels[util.LabelCPUManagerUpdateNode]
+	if !ok {
+		return job, nil
+	}
+
+	node, err := h.nodeCache.Get(nodeName)
+	if err != nil {
+		logrus.WithField("node_name", nodeName).WithError(err).Error("failed to get node from cache")
+		return job, err
+	}
+
+	if condition.Cond(batchv1.JobComplete).IsTrue(job) {
+		return nil, h.updateCPUManagerStatus(node, job, CPUManagerSuccessStatus)
+	}
+
+	if condition.Cond(batchv1.JobFailed).IsTrue(job) {
+		return nil, h.updateCPUManagerStatus(node, job, CPUManagerFailedStatus)
+	}
+
+	return job, nil
+}
+
+func (h *cpuManagerNodeHandler) updateCPUManagerStatus(node *corev1.Node, job *batchv1.Job, status CPUManagerStatus) error {
+	updateStatus := &CPUManagerUpdateStatus{
+		Status:  status,
+		Policy:  CPUManagerPolicy(job.Labels[util.LabelCPUManagerUpdatePolicy]),
+		JobName: job.Name,
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"node_name": node.Name,
+		"job_name":  job.Name,
+		"policy":    updateStatus.Policy,
+	}).Infof("cpu manager job %s", status)
+
+	if _, err := h.nodeClient.Update(setUpdateStatus(node, updateStatus)); err != nil {
+		logrus.WithField("node_name", node.Name).WithError(err).Errorf("failed to update node cpu manager %s status", status)
+		return err
+	}
+
+	return nil
+}
+
+func GetCPUManagerUpdateStatus(jsonString string) (*CPUManagerUpdateStatus, error) {
+	cpuManagerStatus := &CPUManagerUpdateStatus{}
+
+	if err := json.Unmarshal([]byte(jsonString), cpuManagerStatus); err != nil {
+		return nil, err
+	}
+	if cpuManagerStatus.Status != CPUManagerRequestedStatus && cpuManagerStatus.Status != CPUManagerRunningStatus && cpuManagerStatus.Status != CPUManagerSuccessStatus && cpuManagerStatus.Status != CPUManagerFailedStatus {
+		return nil, errors.New("invalid status")
+	}
+	if cpuManagerStatus.Policy != CPUManagerNonePolicy && cpuManagerStatus.Policy != CPUManagerStaticPolicy {
+		return nil, errors.New("invalid policy")
+	}
+	return cpuManagerStatus, nil
+}
+
+func toFailedStatus(updateStatus *CPUManagerUpdateStatus) *CPUManagerUpdateStatus {
+	newUpdateStatus := CPUManagerUpdateStatus(*updateStatus)
+	newUpdateStatus.Status = CPUManagerFailedStatus
+	return &newUpdateStatus
+}
+
+func toRunningStatus(updateStatus *CPUManagerUpdateStatus, job *batchv1.Job) *CPUManagerUpdateStatus {
+	newUpdateStatus := CPUManagerUpdateStatus(*updateStatus)
+	newUpdateStatus.Status = CPUManagerRunningStatus
+	newUpdateStatus.JobName = job.Name
+	return &newUpdateStatus
+}
+
+func setUpdateStatus(node *corev1.Node, updateStatus *CPUManagerUpdateStatus) *corev1.Node {
+	jsonStr, _ := json.Marshal(updateStatus)
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+	node.Annotations[util.AnnotationCPUManagerUpdateStatus] = string(jsonStr)
+	return node
+}
+
+func (h *cpuManagerNodeHandler) getJob(policy CPUManagerPolicy, node *corev1.Node, image string) *batchv1.Job {
+	hostPathDirectory := corev1.HostPathDirectory
+	labels := map[string]string{
+		util.LabelCPUManagerUpdateNode:   node.Name,
+		util.LabelCPUManagerUpdatePolicy: string(policy),
+	}
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: name.SafeConcatName(node.Name, "update-cpu-manager-"),
+			Namespace:    h.namespace,
+			Labels:       labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: node.APIVersion,
+					Kind:       node.Kind,
+					Name:       node.Name,
+					UID:        node.UID,
+				},
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            ptr.To(int32(0)), // do not retry
+			TTLSecondsAfterFinished: ptr.To(CPUManagerJobTTLInSec),
+			ActiveDeadlineSeconds:   ptr.To(CPUManagerJobTimeoutInSec),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					HostPID:       true,
+					Containers: []corev1.Container{
+						{
+							Name:    "update-cpu-manager",
+							Image:   image,
+							Command: []string{"sh"},
+							Args:    []string{"-e", CPUManagerScriptPath, node.Name, string(policy)},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "host-root", MountPath: CPUManagerRootMountPath},
+								{Name: "helpers", MountPath: CPUManagerScriptMountPath},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "HOST_DIR",
+									Value: CPUManagerRootMountPath,
+								},
+								{
+									Name:  "WAIT_LABEL_TIMEOUT",
+									Value: strconv.FormatInt(CPUManagerWaitLabelTimeoutInSec, 10),
+								},
+							},
+						},
+					},
+					ServiceAccountName: "harvester",
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+									MatchExpressions: []corev1.NodeSelectorRequirement{{
+										Key:      corev1.LabelHostname,
+										Operator: corev1.NodeSelectorOpIn,
+										Values: []string{
+											node.Name,
+										},
+									}},
+								}},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "host-root",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/",
+									Type: &hostPathDirectory,
+								},
+							},
+						},
+						{
+							Name: "helpers",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: helperConfigMapName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (h *cpuManagerNodeHandler) submitJob(updateStatus *CPUManagerUpdateStatus, node *corev1.Node) (*batchv1.Job, error) {
+	image, err := catalog.FetchAppChartImage(h.appCache, h.namespace, releaseAppHarvesterName, []string{"generalJob", "image"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get harvester image (%s): %v", image.ImageName(), err)
+	}
+
+	job, err := h.jobClient.Create(h.getJob(updateStatus.Policy, node, image.ImageName()))
+	if err != nil {
+		return nil, err
+	}
+
+	return job, nil
+}

--- a/pkg/controller/master/node/cpu_manager_controller_test.go
+++ b/pkg/controller/master/node/cpu_manager_controller_test.go
@@ -1,0 +1,20 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetCPUManagerUpdateStatus(t *testing.T) {
+	_, err := GetCPUManagerUpdateStatus(`{"policy":"foo","status":"requested"}`)
+	assert.Equal(t, "invalid policy", err.Error())
+
+	_, err = GetCPUManagerUpdateStatus(`{"policy":"static","status":"bar"}`)
+	assert.Equal(t, "invalid status", err.Error())
+
+	updateStatus, err := GetCPUManagerUpdateStatus(`{"policy":"static","status":"requested"}`)
+	assert.Nil(t, err)
+	assert.Equal(t, updateStatus.Policy, CPUManagerStaticPolicy)
+	assert.Equal(t, updateStatus.Status, CPUManagerRequestedStatus)
+}

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -284,7 +284,7 @@ func selectPromoteNode(nodeList []*corev1.Node) *corev1.Node {
 	nodeNumber := len(nodeList)
 	canBeManagementNodeCount := nodeNumber
 	for _, node := range nodeList {
-		isManagement := isManagementRole(node)
+		isManagement := IsManagementRole(node)
 
 		if isManagement {
 			managementNumber++
@@ -432,9 +432,9 @@ func isHarvesterNode(node *corev1.Node) bool {
 	return ok
 }
 
-// isManagementRole determine whether it's an management node based on the node's label.
+// IsManagementRole determine whether it's an management node based on the node's label.
 // Management Role included: master, control-plane, etcd
-func isManagementRole(node *corev1.Node) bool {
+func IsManagementRole(node *corev1.Node) bool {
 	if value, ok := node.Labels[KubeMasterNodeLabelKey]; ok {
 		return value == "true"
 	}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -37,6 +37,7 @@ var registerFuncs = []registerFunc{
 	node.DownRegister,
 	node.RemoveRegister,
 	node.VolumeDetachRegister,
+	node.CPUManagerRegister,
 	machine.ControlPlaneRegister,
 	setting.Register,
 	template.Register,

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -120,4 +120,8 @@ const (
 	VirtualHostedStyle = "VIRTUAL_HOSTED_STYLE"
 
 	DefaultResourceQuotaName = "default-resource-quota"
+
+	AnnotationCPUManagerUpdateStatus = prefix + "/cpu-manager-update-status"
+	LabelCPUManagerUpdateNode        = prefix + "/cpu-manager-update-node"
+	LabelCPUManagerUpdatePolicy      = prefix + "/cpu-manager-update-policy"
 )

--- a/pkg/util/fakeclients/job.go
+++ b/pkg/util/fakeclients/job.go
@@ -3,12 +3,43 @@ package fakeclients
 import (
 	"context"
 
+	"github.com/rancher/wrangler/v3/pkg/generic"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	batchv1type "k8s.io/client-go/kubernetes/typed/batch/v1"
 )
+
+type JobCache func(string) batchv1type.JobInterface
+
+func (c JobCache) Get(_, _ string) (*batchv1.Job, error) {
+	panic("implement me")
+}
+
+func (c JobCache) List(namespace string, selector labels.Selector) ([]*batchv1.Job, error) {
+	list, err := c(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*batchv1.Job, 0, len(list.Items))
+	for _, job := range list.Items {
+		obj := job
+		result = append(result, &obj)
+	}
+	return result, err
+}
+
+func (c JobCache) AddIndexer(_ string, _ generic.Indexer[*batchv1.Job]) {
+	panic("implement me")
+}
+
+func (c JobCache) GetByIndex(_, _ string) ([]*batchv1.Job, error) {
+	panic("implement me")
+}
 
 type JobClient func(string) batchv1type.JobInterface
 

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -1,26 +1,46 @@
 package node
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/selection"
+
 	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
+
+	"github.com/rancher/wrangler/pkg/condition"
 )
 
-func NewValidator(nodeCache v1.NodeCache) types.Validator {
+func NewValidator(nodeCache v1.NodeCache, jobCache ctlbatchv1.JobCache, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) types.Validator {
 	return &nodeValidator{
 		nodeCache: nodeCache,
+		jobCache:  jobCache,
+		vmiCache:  vmiCache,
 	}
 }
 
 type nodeValidator struct {
 	types.DefaultValidator
 	nodeCache v1.NodeCache
+	jobCache  ctlbatchv1.JobCache
+	vmiCache  ctlkubevirtv1.VirtualMachineInstanceCache
 }
 
 func (v *nodeValidator) Resource() types.Resource {
@@ -45,7 +65,13 @@ func (v *nodeValidator) Update(_ *types.Request, oldObj runtime.Object, newObj r
 		return err
 	}
 
-	return validateCordonAndMaintenanceMode(oldNode, newNode, nodeList)
+	if err := validateCordonAndMaintenanceMode(oldNode, newNode, nodeList); err != nil {
+		return err
+	}
+	if err := v.validateCPUManagerOperation(newNode); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validateCordonAndMaintenanceMode(oldNode, newNode *corev1.Node, nodeList []*corev1.Node) error {
@@ -70,4 +96,145 @@ func validateCordonAndMaintenanceMode(oldNode, newNode *corev1.Node, nodeList []
 		}
 	}
 	return werror.NewBadRequest("can't enable maintenance mode or cordon on the last available node")
+}
+
+func (v *nodeValidator) validateCPUManagerOperation(node *corev1.Node) error {
+	annot, ok := node.Annotations[util.AnnotationCPUManagerUpdateStatus]
+	if !ok {
+		return nil
+	}
+
+	// check if the node is in witness role
+	if _, found := node.Labels[ctlnode.HarvesterWitnessNodeLabelKey]; found {
+		return werror.NewBadRequest("The witness node is unable to update the CPU manager policy.")
+	}
+
+	updateStatus, err := ctlnode.GetCPUManagerUpdateStatus(annot)
+	if err != nil {
+		return werror.NewBadRequest(fmt.Sprintf("Failed to retrieve cpu-manager-update-status from annotation: %v", err))
+	}
+	// only validate when update status is requested
+	if updateStatus.Status != ctlnode.CPUManagerRequestedStatus {
+		return nil
+	}
+	policy := updateStatus.Policy
+
+	// check if cpu manager policy is the same
+	if err := checkCPUManagerLabel(node, policy); err != nil {
+		return err
+	}
+	// check if there is other job that still updating cpu manager policy to the same node
+	if err := checkCurrentNodeCPUManagerJobs(node, v.jobCache); err != nil {
+		return err
+	}
+	// check if this node is master and there are other master nodes undating cpu manager policy
+	// since the policy update on master node need to restart rke2-server, we only allow one master node update policy
+	if err := checkMasterNodeJobs(node, v.nodeCache, v.jobCache); err != nil {
+		return err
+	}
+	// check if there is any vm that enable cpu pinning while cpu manager is going to be disabled
+	if err := checkCPUPinningVMIs(node, policy, v.vmiCache); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkCPUManagerLabel(node *corev1.Node, policy ctlnode.CPUManagerPolicy) error {
+	cpuManagerLabel, err := strconv.ParseBool(node.Labels[kubevirtv1.CPUManager])
+	// means CPUManager feature gate not enabled
+	if err != nil {
+		return werror.NewBadRequest("label cpumanager not found")
+	}
+	// check if the cpu manager policy is the same
+	if ((policy == ctlnode.CPUManagerStaticPolicy) && cpuManagerLabel) || ((policy == ctlnode.CPUManagerNonePolicy) && !cpuManagerLabel) {
+		return werror.NewBadRequest(fmt.Sprintf("current cpu manager policy is already the same as requested value: %s", policy))
+	}
+	return nil
+}
+
+func checkCurrentNodeCPUManagerJobs(node *corev1.Node, jobCache ctlbatchv1.JobCache) error {
+	jobNames, err := getCPUManagerRunningJobNamesOnNodes(jobCache, []string{node.Name})
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	if len(jobNames) > 0 {
+		return werror.NewBadRequest(fmt.Sprintf("there is other job %s updating the cpu manager policy for this node %s", strings.Join(jobNames, ", "), node.Name))
+	}
+	return nil
+}
+
+func checkMasterNodeJobs(node *corev1.Node, nodeCache v1.NodeCache, jobCache ctlbatchv1.JobCache) error {
+	// the node is worker, no need to do validation
+	if !ctlnode.IsManagementRole(node) {
+		return nil
+	}
+
+	nodes, err := nodeCache.List(labels.Everything())
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+
+	// collect master node names except the node itself
+	masterNodeNames := []string{}
+	for _, n := range nodes {
+		if n.Name != node.Name && ctlnode.IsManagementRole(n) {
+			masterNodeNames = append(masterNodeNames, n.Name)
+		}
+	}
+
+	if len(masterNodeNames) == 0 {
+		return nil
+	}
+
+	jobNames, err := getCPUManagerRunningJobNamesOnNodes(jobCache, masterNodeNames)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	if len(jobNames) > 0 {
+		return werror.NewBadRequest(fmt.Sprintf("the node you are trying to update the cpu manager policy is a master node, and only one master node can be updated at a time, while job %s is updating the policy for other master nodes",
+			strings.Join(jobNames, ", ")))
+	}
+
+	return nil
+}
+
+func getCPUManagerRunningJobNamesOnNodes(jobCache ctlbatchv1.JobCache, nodeNames []string) ([]string, error) {
+	if len(nodeNames) == 0 {
+		return []string{}, werror.NewInternalError("nodeNames size should > 0")
+	}
+	requirement, err := labels.NewRequirement(util.LabelCPUManagerUpdateNode, selection.In, nodeNames)
+	if err != nil {
+		return []string{}, werror.NewInternalError(fmt.Sprintf("failed to create requirement: %s", err.Error()))
+	}
+	labelSelector := labels.NewSelector().Add(*requirement)
+	jobs, err := jobCache.List("", labelSelector)
+	if err != nil {
+		return []string{}, err
+	}
+	runningJobNames := []string{}
+	for _, job := range jobs {
+		if !condition.Cond(batchv1.JobComplete).IsTrue(job) && !condition.Cond(batchv1.JobFailed).IsTrue(job) {
+			runningJobNames = append(runningJobNames, job.Name)
+		}
+	}
+	return runningJobNames, nil
+}
+
+func checkCPUPinningVMIs(node *corev1.Node, policy ctlnode.CPUManagerPolicy, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) error {
+	if policy != ctlnode.CPUManagerNonePolicy {
+		return nil
+	}
+
+	vmis, err := virtualmachineinstance.ListByNode(node, labels.NewSelector(), vmiCache)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+
+	for _, vmi := range vmis {
+		if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.DedicatedCPUPlacement {
+			return werror.NewBadRequest("there should not be any running VMs with CPU pinning when disabling the CPU manager")
+		}
+	}
+	return nil
 }

--- a/pkg/webhook/resources/node/validator_test.go
+++ b/pkg/webhook/resources/node/validator_test.go
@@ -6,8 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	batchv1 "k8s.io/api/batch/v1"
 
 	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
+
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestValidateCordonAndMaintenanceMode(t *testing.T) {
@@ -210,6 +219,408 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 		err := validateCordonAndMaintenanceMode(tc.oldNode, tc.newNode, tc.nodeList)
 		if tc.expectedError {
 			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}
+
+func TestValidateCPUManagerOperation(t *testing.T) {
+	k8sclientset := k8sfake.NewSimpleClientset()
+	client := fake.NewSimpleClientset()
+
+	validator := &nodeValidator{
+		nodeCache: fakeclients.NodeCache(k8sclientset.CoreV1().Nodes),
+		jobCache:  fakeclients.JobCache(k8sclientset.BatchV1().Jobs),
+		vmiCache:  fakeclients.VirtualMachineInstanceCache(client.KubevirtV1().VirtualMachineInstances),
+	}
+
+	assert.Equal(t, werror.NewBadRequest("Failed to retrieve cpu-manager-update-status from annotation: invalid policy"),
+		validator.validateCPUManagerOperation(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "node1",
+				Annotations: map[string]string{util.AnnotationCPUManagerUpdateStatus: `{"status": "running", "policy": "foo"}`},
+			},
+		}))
+
+	assert.Equal(t, werror.NewBadRequest("The witness node is unable to update the CPU manager policy."),
+		validator.validateCPUManagerOperation(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "node1",
+				Annotations: map[string]string{util.AnnotationCPUManagerUpdateStatus: `{"status": "requested", "policy": "static"}`},
+				Labels:      map[string]string{ctlnode.HarvesterWitnessNodeLabelKey: "true"},
+			},
+		}))
+
+	assert.Nil(t, validator.validateCPUManagerOperation(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+	}))
+
+	assert.Nil(t, validator.validateCPUManagerOperation(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node1",
+			Annotations: map[string]string{util.AnnotationCPUManagerUpdateStatus: `{"status": "running", "policy": "static"}`},
+		},
+	}))
+}
+
+func TestCheckCPUManagerLabel(t *testing.T) {
+	nodeWithLabels := func(labels map[string]string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: labels,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name   string
+		policy ctlnode.CPUManagerPolicy
+		node   *corev1.Node
+		errMsg string
+	}{
+		{
+			name:   "invalid update: invalid nil label",
+			policy: ctlnode.CPUManagerNonePolicy,
+			node:   &corev1.Node{},
+			errMsg: "label cpumanager not found",
+		},
+		{
+			name:   "invalid update: invalid label value",
+			policy: ctlnode.CPUManagerNonePolicy,
+			node:   nodeWithLabels(map[string]string{kubevirtv1.CPUManager: ""}),
+			errMsg: "label cpumanager not found",
+		},
+		{
+			name:   "invalid update: the CPU manager policy remains unchanged, both are static",
+			policy: ctlnode.CPUManagerStaticPolicy,
+			node:   nodeWithLabels(map[string]string{kubevirtv1.CPUManager: "true"}),
+			errMsg: "current cpu manager policy is already the same as requested value: static",
+		},
+		{
+			name:   "invalid update: the CPU manager policy remains unchanged, both are none",
+			policy: ctlnode.CPUManagerNonePolicy,
+			node:   nodeWithLabels(map[string]string{kubevirtv1.CPUManager: "false"}),
+			errMsg: "current cpu manager policy is already the same as requested value: none",
+		},
+		{
+			name:   "valid update: the CPU manager policy changed",
+			policy: ctlnode.CPUManagerStaticPolicy,
+			node:   nodeWithLabels(map[string]string{kubevirtv1.CPUManager: "false"}),
+			errMsg: "",
+		},
+		{
+			name:   "valid update: the CPU manager policy changed",
+			policy: ctlnode.CPUManagerNonePolicy,
+			node:   nodeWithLabels(map[string]string{kubevirtv1.CPUManager: "true"}),
+			errMsg: "",
+		},
+	}
+	for _, tc := range testCases {
+		err := checkCPUManagerLabel(tc.node, tc.policy)
+		if tc.errMsg != "" {
+			assert.NotNil(t, err, tc.name)
+			assert.Equal(t, tc.errMsg, err.Error(), tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}
+
+func TestCheckCPUManagerJobs(t *testing.T) {
+	node0 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-0",
+		},
+	}
+	testCases := []struct {
+		name   string
+		node   *corev1.Node
+		jobs   []*batchv1.Job
+		errMsg string
+	}{
+		{
+			name:   "valid update: empty jobs",
+			node:   node0,
+			jobs:   []*batchv1.Job{},
+			errMsg: "",
+		},
+		{
+			name: "invalid update: one cpumanager running jobs on node-0",
+			node: node0,
+			jobs: []*batchv1.Job{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job-1",
+						Labels: map[string]string{
+							util.LabelCPUManagerUpdateNode: "node-0",
+						},
+					},
+				},
+			},
+			errMsg: "there is other job job-1 updating the cpu manager policy for this node node-0",
+		},
+		{
+			name: "valid update: no cpumanager running jobs on node-0",
+			node: node0,
+			jobs: []*batchv1.Job{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job1",
+						Labels: map[string]string{
+							util.LabelCPUManagerUpdateNode: "node-0",
+						},
+					},
+					Status: batchv1.JobStatus{
+						Conditions: []batchv1.JobCondition{
+							{
+								Type:   batchv1.JobComplete,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job2",
+						Labels: map[string]string{
+							util.LabelCPUManagerUpdateNode: "node-0",
+						},
+					},
+					Status: batchv1.JobStatus{
+						Conditions: []batchv1.JobCondition{
+							{
+								Type:   batchv1.JobFailed,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job3",
+						Labels: map[string]string{
+							util.LabelCPUManagerUpdateNode: "node-1",
+						},
+					},
+				},
+			},
+			errMsg: "",
+		},
+	}
+	for _, tc := range testCases {
+		k8sclientset := k8sfake.NewSimpleClientset()
+		for _, job := range tc.jobs {
+			err := k8sclientset.Tracker().Add(job)
+			assert.Nil(t, err, "Mock resource should add into fake controller tracker")
+		}
+		jobCache := fakeclients.JobCache(k8sclientset.BatchV1().Jobs)
+		err := checkCurrentNodeCPUManagerJobs(tc.node, jobCache)
+		if tc.errMsg != "" {
+			assert.NotNil(t, err, tc.name)
+			assert.Equal(t, tc.errMsg, err.Error(), tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}
+
+func TestCheckMasterNodeJobs(t *testing.T) {
+	masterNode0 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-0",
+			Labels: map[string]string{
+				ctlnode.KubeMasterNodeLabelKey: "true",
+			},
+		},
+	}
+	masterNode1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Labels: map[string]string{
+				ctlnode.KubeMasterNodeLabelKey: "true",
+			},
+		},
+	}
+	workerNode1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+	}
+	testCases := []struct {
+		name        string
+		currentNode *corev1.Node
+		nodes       []*corev1.Node
+		jobs        []*batchv1.Job
+		errMsg      string
+	}{
+		{
+			name: "valid update: node-0 not a master node",
+			currentNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-0",
+				},
+			},
+			nodes:  []*corev1.Node{},
+			jobs:   []*batchv1.Job{},
+			errMsg: "",
+		},
+		{
+			name:        "valid update: only one master node",
+			currentNode: masterNode0,
+			nodes:       []*corev1.Node{masterNode0},
+			jobs:        []*batchv1.Job{},
+			errMsg:      "",
+		},
+		{
+			name:        "valid update: no other master node update",
+			currentNode: masterNode0,
+			nodes:       []*corev1.Node{masterNode0, workerNode1},
+			jobs: []*batchv1.Job{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							util.LabelCPUManagerUpdateNode: "node-1",
+						},
+					},
+				},
+			},
+			errMsg: "",
+		},
+		{
+			name:        "valid update: no other master node update",
+			currentNode: masterNode0,
+			nodes:       []*corev1.Node{masterNode0, masterNode1},
+			jobs:        []*batchv1.Job{},
+			errMsg:      "",
+		},
+		{
+			name:        "invalid update: other master also update cpu manager",
+			currentNode: masterNode0,
+			nodes:       []*corev1.Node{masterNode0, masterNode1},
+			jobs: []*batchv1.Job{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job-1",
+						Labels: map[string]string{
+							util.LabelCPUManagerUpdateNode: "node-1",
+						},
+					},
+				},
+			},
+			errMsg: "the node you are trying to update the cpu manager policy is a master node, and only one master node can be updated at a time, while job job-1 is updating the policy for other master nodes",
+		},
+	}
+	for _, tc := range testCases {
+		k8sclientset := k8sfake.NewSimpleClientset()
+		for _, node := range tc.nodes {
+			err := k8sclientset.Tracker().Add(node)
+			assert.Nil(t, err, "Mock resource should add into fake controller tracker")
+		}
+		for _, job := range tc.jobs {
+			err := k8sclientset.Tracker().Add(job)
+			assert.Nil(t, err, "Mock resource should add into fake controller tracker")
+		}
+		nodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
+		jobCache := fakeclients.JobCache(k8sclientset.BatchV1().Jobs)
+		err := checkMasterNodeJobs(tc.currentNode, nodeCache, jobCache)
+		if tc.errMsg != "" {
+			assert.NotNil(t, err, tc.name)
+			assert.Equal(t, tc.errMsg, err.Error(), tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}
+
+func TestCheckCPUPinningVMIs(t *testing.T) {
+	node0 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-0",
+		},
+	}
+	testCases := []struct {
+		name   string
+		node   *corev1.Node
+		policy ctlnode.CPUManagerPolicy
+		vmis   []*kubevirtv1.VirtualMachineInstance
+		errMsg string
+	}{
+		{
+			name:   "valid udpate: no need to do validation when update policy to static",
+			node:   node0,
+			policy: ctlnode.CPUManagerStaticPolicy,
+			vmis:   []*kubevirtv1.VirtualMachineInstance{},
+			errMsg: "",
+		},
+		{
+			name:   "valid udpate: no cpu pinning enabled vm in node-0",
+			node:   node0,
+			policy: ctlnode.CPUManagerNonePolicy,
+			vmis: []*kubevirtv1.VirtualMachineInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vm-0",
+						Labels: map[string]string{
+							util.LabelNodeNameKey: "node-0",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vm-1",
+						Labels: map[string]string{
+							util.LabelNodeNameKey: "node-1",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							CPU: &kubevirtv1.CPU{
+								DedicatedCPUPlacement: true,
+							},
+						},
+					},
+				},
+			},
+			errMsg: "",
+		},
+		{
+			name:   "invalid udpate: there is a cpu pinning enabled vm in node-0",
+			node:   node0,
+			policy: ctlnode.CPUManagerNonePolicy,
+			vmis: []*kubevirtv1.VirtualMachineInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vm-0",
+						Labels: map[string]string{
+							util.LabelNodeNameKey: "node-0",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							CPU: &kubevirtv1.CPU{
+								DedicatedCPUPlacement: true,
+							},
+						},
+					},
+				},
+			},
+			errMsg: "there should not be any running VMs with CPU pinning when disabling the CPU manager",
+		},
+	}
+	for _, tc := range testCases {
+		var clientset = fake.NewSimpleClientset()
+		for _, vmi := range tc.vmis {
+			err := clientset.Tracker().Add(vmi)
+			assert.Nil(t, err, "Mock resource should add into fake controller tracker")
+		}
+		vmiCache := fakeclients.VirtualMachineInstanceCache(clientset.KubevirtV1().VirtualMachineInstances)
+		err := checkCPUPinningVMIs(tc.node, tc.policy, vmiCache)
+		if tc.errMsg != "" {
+			assert.NotNil(t, err, tc.name)
+			assert.Equal(t, tc.errMsg, err.Error(), tc.name)
 		} else {
 			assert.Nil(t, err, tc.name)
 		}

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -163,6 +163,49 @@ func TestPatchResourceOvercommit(t *testing.T) {
 	}
 }
 
+func TestPatchResourceOvercommitWithDedicatedCPUPlacement(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Resources: kubevirtv1.ResourceRequirements{
+							Limits: map[v1.ResourceName]resource.Quantity{
+								v1.ResourceCPU:    *resource.NewQuantity(int64(8), resource.DecimalSI),
+								v1.ResourceMemory: *resource.NewQuantity(int64(math.Pow(2, 30)), resource.BinarySI), // 1Gi
+							},
+						},
+						CPU: &kubevirtv1.CPU{
+							Cores:                 8,
+							Sockets:               1,
+							DedicatedCPUPlacement: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	setting := &harvesterv1.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "overcommit-config",
+		},
+		Default: `{"cpu":200,"memory":400,"storage":800}`,
+	}
+	clientset := fake.NewSimpleClientset()
+	clientset.Tracker().Add(setting)
+	mutator := NewMutator(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+		fakeclients.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions))
+	actual, err := mutator.(*vmMutator).patchResourceOvercommit(vm)
+	assert.Nil(t, err)
+	assert.Equal(t,
+		[]string{
+			"{\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/memory\", \"value\": {\"guest\":\"924Mi\"}}",
+			"{\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/resources/requests\", \"value\": {\"cpu\":\"8\",\"memory\":\"1Gi\"}}"},
+		actual)
+}
+
 func TestPatchAffinity(t *testing.T) {
 	vm1 := &kubevirtv1.VirtualMachine{
 		Spec: kubevirtv1.VirtualMachineSpec{

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -44,7 +44,10 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 
 	resources := []types.Resource{}
 	validators := []types.Validator{
-		node.NewValidator(clients.Core.Node().Cache()),
+		node.NewValidator(
+			clients.Core.Node().Cache(),
+			clients.Batch.Job().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache()),
 		persistentvolumeclaim.NewValidator(
 			clients.Core.PersistentVolumeClaim().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),


### PR DESCRIPTION
~~Blocked by https://github.com/harvester/harvester-installer/pull/756~~

**Problem:**
Implement CPU Pinning feature

**Solution:**
Introduce two endpoints:
- enable cpu manager: `/v1/harvester/nodes/{node_name}?action=enableCPUManager`, which turn cpu manager policy into `static` on the node. Then user could create vm with cpu pinning and deploy those vm to those nodes enable cpu manager.
- disable cpu manager: `/v1/harvester/nodes/{node_name}?action=disableCPUManager`, which turn cpu manager policy into `none`, note that if there is any vm with cpu pinning on the node that needed to disable cpu manager, an error raise `there should not be any running VMs with CPU pinning when disabling the CPU manager`.

for more details, please check the HEP: https://github.com/harvester/harvester/pull/5803

**Related Issue:**
related to https://github.com/harvester/harvester/issues/2305,

**Test plan:**
prerequisite: 
~~- build iso, note that you need to apply this patch
[0001-custom-installer.patch](https://github.com/user-attachments/files/16435446/0001-custom-installer.patch) after checkout to the branch which belongs to this PR. The patch change the harvester-installer version as I have to add some config files through harvester-installer while https://github.com/harvester/harvester-installer/pull/756 not merged yet.~~
- prepare 3 nodes harvester cluster
- create api key: click dashboard top right profile picture > Account & API Keys > Create API Key
- Use the following curl cmd to enable/disable cpu manager:
  a. enable cpu manager
  ```shell
      curl 'https://192.168.100.131/v1/harvester/nodes/{node_name}?action=enableCPUManager' \
      -X 'POST' \
      -H 'Authorization: Bearer <API_KEY>' \
      --insecure
  ```
  b. disable cpu manager
  ```shell
      curl 'https://192.168.100.131/v1/harvester/nodes/{node_name}?action=disableCPUManager' \
      -X 'POST' \
      -H 'Authorization: Bearer <API_KEY>' \
      --insecure
  ```

### Test enable/disable cpu pinning
1. enable cpu manager on harvester-node-0
2. Open k8s and there should have a job name start with `harvester-node-0-update-cpu-manager-` wait until the job done.
3. create vm named `test` with cpu pinning: go to dashboard and click `Virtual Machines` tab, click `Create` fill the Name, CPU, Memory, Volumes>Image field, and then click `Edit as YAML`. Add `dedicatedCpuPlacement: true` to `.spec.template.spec.domain.cpu`. And then click `Create`.
<img width="316" alt="image" src="https://github.com/user-attachments/assets/e35468ce-ff64-4849-a0ea-cebdf90c53c6">

4. make sure the cpu pinning works by using the following cmd
  ```
  kubectl exec {virt-launcher-pod-id} -- virsh dumpxml default_test | awk "/<cputune>/,/<\/cputune>/"
  ```
  the cmd should output something like belows, depends on the cpu size, there should have the corresponding `vcpupin` xml fields.
  ```
    <cputune>
      <vcpupin vcpu='0' cpuset='1'/>
      ...
    </cputune>
  ```
5. disable cpu manager in harvester-node-0, and verify user can't disable cpu manager when there is a cpu pinned vm in harvester-node-0.
An error raise: `admission webhook "validator.harvesterhci.io" denied the request: there should not be any running VMs with CPU pinning when disabling the CPU manager`
6. stop the vm `test`
7. disable cpu manager in harvester-node-0

###  Verify only one master node could enable/disable cpu manager
1. enable cpu manager on harvester-node-0, no need to wait until cpu manager job done, go to step 2.
2. enable cpu manager on harvester-node-1
In step 2, an error raised: `admission webhook "validator.harvesterhci.io" denied the request: there is another master node updating the CPU manager policy`. Enabling or disabling the CPU manager requires restarting the kubelet, which in turn necessitates restarting the rke2-server. Since we are using a three-node setup where all nodes have the master role, restarting all rke2-servers simultaneously could lead to the entire cluster going offline. Therefore, the CPU manager update process allows only one master node to update at a time.

### Verify there should be only one job enable/disable cpu manager per node
1. enable cpu manager on harvester-node-0, no need to wait until cpu manager job done, go to step 2.
2. enable or disable cpu manager on harvester-node-0
An error raise: `admission webhook "validator.harvesterhci.io" denied the request: there is other ongoing job updating cpu manager policy`

### Verify we can't enable cpu manager when it is enabled, and we can't disable cpu manager when it's disabled 
1. enable cpu manager on harvester-node-0, wait until cpu manager job done, go to step 2.
2. enable cpu manager on harvester-node-0, an error raises
`admission webhook "validator.harvesterhci.io" denied the request: same cpu manager policy`

### Test reboot
1. Create vm with cpu pinning
2. Reboot harvester node
3. After reboot, check rke2-server or rke2-agent  (depends on the node role) start up successfully and vm is running.

### Test upgrade path
Loop through all tests mentioned above under these 2 scenarios:
1. Test single node upgrade path: Prepare a one node harvester and upgrade to the version that include this feature
2. Test multi node upgrade path: Prepare multi nodes harvester cluster and upgrade to the version that include this feature.
```yaml
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master
  namespace: harvester-system
spec:
  isoURL: http://192.168.100.1:8000/harvester-master-amd64.iso
---
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  annotations:
    harvesterhci.io/skip-version-check: "true"
    harvesterhci.io/skipWebhook: "true"
  generateName: hvst-upgrade-
  namespace: harvester-system
spec:
  version: "master"
  logEnabled: false
```