### PR TITLE
controller/settings: ignore the empty value of NTP servers

### DIFF
--- a/pkg/controller/master/setting/nodeconfig.go
+++ b/pkg/controller/master/setting/nodeconfig.go
@@ -79,8 +79,10 @@ func (h *Handler) nodeOnChanged(_ string, node *corev1.Node) (*corev1.Node, erro
 		return nil, err
 	}
 	ntpSettings := &util.NTPSettings{}
-	if err := json.Unmarshal([]byte(ntpServersSetting.Value), ntpSettings); err != nil {
-		return nil, fmt.Errorf("failed to parse NTP settings: %v", err)
+	if ntpServersSetting.Value != "" {
+		if err := json.Unmarshal([]byte(ntpServersSetting.Value), ntpSettings); err != nil {
+			return nil, fmt.Errorf("failed to parse NTP settings: %v", err)
+		}
 	}
 	ntpServers := util.ReGenerateNTPServers(ntpSettings)
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
If the NTP servers of settings somehow is empty, we will see the following logs from the nodeconfig controller
```
time="2024-09-04T02:39:14Z" level=error msg="error syncing 'harvester-vm-0-default': handler harvester-setting-controller: failed to parse NTP settings: unexpected end of JSON input, requeuing"
time="2024-09-04T02:39:20Z" level=error msg="error syncing 'harvester-vm-1-default': handler harvester-setting-controller: failed to parse NTP settings: unexpected end of JSON input, requeuing"
time="2024-09-04T02:39:23Z" level=error msg="error syncing 'harvester-vm-2-default': handler harvester-setting-controller: failed to parse NTP settings: unexpected end of JSON input, requeuing"
```

**Solution:**
Do no-op when the NTP servers is empty in settings.

**Related Issue:**
https://github.com/harvester/harvester/issues/6492

**Test plan:**
1. Create harvester cluster
2. Remove the NTP servers from settings
3. Ensure that the harvester pod does not pop up the above logs.