### PR TITLE
Fix the additional-guest-memory-overhead-ratio not synced on the initial installation

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -41,6 +41,8 @@ var (
 		// The Longhorn storage over-provisioning percentage is set to 100, whereas Harvester uses 200.
 		// This needs to be synchronized when Harvester starts.
 		settings.OvercommitConfigSettingName,
+		// always run this when Harvester POD starts
+		settings.AdditionalGuestMemoryOverheadRatioName,
 	}
 	skipHashCheckSettings = []string{
 		settings.AutoRotateRKE2CertsSettingName,


### PR DESCRIPTION
Fix the additional-guest-memory-overhead-ratio not synced on the initial installation

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The setting `additional-guest-memory-overhead-ratio` in not synced to kubevirt when the cluster is freshly installed.


Such differences are observed on a newly installed cluster:
```
settings.harvesterhci.io additional-guest-memory-overhead-ratio -oyaml
apiVersion: harvesterhci.io/v1beta1
default: "1.5"
kind: Setting
metadata:
  creationTimestamp: "2024-10-08T08:54:38Z"
  generation: 1
  name: additional-guest-memory-overhead-ratio
  resourceVersion: "6218"
  uid: 73403dca-f0a3-4c46-a29c-b8c353fe4a1f
status: {}

settings.harvesterhci.io kubeconfig-default-token-ttl-minutes -oyaml
apiVersion: harvesterhci.io/v1beta1
default: "0"
kind: Setting
metadata:
  annotations:
    harvesterhci.io/hash: d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f
  creationTimestamp: "2024-10-08T08:54:38Z"
  generation: 4
  name: kubeconfig-default-token-ttl-minutes
  resourceVersion: "25686"
  uid: b89ca1aa-d389-497e-ab9a-287540657c5d
status:
  conditions:
  - lastUpdateTime: "2024-10-09T11:37:08Z"
    status: "False"
    type: configured
```

The handler has some complex mechanisms to deal with different cases:

https://github.com/harvester/harvester/blob/ca2960c777fe878086a2885446f8772cfbafe3c1/pkg/controller/master/setting/handler.go#L97

https://github.com/harvester/harvester/blob/ca2960c777fe878086a2885446f8772cfbafe3c1/pkg/controller/master/setting/handler.go#L109



**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add this setting to bootstrap list as well, sure it runs even on freshly installed cluster.

**Related Issue:**
https://github.com/harvester/harvester/issues/5768

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install a new cluster
2. check `additional-guest-memory-overhead-ratio` default value is synced to `kubevirt`
```
$ kubectl get kubevirt -n harvester-system kubevirt -oyaml | grep overhead -i
    additionalGuestMemoryOverheadRatio: "1.5"

```