### PR TITLE
change how addon controller sets backoff limit

### DIFF
--- a/pkg/controller/master/addon/addon_processing.go
+++ b/pkg/controller/master/addon/addon_processing.go
@@ -121,13 +121,6 @@ func (h *Handler) waitForAddonDisable(a *harvesterv1.Addon) (*harvesterv1.Addon,
 	}
 
 	if ok {
-		// if job is not complete, wait for completion
-		logrus.Debugf("patching backoff limit for job %s in ns %s", j.Name, j.Namespace)
-		err = h.patchJobBackoff(j)
-		if err != nil {
-			return aObj, err
-		}
-
 		if !isJobComplete(j) {
 			return h.enqueueAfter(aObj)
 		}
@@ -271,14 +264,6 @@ func (h *Handler) reconcileCurrentInstallationJob(hc *helmv1.HelmChart, aObj *ha
 		return aObj, err
 	}
 
-	if ok {
-		// if job is not complete, wait for completion
-		logrus.Debugf("patching backoff limit for job %s in ns %s", j.Name, j.Namespace)
-		err = h.patchJobBackoff(j)
-		if err != nil {
-			return aObj, err
-		}
-	}
 	// the current job on hc is from the previous deploy/update
 	// or job is not complete. then wait for this to be completed
 	if !ok || !isJobComplete(j) {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
post upgrade to rke2 v1.28.12 addon processing is stuck as there is a conflict in the helmchart install job being created.

The job keeps getting recreated, causing the chart revision to be upgraded until eventually the job successfully completes.

we can see the following in the rke2 server logs

```
Aug 13 02:43:37 master-build rke2[23420]: time="2024-08-13T02:43:37Z" level=error msg="error syncing 'harvester-system/vm-import-controller': handler helm-controller-chart-registration: failed to update harvester-system/helm-install-vm-import-controller batch/v1, Kind=Job for helm-controller-chart-registration harvester-system/vm-import-controller: create or replace job, requeuing"
Aug 13 02:43:38 master-build rke2[23420]: time="2024-08-13T02:43:38Z" level=error msg="error syncing 'harvester-system/vm-import-controller': handler helm-controller-chart-registration: failed to update harvester-system/helm-install-vm-import-controller batch/v1, Kind=Job for helm-controller-chart-registration harvester-system/vm-import-controller: create or replace job, requeuing"
Aug 13 02:43:40 master-build rke2[23420]: time="2024-08-13T02:43:40Z" level=error msg="error syncing 'harvester-system/vm-import-controller': handler helm-controller-chart-registration: failed to update harvester-system/helm-install-vm-import-controller batch/v1, Kind=Job for helm-controller-chart-registration harvester-system/vm-import-controller: create or replace job, requeuing"
```

With additional debugging this is being caused by the addon controller attempting to patch the job backofflimit from the default of 1000 to 5, and this causes the job to be recreated.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
HelmChart crd now exposes the job backofflimit in its spec, which can now be used directly by the addon controller.

The PR drops the patch in favor of setting the backofflimit in the HelmChart crd spec directly.

**Related Issue:**
https://github.com/harvester/harvester/issues/6327
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
