### PR TITLE
fix: Virtual Machine Image should keep track with LH BackingImage's DiskFileStatusMap

### DIFF
--- a/pkg/controller/master/image/vm_image_controller.go
+++ b/pkg/controller/master/image/vm_image_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harvesterv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/ref"
@@ -397,6 +398,9 @@ func handleFail(image *harvesterv1.VirtualMachineImage, cond condition.Cond, err
 		harvesterv1.ImageRetryLimitExceeded.False(image)
 		harvesterv1.ImageRetryLimitExceeded.Message(image, errMsg)
 	}
+	harvesterv1beta1.ImageImported.Unknown(image)
+	harvesterv1beta1.ImageImported.Reason(image, err.Error())
+	harvesterv1beta1.ImageImported.Message(image, err.Error())
 	return image
 }
 


### PR DESCRIPTION
**Problem:**
VirtualMachineImages do not keep in sync with LH BackingImage's DiskFileStatusMap

**Solution:**
VirtualMachineImages should update the status if there is no ready file in LH BackingImage's DiskFileStatusMap

**Related Issue:**
#6894 

**Test plan:**
1. Preparing a v1.3.2 Harvester cluster
2. Creating two images
3. Upgrading Harvester to v1.4.0-rc4
4. Existing images should be in an active state
5. Creating new images successfully
