### PR TITLE
fix(restore): send start request if related vmi is not found

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -925,7 +925,7 @@ func (h *RestoreHandler) startVM(vm *kubevirtv1.VirtualMachine) error {
 		vmi, err := h.vmiCache.Get(vm.Namespace, vm.Name)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				return nil
+				return h.restClient.Put().Namespace(vm.Namespace).Resource("virtualmachines").SubResource("start").Name(vm.Name).Do(h.context).Error()
 			}
 			return err
 		}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
When volume resources is ready for a restoring VM, we try to send a start request. However, if `runStrategy` is `RerunOnFailure` and related VMI is not existent, we do nothing.

https://github.com/harvester/harvester/blob/19bc22db86ec0c9d796ec1d9116c3ddce908082a/pkg/controller/master/backup/restore.go#L914-L938

**Solution:**
We should send a start request if VMI is not found.

**Related Issue:**
https://github.com/harvester/harvester/issues/6895

**Test plan:**
1. Create a new cluster with this PR.
2. Create a VM with `RerunOnFailure`.
3. Create a backup target.
4. Create a backup.
5. SSH into the VM and use command to shutdown it. (Don't click `stop` button on the UI, because this behavior change the `runStrategy`.)
6. Make sure the stopped VM `runStrategy` is `RerunOnFailure`.
7. Use the backup to restore replace the VM.
8. Check the VM can be restarted.
