### PR TITLE
Add Rancher's VEXHub reports to Trivy scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,10 +9,13 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Download Rancher's VEX Hub report
+        run: curl -fsSO https://raw.githubusercontent.com/rancher/vexhub/refs/heads/main/reports/rancher.openvex.json
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@master
@@ -22,8 +25,11 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
+        env:
+          TRIVY_VEX: rancher.openvex.json
+          TRIVY_SHOW_SUPPRESSED: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Known false-positive CVEs might be reported in the current Trivy scan workflow. This leads to noisy CVEs alerts that can ideally be suppressed without concerns.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Feed Rancher's VEX Hub reports into the Trivy scan workflow to remove the already identified false-positive CVEs.

This PR also:
- Update Ubuntu's version.
- Bump `actions/checkout` to `v4`.
- Bump `github/codeql-action/upload-sarif` to `v3`, because `v2` is about to be deprecated as can be seen in the workflow's output (https://github.com/harvester/harvester/actions/runs/11368174861).

**Related Issue:**
Closes https://github.com/harvester/harvester/issues/6802

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Not needed.