### PR TITLE
Deny to delete the harvester-longhorn sc

### DIFF
--- a/deploy/charts/harvester/templates/harvester-storageclass.yaml
+++ b/deploy/charts/harvester/templates/harvester-storageclass.yaml
@@ -3,8 +3,9 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: harvester-longhorn
-{{- if .Values.storageClass.defaultStorageClass }}
   annotations:
+    harvesterhci.io/is-reserved-storageclass: "true"
+{{- if .Values.storageClass.defaultStorageClass }}
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 provisioner: driver.longhorn.io

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -146,4 +146,11 @@ const (
 	VClusterNamespace          = "rancher-vcluster"
 	LablelVClusterAppNameKey   = "app"
 	LablelVClusterAppNameValue = "vcluster"
+
+	StorageClassHarvesterLonghorn = "harvester-longhorn" // the initial & default storageclass
+	HarvesterChartReleaseName     = "harvester"          // the release name
+
+	// copied from helm pkg/action/validate.go
+	HelmReleaseNameAnnotation      = "meta.helm.sh/release-name"
+	HelmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 )

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -41,6 +41,10 @@ const (
 	// Add to rancher-monitoring addon to record grafana pv name
 	AnnotationGrafanaPVName = prefix + "/grafana-pv-name"
 
+	// Add to harvester-longhorn storageclass to protect it
+	// For any storageclass created & protected by controller, the controller can utilize this annotation
+	AnnotationIsReservedStorageClass = prefix + "/is-reserved-storageclass"
+
 	ContainerdRegistrySecretName = "harvester-containerd-registry"
 	ContainerdRegistryFileName   = "registries.yaml"
 

--- a/pkg/webhook/resources/storageclass/validator_test.go
+++ b/pkg/webhook/resources/storageclass/validator_test.go
@@ -137,6 +137,28 @@ func Test_storageClassValidator_Delete(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "storage class harvester-longhorn can't be deleted",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: util.StorageClassHarvesterLonghorn,
+					Annotations: map[string]string{
+						util.HelmReleaseNameAnnotation:      util.HarvesterChartReleaseName,
+						util.HelmReleaseNamespaceAnnotation: util.HarvesterSystemNamespaceName,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "storage class can be deleted",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "customized",
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	harvesterClientSet := harvesterFake.NewSimpleClientset(&v1beta1.VirtualMachineImage{

--- a/pkg/webhook/resources/storageclass/validator_test.go
+++ b/pkg/webhook/resources/storageclass/validator_test.go
@@ -138,7 +138,43 @@ func Test_storageClassValidator_Delete(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "storage class harvester-longhorn can't be deleted",
+			name: "storage class any with AnnotationIsReservedStorageClass true can't be deleted",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "any",
+					Annotations: map[string]string{
+						util.AnnotationIsReservedStorageClass: "true",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "storage class any with AnnotationIsReservedStorageClass false can be deleted",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "any",
+					Annotations: map[string]string{
+						util.AnnotationIsReservedStorageClass: "false",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "storage class harvester-longhorn with AnnotationIsReservedStorageClass false can be deleted too",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: util.StorageClassHarvesterLonghorn,
+					Annotations: map[string]string{
+						util.AnnotationIsReservedStorageClass: "false",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "storage class harvester-longhorn without AnnotationIsReservedStorageClass can't be deleted",
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: util.StorageClassHarvesterLonghorn,
@@ -151,10 +187,10 @@ func Test_storageClassValidator_Delete(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "storage class can be deleted",
+			name: "storage class others without AnnotationIsReservedStorageClass can be deleted",
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "customized",
+					Name: "others",
 				},
 			},
 			expectError: false,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The `harvester-longhorn` SC can be deleted.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Allow to use annotation `harvesterhci.io/is-reserved-storageclass: "true"` to protect any SC
2. Add annotation `harvesterhci.io/is-reserved-storageclass: "true"` to harvester chart to protect the default harvester-longhorn SC.
3. For legacy `harvester-longhorn` SC, protect it as well when there is no `harvesterhci.io/is-reserved-storageclass: "true"` annotation.

**Related Issue:**
https://github.com/harvester/harvester/issues/6678

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Create a new SC and set it as default
4. Delete the `harvester-longhorn` SC, which should be blocked by webhook.


![image](https://github.com/user-attachments/assets/9308278b-a474-4106-a6ab-802c2bcd8726)

5. Create a new SC, and add annotation `harvesterhci.io/is-reserved-storageclass: "true"` manually, the SC can't be deleted.
```
$kubectl get storageclass test -oyaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    harvesterhci.io/is-reserved-storageclass: "true"  // add this manually
  creationTimestamp: "2024-10-01T09:13:09Z"
  name: test
  resourceVersion: "111649"
  uid: 4cd9771f-a6d2-4734-8cad-11663c171994
parameters:
  dataEngine: v1
  encrypted: "false"
  migratable: "true"
  numberOfReplicas: "1"
  staleReplicaTimeout: "30"
provisioner: driver.longhorn.io
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

![image](https://github.com/user-attachments/assets/7f599de7-354a-467c-9ac8-b4cc1e32a4b7)

