### PR TITLE
improve nvidia-driver-toolkit upgrade

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -595,3 +595,15 @@ EOF
   # wait status only when enabled and already AddonDeploySuccessful
   wait_for_addon_upgrade_deployment $name $namespace $enabled $curstatus
 }
+
+
+upgrade_nvidia_driver_toolkit_addon()
+{
+  # patch nvidia-driver-toolkit with existing location before performing upgrade
+  CURRENTENDPOINT=$(kubectl get addons.harvester nvidia-driver-toolkit -n harvester-system -o yaml | yq .spec.valuesContent | yq '.driverLocation // "empty"')
+  if [ ${CURRENTENDPOINT} != "empty" ]
+  then
+    sed -i "s|HTTPENDPOINT/NVIDIA-Linux-x86_64-vgpu-kvm.run|${CURRENTENDPOINT}|" /usr/local/share/addons/nvidia-driver-toolkit.yaml
+  fi
+  upgrade_addon nvidia-driver-toolkit harvester-system
+}

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -752,7 +752,7 @@ upgrade_addon_rancher_logging()
 upgrade_addons()
 {
   wait_for_addons_crd
-  addons="vm-import-controller pcidevices-controller harvester-seeder nvidia-driver-toolkit"
+  addons="vm-import-controller pcidevices-controller harvester-seeder"
   for addon in $addons; do
     upgrade_addon $addon "harvester-system"
   done
@@ -761,6 +761,7 @@ upgrade_addons()
   # from v1.2.0, they are upgraded per following
   upgrade_addon_rancher_monitoring
   upgrade_addon_rancher_logging
+  upgrade_nvidia_driver_toolkit_addon
 }
 
 reuse_vlan_cn() {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
If nvidia-driver-toolkit is enabled, then during upgrade the driver endpoint gets cleared since the default addon upgrade process replaces the valuesContent and version info from the new addon spec packaged in the upgrade container.

As a result of this patch, the nvidia-driver-toolkit gets upgraded with the driverLocation set to place holder location in the  addon. This results in new driver never being reinstalled post upgrade, and causes VM's with vGPU's to fail.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces a minor change to extract the `driverLocation` from existing addon and using the same to patch the addon upgrade manifest, before the actual addon upgrade is performed.

**Related Issue:**
https://github.com/harvester/harvester/issues/6521
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Test the change is simple as we do not need an actual node which supports vGPUs

* Install a Harvester v1.3.2 cluster
* Post install edit the `driverLocation` and set it to a non default endpoint, say `http://fakeendpoint/vgpu.kvm`
* Trigger upgrade of cluster with new iso built from current change
* Post upgrade the addon should be upgraded, while retaining the `driverLocation`
