### PR TITLE
minor changes to handle arm upgrade version files

### DIFF
--- a/pkg/controller/master/migration/vmim_controller_test.go
+++ b/pkg/controller/master/migration/vmim_controller_test.go
@@ -1,3 +1,5 @@
+//go:build linux && amd64
+
 package migration
 
 import (

--- a/pkg/controller/master/upgrade/version_syncer.go
+++ b/pkg/controller/master/upgrade/version_syncer.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net/http"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -198,7 +199,11 @@ func (s *versionSyncer) cleanupVersions(currentVersion string) error {
 
 func (s *versionSyncer) getNewVersion(v Version) (*harvesterv1.Version, error) {
 	releaseDownloadURL := settings.ReleaseDownloadURL.Get()
-	url := fmt.Sprintf("%s/%s/version.yaml", releaseDownloadURL, v.Name)
+	var archSuffix string
+	if runtime.GOARCH == "arm64" {
+		archSuffix = "-arm64"
+	}
+	url := fmt.Sprintf("%s/%s/version%s.yaml", releaseDownloadURL, v.Name, archSuffix)
 	resp, err := s.httpClient.Get(url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The upgrade controller is currently setup to only download the version.yaml from harvester releases.
With the introduction of arm based harvester builds in v1.3.0, this can cause issues as the version.yaml is limited to amd64 architecture artefacts only. For arm artefacts the ci generates a corresponding version-arm64.yaml

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Minor change in version_syncer.go to lookup runtime architecture and download the appropriate version file.

This will allow an upgrade path for arm only clusters.

For mixed arch clusters more work is needed in future releases. 

**Related Issue:**
https://github.com/harvester/harvester/issues/6257

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
