### PR TITLE
Fix Restored VM Stuck for the Replacing case (#6132)

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -547,6 +547,12 @@ func (h *RestoreHandler) reconcileVM(
 
 	vmCpy := vm.DeepCopy()
 	vmCpy.Spec = backup.Status.SourceSpec.Spec
+
+	//if the source runStratedy is RerunOnFailure, Kubevirt will not start the new VMI
+	//set the VM runStrategy as Halted, VMI will be kicked off in startVM()
+	haltedRunStrategy := kubevirtv1.RunStrategyHalted
+	vmCpy.Spec.RunStrategy = &haltedRunStrategy
+
 	vmCpy.Spec.Template.Spec.Volumes = newVolumes
 	if vmCpy.Annotations == nil {
 		vmCpy.Annotations = make(map[string]string)


### PR DESCRIPTION
**Problem:**
Restore from backup to replace existing vm would stuck in Restoring with WaitingForVolumeBinding

**Solution:**
To replace the existing case, set `RunStratedy` as `Halted` first, then the Harvester controller will try to kick off the VMI

**Related Issue:**
#6312 

**Test plan:**
- Creating a VM
- Setting the backup target (not required for snapshot case)
- Creating a backup/snapshot for the VM
- Shutting down the VM
- Restore backup/snapshot to existing VM as deletion/retain policy
- The restored VM should be created successfully
