### PR TITLE
fix: deny removing upgrade request if it is in upgrade node phase

### DIFF
--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -401,6 +401,12 @@ func (v *upgradeValidator) Delete(_ *types.Request, oldObj runtime.Object) error
 		return werror.NewBadRequest(fmt.Sprintf("cluster %s/%s status is provisioning, please wait for it to be provisioned", util.FleetLocalNamespaceName, util.LocalClusterName))
 	}
 
+	// If fleet-local/local cluster.provisioning.cattle.io is upgrading, deny removing upgrade CR request.
+	// If upgrade is removed, the cluster may have different RKE2 version nodes. It will make next upgrade fail.
+	if v1beta1.NodesUpgraded.IsUnknown(oldUpgrade) {
+		return werror.NewBadRequest("node upgrade is in progressing, please wait for it to be provisioned")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
If there is NodeUpgraded condition, it means provisioning cluster is updated. In this case, if users remove upgrade CR, the cluster may have inconsistent node version.

**Solution:**
Deny removing upgrade CR if NodeUpgraded condition is unknown.

**Related Issue:**
https://github.com/harvester/harvester/issues/6258

**Test plan:**
1. Create a v1.3.1 harvester cluster.
2. Upgrade to this branch.
3. When NodeUpgraded condition is unknown, remove the upgrade CR. The operation should be denied.

```
kubectl delete upgrade.harvesterhci.io hvst-upgrade-gk9t6 -n harvester-system
Error from server (BadRequest): admission webhook "validator.harvesterhci.io" denied the request: node upgrade is in progressing, please wait for it to be provisioned
```
