### PR TITLE
In upgrade path bump eventrouter to v0.3.2

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -517,8 +517,8 @@ upgrade_addon_rancher_logging_with_patch_eventrouter_image()
   if [ $EXIT_CODE != 0 ]; then
     echo "eventrouter is not found, need not patch"
   else
-    if [[ "rancher/harvester-eventrouter:v0.3.1" > $tag ]]; then
-      echo "eventrouter image is $tag, will patch to v0.3.1"
+    if [[ "rancher/harvester-eventrouter:v0.3.2" > $tag ]]; then
+      echo "eventrouter image is $tag, will patch to v0.3.2"
       fixeventrouter=true
     else
       echo "eventrouter image is updated, need not patch"
@@ -536,7 +536,7 @@ upgrade_addon_rancher_logging_with_patch_eventrouter_image()
   cat $valuesfile
 
   if [[ $fixeventrouter == true ]]; then
-    yq -e '.eventTailer.workloadOverrides.containers[0].image = "rancher/harvester-eventrouter:v0.3.1"' -i $valuesfile
+    yq -e '.eventTailer.workloadOverrides.containers[0].image = "rancher/harvester-eventrouter:v0.3.2"' -i $valuesfile
   fi
 
   # add 4 spaces to each line


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

With new eventrouter v0.3.2 image tag, the upgrade path should be processed as well.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add upgrade related processing.

**Related Issue:**
https://github.com/harvester/harvester/issues/6568

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install v1.3.2
2. Enable rancher-logging addon
3. Upgrade to v1.4.0, check the eventrouter image tag is v0.3.2

note: the upgrade processing in v1.3 branch is on another PR: https://github.com/harvester/harvester/pull/6613