### PR TITLE
chore: Configure Mergify to open backport PRs by labels

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,34 @@
+pull_request_rules:
+- name: Automatically open v1.4 backport PR
+  conditions:
+    - base=main
+    - label="backport-to/v1.4"
+  actions:
+    backport:
+      branches:
+        - v1.4
+      assignees:
+        - "{{ author }}"
+
+- name: Automatically open v1.3 backport PR
+  conditions:
+    - base=main
+    - label="backport-to/v1.3"
+  actions:
+    backport:
+      branches:
+        - v1.3
+      assignees:
+        - "{{ author }}"
+
+- name: Automatically open v1.2 backport PR
+  conditions:
+    - base=main
+    - label="backport-to/v1.2"
+  actions:
+    backport:
+      branches:
+        - v1.2
+      assignees:
+        - "{{ author }}"
+


### PR DESCRIPTION
Use Mergify to automatically create backport PRs according to `backport-to/<branch>` labels.

The developer can add pre-defined labels on a PR first and corresponding backport PRs will be open once the PR in review is merged. Unfortunately, I can't find a good way to template the branch, we'll need to add a rule for v1.5+ branches later.

Example: https://github.com/bk201/test-gha/pull/10
