### PR TITLE
make VM/Volume snapshot works well on the LVM volume

### DIFF
--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -396,8 +396,18 @@ func (h *Handler) getVolumeBackups(backup *harvesterv1.VirtualMachineBackup, vm 
 // getCSIDriverMap retrieves VolumeSnapshotClassName for each csi driver
 func (h *Handler) getCSIDriverMap(backup *harvesterv1.VirtualMachineBackup) (map[string]string, map[string]snapshotv1.VolumeSnapshotClass, error) {
 	csiDriverConfig := map[string]settings.CSIDriverInfo{}
-	if err := json.Unmarshal([]byte(settings.CSIDriverConfig.Get()), &csiDriverConfig); err != nil {
+	if err := json.Unmarshal([]byte(settings.CSIDriverConfig.GetDefault()), &csiDriverConfig); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, settings.CSIDriverConfig.GetDefault())
+	}
+	tmpDriverConfig := map[string]settings.CSIDriverInfo{}
+	if err := json.Unmarshal([]byte(settings.CSIDriverConfig.Get()), &tmpDriverConfig); err != nil {
 		return nil, nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, settings.CSIDriverConfig.Get())
+	}
+
+	for key, val := range tmpDriverConfig {
+		if _, ok := csiDriverConfig[key]; !ok {
+			csiDriverConfig[key] = val
+		}
 	}
 
 	csiDriverVolumeSnapshotClassNameMap := map[string]string{}

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -363,10 +363,8 @@ func (h *Handler) getVolumeBackups(backup *harvesterv1.VirtualMachineBackup, vm 
 			return nil, fmt.Errorf("PV %s is not from CSI driver, cannot take a %s", pv.Name, backup.Spec.Type)
 		}
 
-		lhvolume, err := h.volumeCache.Get(util.LonghornSystemNamespaceName, pv.Name)
-		if err != nil {
-			return nil, err
-		}
+		storageCapacity := pv.Spec.Capacity[corev1.ResourceStorage]
+		volumeSize := storageCapacity.Value()
 
 		volumeBackupName := fmt.Sprintf("%s-volume-%s", backup.Name, pvcName)
 
@@ -384,7 +382,7 @@ func (h *Handler) getVolumeBackups(backup *harvesterv1.VirtualMachineBackup, vm 
 				Spec: pvc.Spec,
 			},
 			ReadyToUse: pointer.BoolPtr(false),
-			VolumeSize: lhvolume.Spec.Size,
+			VolumeSize: volumeSize,
 		}
 
 		volumeBackups = append(volumeBackups, vb)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -150,6 +150,10 @@ func (s Setting) Set(value string) error {
 	return nil
 }
 
+func (s Setting) GetDefault() string {
+	return s.Default
+}
+
 func (s Setting) Get() string {
 	if provider == nil {
 		s := settings[s.Name]


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
If the VM attaches the LVM volume, it cannot take snapshot even if the LVM CSI driver supports the snapshot.

**Solution:**
Make sure the VM/Volume snapshot path works.

**Related Issue:**

**Test plan:**
1. create harvester cluster
2. enable LVM with addon (REF: https://github.com/harvester/experimental-addons/pull/18)

~3. create VolumeSnapshotClass by following yaml~
```
apiVersion: snapshot.storage.k8s.io/v1
deletionPolicy: Delete
driver: lvm.driver.harvesterhci.io
kind: VolumeSnapshotClass
metadata:
  name: lvm-snapshot
```

4. Modify the settings `csi-driver-config` as below:
```
apiVersion: harvesterhci.io/v1beta1
default: '{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}'
kind: Setting
metadata:
  name: csi-driver-config
status: {}
value: '{"lvm.driver.harvesterhci.io":{"volumeSnapshotClassName":"lvm-snapshot"}}'
```
5. make sure the snapshot feature works (for both VM/Volume)

~We would like to make steps 3 and 4 can be automatically applied when we enable the addon.
But for now, we need to manually config it.~

**UPDATE** Use the latest addon yaml to complete steps 3 when enable the addon.