### PR TITLE
Fix CI failure

### DIFF
--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -26,14 +26,10 @@ import (
 )
 
 const (
-	nodeDrainController                 = "node-drain-controller"
-	defaultWorkloadType                 = "VirtualMachineInstance"
-	defaultSingleCPCount                = 1
-	defaultHACPCount                    = 3
-	LastHealthyReplicaKey               = "LastHealthyReplica"
-	ContainerDiskOrCDRomKey             = "CDRomOrContainerDiskPresent"
-	NodeSchedulingRequirementsNotMetKey = "NodeSchedulingRequirementsNotMet"
-	MaintainModeStrategyKey             = "MaintainModeStrategy"
+	nodeDrainController  = "node-drain-controller"
+	defaultWorkloadType  = "VirtualMachineInstance"
+	defaultSingleCPCount = 1
+	defaultHACPCount     = 3
 )
 
 // ControllerHandler to drain nodes.
@@ -157,7 +153,7 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 				}
 			}
 
-			shutdownVMs[MaintainModeStrategyKey] = maintainModeStrategyVMs
+			shutdownVMs[util.MaintainModeStrategyKey] = maintainModeStrategyVMs
 		}
 
 		// Shutdown ALL VMs on that node forcibly? This is activated by a
@@ -334,7 +330,7 @@ func (ndc *ControllerHandler) FindNonMigratableVMS(node *corev1.Node) (map[strin
 	}
 
 	if len(impactedVMDetails) > 0 {
-		result[LastHealthyReplicaKey] = impactedVMDetails
+		result[util.LastHealthyReplicaKey] = impactedVMDetails
 	}
 
 	// list all VMI's currently scheduled on this node
@@ -350,7 +346,7 @@ func (ndc *ControllerHandler) FindNonMigratableVMS(node *corev1.Node) (map[strin
 
 	cdromOrContainerDiskVMs, err := findVMSwithCDROMOrContainerDisk(vmiList)
 	if len(cdromOrContainerDiskVMs) > 0 {
-		result[ContainerDiskOrCDRomKey] = cdromOrContainerDiskVMs
+		result[util.ContainerDiskOrCDRomKey] = cdromOrContainerDiskVMs
 	}
 
 	for k, v := range IdentifyNonMigratableVMS(vmiList) {
@@ -363,7 +359,7 @@ func (ndc *ControllerHandler) FindNonMigratableVMS(node *corev1.Node) (map[strin
 	}
 
 	if len(unschedulableVMs) > 0 {
-		result[NodeSchedulingRequirementsNotMetKey] = unschedulableVMs
+		result[util.NodeSchedulingRequirementsNotMetKey] = unschedulableVMs
 	}
 
 	return result, nil

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -158,4 +158,10 @@ const (
 	// copied from helm pkg/action/validate.go
 	HelmReleaseNameAnnotation      = "meta.helm.sh/release-name"
 	HelmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
+
+	// moved from nodedrain_controller for public usage
+	ContainerDiskOrCDRomKey             = "CDRomOrContainerDiskPresent"
+	NodeSchedulingRequirementsNotMetKey = "NodeSchedulingRequirementsNotMet"
+	MaintainModeStrategyKey             = "MaintainModeStrategy"
+	LastHealthyReplicaKey               = "LastHealthyReplica"
 )


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

CI fails randomly: the returned data is a list, the members are randomly placed as they were converted from a map.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Check each return item precisely.

**Related Issue:**
https://github.com/harvester/harvester/issues/6919

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

make test, no random failures

```
go test -v -count 20 -run ^Test_vmWithPCIDevices
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
=== RUN   Test_vmWithPCIDevices
--- PASS: Test_vmWithPCIDevices (0.00s)
PASS
ok  	github.com/harvester/harvester/pkg/api/node	0.038s
```
