### PR TITLE
feat: create fleet-default namespace

### DIFF
--- a/pkg/data/add.go
+++ b/pkg/data/add.go
@@ -15,6 +15,9 @@ func Init(ctx context.Context, mgmtCtx *config.Management, options config.Option
 	if err := addPublicNamespace(mgmtCtx.Apply); err != nil {
 		return err
 	}
+	if err := addFleetDefaultNamespace(mgmtCtx.Apply); err != nil {
+		return err
+	}
 	if err := addAPIService(mgmtCtx.Apply, options.Namespace); err != nil {
 		return err
 	}

--- a/pkg/data/rancher.go
+++ b/pkg/data/rancher.go
@@ -1,0 +1,23 @@
+package data
+
+import (
+	"github.com/rancher/wrangler/v3/pkg/apply"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	FleetDefaultNamespace = "fleet-default"
+)
+
+// To fix missing namespace error in Rancher v2.9.2.
+// https://github.com/harvester/harvester/issues/6692
+func addFleetDefaultNamespace(apply apply.Apply) error {
+	return apply.
+		WithDynamicLookup().
+		WithSetID(FleetDefaultNamespace).
+		ApplyObjects(
+			&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: FleetDefaultNamespace},
+			})
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
In Rancher v2.9.2, it keeps showing error message like:

```
2024/10/02 09:26:41 [ERROR] error syncing 'local/default-token': handler cluster-registration-token: failed to create fleet-default/rke2-machineconfig-cleanup-sa /v1, Kind=ServiceAccount for rke2-machine-config-cleanup: namespaces "fleet-default" not found, failed to create fleet-default/rke2-machineconfig-cleanup-script /v1, Kind=ConfigMap for rke2-machine-config-cleanup: namespaces "fleet-default" not found, failed to create fleet-default/rke2-machineconfig-cleanup-cronjob batch/v1, Kind=CronJob for rke2-machine-config-cleanup: namespaces "fleet-default" not found, requeuing
2024/10/02 09:28:41 [ERROR] error syncing 'local/default-token': handler cluster-registration-token: failed to create fleet-default/rke2-machineconfig-cleanup-sa /v1, Kind=ServiceAccount for rke2-machine-config-cleanup: namespaces "fleet-default" not found, failed to create fleet-default/rke2-machineconfig-cleanup-script /v1, Kind=ConfigMap for rke2-machine-config-cleanup: namespaces "fleet-default" not found, failed to create fleet-default/rke2-machineconfig-cleanup-cronjob batch/v1, Kind=CronJob for rke2-machine-config-cleanup: namespaces "fleet-default" not found, requeuing
2024/10/02 09:30:41 [ERROR] error syncing 'local/default-token': handler cluster-registration-token: failed to create fleet-default/rke2-machineconfig-cleanup-sa /v1, Kind=ServiceAccount for rke2-machine-config-cleanup: namespaces "fleet-default" not found, failed to create fleet-default/rke2-machineconfig-cleanup-script /v1, Kind=ConfigMap for rke2-machine-config-cleanup: namespaces "fleet-default" not found, failed to create fleet-default/rke2-machineconfig-cleanup-cronjob batch/v1, Kind=CronJob for rke2-machine-config-cleanup: namespaces "fleet-default" not found, requeuing
```

**Solution:**
The root cause is there is no `fleet-default` namespace in the Harvester. Create it to avoid this error.

**Related Issue:**
https://github.com/harvester/harvester/issues/6692

**Test plan:**
1. Create a Harvester cluster.
2. Make sure there is service account `fleet-default/rke2-machineconfig-cleanup-sa`. There may still have some error messages, because we deploy Rancher before Harvester. Eventually, the message will not keep showing.
