### PR TITLE
bump(chart): sync node-manager & node-disk-manager versions in values.yaml

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -374,7 +374,7 @@ harvester-node-disk-manager:
     repository: rancher/harvester-node-disk-manager
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.7.1
+    tag: v0.7.3
 
 csi-snapshotter:
   ## Specify whether to install the csi-snapshotter
@@ -508,12 +508,12 @@ harvester-node-manager:
   image:
     pullPolicy: IfNotPresent
     repository: rancher/harvester-node-manager
-    tag: v0.3.0
+    tag: v0.3.2
   webhook:
     image:
       pullPolicy: IfNotPresent
       repository: rancher/harvester-node-manager-webhook
-      tag: v0.3.0
+      tag: v0.3.2
 
 snapshot-validation-webhook:
   enabled: true


### PR DESCRIPTION
This was missed in https://github.com/harvester/harvester/pull/6567