### PR TITLE
fix(upgrade): source "upgrade to" version from repoinfo

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -299,7 +299,7 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 		toUpdate.Status.RepoInfo = repoInfoStr
 
 		// Upgrade Eligibility Check
-		isEligible, reason := upgradeEligibilityCheck(upgrade)
+		isEligible, reason := upgradeEligibilityCheck(toUpdate)
 
 		if !isEligible {
 			setUpgradeCompletedCondition(toUpdate, StateFailed, corev1.ConditionFalse, reason, "")

--- a/pkg/upgradehelper/versionguard/version_test.go
+++ b/pkg/upgradehelper/versionguard/version_test.go
@@ -19,6 +19,7 @@ const (
 var (
 	repoInfoTemplate = `
 release:
+  harvester: %s
   minUpgradableVersion: %s
 `
 )
@@ -38,12 +39,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2.2",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.1",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.1"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2", "v1.2.1"),
 				},
 			},
 			strictMode: true,
@@ -55,12 +53,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2.2",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.0",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.1"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2", "v1.2.1"),
 				},
 			},
 			strictMode:  true,
@@ -73,12 +68,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2.0",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.1",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.1.2"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.0", "v1.1.2"),
 				},
 			},
 			strictMode:  true,
@@ -91,12 +83,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2.2-rc1",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.1",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.1"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2-rc1", "v1.2.1"),
 				},
 			},
 			strictMode: true,
@@ -108,12 +97,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2.2-rc2",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.2-rc1",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.1"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2-rc2", "v1.2.1"),
 				},
 			},
 			strictMode: true,
@@ -125,12 +111,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2.2-rc1",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.2-rc2",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.1"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2-rc1", "v1.2.1"),
 				},
 			},
 			strictMode:  true,
@@ -143,11 +126,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2-head",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.1",
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2-head", ""),
 				},
 			},
 			strictMode: true,
@@ -159,11 +140,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.3-head",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2-head",
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.3-head", ""),
 				},
 			},
 			strictMode: true,
@@ -175,12 +154,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.3.1",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2-head",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.3.1", "v1.2.2"),
 				},
 			},
 			strictMode:  true,
@@ -193,12 +169,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.3.1",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2-head",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.3.1", "v1.2.2"),
 				},
 			},
 			strictMode: false,
@@ -210,12 +183,9 @@ func TestCheck(t *testing.T) {
 					Namespace: testUpgradeNamespace,
 					Name:      testUpgradeName,
 				},
-				Spec: v1beta1.UpgradeSpec{
-					Version: "v1.2.2",
-				},
 				Status: v1beta1.UpgradeStatus{
 					PreviousVersion: "v1.2.2-rc1",
-					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.1"),
+					RepoInfo:        fmt.Sprintf(repoInfoTemplate, "v1.2.2", "v1.2.1"),
 				},
 			},
 			strictMode: true,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

A user may manually create a version CR with custom naming to trigger an upgrade. For instance:

```
cat > ./version.yaml << EOF
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: local-upgrade
  namespace: harvester-system
spec:
  isoChecksum: 2b99b0870d3363b393bb7900c53b8a1f529e150519558cea672e9ff8eab19ba0dac3f35688e49cdc2ac3ba0d253017fd3d8790cb229856735e30c524f56f22a7
  isoURL: http://192.168.1.1/harvester-amd64.iso
EOF
```

The name of the Version CR is then used to create the corresponding Upgrade CR. It will be in the `.spec.version` field. The upgrade eligibility check currently relies on that field to determine what version it will upgrade to. Apparently, it's not so reliable. We need to fix this.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The `.spec.version` field in the Upgrade CR is not reliable. Instead of relying on that field to determine the "upgrade to" version, we read from the release version of the `.status.repoInfo` field. Those information is populated from the content in the ISO image.

**Related Issue:**

#5494 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a single-node Harvester cluster containing this fix
2. Fake the version to v1.4.0 by adding `HARVESTER_SERVER_VERSION=v1.4.0` environment variable to the `harvester` Deployment
3. Trigger an upgrade to v1.3.2 (simulating a downgrade)
   1. Create a Version CR with a custom name, e.g., `local-upgrade`
   2. Apply the Version CR
   3. Choose the version and click the upgrade button from the dashboard
4. The upgrade should end in the "downgrading is prohibited" error after the upgrade repo VM is up and running.
   <img src="https://github.com/user-attachments/assets/1fd2bff6-c632-4c4f-ba07-3da6018e5aec" height="600">
