### PR TITLE
Ensure Target Directories Exists During Upgrade's Image-Preload Phase

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -16,7 +16,7 @@ download_file()
   echo "Downloading the file from \"$url\" to \"$output\"..."
   local i=0
   while [[ "$i" -lt 100 ]]; do
-    curl -sSfL "$url" -o "$output" && break
+    curl -sSfL "$url" -o "$output" --create-dirs && break
     echo "Failed to download the requested file from \"$url\" to \"$output\" with error code: $?, retrying ($i)..."
     sleep 10
     i=$((i + 1))


### PR DESCRIPTION
This PR updates the `curl` calls used during the upgrade's prepare job to ensure any missing target folders are created.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

There are reported cases where upgrade failed during the "prepare" job phase because the `curl` command wasn't able to download the image list files to the missing target directory.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Update the `curl` call in the `package/upgrade/lib.sh` script to use the built-in `--create-dirs` option to automatically create the necessary local directory hierarchy.

From the [`man` doc](https://curl.se/docs/manpage.html):

```
--create-dirs

When used in conjunction with the [-o, --output](https://curl.se/docs/manpage.html#-o) option, 
curl creates the necessary local directory hierarchy as needed. This option creates the directories 
mentioned with the [-o, --output](https://curl.se/docs/manpage.html#-o) option combined with 
the path possibly set with [--output-dir](https://curl.se/docs/manpage.html#--output-dir). If 
the combined output filename uses no directory, or if the directories it mentions already exist, 
no directories are created.
```

**Related Issue:**

#6963

**Test plan:**

i. Using `v1.3.1`, build a local ISO to include changes in this PR
i. Install and set up Harvester using the local ISO
i. Perform an upgrade following the [upgrade documentation](https://docs.harvesterhci.io/v1.3/upgrade/v1-3-1-to-v1-3-2)
i. Ensure that the upgrade completed successfully
i. Ensure that the `cattle-system/apply-hvst-upgrade-4hgz2-prepare-on-*` pod completed successfully

Additional verification:

* Launch the upgrade [container](https://github.com/harvester/harvester/blob/master/package/upgrade/Dockerfile) with a bind mount setting using Docker. Confirm that the in-container `curl` commands could successfully create the missing folder on the host

e.g., call `download_file` from within the container even though `/var/lib/rancher/agent/images/` doesn't exist on the host:

```sh
# call download_file within the container
2d5431e7ceee:/ # source /usr/local/bin/lib.sh
2d5431e7ceee:/ # download_file https://releases.rancher.com/harvester/v1.4.0-rc5/version.yaml /host/var/lib/rancher/agent/images/version.yaml
```

on the host, the `/var/lib/rancher/agent/images/` would have been created and the downloaded file written, as long as the container `uid` has `rw` permissions to the target path:

```sh
$ sudo ls -al /var/lib/rancher/agent/images/ 
total 12
drwxr-x--- 2 root root 4096 Nov 12 14:32 .
drwxr-x--- 3 root root 4096 Nov 12 14:32 ..
-rw-r--r-- 1 root root  378 Nov 12 14:32 version.yaml
```
