### PR TITLE
fix(upgradelog): adapt to new extravolume mechanics

### DIFF
--- a/pkg/api/upgradelog/handler.go
+++ b/pkg/api/upgradelog/handler.go
@@ -334,7 +334,7 @@ func prepareLogPackager(upgradeLog *harvesterv1.UpgradeLog, imageVersion, archiv
 							Name: "log-archive",
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: name.SafeConcatName(upgradeLog.Name, util.UpgradeLogArchiveComponent),
+									ClaimName: ctlupgradelog.GetUpgradeLogPvcName(upgradeLog),
 								},
 							},
 						},

--- a/pkg/controller/master/upgradelog/register.go
+++ b/pkg/controller/master/upgradelog/register.go
@@ -16,6 +16,7 @@ const (
 	loggingControllerName       = "harvester-upgradelog-logging-controller"
 	statefulSetControllerName   = "harvester-upgradelog-statefulset-controller"
 	managedChartControllerName  = "harvester-upgradelog-managedchart-controller"
+	pvcControllerName           = "harvester-upgradelog-pvc-controller"
 	upgradeControllerName       = "harvester-upgradelog-upgrade-controller"
 )
 
@@ -69,6 +70,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	jobController.OnChange(ctx, jobControllerName, handler.OnJobChange)
 	statefulSetController.OnChange(ctx, statefulSetControllerName, handler.OnStatefulSetChange)
 	managedChartController.OnChange(ctx, managedChartControllerName, handler.OnManagedChartChange)
+	pvcController.OnChange(ctx, pvcControllerName, handler.OnPvcChange)
 	upgradeController.OnChange(ctx, upgradeControllerName, handler.OnUpgradeChange)
 
 	return nil


### PR DESCRIPTION

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The UpgradeLog feature is broken in the master build. The `fluentd` StatefulSet-populated PVC is malformed; therefore the StatefulSet could not start normally. The entire Harvester upgrade is jammed.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

As for logging-operator v4.4.0, the way ExtraVolume is handled is different. It's impossible to make the fluentd Pod associate with a pre-created PVC. The PVC has now been created along with the fluentd StatefulSet. The UpgradeLog mechanics adapt the new upstream behavior to reconcile the StatefulSet populated PVC instead of creating a new one.

An UpgradeLog OwnerReference will be added to the PVC to make it live "longer" than its original owner/creator, i.e., the Logging object.

**Related Issue:**

#6272 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Test the following two upgrade scenario (both with the upgradelog feature enabled):
- Upgrade a Harvester cluster from v1.3.1 to master (to make sure we don't break anything)
- Upgrade a Harvester cluster from master to master (to make sure the fix is effective)

For both scenario, please try to download the upgradelog at the following time point:
- During the upgrade
- After the upgrade success (or failed, either should work)