### PR TITLE
fix: upgrade to rancher v2.9.2

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -543,6 +543,7 @@ upgrade_harvester() {
   cat >harvester-crd.yaml <<EOF
 spec:
   version: $REPO_HARVESTER_CHART_VERSION
+  timeoutSeconds: 60
 EOF
   kubectl patch managedcharts.management.cattle.io harvester-crd -n fleet-local --patch-file ./harvester-crd.yaml --type merge
 
@@ -564,6 +565,9 @@ EOF
   fi
 
   patch_longhorn_settings harvester.yaml
+
+  # set timeoutSeconds to 10 minutes to avoid context deadline exceeded in post upgrade hooks
+  yq eval '.spec.timeoutSeconds = 600' -i harvester.yaml
 
   kubectl apply -f ./harvester.yaml
 
@@ -597,6 +601,7 @@ upgrade_managedchart_monitoring_crd() {
   cat >"$nm".yaml <<EOF
 spec:
   version: $REPO_MONITORING_CHART_VERSION
+  timeoutSeconds: 60
 EOF
 
   kubectl patch managedcharts.management.cattle.io "$nm" -n fleet-local --patch-file ./"$nm".yaml --type merge
@@ -630,6 +635,7 @@ upgrade_managedchart_logging_crd() {
   cat >"$nm".yaml <<EOF
 spec:
   version: $REPO_LOGGING_CHART_VERSION
+  timeoutSeconds: 60
 EOF
 
   kubectl patch managedcharts.management.cattle.io "$nm" -n fleet-local --patch-file ./"$nm".yaml --type merge

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -236,6 +236,8 @@ upgrade_rancher() {
   cd $UPGRADE_TMP_DIR/rancher
 
   ./helm get values rancher -n cattle-system -o yaml >values.yaml
+  # Remove extraEnv fields from values.yaml. We don't want config like CATTLE_SHELL_IMAGE to overwrite shell-image setting.
+  yq -i 'del(.extraEnv)' values.yaml
   echo "Rancher values:"
   cat values.yaml
 


### PR DESCRIPTION
**Solution:**
1. We use rancher/shell:v0.1.26 image, which can't fulfill helm operation pods in Rancher v2.9.2. Remove related environment variables and shell-image setting value, so Rancher v2.9.2 can use default shell-image v0.2.1.
2. Without `timeoutSeconds` in managed charts, helm hooks job may get "context deadline exceeded". Add `timeoutSeconds` to harvester/harvester-crd/rancher-montoring-crd/rancher-logging-crd managed charts.
3. The fleet-agent is deployed as statefulset after fleet v0.10.1, so we have to change upgrade_manifest.sh with correct type.

**Related Issue:**
https://github.com/harvester/harvester/issues/6584

**Test plan:**
Please build image with https://github.com/harvester/harvester-installer/pull/840.
Test upgrade from v1.3.2 to this branch can work.
