### PR TITLE
fix(backup): update backup status if there is condition change

### DIFF
--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -866,6 +866,10 @@ func (h *Handler) uploadVMBackupMetadata(vmBackup *harvesterv1.VirtualMachineBac
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: currentTime().Format(time.RFC3339),
 	})
+	if !reflect.DeepEqual(vmBackup.Status, vmBackupCopy.Status) {
+		_, err = h.vmBackups.Update(vmBackupCopy)
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We didn't update VMBackup when we set a `MetadataReady` condition.

**Solution:**
Updated it if VMBackup status is different from previous one.

**Related Issue:**
https://github.com/harvester/harvester/issues/6766

**Test plan:**
1. Setting a backup target.
2. Creating a VM and having a VMBackup.
3. Check VMBackup CR's MetadataReady condition is true.
