### PR TITLE
Fix setting log-level and kubeconfig-default-token-ttl-minutes

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -43,6 +43,8 @@ var (
 	}
 	skipHashCheckSettings = []string{
 		settings.AutoRotateRKE2CertsSettingName,
+		settings.LogLevelSettingName,
+		settings.KubeconfigDefaultTokenTTLMinutesSettingName,
 	}
 )
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -33,7 +33,7 @@ var (
 	UpgradeCheckerEnabled                  = NewSetting("upgrade-checker-enabled", "true")
 	UpgradeCheckerURL                      = NewSetting("upgrade-checker-url", "https://harvester-upgrade-responder.rancher.io/v1/checkupgrade")
 	ReleaseDownloadURL                     = NewSetting("release-download-url", "https://releases.rancher.com/harvester")
-	LogLevel                               = NewSetting("log-level", "info") // options are info, debug and trace
+	LogLevel                               = NewSetting(LogLevelSettingName, "info") // options are info, debug and trace
 	SSLCertificates                        = NewSetting(SSLCertificatesSettingName, "{}")
 	SSLParameters                          = NewSetting(SSLParametersName, "{}")
 	SupportBundleImage                     = NewSetting(SupportBundleImageName, "{}")
@@ -92,6 +92,7 @@ const (
 	SupportBundleNodeCollectionTimeoutName            = "support-bundle-node-collection-timeout"
 	UpgradeConfigSettingName                          = "upgrade-config"
 	LonghornV2DataEngineSettingName                   = "longhorn-v2-data-engine-enabled"
+	LogLevelSettingName                               = "log-level"
 )
 
 func init() {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Per issue describtion.

When settings are not added to `skipHashCheckSettings`, they will only be applied once when the change happens, and later they are not applied again when Harvester POD restarts.

In this context, it is not a `setting` but rather an `action`.

```
	skipHashCheckSettings = []string{
		settings.AutoRotateRKE2CertsSettingName,
		settings.LogLevelSettingName,
		settings.KubeconfigDefaultTokenTTLMinutesSettingName,
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Let setting rerun when pod starting.

No matter a change is changed or not, the controller should bring no harm to rerun.

**Related Issue:**
https://github.com/harvester/harvester/issues/6395
https://github.com/harvester/harvester/issues/6378

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Refer issue: https://github.com/harvester/harvester/issues/6395#issuecomment-2302338402