### PR TITLE
Fix incorrect variable name in upgrade_node

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -498,7 +498,7 @@ EOF
 # system-reserved/kube-reserved is required if we want to set cpu-manager-policy to static
 set_reserved_resource() {
   local cores=$(chroot $HOST_DIR nproc)
-  local reserverdCPU=$(calculateCPUReservedInMilliCPU $cores $MAX_PODS)
+  local reservedCPU=$(calculateCPUReservedInMilliCPU $cores $MAX_PODS)
   # make system:kube cpu reservation ration 2:3
   local systemReservedCPU=$((reservedCPU * 2 * 2 / 5))
   local kubeReservedCPU=$((reservedCPU * 2 * 3 / 5))


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
After upgrade from `v1.3.2` to harvester `v1.4.0-dev-20240918`. After enabling CPUManager, the node remains in `cordoned` state. From UI is complains that Kubelet stopped posting node status. 
![image](https://github.com/user-attachments/assets/e4890782-a51d-4d54-9c75-539efa61d43e)

The root cause is upgrade_node.sh#set_reserved_resource use incorrect variable name, this lead both `systemReservedCPU` and `kubeReservedCPU` to zero thus make static cpu manager policy not work and make kubelet failed to start.

From the log `/var/lib/rancher/rke2/agent/logs/kubelet.log` we can see error as belows.
```
E0925 09:22:52.429151   16618 container_manager_linux.go:329] "Failed to initialize cpu manager" err="[cpumanager] unable to determine reserved CPU resources for static policy"
```

**Solution:**
Fix the incorrect variable name.

**Related Issue:**
https://github.com/harvester/harvester/issues/6641

**Test plan:**
- Prepare v1.3.2 single node cluster (easy to test)
- Upgrade to harvester version which includes this fix
- Enable CPU Manager through UI, and the node should remains in `Active` state in UI.