### PR TITLE
ci: add daily builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
     tags:
     - v*
   pull_request:
+  schedule:
+    - cron: "10 0,12 * * *"
 jobs:
   build-binaries:
     name: Build binaries


### PR DESCRIPTION
**Problem:**
As seen when testing https://github.com/harvester/harvester/issues/6215, we had an ISO build from a stable branch (v1.3) which was missing a change from harvester-installer, because that change happened _after_ the latest change in the harvester repo. Doing daily builds of all stable branches will help to mitigate this in future.

**Solution:**
Backport commit 11adde7ee31f06beba85ed85709f357e8d076950

**Related Issue:**
N/A

**Test plan:**
N/A
