### PR TITLE
Restore running VMs after upgrade in single node cluster

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -58,7 +58,7 @@ var (
 	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.3.0","harvester-csi-provider":">=0.0.1 <0.3.0"}`)
 	NTPServers             = NewSetting(NTPServersSettingName, "")
 	WhiteListedSettings    = []string{"server-version", "default-storage-class", "harvester-csi-ccm-versions", "default-vm-termination-grace-period-seconds"}
-	UpgradeConfigSet       = NewSetting(UpgradeConfigSettingName, `{"imagePreloadOption":{"strategy":{"type":"sequential"}}}`)
+	UpgradeConfigSet       = NewSetting(UpgradeConfigSettingName, `{"imagePreloadOption":{"strategy":{"type":"sequential"}}, "restoreVM": false}`)
 )
 
 const (
@@ -365,6 +365,8 @@ type ImagePreloadOption struct {
 type UpgradeConfig struct {
 	// Options for the Image Preload phase of Harvester Upgrade
 	PreloadOption ImagePreloadOption `json:"imagePreloadOption,omitempty"`
+	// set true to restore vm to the pre-upgrade state, this option only works under single node.
+	RestoreVM bool `json:"restoreVM,omitempty"`
 }
 
 func DecodeConfig[T any](value string) (*T, error) {


### PR DESCRIPTION
**Problem:**
When you upgrade a single node it will turn off all VMs. And there was some talk of having the VMs going back to previous state.

**Solution:**
Add new setting `restoreVMs` to `UpgradeConfig`. This setting trigger harvester to store running vms namespace/name to secret before upgrade, and start those VMs based on the info stored in secret after upgrade. Note this setting only works when cluster is single node. **About the paused VMs, we leave them to stopped state.**

**Related Issue:**
https://github.com/harvester/harvester/issues/4005

**Test plan:**
1. Create iso based on this pr/branch
2. Use ipxe to create single node cluster, 
3. Create 4 VMs with 2 running VMs, 1 stopped VM, and 1 paused VM. 
  ![image](https://github.com/user-attachments/assets/8b984a23-214c-4aaa-a9ae-dbe61e1910c4)
4. Apply the following yaml to update `restoreVM: true` in Setting upgrade-config
  ```yaml
  apiVersion: harvesterhci.io/v1beta1
  value: '{"imagePreloadOption":{"strategy":{"type":"sequential"}}, "restoreVM": true}'
  kind: Setting
  metadata:
    name: upgrade-config
  ```
5. Use the following yaml to upgrade harvester, note that the iso in isoURL should be the same one build in step1.
  ```yaml
  apiVersion: harvesterhci.io/v1beta1
  kind: Version
  metadata:
    name: master
    namespace: harvester-system
  spec:
    isoURL: http://192.168.100.1:8000/harvester-master-amd64.iso
  ---
  apiVersion: harvesterhci.io/v1beta1
  kind: Upgrade
  metadata:
    annotations:
      harvesterhci.io/skip-version-check: "true"
      harvesterhci.io/skipWebhook: "true"
    generateName: hvst-upgrade-
    namespace: harvester-system
  spec:
    version: "master"
    logEnabled: false
  ```
6. Verify all VMs were running before upgrade are still in running state after upgrade. And the paused vm before upgrade are stopped after upgrade.
![image](https://github.com/user-attachments/assets/a6529fed-c14a-4e14-8c11-49783fa4dcc3)
