### PR TITLE
Hardening the `syncHTTPProxy` function

### DIFF
--- a/pkg/controller/master/setting/http_proxy.go
+++ b/pkg/controller/master/setting/http_proxy.go
@@ -18,7 +18,16 @@ const (
 func (h *Handler) syncHTTPProxy(setting *harvesterv1.Setting) error {
 	// Add envs to the backup secret used by Longhorn backups
 	var httpProxyConfig util.HTTPProxyConfig
-	if err := json.Unmarshal([]byte(setting.Value), &httpProxyConfig); err != nil {
+	value := setting.Value
+	if value == "" {
+		value = setting.Default
+		// We need to check again because `Default` is allowed to be empty
+		// as well.
+		if value == "" {
+			value = "{}"
+		}
+	}
+	if err := json.Unmarshal([]byte(value), &httpProxyConfig); err != nil {
 		return err
 	}
 	backupConfig := map[string]string{


### PR DESCRIPTION
**Problem:**
The Harvester settings do not recognize a JSON type, so the setting `http-proxy` is a string. This string can be empty and therefore leads to an error when decoding the string assumed to be JSON. 

**Solution:**
To make the function more robust by using the settings `Default` if the `Value` is empty.

**Related Issue:**
Related to: https://github.com/harvester/harvester/issues/6473

**Test plan:**
n/a
