### PR TITLE
improve maintenance mode api calls

### DIFF
--- a/tests/integration/api/host_apis_test.go
+++ b/tests/integration/api/host_apis_test.go
@@ -152,11 +152,9 @@ var _ = Describe("verify host APIs", func() {
 				}, "30s", "5s").ShouldNot(HaveOccurred())
 			})
 
-			By("enable maintenance mode of the host", func() {
-				MustFinallyBeTrue(func() bool {
-					respCode, respBody, err = helper.PostObjectAction(nodeObjectAPI, nodeapi.MaintenanceModeInput{Force: ""}, "enableMaintenanceMode")
-					return CheckRespCodeIs(http.StatusNoContent, "post enableMaintenanceMode action", err, respCode, respBody)
-				}, 30*time.Second, 5*time.Second)
+			By("attempting to enable maintenance mode on controlplane host", func() {
+				respCode, respBody, err = helper.PostObjectAction(nodeObjectAPI, nodeapi.MaintenanceModeInput{Force: ""}, "enableMaintenanceMode")
+				MustRespCodeIs(http.StatusInternalServerError, "enable maintenance", err, respCode, respBody)
 			})
 
 			By("then the node maintain-status is not set", func() {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Our current automation tests use `enableMaintenance` api call to place a node in maintenance mode.

The api currently skips the check for `maintenancePossible` which is run by the UI as part of the `enableMaintenance` operation. This currently causes failures during tests.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Minor change to `enableMaintenance` api call to run `maintenancePossible` before executing the actual maintenance operation.

**Related Issue:**
https://github.com/harvester/harvester/issues/5365
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Provision a single node or two node cluster

Before the change:
* On the controlplane node run the `enableMaintenance` api call
```
curl -u "${CATTLE_ACCESS_KEY}:${CATTLE_SECRET_KEY}" \
-X POST \
-H 'Accept: application/json' \
-H 'Content-Type: application/json' \
'https://endpoint/v1/harvester/nodes/node-1-dhcp?action=maintenancePossible'
```
* The call is successful and controlplane node is annotated with maintenance request key/value pair
`harvesterhci.io/drain-requested: true`

Post the change:
* On the controlplane node run the `enableMaintenance` api call
```
curl -u "${CATTLE_ACCESS_KEY}:${CATTLE_SECRET_KEY}" \
-X POST \
-H 'Accept: application/json' \
-H 'Content-Type: application/json' \
'https://endpoint/v1/harvester/nodes/node-1-dhcp?action=maintenancePossible'
```

* The call fails with http response code 500, and message 
```single controlplane cluster, cannot place controlplane in maintenance mode```
