### PR TITLE
upgrade: update harvester csi driver rbac

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -363,9 +363,9 @@ harvester-network-controller:
       tag: master-head
 
 harvester-networkfs-manager:
-  ## Specify to install harvester node disk manager,
-  ## defaults to "false".
-  enabled: false
+  ## Specify to install harvester networkfs manager,
+  ## defaults to "true".
+  enabled: true
 
   image:
     repository: rancher/harvester-networkfs-manager


### PR DESCRIPTION
    - To support RWX volume feature, we need new rbac for csi-driver role

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
`harvesterhci.io:csi-driver` needs new RBAC permissions to support RWX feature.

**Solution:**
Apply for needed permission when upgrade

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
