### PR TITLE
Sync VM when migration is aborted

### DIFF
--- a/pkg/controller/master/migration/vmi_controller.go
+++ b/pkg/controller/master/migration/vmi_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,10 +38,8 @@ func (h *Handler) OnVmiChanged(_ string, vmi *kubevirtv1.VirtualMachineInstance)
 
 	if vmi.Annotations[util.AnnotationMigrationUID] == string(vmi.Status.MigrationState.MigrationUID) &&
 		vmi.Status.MigrationState.Completed {
-		if err := h.resetHarvesterMigrationStateInVMI(vmi); err != nil {
-			return vmi, err
-		}
-		if err := h.syncVM(vmi); err != nil {
+		if err := h.resetHarvesterMigrationStateInVmiAndSyncVM(vmi); err != nil {
+			logrus.Infof("vmi %s/%s finished migration but fail to reset state %s", vmi.Namespace, vmi.Name, err.Error())
 			return vmi, err
 		}
 	}

--- a/pkg/controller/master/virtualmachine/vmi_network_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller.go
@@ -3,6 +3,7 @@ package virtualmachine
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -47,7 +48,6 @@ func (h *VMNetworkController) SetDefaultNetworkMacAddress(id string, vmi *kubevi
 }
 
 func (h *VMNetworkController) updateVMDefaultNetworkMacAddress(vmi *kubevirtv1.VirtualMachineInstance) error {
-	logrus.Debugf("update default network mac address of the vm: %s\n", vmi.Name)
 	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
 		return err
@@ -71,6 +71,11 @@ func (h *VMNetworkController) updateVMDefaultNetworkMacAddress(vmi *kubevirtv1.V
 		}
 	}
 
+	if reflect.DeepEqual(vmCopy.Spec.Template.Spec.Domain.Devices, vm.Spec.Template.Spec.Domain.Devices) {
+		return nil
+	}
+
+	logrus.Debugf("update default network mac address of the vm: %s", vmi.Name)
 	if err := h.regenerateControllerRevision(vmi, vm); err != nil {
 		return err
 	}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Abort migration quickly after clicking `migrate` menu, the UI menu then hang on `abortMigration`.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

UI should not hange.

**Related Issue:**
#6193 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Per the description of #6193 

Additional:
1. The migration log is also enhanced to have like:

```
time="2024-07-25T14:04:00Z" level=info msg="start migration of vm default/vm1 to node harv2, vmim vm1-wxzv8"
time="2024-07-25T14:04:03Z" level=info msg="abort migration of vm default/vm1, delete vmim vm1-wxzv8"
```

2. Such annoying debug log is removed:

```
time="2024-07-25T13:17:56Z" level=debug msg="update default network mac address of the vm: vm1\n"
time="2024-07-25T13:17:56Z" level=debug msg="update default network mac address of the vm: vm1\n"
```