### PR TITLE
harvester upgrade lookup enhancements

### DIFF
--- a/pkg/controller/master/upgrade/version_syncer.go
+++ b/pkg/controller/master/upgrade/version_syncer.go
@@ -149,17 +149,21 @@ func (s *versionSyncer) getExtraInfo() (map[string]string, error) {
 }
 
 func (s *versionSyncer) syncVersions(resp CheckUpgradeResponse, currentVersion string) error {
-	if err := s.cleanupVersions(currentVersion); err != nil {
+	if err := s.cleanupVersions(currentVersion, resp.Versions); err != nil {
 		return err
 	}
 
+	// iterate over response and identify if a new version needs to be created
 	for _, v := range resp.Versions {
 		newVersion, err := s.getNewVersion(v)
 		if err != nil {
 			return err
 		}
 
-		if !canUpgrade(currentVersion, newVersion) {
+		// newVersion CRD is created from the version.yaml created from the release artifact
+		// this needs to be changed to use the min version coming from the upgrade responder
+		// as this could be dynamically update and will cause cleanup of older versions
+		if !canUpgrade(currentVersion, newVersion, v) {
 			continue
 		}
 
@@ -174,21 +178,28 @@ func (s *versionSyncer) syncVersions(resp CheckUpgradeResponse, currentVersion s
 			}
 		}
 	}
+
 	return nil
 }
 
 // cleanupVersions remove version resources that's can't be upgraded to anymore
-func (s *versionSyncer) cleanupVersions(currentVersion string) error {
+func (s *versionSyncer) cleanupVersions(currentVersion string, remoteVersions []Version) error {
 	versions, err := s.versionClient.List(s.namespace, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for i := range versions.Items {
-		v := versions.Items[i]
-		if !canUpgrade(currentVersion, &v) {
-			if err := s.versionClient.Delete(v.Namespace, v.Name, &metav1.DeleteOptions{}); err != nil {
-				return err
+	for _, version := range remoteVersions {
+		for i, v := range versions.Items {
+			versionObj := v
+			if !canUpgrade(currentVersion, &versionObj, version) {
+				if err := s.versionClient.Delete(v.Namespace, v.Name, &metav1.DeleteOptions{}); err != nil {
+					if apierrors.IsNotFound(err) {
+						continue // likely object has been removed so we can continue
+					}
+					return err
+				}
+				versions.Items = append(versions.Items[:i], versions.Items[i+1:]...)
 			}
 		}
 	}
@@ -226,13 +237,13 @@ func (s *versionSyncer) getNewVersion(v Version) (*harvesterv1.Version, error) {
 	return &newVersion, nil
 }
 
-func canUpgrade(currentVersion string, newVersion *harvesterv1.Version) bool {
+func canUpgrade(currentVersion string, newVersion *harvesterv1.Version, responderVersion Version) bool {
 	switch {
 	case newVersion.Spec.ISOURL == "" || newVersion.Spec.ISOChecksum == "":
 		return false
-	case slice.ContainsString(newVersion.Spec.Tags, "dev"):
+	case slice.ContainsString(responderVersion.Tags, "dev"):
 		return true
-	case gversion.Compare(currentVersion, newVersion.Name, "<") && (newVersion.Spec.MinUpgradableVersion == "" || gversion.Compare(currentVersion, newVersion.Spec.MinUpgradableVersion, ">=")):
+	case gversion.Compare(currentVersion, responderVersion.Name, "<") && (responderVersion.MinUpgradableVersion == "" || gversion.Compare(currentVersion, responderVersion.MinUpgradableVersion, ">=")):
 		return true
 	default:
 		return false

--- a/pkg/controller/master/upgrade/version_syncer_test.go
+++ b/pkg/controller/master/upgrade/version_syncer_test.go
@@ -1,22 +1,38 @@
 package upgrade
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+const (
+	defaultNamespace = "harvester-system"
 )
 
 func TestGetUpgradableVersions(t *testing.T) {
 	type input struct {
-		newVersions    []harvesterv1.Version
+		newVersions    harvesterv1.Version
+		respVersion    Version
 		currentVersion string
 	}
 	type output struct {
-		canUpgrades []bool
+		canUpgrades bool
 	}
 	var testCases = []struct {
 		name     string
@@ -24,212 +40,150 @@ func TestGetUpgradableVersions(t *testing.T) {
 		expected output
 	}{
 		{
-			name: "test1",
+			name: "no iso url specified",
 			given: input{
 				currentVersion: "v0.1.0",
-				newVersions: []harvesterv1.Version{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.3.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2021-01-01T00:00:00Z",
-							MinUpgradableVersion: "v0.2.0",
-							Tags:                 []string{"latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.3.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2021-01-01T00:00:00Z",
-							MinUpgradableVersion: "v0.2.0",
-							Tags:                 []string{"dev", "latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.2.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2020-01-01T00:00:00Z",
-							MinUpgradableVersion: "v0.1.0",
-							Tags:                 []string{"v0.2-latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
-					},
-					// Lack of ISOURL and ISOChecksum
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.2.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2020-01-01T00:00:00Z",
-							MinUpgradableVersion: "v0.1.0",
-							Tags:                 []string{"v0.2-latest"},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.3.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2021-01-01T00:00:00Z",
-							MinUpgradableVersion: "",
-							Tags:                 []string{"latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
+				respVersion: Version{
+					Name:                 "v0.2.0",
+					MinUpgradableVersion: "v0.1.0",
+					Tags:                 []string{"v0.2.0"},
+				},
+				newVersions: harvesterv1.Version{
+					Spec: harvesterv1.VersionSpec{
+						ISOURL:      "",
+						ISOChecksum: "xxx",
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{false, true, true, false, true},
+				canUpgrades: false,
 			},
 		},
 		{
-			name: "test2",
+			name: "no iso checksum specified",
 			given: input{
-				currentVersion: "dev",
-				newVersions: []harvesterv1.Version{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.1.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2021-01-01T00:00:00Z",
-							MinUpgradableVersion: "v0.1.0-rc1",
-							Tags:                 []string{"v0.1.0"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.2.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2020-01-01T00:00:00Z",
-							MinUpgradableVersion: "dev",
-							Tags:                 []string{"v0.2.0"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.2.1",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2020-06-01T00:00:00Z",
-							MinUpgradableVersion: "dev",
-							Tags:                 []string{"v0.2.1", "latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.2.1",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2020-06-01T00:00:00Z",
-							MinUpgradableVersion: "",
-							Tags:                 []string{"v0.2.1", "latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
+				currentVersion: "v0.1.0",
+				respVersion: Version{
+					Name:                 "v0.2.0",
+					MinUpgradableVersion: "v0.1.0",
+					Tags:                 []string{"v0.2.0"},
+				},
+				newVersions: harvesterv1.Version{
+					Spec: harvesterv1.VersionSpec{
+						ISOURL:      "http://server/harvester.iso",
+						ISOChecksum: "",
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{false, true, true, true},
+				canUpgrades: false,
 			},
 		},
 		{
-			name: "test3",
+			name: "dev tag",
 			given: input{
-				currentVersion: "v0.3.0",
-				newVersions: []harvesterv1.Version{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.4.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate: "2021-01-01T00:00:00Z",
-							Tags:        []string{"latest"},
-							ISOChecksum: "xxx",
-							ISOURL:      "https://somehwere/harvester.iso",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.4.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2021-01-01T00:00:00Z",
-							MinUpgradableVersion: "v0.3.0",
-							Tags:                 []string{"latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
+				currentVersion: "v0.1.0",
+				respVersion: Version{
+					Name:                 "v0.3.0",
+					MinUpgradableVersion: "v0.2.0",
+					Tags:                 []string{"v0.3.0", "dev"},
+				},
+				newVersions: harvesterv1.Version{
+					Spec: harvesterv1.VersionSpec{
+						ISOURL:      "http://server/harvester.iso",
+						ISOChecksum: "xxxx",
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{true, true},
+				canUpgrades: true,
 			},
 		},
 		{
-			name: "test4",
+			name: "current version name more than responder version name",
 			given: input{
 				currentVersion: "v0.2.0",
-				newVersions: []harvesterv1.Version{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.2.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate: "2021-01-01T00:00:00Z",
-							Tags:        []string{"latest"},
-							ISOChecksum: "xxx",
-							ISOURL:      "https://somehwere/harvester.iso",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "v0.2.0",
-						},
-						Spec: harvesterv1.VersionSpec{
-							ReleaseDate:          "2021-01-01T00:00:00Z",
-							MinUpgradableVersion: "v0.2.0",
-							Tags:                 []string{"latest"},
-							ISOChecksum:          "xxx",
-							ISOURL:               "https://somehwere/harvester.iso",
-						},
+				respVersion: Version{
+					Name:                 "v0.1.0",
+					MinUpgradableVersion: "v0.1.0",
+					Tags:                 []string{"v0.1.0"},
+				},
+				newVersions: harvesterv1.Version{
+					Spec: harvesterv1.VersionSpec{
+						ISOURL:      "http://server/harvester.iso",
+						ISOChecksum: "xxxx",
 					},
 				},
 			},
 			expected: output{
-				canUpgrades: []bool{false, false},
+				canUpgrades: false,
+			},
+		},
+		{
+			name: "current version name less than responder version name and no min upgradable version",
+			given: input{
+				currentVersion: "v0.2.0",
+				respVersion: Version{
+					Name:                 "v0.4.0",
+					MinUpgradableVersion: "",
+					Tags:                 []string{"v0.4.0"},
+				},
+				newVersions: harvesterv1.Version{
+					Spec: harvesterv1.VersionSpec{
+						ISOURL:      "http://server/harvester.iso",
+						ISOChecksum: "xxxx",
+					},
+				},
+			},
+			expected: output{
+				canUpgrades: true,
+			},
+		},
+		{
+			name: "current version name less than responder version name and min upgradable version not met",
+			given: input{
+				currentVersion: "v0.2.0",
+				respVersion: Version{
+					Name:                 "v0.4.0",
+					MinUpgradableVersion: "v0.3.0",
+					Tags:                 []string{"v0.4.0"},
+				},
+				newVersions: harvesterv1.Version{
+					Spec: harvesterv1.VersionSpec{
+						ISOURL:      "http://server/harvester.iso",
+						ISOChecksum: "xxxx",
+					},
+				},
+			},
+			expected: output{
+				canUpgrades: false,
+			},
+		},
+		{
+			name: "current version name less than responder version name and min upgradable version requirement met",
+			given: input{
+				currentVersion: "v0.2.0",
+				respVersion: Version{
+					Name:                 "v0.3.0",
+					MinUpgradableVersion: "v0.2.0",
+					Tags:                 []string{"v0.3.0"},
+				},
+				newVersions: harvesterv1.Version{
+					Spec: harvesterv1.VersionSpec{
+						ISOURL:      "http://server/harvester.iso",
+						ISOChecksum: "xxxx",
+					},
+				},
+			},
+			expected: output{
+				canUpgrades: true,
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		var actual output
-
-		for i := range tc.given.newVersions {
-			actual.canUpgrades = append(actual.canUpgrades, canUpgrade(tc.given.currentVersion, &tc.given.newVersions[i]))
-		}
-
-		assert.Equal(t, tc.expected, actual, "case %q", tc.name)
+		nv := tc.given.newVersions
+		assert.Equal(t, tc.expected.canUpgrades, canUpgrade(tc.given.currentVersion, &nv, tc.given.respVersion), "case %q", tc.name)
 	}
 }
 
@@ -256,5 +210,145 @@ func Test_formatQuantityToGi(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.want, formatQuantityToGi(&q))
 		})
+	}
+}
+
+func Test_syncVersions(t *testing.T) {
+	versionObjs := []runtime.Object{
+		&harvesterv1.Version{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "v1.4.0",
+				Namespace: defaultNamespace,
+			},
+			Spec: harvesterv1.VersionSpec{
+				ISOURL:               "server/harvester.iso",
+				ISOChecksum:          "xxx",
+				MinUpgradableVersion: "v1.3.0",
+			},
+		},
+		&harvesterv1.Version{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "v1.3.0",
+				Namespace: defaultNamespace,
+			},
+			Spec: harvesterv1.VersionSpec{
+				ISOURL:               "server/harvester.iso",
+				ISOChecksum:          "xxx",
+				MinUpgradableVersion: "v1.2.2",
+			},
+		},
+		&harvesterv1.Version{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "v1.3.1",
+				Namespace: defaultNamespace,
+			},
+			Spec: harvesterv1.VersionSpec{
+				ISOURL:               "",
+				ISOChecksum:          "xxx",
+				MinUpgradableVersion: "v1.2.2",
+			},
+		},
+	}
+
+	resp := CheckUpgradeResponse{
+		Versions: []Version{
+			{
+				Name:                 "v1.1.0",
+				MinUpgradableVersion: "v1.0.0",
+				Tags:                 []string{"v1.1.0"},
+			},
+			{
+				Name:                 "v1.1.1",
+				MinUpgradableVersion: "v1.1.0",
+				Tags:                 []string{"v1.1.1"},
+			},
+			{
+				Name:                 "v1.1.2",
+				MinUpgradableVersion: "v1.1.1",
+				Tags:                 []string{"v1.1.2"},
+			},
+			{
+				Name:                 "v1.2.1",
+				MinUpgradableVersion: "v1.1.2",
+				Tags:                 []string{"v1.2.1"},
+			},
+			{
+				Name:                 "v1.3.0",
+				MinUpgradableVersion: "v1.2.2",
+				Tags:                 []string{"v1.2.2"},
+			},
+			{
+				Name:                 "v1.3.0",
+				MinUpgradableVersion: "v1.2.2",
+				Tags:                 []string{"v1.2.2"},
+			},
+			{
+				Name:                 "v1.3.1",
+				MinUpgradableVersion: "v1.3.0",
+				Tags:                 []string{"v1.3.0"},
+			},
+		},
+	}
+	server := fakeHTTPEndpoint(resp)
+	server.Start()
+	defer server.Close()
+	settings.ReleaseDownloadURL.Set(server.URL)
+	client := fake.NewSimpleClientset(versionObjs...)
+	vc := fakeclients.VersionClient(client.HarvesterhciV1beta1().Versions)
+	assert := require.New(t)
+	vs := versionSyncer{
+		ctx:           context.TODO(),
+		namespace:     defaultNamespace,
+		httpClient:    server.Client(),
+		versionClient: vc,
+	}
+	err := vs.syncVersions(resp, "v1.3.0")
+	assert.NoError(err)
+	versionList, err := vc.List(defaultNamespace, metav1.ListOptions{})
+	assert.NoError(err)
+	assert.Len(versionList.Items, 1, "expected to find 1 version object only")
+
+}
+
+type fakeResponder struct {
+	resp CheckUpgradeResponse
+}
+
+func fakeHTTPEndpoint(resp CheckUpgradeResponse) *httptest.Server {
+	r := mux.NewRouter()
+	responder := fakeResponder{
+		resp: resp,
+	}
+	r.HandleFunc("/{version}/version.yaml", responder.versionResponder)
+	s := httptest.NewUnstartedServer(r)
+	return s
+}
+
+func (r fakeResponder) versionResponder(rw http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	for _, v := range r.resp.Versions {
+		if vars["version"] == v.Name {
+			generateResponse(rw, v)
+			return
+		}
+	}
+	rw.WriteHeader(http.StatusNotFound)
+}
+
+func generateResponse(rw http.ResponseWriter, v Version) {
+	harvesterVersion := harvesterv1.Version{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v.Name,
+		},
+		Spec: harvesterv1.VersionSpec{
+			ISOURL:      "fakeurl/image.iso",
+			ISOChecksum: "xxxx",
+		},
+	}
+	err := json.NewEncoder(rw).Encode(&harvesterVersion)
+	if err != nil {
+		logrus.Errorf("error encoding response: %v", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 }

--- a/pkg/util/fakeclients/version.go
+++ b/pkg/util/fakeclients/version.go
@@ -6,6 +6,9 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	harv1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/harvesterhci.io/v1beta1"
@@ -23,5 +26,43 @@ func (c VersionCache) AddIndexer(_ string, _ generic.Indexer[*harvesterv1.Versio
 	panic("implement me")
 }
 func (c VersionCache) GetByIndex(_, _ string) ([]*harvesterv1.Version, error) {
+	panic("implement me")
+}
+
+type VersionClient func(string) harv1type.VersionInterface
+
+func (c VersionClient) Update(version *harvesterv1.Version) (*harvesterv1.Version, error) {
+	return c(version.Namespace).Update(context.TODO(), version, metav1.UpdateOptions{})
+}
+
+func (c VersionClient) Get(namespace, name string, options metav1.GetOptions) (*harvesterv1.Version, error) {
+	return c(namespace).Get(context.TODO(), name, options)
+}
+
+func (c VersionClient) Create(version *harvesterv1.Version) (*harvesterv1.Version, error) {
+	return c(version.Namespace).Create(context.TODO(), version, metav1.CreateOptions{})
+}
+
+func (c VersionClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return c(namespace).Delete(context.TODO(), name, *options)
+}
+
+func (c VersionClient) List(namespace string, options metav1.ListOptions) (*harvesterv1.VersionList, error) {
+	return c(namespace).List(context.TODO(), options)
+}
+
+func (c VersionClient) UpdateStatus(_ *harvesterv1.Version) (*harvesterv1.Version, error) {
+	panic("implement me")
+}
+
+func (c VersionClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c VersionClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *harvesterv1.Version, err error) {
+	panic("implement me")
+}
+
+func (c VersionClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*harvesterv1.Version, *harvesterv1.VersionList], error) {
 	panic("implement me")
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Harvester upgrade responder currently does not have the logic to clean up Version CRD's if the ugprade responder version gets udpated. 
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR changes on version sync is handled in the harvester controller. This will allow for harvester team to update `MinUpgradableVersion` for an existing version, to trigger harvester clusters to update the version objects available for upgrade.
This will allow us to technically trigger rollback of version upgrade offers available from the harvester responder

**Related Issue:**
https://github.com/harvester/harvester/issues/5102
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
