### PR TITLE
Harvester-webhook uses same upgrade strategy as harvester

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -144,6 +144,10 @@ metadata:
     app.kubernetes.io/name: harvester-webhook
     app.kubernetes.io/component: webhook-server
 spec:
+{{- if .Values.webhook.strategy }}
+  strategy:
+{{ toYaml .Values.webhook.strategy | indent 4 }}
+{{- end }}
   selector:
     matchLabels:
 {{ include "harvester.immutableLabels" . | indent 6 }}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -143,8 +143,8 @@ tolerations: []
 ##
 strategy:
   rollingUpdate:
-    maxSurge: 2
-    maxUnavailable: 2
+    maxSurge: 1
+    maxUnavailable: 1
   type: RollingUpdate
 
 ## Specify the parameter of containers.
@@ -445,6 +445,13 @@ webhook:
     tag: master-head
 
   httpsPort: 9443
+
+  ## Specify the update strategy of the harvester-webhook workload.
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
 
 upgrade:
   image:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The K8s default upgrade strategy is not fully fit for `harvester-webhook` deployment, instead it should keep the same strategy as `harvester` deployment.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Update the deployment template.

**Related Issue:**

https://github.com/harvester/harvester/issues/6486
For reference: #6432 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Upgrade to the version, the `harvester-webhook` deployment has same `strategy` as `harvester` deployment.

2. On a single-node harvester cluster, edit the `harvester-webhook` deployment with a new image tag, the harvester-webhook pod will not be replaced at once, instead, you need to delete the current running pod manually to help the replaced POD to be running. After this patch, the POD will be replaced right now.

_

local test, a newly installed Harvester cluster.

```
 deployment -n harvester-system harvester-webhook -oyaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    helm.sh/resource-policy: keep
    management.cattle.io/scale-available: "3"
..
  creationTimestamp: "2024-09-03T15:59:18Z"
  generation: 1
..
  name: harvester-webhook
  namespace: harvester-system
..
spec:
  progressDeadlineSeconds: 600
  replicas: 1
..
  strategy:
    rollingUpdate:
      maxSurge: 2
      maxUnavailable: 2
    type: RollingUpdate
```

same as Harvester deployment:
```
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/component: apiserver
      app.kubernetes.io/name: harvester
      app.kubernetes.io/part-of: harvester
      helm.sh/release: harvester
  strategy:
    rollingUpdate:
      maxSurge: 2
      maxUnavailable: 2
    type: RollingUpdate
```


With the help of PR https://github.com/harvester/harvester-installer/pull/828 to get an ISO