### PR TITLE
Upgrade: patch rancher shell-image to v0.1.26

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -245,6 +245,16 @@ upgrade_rancher() {
     exit 1
   fi
 
+  # When upgrading to Harvester v1.3.2, patch Rancher shell-image to v0.1.26 if necessary
+  local shellimage=$(kubectl get settings.management.cattle.io shell-image -ojsonpath='{.value}')
+  if [[ "$shellimage" = "" ]] || [[ "$shellimage" < "rancher/shell:v0.1.26" ]]; then
+    echo "rancher shell-image is $shellimage, will be patched to v0.1.26"
+    kubectl patch settings.management.cattle.io shell-image --type merge -p '{"value":"rancher/shell:v0.1.26"}'
+    kubectl get settings.management.cattle.io shell-image
+  else
+    echo "rancher shell-image is $shellimage, patch is not needed"
+  fi
+
   if [ "$RANCHER_CURRENT_VERSION" = "$REPO_RANCHER_VERSION" ]; then
     echo "Skip update Rancher. The version is already $RANCHER_CURRENT_VERSION"
     return


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

https://github.com/harvester/harvester/issues/6283

The rancher shell default image v0.1.24 has CVE issues.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Patch Rancher shell version to v0.1.26

**Related Issue:**
https://github.com/harvester/harvester/issues/6283

Related installer PR: https://github.com/harvester/harvester-installer/pull/813

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
```
1. not set, patch
Rancher shell-image is  , will be patched to v0.1.26
setting.management.cattle.io/shell-image patched
NAME          VALUE
shell-image   rancher/shell:v0.1.26


2. lower version, patch
Rancher shell-image is rancher/shell:v0.1.24, will be patched to v0.1.26
setting.management.cattle.io/shell-image patched
NAME          VALUE
shell-image   rancher/shell:v0.1.26

3. updated, no patch
Rancher shell-image is rancher/shell:v0.1.26, patch is not needed
```
