### PR TITLE
http-proxy doesn't allow it to be reset to its default value

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -241,11 +241,14 @@ func validateHTTPProxyHelper(value string, nodes []*corev1.Node) error {
 		return err
 	}
 
-	// Make sure the node's IP addresses is set in 'noProxy'. These IP
-	// addresses can be specified individually or via CIDR address.
-	err := validateNoProxy(httpProxyConfig.NoProxy, nodes)
-	if err != nil {
-		return err
+	// Make sure the node's IP addresses are set in `NoProxy` if `HTTPProxy`
+	// or `HTTPSProxy` are configured. These IP addresses can be specified
+	// individually or via CIDR address.
+	if httpProxyConfig.HTTPProxy != "" || httpProxyConfig.HTTPSProxy != "" {
+		err := validateNoProxy(httpProxyConfig.NoProxy, nodes)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -262,8 +262,11 @@ func (v *settingValidator) validateHTTPProxy(setting *v1beta1.Setting) error {
 		}
 	}
 
-	if err := validateHTTPProxyHelper(setting.Value, nodes); err != nil {
-		return werror.NewInvalidError(err.Error(), settings.KeywordValue)
+	// Validate the value only if it is not the default value.
+	if setting.Value != setting.Default {
+		if err := validateHTTPProxyHelper(setting.Value, nodes); err != nil {
+			return werror.NewInvalidError(err.Error(), settings.KeywordValue)
+		}
 	}
 	return nil
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -534,6 +534,114 @@ func Test_validateNoProxy_2(t *testing.T) {
 	}
 }
 
+func Test_validateHTTPProxyHelper(t *testing.T) {
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node0",
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{
+						Type:    corev1.NodeInternalIP,
+						Address: "192.168.0.30",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{
+						Type:    corev1.NodeInternalIP,
+						Address: "192.168.0.31",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{
+						Type:    corev1.NodeInternalIP,
+						Address: "192.168.0.32",
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		value       string
+		expectedErr bool
+	}{
+		{
+			name:        "empty string",
+			value:       "",
+			expectedErr: false,
+		},
+		{
+			name:        "empty JSON object",
+			value:       "{}",
+			expectedErr: false,
+		},
+		{
+			name:        "empty httpProxy/httpsProxy/noProxy",
+			value:       `{"httpProxy": "", "httpsProxy": "", "noProxy": ""}`,
+			expectedErr: false,
+		},
+		{
+			name:        "empty httpProxy/httpsProxy",
+			value:       `{"httpProxy": "", "httpsProxy": "", "noProxy": "xyz"}`,
+			expectedErr: false,
+		},
+		{
+			name:        "not empty httpProxy/noProxy - failure",
+			value:       `{"httpProxy": "foo", "httpsProxy": "", "noProxy": "xyz"}`,
+			expectedErr: true,
+		},
+		{
+			name:        "not empty httpsProxy/noProxy - failure",
+			value:       `{"httpProxy": "", "httpsProxy": "bar", "noProxy": "xyz"}`,
+			expectedErr: true,
+		},
+		{
+			name:        "not empty httpProxy/httpsProxy/noProxy - failure",
+			value:       `{"httpProxy": "foo", "httpsProxy": "bar", "noProxy": "xyz"}`,
+			expectedErr: true,
+		},
+		{
+			name:        "not empty httpProxy/noProxy - success",
+			value:       `{"httpProxy": "foo", "httpsProxy": "", "noProxy": "192.168.0.0/24"}`,
+			expectedErr: false,
+		},
+		{
+			name:        "not empty httpsProxy/noProxy - success",
+			value:       `{"httpProxy": "", "httpsProxy": "bar", "noProxy": "192.168.0.0/24"}`,
+			expectedErr: false,
+		},
+		{
+			name:        "not empty httpProxy/httpsProxy/noProxy - success",
+			value:       `{"httpProxy": "foo", "httpsProxy": "bar", "noProxy": "192.168.0.0/24"}`,
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHTTPProxyHelper(tt.value, nodes)
+			assert.Equal(t, tt.expectedErr, err != nil)
+		})
+	}
+}
+
 func Test_validateKubeconfigTTLSetting(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**Problem:**
The setting `http-proxy` in the Harvester Settings can not be reset to the configured defaults by pressing `Use the default value` in the UI.

**Solution:**
Check if the value to be set equals the configured default value. If yes, abort validation and exit without error.

**Related Issue:**
https://github.com/harvester/harvester/issues/6440

**Test plan:**
1. Go to the advanced settings page.
2. Go to `http-proxy` and select the `Edit Setting` action menu.
3. Add the CIDR that fits your cluster, e.g. `192.168.0.0/24`. Press `Save`.
4. Edit the setting again and press the `Use the default value` button. Press `Save`.
5. No error should appear and the browser should be redirected to the previous settings page.
