### PR TITLE
disable multipathd as default behaviour in upgrade to v1.4.0

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -627,6 +627,18 @@ EOF
   GRUBENV_FILE="/oem/grubcustom"
   chroot $HOST_DIR /bin/bash -c "if ! [ -f ${GRUBENV_FILE} ]; then touch ${GRUBENV_FILE}; fi" 
 
+  multiPathEnabled=$(yq '.os.externalStorageConfig.enabled // false' ${HOST_DIR}/oem/harvester.config)
+  if [ ${multiPathEnabled} == false ]
+  then
+    thirdPartyArgs=$(chroot $HOST_DIR grub2-editenv /oem/grubenv list |grep third_party_kernel_args | awk -F"third_party_kernel_args=" '{print $2}')
+    if [[ ${thirdPartyArgs} != *"multipath=off"* ]]
+    then
+      thirdPartyArgs="${thirdPartyArgs} multipath=off"
+      thirdPartyArgs=$(echo ${thirdPartyArgs} | xargs)
+      chroot $HOST_DIR grub2-editenv /oem/grubenv set third_party_kernel_args="${thirdPartyArgs}"
+    fi
+  fi
+
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
v1.4.0 builds enable multipathd by default in the iso. This is needed to help install to multipath devices where needed and users can subsequently enable multipathd via harvester.config

The side effect of this change is during upgrade when the v1.4 based image is replaced on the node multipath is enabled by default and kernel boots off the /dev/mapper devices even though multipathd gets disabled later in the boot sequence.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR adds an extra check in the upgrade path to pass an additional kernel argument via /oem/grubenv file to add `multipath=off` to the kernel parameters.

This results in multipathd being disabled post boot and no /dev/mapper devices being created when they are not needed.

**Related Issue:**
https://github.com/harvester/harvester/issues/6646

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
* Install a harvester v1.3.2 cluster
* Upgrade cluster to v1.4-head or v1.4.0-rc5
* Post upgrade run `df -h` on the nodes and there should be no `/dev/mapper` based devices used for mount
* `dmesg |grep -i multipath` should show `multipath=off` in the kernel arguments