### PR TITLE
Improve vm migration ux to include VM's with hostname specification

### DIFF
--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -456,6 +456,8 @@ func filterNodesForNodeSelector(possibleNodes []*corev1.Node, vmi *kubevirtv1.Vi
 				validNodes = append(validNodes, v)
 			}
 		}
+	} else {
+		return possibleNodes
 	}
 	return validNodes
 }

--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -421,7 +421,7 @@ func (ndc *ControllerHandler) CheckVMISchedulingRequirements(originalNode *corev
 		return nil, fmt.Errorf("error listing nodes from nodeCache: %v", err)
 	}
 	for _, vmi := range vmiList {
-		var possibleNodes []string
+		var possibleNodes, validNodes []*corev1.Node
 		if vmi.Spec.Affinity != nil && vmi.Spec.Affinity.NodeAffinity != nil && vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 			nodeAffinitySelector, err := nodeaffinity.NewNodeSelector(vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 			if err != nil {
@@ -430,16 +430,34 @@ func (ndc *ControllerHandler) CheckVMISchedulingRequirements(originalNode *corev
 			// identify if nodeAffinity can be met by other nodes and node is ready
 			for _, v := range nodeList {
 				if nodeAffinitySelector.Match(v) && v.Name != originalNode.Name && isNodeReady(v) {
-					possibleNodes = append(possibleNodes, v.Name)
+					possibleNodes = append(possibleNodes, v)
 				}
 			}
+
+			validNodes = filterNodesForNodeSelector(possibleNodes, vmi)
 			// no valid node found that could meet the requirements
-			if len(possibleNodes) == 0 {
+			if len(validNodes) == 0 {
 				impactedVMS = append(impactedVMS, namespacedVMName(vmi))
 			}
 		}
 	}
 	return impactedVMS, nil
+}
+
+// filterNodesForNodeSelector will filter nodes for vmi node selector requirement match
+func filterNodesForNodeSelector(possibleNodes []*corev1.Node, vmi *kubevirtv1.VirtualMachineInstance) []*corev1.Node {
+	var validNodes []*corev1.Node
+	// VM's may also have node selector, which is used when defining specific hostnames
+	if vmi.Spec.NodeSelector != nil && len(vmi.Spec.NodeSelector) > 0 {
+		vmiNodeSelector := labels.SelectorFromSet(vmi.Spec.NodeSelector)
+		for _, v := range possibleNodes {
+			nodeLabels := labels.Set(v.GetLabels())
+			if vmiNodeSelector.Matches(nodeLabels) {
+				validNodes = append(validNodes, v)
+			}
+		}
+	}
+	return validNodes
 }
 
 func isNodeReady(node *corev1.Node) bool {

--- a/pkg/controller/master/nodedrain/nodedrain_controller_test.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller_test.go
@@ -2,6 +2,7 @@ package nodedrain
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -283,4 +284,348 @@ func Test_listVMI(t *testing.T) {
 	assert.NoError(err, "expected no error")
 	assert.Len(vmiList, 1, "expected to find only 1 vmi")
 	assert.Contains(vmiList, failingVM, "expected to find failingVM only")
+}
+
+const vmiListString = `
+{
+    "apiVersion": "kubevirt.io/v1",
+    "kind": "VirtualMachineInstance",
+    "metadata": {
+        "annotations": {
+            "harvesterhci.io/sshNames": "[\"default/gm\"]",
+            "kubevirt.io/latest-observed-api-version": "v1",
+            "kubevirt.io/storage-observed-api-version": "v1",
+            "kubevirt.io/vm-generation": "2"
+        },
+        "creationTimestamp": "2024-08-22T02:38:46Z",
+        "finalizers": [
+            "kubevirt.io/virtualMachineControllerFinalize",
+            "foregroundDeleteVirtualMachine",
+            "wrangler.cattle.io/harvester-lb-vmi-controller"
+        ],
+        "generation": 12,
+        "labels": {
+            "harvesterhci.io/vmName": "pinned-to-host",
+            "kubevirt.io/nodeName": "harvester-kfs2c"
+        },
+        "name": "pinned-to-host",
+        "namespace": "default",
+        "ownerReferences": [
+            {
+                "apiVersion": "kubevirt.io/v1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "VirtualMachine",
+                "name": "pinned-to-host",
+                "uid": "c0630daf-d1d2-417b-91d6-a707f0e7e9d0"
+            }
+        ],
+        "resourceVersion": "10393539",
+        "uid": "6dd94105-90c6-4646-8fe7-3341b775d7ad"
+    },
+    "spec": {
+        "affinity": {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "network.harvesterhci.io/mgmt",
+                                    "operator": "In",
+                                    "values": [
+                                        "true"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "architecture": "amd64",
+        "domain": {
+            "cpu": {
+                "cores": 2,
+                "model": "host-model",
+                "sockets": 1,
+                "threads": 1
+            },
+            "devices": {
+                "disks": [
+                    {
+                        "bootOrder": 1,
+                        "disk": {
+                            "bus": "virtio"
+                        },
+                        "name": "disk-0"
+                    },
+                    {
+                        "disk": {
+                            "bus": "virtio"
+                        },
+                        "name": "cloudinitdisk"
+                    }
+                ],
+                "inputs": [
+                    {
+                        "bus": "usb",
+                        "name": "tablet",
+                        "type": "tablet"
+                    }
+                ],
+                "interfaces": [
+                    {
+                        "bridge": {},
+                        "model": "virtio",
+                        "name": "default"
+                    }
+                ]
+            },
+            "features": {
+                "acpi": {
+                    "enabled": true
+                }
+            },
+            "firmware": {
+                "uuid": "eb76ee29-5ae6-57ad-b9c8-b238feb1e709"
+            },
+            "machine": {
+                "type": "q35"
+            },
+            "memory": {
+                "guest": "3996Mi"
+            },
+            "resources": {
+                "limits": {
+                    "cpu": "2",
+                    "memory": "4Gi"
+                },
+                "requests": {
+                    "cpu": "125m",
+                    "memory": "2730Mi"
+                }
+            }
+        },
+        "evictionStrategy": "LiveMigrateIfPossible",
+        "hostname": "pinned-to-host",
+        "networks": [
+            {
+                "multus": {
+                    "networkName": "default/workload"
+                },
+                "name": "default"
+            }
+        ],
+        "nodeSelector": {
+            "kubernetes.io/hostname": "harvester-kfs2c"
+        },
+        "terminationGracePeriodSeconds": 120,
+        "volumes": [
+            {
+                "name": "disk-0",
+                "persistentVolumeClaim": {
+                    "claimName": "pinned-to-host-disk-0-dopwc"
+                }
+            },
+            {
+                "cloudInitNoCloud": {
+                    "networkDataSecretRef": {
+                        "name": "pinned-to-host-5bphm"
+                    },
+                    "secretRef": {
+                        "name": "pinned-to-host-5bphm"
+                    }
+                },
+                "name": "cloudinitdisk"
+            }
+        ]
+    },
+    "status": {
+        "activePods": {
+            "59b3891b-7043-403a-8688-414942ae40fc": "harvester-kfs2c"
+        },
+        "conditions": [
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2024-08-22T02:39:08Z",
+                "status": "True",
+                "type": "Ready"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": null,
+                "status": "True",
+                "type": "LiveMigratable"
+            },
+            {
+                "lastProbeTime": "2024-08-22T02:39:55Z",
+                "lastTransitionTime": null,
+                "status": "True",
+                "type": "AgentConnected"
+            }
+        ],
+        "currentCPUTopology": {
+            "cores": 2,
+            "sockets": 1,
+            "threads": 1
+        },
+        "guestOSInfo": {
+            "id": "opensuse-leap",
+            "kernelRelease": "6.4.0-150600.23.17-default",
+            "kernelVersion": "#1 SMP PREEMPT_DYNAMIC Tue Jul 30 06:37:32 UTC 2024 (9c450d7)",
+            "name": "openSUSE Leap",
+            "prettyName": "openSUSE Leap 15.6",
+            "version": "15.6",
+            "versionId": "15.6"
+        },
+        "interfaces": [
+            {
+                "infoSource": "domain, guest-agent, multus-status",
+                "interfaceName": "eth0",
+                "ipAddress": "172.19.106.159",
+                "ipAddresses": [
+                    "172.19.106.159",
+                    "fe80::ca9:6fff:fe37:139"
+                ],
+                "mac": "0e:a9:6f:37:01:39",
+                "name": "default",
+                "queueCount": 1
+            }
+        ],
+        "launcherContainerImageVersion": "registry.suse.com/suse/sles/15.5/virt-launcher:1.1.1-150500.8.15.1",
+        "machine": {
+            "type": "pc-q35-7.1"
+        },
+        "memory": {
+            "guestAtBoot": "3996Mi",
+            "guestCurrent": "3996Mi",
+            "guestRequested": "3996Mi"
+        },
+        "migrationMethod": "BlockMigration",
+        "migrationTransport": "Unix",
+        "nodeName": "harvester-kfs2c",
+        "phase": "Running",
+        "phaseTransitionTimestamps": [
+            {
+                "phase": "Pending",
+                "phaseTransitionTimestamp": "2024-08-22T02:38:46Z"
+            },
+            {
+                "phase": "Scheduling",
+                "phaseTransitionTimestamp": "2024-08-22T02:38:47Z"
+            },
+            {
+                "phase": "Scheduled",
+                "phaseTransitionTimestamp": "2024-08-22T02:39:08Z"
+            },
+            {
+                "phase": "Running",
+                "phaseTransitionTimestamp": "2024-08-22T02:39:11Z"
+            }
+        ],
+        "qosClass": "Burstable",
+        "runtimeUser": 107,
+        "selinuxContext": "none",
+        "virtualMachineRevisionName": "revision-start-vm-c0630daf-d1d2-417b-91d6-a707f0e7e9d0-1",
+        "volumeStatus": [
+            {
+                "name": "cloudinitdisk",
+                "size": 1048576,
+                "target": "vdb"
+            },
+            {
+                "name": "disk-0",
+                "persistentVolumeClaimInfo": {
+                    "accessModes": [
+                        "ReadWriteMany"
+                    ],
+                    "capacity": {
+                        "storage": "10Gi"
+                    },
+                    "filesystemOverhead": "0.055",
+                    "requests": {
+                        "storage": "10Gi"
+                    },
+                    "volumeMode": "Block"
+                },
+                "target": "vda"
+            }
+        ]
+    }
+}`
+
+func Test_virtualMachineContainsHostName(t *testing.T) {
+	assert := require.New(t)
+	vmi := &kubevirtv1.VirtualMachineInstance{}
+	err := json.Unmarshal([]byte(vmiListString), vmi)
+	assert.NoError(err, "exepcted no error during generation of vmi list")
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-kfs2c",
+			Labels: map[string]string{
+				"kubernetes.io/hostname":       "harvester-kfs2c",
+				"network.harvesterhci.io/mgmt": "true",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-qhgd4",
+			Labels: map[string]string{
+				"kubernetes.io/hostname":       "harvester-qhgd4",
+				"network.harvesterhci.io/mgmt": "true",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	node3 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-rmvzg",
+			Labels: map[string]string{
+				"kubernetes.io/hostname":       "harvester-rmvzg",
+				"network.harvesterhci.io/mgmt": "true",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	k8sclientset := k8sfake.NewSimpleClientset(node1, node2, node3)
+
+	ndc := &ControllerHandler{
+		nodes:      fakeclients.NodeClient(k8sclientset.CoreV1().Nodes),
+		nodeCache:  fakeclients.NodeCache(k8sclientset.CoreV1().Nodes),
+		restConfig: nil,
+		context:    context.TODO(),
+	}
+
+	var vmiList []*kubevirtv1.VirtualMachineInstance
+	vmiList = append(vmiList, vmi)
+	nonMigratableVMIs, err := ndc.CheckVMISchedulingRequirements(node1, vmiList)
+	assert.NoError(err)
+	assert.Len(nonMigratableVMIs, 1, "expected to find 1 VMI")
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Existing work done to address https://github.com/harvester/harvester/issues/4888 includes changes to identify VM's
* which are marked non migratable by kubevirt
* identify VM's which have their last healthy replica on the node being placed in toe maintenance mode 
* VM's which have node scheduling requirements which prevents it from being scheduled on other nodes in the cluster
* VM's which have container disk or a cdrom

This currently skips VM's which have node selector requriements

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces an additional check to find VM's with node selector requirements such as when hostname is added using `kubernetes.io/hostname` label

**Related Issue:**
https://github.com/harvester/harvester/issues/6509
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
