### PR TITLE
Update support-bundle-image default value per chart defnition

### DIFF
--- a/deploy/charts/harvester/templates/_helpers.tpl
+++ b/deploy/charts/harvester/templates/_helpers.tpl
@@ -105,3 +105,21 @@ NB(thxCode): Use this value to unify the control tag and condition of KubeVirt.
 {{- .Values.tags.kubevirt | toString -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Get Support-bundle-kit image environment for updating the default values per current release.
+*/}}
+{{- define "harvester.supportBundleImageEnv" -}}
+{{- $result := dict -}}
+{{- range $k, $v := .Values -}}
+{{- if eq (toString $k) "support-bundle-kit" -}}
+{{- $result = $v -}}
+{{- end -}}
+{{- end -}}
+{{- with $result -}}
+{{- with .image -}}
+- name: HARVESTER_SUPPORT_BUNDLE_IMAGE_DEFAULT_VALUE
+  value: {{ printf "{\"repository\":\"%s\",\"tag\":\"%s\",\"imagePullPolicy\":\"%s\"}" .repository .tag .imagePullPolicy | squote }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
             - name: GOCOVERDIR
               value: /go-cover-dir
 {{- end }}
+{{ include "harvester.supportBundleImageEnv" . | indent 12 }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pkg/controller/master/setting/support_bundle_image_test.go
+++ b/pkg/controller/master/setting/support_bundle_image_test.go
@@ -63,4 +63,120 @@ func Test_UpdateSupportBundleImage(t *testing.T) {
 
 	assert.Nil(t, err, "failed to get setting")
 	assert.Equal(t, "{\"repository\":\"test-repository\",\"tag\":\"v3.3\",\"imagePullPolicy\":\"IfNotPresent\"}", s.Default)
+
+	// image tag is empty, do not update
+	err = UpdateSupportBundleImage(
+		fakeclients.HarvesterSettingClient(clientset.HarvesterhciV1beta1().Settings),
+		fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+		&catalogv1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.name",
+				Namespace: namespace,
+			},
+			Spec: catalogv1.ReleaseSpec{
+				Chart: &catalogv1.Chart{
+					Values: map[string]interface{}{
+						"support-bundle-kit": map[string]interface{}{
+							"image": map[string]interface{}{
+								"repository":      "",
+								"tag":             "",
+								"imagePullPolicy": "IfNotPresent",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err, "failed to update setting")
+	s, err = clientset.HarvesterhciV1beta1().Settings().Get(
+		context.TODO(),
+		settings.SupportBundleImageName,
+		metav1.GetOptions{})
+
+	assert.Nil(t, err, "failed to get setting")
+	// keeps unchanged
+	assert.Equal(t, "{\"repository\":\"test-repository\",\"tag\":\"v3.3\",\"imagePullPolicy\":\"IfNotPresent\"}", s.Default)
+
+	// image map is empty, do not update
+	err = UpdateSupportBundleImage(
+		fakeclients.HarvesterSettingClient(clientset.HarvesterhciV1beta1().Settings),
+		fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+		&catalogv1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.name",
+				Namespace: namespace,
+			},
+			Spec: catalogv1.ReleaseSpec{
+				Chart: &catalogv1.Chart{
+					Values: map[string]interface{}{
+						"support-bundle-kit": map[string]interface{}{
+							"image": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err, "failed to update setting")
+	s, err = clientset.HarvesterhciV1beta1().Settings().Get(
+		context.TODO(),
+		settings.SupportBundleImageName,
+		metav1.GetOptions{})
+
+	assert.Nil(t, err, "failed to get setting")
+	// keeps unchanged
+	assert.Equal(t, "{\"repository\":\"test-repository\",\"tag\":\"v3.3\",\"imagePullPolicy\":\"IfNotPresent\"}", s.Default)
+
+	// invalid key from app
+	err = UpdateSupportBundleImage(
+		fakeclients.HarvesterSettingClient(clientset.HarvesterhciV1beta1().Settings),
+		fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+		&catalogv1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.name",
+				Namespace: namespace,
+			},
+			Spec: catalogv1.ReleaseSpec{
+				Chart: &catalogv1.Chart{
+					Values: map[string]interface{}{
+						"support-bundle-kit-error-name": map[string]interface{}{
+							"image": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err, "failed to update setting")
+	s, err = clientset.HarvesterhciV1beta1().Settings().Get(
+		context.TODO(),
+		settings.SupportBundleImageName,
+		metav1.GetOptions{})
+
+	assert.Nil(t, err, "failed to get setting")
+	// keeps unchanged
+	assert.Equal(t, "{\"repository\":\"test-repository\",\"tag\":\"v3.3\",\"imagePullPolicy\":\"IfNotPresent\"}", s.Default)
+
+	// empty chart from app
+	err = UpdateSupportBundleImage(
+		fakeclients.HarvesterSettingClient(clientset.HarvesterhciV1beta1().Settings),
+		fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+		&catalogv1.App{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.name",
+				Namespace: namespace,
+			},
+			Spec: catalogv1.ReleaseSpec{},
+		},
+	)
+	assert.Nil(t, err, "failed to update setting")
+	s, err = clientset.HarvesterhciV1beta1().Settings().Get(
+		context.TODO(),
+		settings.SupportBundleImageName,
+		metav1.GetOptions{})
+
+	assert.Nil(t, err, "failed to get setting")
+	// keeps unchanged
+	assert.Equal(t, "{\"repository\":\"test-repository\",\"tag\":\"v3.3\",\"imagePullPolicy\":\"IfNotPresent\"}", s.Default)
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -191,6 +191,10 @@ func GetEnvKey(key string) string {
 	return "HARVESTER_" + strings.ToUpper(strings.Replace(key, "-", "_", -1))
 }
 
+func GetEnvDefaultValueKey(key string) string {
+	return "HARVESTER_" + strings.ToUpper(strings.Replace(key, "-", "_", -1)) + "_DEFAULT_VALUE"
+}
+
 func IsRelease() bool {
 	return !strings.Contains(ServerVersion.Get(), "head") && releasePattern.MatchString(ServerVersion.Get())
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

https://github.com/harvester/harvester/issues/6277

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Use chart and Pod ENV to update setting's default value when it is not fit for hard-coded on source code.

Avoid updatting empty value to settings.Dfault


Inspired from https://github.com/harvester/harvester-installer/pull/813, Harvester should allow to replace the default value and current value of settings from Pod ENV.
```
Further, the chart generate the ENV from Values.yaml, thus we don't need addtional code for update.

The current hard-coded settings, will update the Default automatically after upgrade.

For none-hard-coded settings, do this via the chart definition.

```

**Related Issue:**

https://github.com/harvester/harvester/issues/6277

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Create a new cluster, it will have `support-bundle-image` with generation 1 in general; instead of 2 in the past

```
settings.harvesterhci.io support-bundle-image -oyaml
apiVersion: harvesterhci.io/v1beta1
default: '{"repository":"rancher/support-bundle-kit","tag":"master-head","imagePullPolicy":"IfNotPresent"}'
kind: Setting
metadata:
  creationTimestamp: "2024-08-15T19:48:37Z"
  generation: 1
  name: support-bundle-image
  resourceVersion: "6646"
  uid: 01952165-f164-4edd-bc62-e5afa52fcfd8
status: {}
```

2. Upgrade to new version, the `default` value should always match the setting in chart.