### PR TITLE
fix: storage class validation

### DIFF
--- a/pkg/webhook/resources/storageclass/validator_test.go
+++ b/pkg/webhook/resources/storageclass/validator_test.go
@@ -40,18 +40,6 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "invalid encryption value",
-			storageClass: &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "sc2",
-				},
-				Parameters: map[string]string{
-					util.LonghornOptionEncrypted: "false",
-				},
-			},
-			expectError: true,
-		},
-		{
 			name: "secret not found",
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
@@ -65,6 +53,43 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 					util.CSINodeStageSecretNamespaceKey:   "default",
 					util.CSINodePublishSecretNameKey:      "non-existent-secret",
 					util.CSINodePublishSecretNamespaceKey: "default",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "encryption disabled",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sc4",
+				},
+				Parameters: map[string]string{
+					util.LonghornOptionEncrypted: "false",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid encryption value",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sc2",
+				},
+				Parameters: map[string]string{
+					util.LonghornOptionEncrypted: "invalid-value-here",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing parameters for encryption",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sc5",
+				},
+				Parameters: map[string]string{
+					util.LonghornOptionEncrypted:     "true",
+					util.CSIProvisionerSecretNameKey: "non-existent-secret",
 				},
 			},
 			expectError: true,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Currently, storage class validation returns an error when `encrypted` field exists and its value is not `true`.

**Solution:**
We should only return an error when the value is `true` but required parameters are not provided.

**Related Issue:**
https://github.com/harvester/harvester/issues/6631

**Test plan:**
Please check [this unit test file](https://github.com/harvester/harvester/blob/968da91de16ba84cab5e9bd6c026ae7244ab8db1/pkg/webhook/resources/storageclass/validator_test.go) to check different test cases.
