### PR TITLE
minor tweak to how node scheduling requirements are calculated

### DIFF
--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -442,10 +442,9 @@ func (ndc *ControllerHandler) CheckVMISchedulingRequirements(originalNode *corev
 		return nil, fmt.Errorf("error listing nodes from nodeCache: %v", err)
 	}
 	var validNodes []*corev1.Node
-	for i, v := range nodeList {
-		if v.Name == originalNode.Name {
-			validNodes = append(nodeList[:i], nodeList[i+1:]...)
-			break
+	for _, v := range nodeList {
+		if v.Name != originalNode.Name && isNodeReady(v) {
+			validNodes = append(validNodes, v)
 		}
 	}
 	for _, vmi := range vmiList {
@@ -457,7 +456,7 @@ func (ndc *ControllerHandler) CheckVMISchedulingRequirements(originalNode *corev
 			}
 			// identify if nodeAffinity can be met by other nodes and node is ready
 			for _, v := range validNodes {
-				if nodeAffinitySelector.Match(v) && isNodeReady(v) {
+				if nodeAffinitySelector.Match(v) {
 					possibleNodes = append(possibleNodes, v)
 				}
 			}

--- a/pkg/controller/master/nodedrain/nodedrain_controller_test.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller_test.go
@@ -628,4 +628,9 @@ func Test_virtualMachineContainsHostName(t *testing.T) {
 	nonMigratableVMIs, err := ndc.CheckVMISchedulingRequirements(node1, vmiList)
 	assert.NoError(err)
 	assert.Len(nonMigratableVMIs, 1, "expected to find 1 VMI")
+	vmi.Spec.Affinity = nil // simulate a masquerade network
+	nonMigratableVMIs, err = ndc.CheckVMISchedulingRequirements(node1, vmiList)
+	assert.NoError(err)
+	assert.Len(nonMigratableVMIs, 1, "expected to find 1 VMI")
+
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Original PR to identify VM's with hostname specification and mark them unschedulable https://github.com/harvester/harvester/pull/6397 seems to work only when VM's have a VM network in use.

This happens because when a VM network is added,  harvester injects additional node affinity requirements to ensure VM gets scheduled to nodes which support the VM network. This check subsequently also checks if additional nodeSelector is defined. 

When a VM is pinned to a host, a nodeSelector is added by Harvester to allow hostname matching to target node.

This check fails when a masquerade network is used as the check for node affinity requirements is skipped since no network specific affinity rules are added. As a result of this the subsequent nodeSelector based check is also skipped.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR refactors the code to ensure nodeSelector based scheduling checks are run even no affinity requirements are specified for VM.

**Related Issue:**
https://github.com/harvester/harvester/issues/6509
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
