### PR TITLE
ci: pass fixed-length short revision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Declare branch and sha_short
       run: |
-        echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+        echo "sha_short=$(git rev-parse --short=8 "$GITHUB_SHA")" >> "$GITHUB_ENV"
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_ENV"
         if [ "${{ matrix.arch }}" == "x64" ]; then
           echo "arch=amd64" >> "$GITHUB_ENV"
@@ -190,7 +190,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Declare branch and sha_short
+    - name: Declare branch
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_ENV"
 
@@ -400,7 +400,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Declare branch and sha_short
+    - name: Declare branch
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
The short revision has to be in fixed length (8) to let the harvester upgrade controller pick up the correct upgrade image.


**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Harvester can't upgrade from a stable branch. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The cause is the mismatch between the server-version and the image tag. For example: in a crime scene we found the server version is v1.4-cd10d18-head, but the image preloaded on the node has the tag v1.4-cd10d18d-head (hash length different). 
- The server version is defined in https://github.com/harvester/harvester/blob/650dff194086acb3922a1575d284fbc7c8e0fd2b/.github/workflows/build.yml#L60, hash length is undetermined.
- The upgrade image tag is defined in https://github.com/harvester/harvester-installer/blob/f6d189bfc828879096e28786cfd175ec5a439bab/scripts/build-bundle#L333, hash length is 8.

We can specify the short hash length in the ci pipeline.

**Related Issue:**

https://github.com/harvester/harvester/issues/6699

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
The test seems to only be done after the PR is merged and the CI publishes a new ISO.
- Download the published ISO.
- Upgrade to other versions, the preload job should work.