### PR TITLE
Upgrade: drop the potential manual patch upon rancher shell-image

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -245,6 +245,16 @@ upgrade_rancher() {
     exit 1
   fi
 
+  # drop the potential manual patch upon shell-image to v0.1.26 on Harvester v1.3.2
+  local shellimage=$(kubectl get settings.management.cattle.io shell-image -ojsonpath='{.value}')
+  if [[ "$shellimage" = "rancher/shell:v0.1.26" ]]; then
+    echo "rancher shell-image is $shellimage, will be reverted to empty"
+    kubectl patch settings.management.cattle.io shell-image --type merge -p '{"value":""}'
+    kubectl get settings.management.cattle.io shell-image
+  else
+    echo "rancher shell-image is $shellimage, patch is not needed"
+  fi
+
   if [ "$RANCHER_CURRENT_VERSION" = "$REPO_RANCHER_VERSION" ]; then
     echo "Skip update Rancher. The version is already $RANCHER_CURRENT_VERSION"
     return


### PR DESCRIPTION
Upgrade: drop the potential manual patch upon rancher shell-image to v0.1.26 on Harvester v1.3.2

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Harvester v1.4.0 will use Rancher v2.9 version, and the later uses a new shell image `defaultShellVersion: rancher/shell:v0.2.1`

https://github.com/rancher/rancher/blob/3f7c25803c00e5311d89d1144b3c6684b288ed51/pkg/settings/setting.go#L128C78-L128C97
https://github.com/rancher/rancher/blob/a9946d267616beb1be27c3142a4ebaf6186ba3e7/build.yaml#L4

From issue https://github.com/harvester/harvester/issues/6352, the `shell-image` was patched to `v0.1.26` on Harvester v1.3.2 upgrade path, that may affect the further upgrade to v1.4.0.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Upgrade: drop the potential manual patch upon rancher shell-image

**Related Issue:**
https://github.com/harvester/harvester/issues/6352
v1.3.2 installer PR https://github.com/harvester/harvester-installer/pull/813
v1.3.2 upgrade PR https://github.com/harvester/harvester/pull/6347
v1.3.2 issue https://github.com/harvester/harvester/issues/6283

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

v132->v140 upgrade, Rancher should upgrade smoothly, and the value of below CRD object should be empty after upgrade
```
setting.management.cattle.io/shell-image patched
NAME          VALUE
shell-image   
```