### PR TITLE
feat: bump base image to BCI 15.6

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -495,7 +495,7 @@ generalJob:
     # In the Golang limitation, we couldn't parse like "tag": 12.20.
     # So, we must use "tag": "12.20" instead.
     # More details in PR-4896 (https://github.com/harvester/harvester/pull/4896)
-    tag: 15.5
+    tag: 15.6
 
 whereabouts:
   enabled: true

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 # nfs-client is needed by the dep https://github.com/longhorn/backupstore to check backup store availability.
 RUN zypper -n rm container-suseconnect && \

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 RUN zypper -n rm container-suseconnect && \
     zypper -n install curl nfs-client && \

--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -6,13 +6,13 @@ RUN zypper rm -y container-suseconnect && \
     zypper --no-gpg-checks ref && \
     zypper in -y curl e2fsprogs rsync awk zstd jq helm zip unzip nginx && zypper clean -a
 
-ENV KUBECTL_VERSION v1.24.11
-RUN curl -sfL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+ENV KUBECTL_VERSION v1.29.9
+RUN curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
-RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.1.0/virtctl-v1.1.0-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
+RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.2.2/virtctl-v1.2.2-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
-    curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.5/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
+    curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.6/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 
 COPY do_upgrade_node.sh /usr/local/bin/
 COPY upgrade_node.sh /usr/local/bin/

--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 ARG ARCH=amd64
 ENV ARCH=${ARCH}

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -731,7 +731,7 @@ spec:
   tolerations:
   - operator: "Exists"
   upgrade:
-    image: registry.suse.com/bci/bci-base:15.5
+    image: registry.suse.com/bci/bci-base:15.6
     command:
     - chroot
     - /host


### PR DESCRIPTION
**Solution:**
Bump base image to BCI 15.6.
* harvester
* harvester-webhook
* harvester-upgrade
* general job
* skip-restart-rancher-system-agent plan

Update binaries in upgrade image.
* kubectl
* virtctl
* wharfie

**Related Issue:**
https://github.com/harvester/harvester/issues/6568

**Test plan:**
Create a 3-node harvester cluster without error.
