### PR TITLE
fix: download kubectl by arch in upgrade images

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -7,7 +7,7 @@ RUN zypper rm -y container-suseconnect && \
     zypper in -y curl e2fsprogs rsync awk zstd jq helm zip unzip nginx && zypper clean -a
 
 ENV KUBECTL_VERSION v1.29.9
-RUN curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl > /usr/bin/kubectl && \
+RUN curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
 RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.3.1/virtctl-v1.3.1-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Prepare jobs's container image should use correct kubectl binary.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Download kubectl by arch.

**Related Issue:**

https://github.com/harvester/harvester/issues/6257

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
