### PR TITLE
enhancement: storage network webhook checks vcluster statefulset volume

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -142,4 +142,8 @@ const (
 	LabelCPUManagerUpdateNode        = prefix + "/cpu-manager-update-node"
 	LabelCPUManagerUpdatePolicy      = prefix + "/cpu-manager-update-policy"
 	LabelCPUManagerExitCode          = prefix + "/cpu-manager-exit-code"
+
+	VClusterNamespace          = "rancher-vcluster"
+	LablelVClusterAppNameKey   = "app"
+	LablelVClusterAppNameValue = "vcluster"
 )


### PR DESCRIPTION
Storage network webhook checks if vcluster statefulset's volume is attached

**Problem:**
During configuring storage network, the Harvester controller doesn't check the volume used by vCluster.

**Solution:**
The Harvester controller should check the volume used by vCluster

**Related Issue:**
#4397

**Test plan:**
1. Enabling vCluster, and waiting for vCluster is ready
2. Enabling the storage network, should be rejected with the message `please stop vcluster before configuring the storage-network setting`
