### PR TITLE
feat: add secret validator for encryption storage class 

### DIFF
--- a/enhancements/20240805-encrypted-block-volume.md
+++ b/enhancements/20240805-encrypted-block-volume.md
@@ -395,8 +395,10 @@ Before the creation of an encrypted virtual machine is processed by Harvester co
   If it's encrypted, it shows LUKS header information. Otherwise, it shows invalid LUKS device.
   ![](./20240805-encrypted-block-volume/06.png)
 
-  Then, you could use wrong password to `lukeOpen` it.  
+  Then, you could use wrong password to `lukeOpen` it. If passphrase is wrong, it shows `No key available with this passphrase`. If passphrase is correct, it shows `which is in use (already mapped or mounted)` because CSI driver have mounted it. The mounted path is in `/dev/mapper` on the same host.
   ![](./20240805-encrypted-block-volume/07.png)
+- Verify that VM image is encrypted.
+  Suggest that only start one VM without extra disks. After vm starts, there is only one disk in `/dev/longhorn`. Use the same method as in the previous step to verify it.
   
 
 ### Limitations


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
1. Missing secret validator when creating an encrypted storage class.
2. Insufficient details on how to check encrypted volumes.

**Solution:**
1. Add secret validator for encryption storage class.
3. Provide more information on how to check encrypted volume.

**Related Issue:**
- https://github.com/harvester/harvester/issues/3129#issuecomment-2400756896
- https://github.com/harvester/harvester/issues/6493#issuecomment-2400758163

**Test plan:**
1. Create a secret that is missing some keys.
2. Create a storage class by selecting the previously created secret.
