### PR TITLE
upgrade: correct the instance-manager checking mechanism when upgrade

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -451,7 +451,7 @@ wait_longhorn_manager() {
 
 wait_longhorn_instance_manager_aio() {
   node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true,node-role.harvesterhci.io/witness!=true -o json | jq -r '.items | length')
-  if [ $node_count -le 2 ]; then
+  if [ $node_count -lt 2 ]; then
     echo "Skip waiting instance-manager (aio), node count: $node_count"
     return
   fi
@@ -468,7 +468,7 @@ wait_longhorn_instance_manager_aio() {
   im_image_checksum="imi-${im_image_checksum:0:8}"
 
   # Wait for instance-manager (aio) pods upgraded to new version first.
-  kubectl get nodes -o json | jq -r '.items[].metadata.name' | while read -r node; do
+  kubectl get nodes.longhorn.io -n longhorn-system -o json | jq -r '.items[].metadata.name' | while read -r node; do
     echo "Checking instance-manager (aio) pod on node $node..."
     while [ true ]; do
       im_count=$(kubectl get instancemanager.longhorn.io --selector=longhorn.io/node=$node,longhorn.io/instance-manager-type=aio,longhorn.io/instance-manager-image=$im_image_checksum -n longhorn-system -o json | jq -r '.items | length')


### PR DESCRIPTION
    - Also correct the condition for single node checking

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The instance-manager checking will hang in an environment with more than three nodes that contain the witness node because the witness node did not run any Longhorn pods.

**Solution:**
Should skip the witness node when checking the instance-manager pod

**Related Issue:**
https://github.com/harvester/harvester/issues/6972

**Test plan:**
1. create five node 1.3.2 cluster that contains the witness node
2. Try to upgrade to v1.4.0
3. Upgrade should be successful.
