### PR TITLE
fix(upgrade): move waiting apiServerURL before waiting fleet cluster

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -110,10 +110,10 @@ wait_rollout_with_loop() {
 wait_cluster_local_and_fleet() {
   wait_new_fileds_in_cluster_fleet_crd
   wait_new_fileds_in_fleet_controller_configmap
+  wait_apiServerURL_in_fleet_controller_configmap
   wait_cluster_local_is_imported
   wait_fleet_agent_is_redeployed
   wait_cluster_local_is_ready
-  wait_apiServerURL_in_fleet_controller_configmap
 }
 
 debug_cluster_local_and_fleet() {

--- a/pkg/controller/master/mcmsettings/fleetcontroller.go
+++ b/pkg/controller/master/mcmsettings/fleetcontroller.go
@@ -36,7 +36,7 @@ func (h *mcmSettingsHandler) watchInternalEndpointSettings(_ string, setting *mg
 		return setting, nil
 	}
 
-	logrus.Debugf("reconcilling fleet-controller config for setting %s", setting.Name)
+	logrus.Infof("reconcilling fleet-controller config for setting %s", setting.Name)
 
 	fleetControllerConfig, err := h.configMapCache.Get(util.DefaultFleetControllerConfigMapNamespace, util.DefaultFleetControllerConfigMapName)
 	if err != nil {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
If `apiServerURL` is empty and it's filled with a new value, a new fleet-agent will start. We do harvester managed chart upgrade after the check. In this case, there may be a race condition.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Move the check before waiting for a ready fleet cluster, so the new agent doesn't cause race conditions.

**Related Issue:**
https://github.com/harvester/harvester/issues/6851

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
