### PR TITLE
Fix incorrect package name in `pkg/api/cluster/formatter.go`

### DIFF
--- a/pkg/api/cluster/formatter.go
+++ b/pkg/api/cluster/formatter.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/rancher/apiserver/pkg/apierror"
-	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"


### PR DESCRIPTION
**Problem:**
execute `make` and I got error
```text
pkg/api/cluster/formatter.go:14:2: cannot find module providing package github.com/rancher/wrangler/pkg/generated/controllers/core/v1: import lookup disabled by -mod=vendor
	(Go version in go.mod is at least 1.14 and vendor directory exists.)
FATA[0011] exit status 1
make: *** [Makefile:11: default] Error 1
```

**Solution:**
Fix incorrect package in `pkg/api/cluster/formatter.go`, the root cause is we change the rancher wrangler version in https://github.com/harvester/harvester/pull/6173

**Related Issue:**
N/A

**Test plan:**
Compile should pass.