### PR TITLE
Upgrade: change LH default settings to fix maintenance mode issues

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -438,6 +438,44 @@ EOF
   kubectl -n cattle-system patch ingress rancher-expose --patch-file ./rancher-expose.yaml --type=merge
 }
 
+patch_longhorn_settings() {
+  # set Longhorn default settings with Harvester expected values, only when they are not set in managedchart and LH uses the default value
+  local target=$1
+  local EXIT_CODE=0
+  # yq returns 'Error: no matches found' if an item is not found
+  yq -e '.spec.values.longhorn.defaultSettings.nodeDrainPolicy' $target || EXIT_CODE=$?
+  if [ $EXIT_CODE != 0 ]; then
+    local ndp=$(kubectl get setting.longhorn.io -n longhorn-system node-drain-policy -ojsonpath="{.value}")
+    if [ $ndp == "block-if-contains-last-replica" ]; then
+      echo "patch longhorn nodeDrainPolicy to allow-if-replica-is-stopped"
+      yq '.spec.values.longhorn.defaultSettings.nodeDrainPolicy = "allow-if-replica-is-stopped"' -i $target
+    else
+      # user may set it from LH UI
+      echo "longhorn nodeDrainPolicy $ndp is not the default value, do not patch"
+    fi
+  else
+    echo "longhorn nodeDrainPolicy has been set in managedchart, do not patch again"
+  fi
+
+  EXIT_CODE=0
+  yq -e '.spec.values.longhorn.defaultSettings.detachManuallyAttachedVolumesWhenCordoned' $target || EXIT_CODE=$?
+  if [ $EXIT_CODE != 0 ]; then
+    local dma=$(kubectl get setting.longhorn.io -n longhorn-system detach-manually-attached-volumes-when-cordoned  -ojsonpath="{.value}")
+    if [ $dma == "false" ]; then
+      echo "patch longhorn detachManuallyAttachedVolumesWhenCordoned to true"
+      yq '.spec.values.longhorn.defaultSettings.detachManuallyAttachedVolumesWhenCordoned = true' -i $target
+    else
+      # user may set it from LH UI
+      echo "longhorn detachManuallyAttachedVolumesWhenCordoned $dma is not the default value, do not patch"
+    fi
+  else
+    echo "longhorn detachManuallyAttachedVolumesWhenCordoned has been set in managedchart, do not patch again"
+  fi
+
+  echo "longhorn related config"
+  yq -e '.spec.values.longhorn' $target || echo "fail to get info .spec.values.longhorn"
+}
+
 upgrade_harvester() {
   echo "Upgrading Harvester"
 
@@ -469,6 +507,8 @@ EOF
   if [ -n "$sc" ] && [ "$UPGRADE_PREVIOUS_VERSION" != "v1.0.3" ]; then
       yq e '.spec.values.storageClass.defaultStorageClass = false' -i harvester.yaml
   fi
+
+  patch_longhorn_settings harvester.yaml
 
   kubectl apply -f ./harvester.yaml
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The Harvester maintenance mode is blocked by manually attached volumes and single-replica volumes.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Change LH default setting to allow node drain on such scenarios.

This is the upgrade PR of PR788, the installer PR needs to be merged first:
- [ ] https://github.com/harvester/harvester-installer/pull/788

**Related Issue:**
https://github.com/harvester/harvester/issues/6264
https://github.com/harvester/harvester/issues/6266

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Per issue steps.
1. Before ugprade, don't set `detach-manually-attached-volumes-when-cordoned` and `node-drain-policy ` on LH and Harvester managedchart,
After upgrade, get such LH default settings:

```
default-data-path                                                 /var/lib/harvester/defaultdisk                    true      7m19s
...
detach-manually-attached-volumes-when-cordoned                    true                                              true      7m19s
...
node-drain-policy                                                 allow-if-replica-is-stopped                       true      7m19s
```

2. Before upgrade, set `detach-manually-attached-volumes-when-cordoned` and `node-drain-policy ` on LH using none-default values, after upgrade, they keep same.

3. Before upgrade,  `detach-manually-attached-volumes-when-cordoned` and `node-drain-policy ` on harvester managed-chart using any valid values, after upgrade, they keep same.

The upgrade will only set the target option when they are not set via harvester managedchart and still using the default values on LH, any other cases will be kept unchanged.