### PR TITLE
fix(webhook): check vm with container disks before upgrade

### DIFF
--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -370,7 +370,7 @@ func (ndc *ControllerHandler) FindNonMigratableVMS(node *corev1.Node) (map[strin
 func findVMSwithCDROMOrContainerDisk(vmiList []*kubevirtv1.VirtualMachineInstance) ([]string, error) {
 	var impactedVMI []string
 	for _, vmi := range vmiList {
-		if vmContainsCDRomOrContainerDisk(vmi) {
+		if virtualmachineinstance.VMContainsCDRomOrContainerDisk(vmi) {
 			impactedVMI = append(impactedVMI, namespacedVMName(vmi))
 		}
 	}
@@ -385,21 +385,6 @@ func ActionHelper(nodeCache ctlcorev1.NodeCache, virtualMachineInstanceCache ctl
 		longhornVolumeCache:         longhornVolumeCache,
 		longhornReplicaCache:        longhornReplicaCache,
 	}
-}
-
-func vmContainsCDRomOrContainerDisk(vmi *kubevirtv1.VirtualMachineInstance) bool {
-	for _, disk := range vmi.Spec.Domain.Devices.Disks {
-		if disk.CDRom != nil {
-			return true
-		}
-	}
-
-	for _, volume := range vmi.Spec.Volumes {
-		if volume.VolumeSource.ContainerDisk != nil {
-			return true
-		}
-	}
-	return false
 }
 
 // IdentifyNonMigratableVMS finds VMI's with kubevirtv1.VirtualMachineInstanceIsMigratable condition


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
A VM with container disk can't be migrated. It will block upgrade in pre-drain status.

**Solution:**
Add webhook to check VM before starting upgrade.

**Related Issue:**
https://github.com/harvester/harvester/issues/7005

**Test plan:**
1. Create a new Harvester cluster.
2. Create a Windows VM and run it.
3. Create an upgrade. The webhook should deny the request.
4. Stop the Windows VM.
5. Create an upgrade again. It should pass.
