### PR TITLE
chore: fix Mergify auto backport base branch [skip ci]

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
 - name: Automatically open v1.4 backport PR
   conditions:
-    - base=main
+    - base=master
     - label="backport-to/v1.4"
   actions:
     backport:
@@ -12,7 +12,7 @@ pull_request_rules:
 
 - name: Automatically open v1.3 backport PR
   conditions:
-    - base=main
+    - base=master
     - label="backport-to/v1.3"
   actions:
     backport:
@@ -23,7 +23,7 @@ pull_request_rules:
 
 - name: Automatically open v1.2 backport PR
   conditions:
-    - base=main
+    - base=master
     - label="backport-to/v1.2"
   actions:
     backport:


### PR DESCRIPTION
The base branch should be `master`.