### PR TITLE
enhancement: Prevent Upgrade if VM Backup (Schedule) Under Processing

### DIFF
--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -9,6 +9,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/controller/master/backup"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 	"github.com/harvester/harvester/pkg/webhook/clients"
@@ -16,6 +17,7 @@ import (
 
 const (
 	VMBackupBySourceUIDIndex              = "harvesterhci.io/vmbackup-by-source-uid"
+	VMBackupByIsProgressing               = "harvesterhci.io/vmbackup-by-is-progressing"
 	VMRestoreByTargetNamespaceAndName     = "harvesterhci.io/vmrestore-by-target-namespace-and-name"
 	VMRestoreByVMBackupNamespaceAndName   = "harvesterhci.io/vmrestore-by-vmbackup-namespace-and-name"
 	VMBackupSnapshotByPVCNamespaceAndName = "harvesterhci.io/vmbackup-snapshot-by-pvc-namespace-and-name"
@@ -23,6 +25,7 @@ const (
 	ImageByExportSourcePVCIndex           = "harvesterhci.io/image-by-export-source-pvc"
 	ScheduleVMBackupBySourceVM            = "harvesterhci.io/svmbackup-by-source-vm"
 	ScheduleVMBackupByCronGranularity     = "harvesterhci.io/svmbackup-by-cron-granularity"
+	ScheduleVMBackupBySuspended           = "harvesterhci.io/svmbackup-by-suspended"
 	ImageByStorageClass                   = "harvesterhci.io/image-by-storage-class"
 	VMInstanceMigrationByVM               = "harvesterhci.io/vmim-by-vm"
 )
@@ -31,6 +34,7 @@ func RegisterIndexers(clients *clients.Clients) {
 	vmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
 	vmBackupCache.AddIndexer(VMBackupBySourceUIDIndex, vmBackupBySourceUID)
 	vmBackupCache.AddIndexer(VMBackupSnapshotByPVCNamespaceAndName, vmBackupSnapshotByPVCNamespaceAndName)
+	vmBackupCache.AddIndexer(VMBackupByIsProgressing, vmBackupByIsProgressing)
 
 	vmRestoreCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache()
 	vmRestoreCache.AddIndexer(VMRestoreByTargetNamespaceAndName, vmRestoreByTargetNamespaceAndName)
@@ -52,6 +56,7 @@ func RegisterIndexers(clients *clients.Clients) {
 	svmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache()
 	svmBackupCache.AddIndexer(ScheduleVMBackupBySourceVM, scheduleVMBackupBySourceVM)
 	svmBackupCache.AddIndexer(ScheduleVMBackupByCronGranularity, scheduleVMBackupByCronGranularity)
+	svmBackupCache.AddIndexer(ScheduleVMBackupBySuspended, scheduleVMBackupBySuspended)
 
 	scInformer := clients.StorageFactory.Storage().V1().StorageClass().Cache()
 	scInformer.AddIndexer(indexeresutil.StorageClassBySecretIndex, indexeresutil.StorageClassBySecret)
@@ -78,6 +83,11 @@ func vmBackupSnapshotByPVCNamespaceAndName(obj *harvesterv1.VirtualMachineBackup
 		result = append(result, fmt.Sprintf("%s/%s", pvc.ObjectMeta.Namespace, pvc.ObjectMeta.Name))
 	}
 	return result, nil
+}
+
+func vmBackupByIsProgressing(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {
+	isProgressingStr := strconv.FormatBool(backup.IsBackupProgressing(obj))
+	return []string{string(isProgressingStr)}, nil
 }
 
 func vmRestoreByTargetNamespaceAndName(obj *harvesterv1.VirtualMachineRestore) ([]string, error) {
@@ -123,6 +133,11 @@ func scheduleVMBackupByCronGranularity(obj *harvesterv1.ScheduleVMBackup) ([]str
 	}
 
 	return []string{granularity.String()}, nil
+}
+
+func scheduleVMBackupBySuspended(obj *harvesterv1.ScheduleVMBackup) ([]string, error) {
+	suspenedStr := strconv.FormatBool(obj.Status.Suspended)
+	return []string{string(suspenedStr)}, nil
 }
 
 func imageByStorageClass(obj *harvesterv1.VirtualMachineImage) ([]string, error) {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -79,6 +79,8 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.ClusterFactory.Cluster().V1beta1().Machine().Cache(),
 			clients.RancherManagementFactory.Management().V3().ManagedChart().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Version().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 			&http.Client{
 				Transport: transport,


### PR DESCRIPTION
**Problem:**
While the VM Backup is under processing, it may occupy one LH VA ticket. This can cause the following VM operation (e.q. VM Live migration) to be blocked by LH VA webhook https://github.com/longhorn/longhorn-manager/blob/5ff1f83aefb2c17365264d7cc111e04415c9cef8/webhook/resources/volumeattachment/validator.go#L121-L124

**Solution:**
Prevent upgrade if there is VM Backup (VM Backup Schedule) under processing

**Related Issue:**
#6754 

**Test plan:**
- Building the Harvester cluster with master-head (`d4c699718434682dda46c201cbbd87e80d23db8d`)
- Setting ManageChart harvester's spec.paused = true
- Updating Harvester Webhook deployment with this PR
- Applying a version manifest upgrade to the same version, e.q. 
  ```
  apiVersion: harvesterhci.io/v1beta1
  kind: Version
  metadata:
    name: master
    namespace: harvester-system
  spec:
    isoURL: http://192.188.0.54:8080/iso/harvester-master-amd64.iso
  ```
- Creating a VM `vm1`
- Creating vmbackup for VM `vm1`, during the backup in progress, start the upgrade
- The upgrade CR creation will be rejected with message `vmbackup <vmabckup name> is under processing`
- Creating a backup schedule for VM `vm1`, and making sure the schedule is not suspended
- Starting the upgrade, the upgrade CR creation will be rejected with the message `schedule <scheduke name> is running`