### PR TITLE
feat: trun on autoCleanupSnapshotWhenDeleteBackup by default

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -407,6 +407,7 @@ longhorn:
     ## Specify the concurrent automatic engine upgrade per node limit
     concurrentAutomaticEngineUpgradePerNodeLimit: 3
     priorityClass: &longhornPriorityClass system-cluster-critical
+    autoCleanupSnapshotWhenDeleteBackup: true
 
   # after upgrade to longhorn 1.6.0, we need to set the priorityClass for longhorn-manager, longhorn-driver and longhorn-ui
   # or it will be default one longhorn-critical


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Enable the setting `autoCleanupSnapshotWhenDeleteBackup`, so LH will automatically remove snapshot if related backup is removed.

**Related Issue:**
https://github.com/harvester/harvester/issues/4478
https://github.com/harvester/harvester/pull/6008#discussion_r1675039351

**Test plan:**

1. Create a Harvester cluster and setup backup-target.
2. Create a backup and check related snapshot is there.
3. Remove the backup and check related snapshot is removed or marked as removed (with `deletionTimestamp`).
