### PR TITLE
Add the missing v122 v131 v132 to upgrade-matrix

### DIFF
--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,6 +1,12 @@
 versions:
+- name: v1.3.2
+  minUpgradableVersion: v1.3.1
+- name: v1.3.1
+  minUpgradableVersion: v1.2.2
 - name: v1.3.0
   minUpgradableVersion: v1.2.2
+- name: v1.2.2
+  minUpgradableVersion: v1.2.1
 - name: v1.2.1
   minUpgradableVersion: v1.1.2
 - name: v1.2.0


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

v122, v131, v132 images lists are not packed into v140 iso, the issue https://github.com/harvester/harvester/issues/5749 can not be validated.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add those missing versions to upgrade-matrix.

**Related Issue:**
https://github.com/harvester/harvester/issues/6620
https://github.com/harvester/harvester/issues/5749

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
via validate https://github.com/harvester/harvester/issues/6620