### PR TITLE
fix(vmimage): prevent removing vmimage if any vmbackup uses it

### DIFF
--- a/pkg/webhook/resources/virtualmachineimage/validator_test.go
+++ b/pkg/webhook/resources/virtualmachineimage/validator_test.go
@@ -194,7 +194,8 @@ func Test_virtualMachineImageValidator_CheckImageSecurityParameters(t *testing.T
 	fakeVMIMageCache := fakeclients.VirtualMachineImageCache(harvesterClientSet.HarvesterhciV1beta1().VirtualMachineImages)
 	fakeSecretCache := fakeclients.SecretCache(coreclientset.CoreV1().Secrets)
 	fakeStorageClassCache := fakeclients.StorageClassCache(coreclientset.StorageV1().StorageClasses)
-	validator := NewValidator(fakeVMIMageCache, nil, nil, nil, fakeSecretCache, fakeStorageClassCache).(*virtualMachineImageValidator)
+	fakeVMBackupCache := fakeclients.VMBackupCache(harvesterClientSet.HarvesterhciV1beta1().VirtualMachineBackups)
+	validator := NewValidator(fakeVMIMageCache, nil, nil, nil, fakeSecretCache, fakeStorageClassCache, fakeVMBackupCache).(*virtualMachineImageValidator)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -70,7 +70,8 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.K8s.AuthorizationV1().SelfSubjectAccessReviews(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion().Cache(),
 			clients.Core.Secret().Cache(),
-			clients.StorageFactory.Storage().V1().StorageClass().Cache()),
+			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()),
 		upgrade.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),
 			clients.Core.Node().Cache(),


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We didn't prevent users from removing VM image when there is a VM backup using it. If users remove the VM image, the related VM backup can't work.

**Solution:**
Prevent users from removing VM image if any vmbackup uses it.

**Related Issue:**
https://github.com/harvester/harvester/issues/6782

**Test plan:**
1. Setup backup target.
2. Create a VM image, VM, and VM backup.
3. Remove VM.
4. Remove VM image. Webhook should prevent this behavior.

![Screenshot 2024-10-15 at 5 29 41 PM](https://github.com/user-attachments/assets/b558d6d1-30ab-4ad7-a27f-55f04fdbc2d1)

