### PR TITLE
arm upgrade path fixes

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -218,7 +218,7 @@ func (r *Repo) createVM(image *harvesterv1.VirtualMachineImage) (*kubevirtv1.Vir
 									BootOrder: &bootOrder,
 									DiskDevice: kubevirtv1.DiskDevice{
 										CDRom: &kubevirtv1.CDRomTarget{
-											Bus: "sata",
+											Bus: "scsi",
 										},
 									},
 									Name: "disk-0",
@@ -226,7 +226,7 @@ func (r *Repo) createVM(image *harvesterv1.VirtualMachineImage) (*kubevirtv1.Vir
 								{
 									DiskDevice: kubevirtv1.DiskDevice{
 										CDRom: &kubevirtv1.CDRomTarget{
-											Bus: "sata",
+											Bus: "scsi",
 										},
 									},
 									Name: "cloudinitdisk",
@@ -248,9 +248,6 @@ func (r *Repo) createVM(image *harvesterv1.VirtualMachineImage) (*kubevirtv1.Vir
 									Name:  "default",
 								},
 							},
-						},
-						Machine: &kubevirtv1.Machine{
-							Type: "q35",
 						},
 						Resources: kubevirtv1.ResourceRequirements{
 							Limits: corev1.ResourceList{

--- a/pkg/controller/master/upgrade/version_syncer.go
+++ b/pkg/controller/master/upgrade/version_syncer.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	gversion "github.com/mcuadros/go-version"
@@ -158,6 +159,9 @@ func (s *versionSyncer) syncVersions(resp CheckUpgradeResponse, currentVersion s
 	for _, v := range resp.Versions {
 		newVersion, err := s.getNewVersion(v)
 		if err != nil {
+			if strings.Contains(err.Error(), "failed to download version") {
+				continue
+			}
 			return err
 		}
 

--- a/pkg/controller/master/upgrade/version_syncer_test.go
+++ b/pkg/controller/master/upgrade/version_syncer_test.go
@@ -320,6 +320,7 @@ func fakeHTTPEndpoint(resp CheckUpgradeResponse) *httptest.Server {
 		resp: resp,
 	}
 	r.HandleFunc("/{version}/version.yaml", responder.versionResponder)
+	r.HandleFunc("/{version}/version-arm64.yaml", responder.versionResponder)
 	s := httptest.NewUnstartedServer(r)
 	return s
 }


### PR DESCRIPTION
fix up version lookup and minor changes to upgrade vm spec to use iscsi bus for iso devices to enable support across both arm64 and amd64 arch

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently when triggering arm upgrades via the version sync, the sync fails as older versions of harvester do not have a corresponding version-arm64.yaml published

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces following changes
* ignores version object if a corresponding version.yaml or version-arm64.yaml is not found
* minor changes to upgrade VM to drop q35 machine type so correct type can be identified based on underlying platform arch
* minor change to switch VM iso bus adapter to scsi, to ensure it is compatible across both amd64 and arm64 arch

**Related Issue:**
https://github.com/harvester/harvester/issues/6257
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
