### PR TITLE
enhancement: vmbackp webhook check if the vm is under migration

### DIFF
--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -93,6 +93,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().ResourceQuota().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache(),
 		),
 		virtualmachinerestore.NewValidator(
 			clients.Core.Namespace().Cache(),


### PR DESCRIPTION
**Problem:**
The VM Backup should not be triggered if the related VM is under migration, this could bring several unexpected situations https://github.com/harvester/harvester/issues/6594#issue-2537769395

**Solution:**
Preventing VM Backup creation if the related VM is under migration

**Related Issue:**
#6594 

**Test plan:**
- Updating `harvester-webhook` deployment with this PR
- Starting VM migration
  - e.q. `$ ./virtctl migrate vm1`
- Creating VM Backup for the VM
- The VM Backup should be rejected with the message `vm <VM name> is in migration`
