### PR TITLE
enhancement: schedule vm backup misc update

### DIFF
--- a/pkg/controller/master/schedulevmbackup/lhbackup.go
+++ b/pkg/controller/master/schedulevmbackup/lhbackup.go
@@ -1,0 +1,79 @@
+package schedulevmbackup
+
+import (
+	"reflect"
+	"strings"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+)
+
+func (h *svmbackupHandler) resolveVolSnapshotRef(namespace string, controllerRef *metav1.OwnerReference) *harvesterv1.VirtualMachineBackup {
+	// We can't look up by UID, so look up by Name and then verify UID.
+	// Don't even try to look up by Name if it's the wrong Kind.
+	if controllerRef.Kind != vmBackupKind.Kind {
+		return nil
+	}
+	backup, err := h.vmBackupCache.Get(namespace, controllerRef.Name)
+	if err != nil {
+		return nil
+	}
+	if backup.UID != controllerRef.UID {
+		// The controller we found with this Name is not the same one that the
+		// ControllerRef points to.
+		return nil
+	}
+	return backup
+}
+
+// TODO: check if this function could be merged with pkg/controller/master/backup/backup_status.go OnLHBackupChanged()
+// Since in v1.4.0 we should not introduce too many changes in vmbackp controller
+func (h *svmbackupHandler) OnLHBackupChanged(_ string, lhBackup *lhv1beta2.Backup) (*lhv1beta2.Backup, error) {
+	if lhBackup == nil || lhBackup.DeletionTimestamp != nil || lhBackup.Spec.SnapshotName == "" {
+		return nil, nil
+	}
+
+	snapshotContent, err := h.snapshotContentCache.Get(strings.Replace(lhBackup.Spec.SnapshotName, "snapshot", "snapcontent", 1))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	snapshot, err := h.snapshotCache.Get(snapshotContent.Spec.VolumeSnapshotRef.Namespace, snapshotContent.Spec.VolumeSnapshotRef.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	controllerRef := metav1.GetControllerOf(snapshot)
+	if controllerRef == nil {
+		return nil, nil
+	}
+
+	vmBackup := h.resolveVolSnapshotRef(snapshot.Namespace, controllerRef)
+	if vmBackup == nil || vmBackup.Status == nil || vmBackup.Status.BackupTarget == nil {
+		return nil, nil
+	}
+
+	vmBackupCpy := vmBackup.DeepCopy()
+	for i, volumeBackup := range vmBackupCpy.Status.VolumeBackups {
+		if *volumeBackup.Name == snapshot.Name {
+			vmBackupCpy.Status.VolumeBackups[i].LonghornBackupName = pointer.StringPtr(lhBackup.Name)
+		}
+	}
+
+	if !reflect.DeepEqual(vmBackup.Status, vmBackupCpy.Status) {
+		if _, err := h.vmBackupClient.Update(vmBackupCpy); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/controller/master/schedulevmbackup/register.go
+++ b/pkg/controller/master/schedulevmbackup/register.go
@@ -6,6 +6,7 @@ import (
 	catalogv1 "github.com/rancher/rancher/pkg/generated/controllers/catalog.cattle.io/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
 	ctlharvbatchv1 "github.com/harvester/harvester/pkg/generated/controllers/batch/v1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
@@ -17,23 +18,32 @@ const (
 	scheduleVMBackupControllerName = "schedule-vm-bakcup-controller"
 	cronJobControllerName          = "cron-job-controller"
 	vmBackupControllerName         = "vm-backup-controller"
+	longhornBackupControllerName   = "longhorn-backup-controller"
+
+	vmBackupKindName = "VirtualMachineBackup"
 )
 
+var vmBackupKind = harvesterv1.SchemeGroupVersion.WithKind(vmBackupKindName)
+
 type svmbackupHandler struct {
-	svmbackupController ctlharvesterv1.ScheduleVMBackupController
-	svmbackupClient     ctlharvesterv1.ScheduleVMBackupClient
-	svmbackupCache      ctlharvesterv1.ScheduleVMBackupCache
-	cronJobsClient      ctlharvbatchv1.CronJobClient
-	cronJobCache        ctlharvbatchv1.CronJobCache
-	vmBackupClient      ctlharvesterv1.VirtualMachineBackupClient
-	vmBackupCache       ctlharvesterv1.VirtualMachineBackupCache
-	snapshotCache       ctlsnapshotv1.VolumeSnapshotCache
-	lhsnapshotClient    ctllonghornv2.SnapshotClient
-	lhsnapshotCache     ctllonghornv2.SnapshotCache
-	settingCache        ctlharvesterv1.SettingCache
-	secretCache         ctlcorev1.SecretCache
-	namespace           string
-	appCache            catalogv1.AppCache
+	svmbackupController  ctlharvesterv1.ScheduleVMBackupController
+	svmbackupClient      ctlharvesterv1.ScheduleVMBackupClient
+	svmbackupCache       ctlharvesterv1.ScheduleVMBackupCache
+	cronJobsClient       ctlharvbatchv1.CronJobClient
+	cronJobCache         ctlharvbatchv1.CronJobCache
+	vmBackupController   ctlharvesterv1.VirtualMachineBackupController
+	vmBackupClient       ctlharvesterv1.VirtualMachineBackupClient
+	vmBackupCache        ctlharvesterv1.VirtualMachineBackupCache
+	snapshotCache        ctlsnapshotv1.VolumeSnapshotCache
+	lhsnapshotClient     ctllonghornv2.SnapshotClient
+	lhsnapshotCache      ctllonghornv2.SnapshotCache
+	settingCache         ctlharvesterv1.SettingCache
+	secretCache          ctlcorev1.SecretCache
+	namespace            string
+	appCache             catalogv1.AppCache
+	lhbackupCache        ctllonghornv2.BackupCache
+	lhbackupClient       ctllonghornv2.BackupClient
+	snapshotContentCache ctlsnapshotv1.VolumeSnapshotContentCache
 }
 
 func Register(ctx context.Context, management *config.Management, options config.Options) error {
@@ -45,22 +55,28 @@ func Register(ctx context.Context, management *config.Management, options config
 	lhsnapshots := management.LonghornFactory.Longhorn().V1beta2().Snapshot()
 	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	secrets := management.CoreFactory.Core().V1().Secret()
+	lhbackups := management.LonghornFactory.Longhorn().V1beta2().Backup()
+	snapshotContents := management.SnapshotFactory.Snapshot().V1().VolumeSnapshotContent()
 
 	svmbackupHandler := &svmbackupHandler{
-		svmbackupController: svmbackups,
-		svmbackupClient:     svmbackups,
-		svmbackupCache:      svmbackups.Cache(),
-		cronJobsClient:      cronJobs,
-		cronJobCache:        cronJobs.Cache(),
-		vmBackupClient:      vmBackups,
-		vmBackupCache:       vmBackups.Cache(),
-		snapshotCache:       snapshots.Cache(),
-		lhsnapshotClient:    lhsnapshots,
-		lhsnapshotCache:     lhsnapshots.Cache(),
-		settingCache:        settings.Cache(),
-		secretCache:         secrets.Cache(),
-		namespace:           options.Namespace,
-		appCache:            appCache,
+		svmbackupController:  svmbackups,
+		svmbackupClient:      svmbackups,
+		svmbackupCache:       svmbackups.Cache(),
+		cronJobsClient:       cronJobs,
+		cronJobCache:         cronJobs.Cache(),
+		vmBackupController:   vmBackups,
+		vmBackupClient:       vmBackups,
+		vmBackupCache:        vmBackups.Cache(),
+		snapshotCache:        snapshots.Cache(),
+		lhsnapshotClient:     lhsnapshots,
+		lhsnapshotCache:      lhsnapshots.Cache(),
+		settingCache:         settings.Cache(),
+		secretCache:          secrets.Cache(),
+		namespace:            options.Namespace,
+		appCache:             appCache,
+		lhbackupCache:        lhbackups.Cache(),
+		lhbackupClient:       lhbackups,
+		snapshotContentCache: snapshotContents.Cache(),
 	}
 
 	svmbackups.OnChange(ctx, scheduleVMBackupControllerName, svmbackupHandler.OnChanged)
@@ -68,5 +84,6 @@ func Register(ctx context.Context, management *config.Management, options config
 	cronJobs.OnChange(ctx, cronJobControllerName, svmbackupHandler.OnCronjobChanged)
 	vmBackups.OnChange(ctx, vmBackupControllerName, svmbackupHandler.OnVMBackupChange)
 	vmBackups.OnRemove(ctx, vmBackupControllerName, svmbackupHandler.OnVMBackupRemove)
+	lhbackups.OnChange(ctx, longhornBackupControllerName, svmbackupHandler.OnLHBackupChanged)
 	return nil
 }

--- a/pkg/controller/master/schedulevmbackup/vmbackup.go
+++ b/pkg/controller/master/schedulevmbackup/vmbackup.go
@@ -30,6 +30,10 @@ func (h *svmbackupHandler) OnVMBackupChange(_ string, vmBackup *harvesterv1.Virt
 		h.svmbackupController.Enqueue(svmbackup.Namespace, svmbackup.Name)
 	}
 
+	if err := checkLHBackupUnexpectedProcessing(h, svmbackup, vmBackup); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 


### PR DESCRIPTION
1. Improve webhook message for multiple svmbackup creation for the same vm
2. Suspend schedule and delete the LH backp if the volumesnapshot is in an error state but LH backup keeps reconciling

**Enhancement:**
1. Improve webhook message for multiple svmbackup creation for the same vm
2. Suspend schedule and delete the LH backp if the volumesnapshot is in an error state but LH backup keeps reconciling
    - If NFS backup target is unreachable, this can make the volumesnapshot already in an error state, however, the related lhbackup is still in processing. The backup controller will hold one LH va ticket and make following snapshot and backup creation stuck. We should suspend the schedule and delete the LH backup as soon as we find this situation

**Related Issue:**
#6621

**Test plan:**

Webhook Improve Case1 - duplicate schedule for the same source VM:
- Updating Harvester Webhook deployment with this PR
- Creating a schedule with `snapshot` type for a VM
- Creating a schedule with `backup` type for the same VM
  - This will be rejected with the message `VM <VM name> already has snapshot schedule`

Webhook Improve Case2 - source VM can't be mutated:
- Updating Harvester Webhook deployment with this PR
- Creating a VM `vm1`
- Apply the following manifest for a backup schedule
  ```
  apiVersion: harvesterhci.io/v1beta1
  kind: ScheduleVMBackup
  metadata:
    annotations:
      harvesterhci.io/svmbackupSkipCronCheck: "enable"
    namespace: default
    name: svmbackup-vm1
  spec:
    cron: '*/2 * * * *'
    retain: 3
    maxFailure: 2
    suspend: true
    vmbackup:
      source:
        apiGroup: kubevirt.io
        kind: VirtualMachine
        name: vm1
      type: backup
  ```
- Changing any field of `spec.vmbackup`
- This will be rejected with the message `source vm can't be changed`

 Controller Improve Case:
- Updating Harvester deployment with this PR
- Configuring a NFS Backup Target
- Creating a VM `vm1`
- Apply the following manifest for a backup schedule
  ```
  apiVersion: harvesterhci.io/v1beta1
  kind: ScheduleVMBackup
  metadata:
    annotations:
      harvesterhci.io/svmbackupSkipCronCheck: "enable"
    namespace: default
    name: svmbackup-vm1
  spec:
    cron: '*/2 * * * *'
    retain: 3
    maxFailure: 2
    suspend: true
    vmbackup:
      source:
        apiGroup: kubevirt.io
        kind: VirtualMachine
        name: vm1
      type: backup
  ```
- Resuming the schedule (`spec.suspend = false`), and disable NFS service immediately
- After few minutes, the `ScheduleVMBackup` should be suspended (`status.suspended = true`)
  - Condition  `BackupSuspend` with message `vmbackup <vmbackup name> vb <volume backup name> in error state but lhbackup <LH backup name> still in processing, usually caused by backup target not reachable`
