### PR TITLE
feat: handle duplicate vm backup and snapshot

### DIFF
--- a/pkg/webhook/resources/virtualmachinebackup/mutator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/mutator.go
@@ -1,0 +1,57 @@
+package virtualmachinebackup
+
+import (
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+type BackupMutator struct {
+	types.DefaultMutator
+	vmBackupCache ctlharvesterv1.VirtualMachineBackupCache
+}
+
+func NewMutator(vmBackupCache ctlharvesterv1.VirtualMachineBackupCache) *BackupMutator {
+	return &BackupMutator{vmBackupCache: vmBackupCache}
+}
+
+func (m *BackupMutator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{"virtualmachinebackups"},
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   v1beta1.SchemeGroupVersion.Group,
+		APIVersion: v1beta1.SchemeGroupVersion.Version,
+		ObjectType: &v1beta1.VirtualMachineBackup{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (m *BackupMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+	newVMBackup := newObj.(*v1beta1.VirtualMachineBackup)
+	vmBackup, err := m.vmBackupCache.Get(newVMBackup.Namespace, newVMBackup.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return types.PatchOps{}, nil
+		}
+		return types.PatchOps{}, err
+	}
+	if newVMBackup.Spec.Type == vmBackup.Spec.Type {
+		return types.PatchOps{}, werror.NewBadRequest(
+			fmt.Sprintf("The %s %s is already existent. Please use another name for it.", vmBackup.Name, vmBackup.Spec.Type))
+	}
+	// https://github.com/harvester/harvester/issues/5855
+	// To better handle error message about duplicated vm backup and snapshot,
+	// we have to do it in mutator. After mutator, there is a schema check and
+	// we can't handle the error message in it.
+	return types.PatchOps{}, werror.NewBadRequest(
+		fmt.Sprintf("VM Backup and Snapshot use same CRD - VirtualMachineBackup. The %s %s is already existent. Please use another name for it.", vmBackup.Name, vmBackup.Spec.Type))
+}

--- a/pkg/webhook/server/mutation.go
+++ b/pkg/webhook/server/mutation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/resources/pod"
 	"github.com/harvester/harvester/pkg/webhook/resources/templateversion"
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachine"
+	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachinebackup"
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachineimage"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
@@ -21,11 +22,13 @@ func Mutation(clients *clients.Clients, options *config.Options) (http.Handler, 
 	settingCache := clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()
 	storageClassCache := clients.StorageFactory.Storage().V1().StorageClass().Cache()
 	nadCache := clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache()
+	vmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
 	mutators := []types.Mutator{
 		pod.NewMutator(settingCache),
 		templateversion.NewMutator(),
 		virtualmachine.NewMutator(settingCache, nadCache),
 		virtualmachineimage.NewMutator(storageClassCache),
+		virtualmachinebackup.NewMutator(vmBackupCache),
 	}
 
 	router := webhook.NewRouter()


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
VM Backup and Snapshot use same CRD, but they're in different pages, so users may wonder why some names can't work.

**Solution:**
Give a better error message to point out VM Backup and Snapshot can't have same name.
![Screenshot 2024-08-28 at 11 19 12 AM](https://github.com/user-attachments/assets/bc0e9384-4a2d-4095-bab0-d34e81ade911)
![Screenshot 2024-08-28 at 11 19 59 AM](https://github.com/user-attachments/assets/00ba489a-40e0-4d4c-ab61-874c8399101e)


**Related Issue:**
https://github.com/harvester/harvester/issues/5855

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
* Create a VM Backup with name `test`.
* Create a VM Snapshot with name `test`. Webhook should return an error message about VM Backup and Snapshot use same CRD.