### PR TITLE
Bump LB image tag to v0.4.1

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -456,12 +456,12 @@ harvester-load-balancer:
   image:
     imagePullPolicy: IfNotPresent
     repository: rancher/harvester-load-balancer
-    tag: v0.4.0
+    tag: v0.4.1
   webhook:
     image:
       imagePullPolicy: IfNotPresent
       repository: rancher/harvester-load-balancer-webhook
-      tag: v0.4.0
+      tag: v0.4.1
 
 kube-vip:
   enabled: false


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

New LB image tag is release for Harvester v1.4.0.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The LB refactor PR https://github.com/harvester/load-balancer-harvester/pull/31 has been merged; a new container image tag v0.4.1 was also released.

Bump LB image tag to v0.4.1.


**Related Issue:**

https://github.com/harvester/harvester/issues/5316
https://github.com/harvester/harvester/issues/4821
https://github.com/harvester/harvester/issues/4972
https://github.com/harvester/harvester/issues/5033

This PR is to replace https://github.com/harvester/charts/pull/275

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install new Harvester v1.4.1 cluster
2. Confirm the LB and LB-webhook are using v0.4.1 image tag.