### PR TITLE
Introducing Harvester Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Harvester
 [![Go Report Card](https://goreportcard.com/badge/github.com/harvester/harvester)](https://goreportcard.com/report/github.com/harvester/harvester)
 [![Releases](https://img.shields.io/github/release/harvester/harvester.svg)](https://github.com/harvester/harvester/releases)
 [![Slack](https://img.shields.io/badge/slack-join-brightgreen)](https://slack.rancher.io/)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Harvester%20Guru-006BFF)](https://gurubase.io/g/harvester)
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. 
 It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. 
@@ -128,6 +127,8 @@ Harvester is 100% open-source software. The project source code is spread across
 If you need any help with Harvester, please join us at either our [Slack](https://slack.rancher.io/) #harvester channel or [forums](https://forums.rancher.com/) where most of our team hangs out at.
 
 If you have any feedback or questions, feel free to [file an issue](https://github.com/harvester/harvester/issues/new/choose).
+
+You can also [Ask Harvester Guru](https://gurubase.io/g/harvester), it is a Harvester-focused AI to answer your questions.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If you need any help with Harvester, please join us at either our [Slack](https:
 
 If you have any feedback or questions, feel free to [file an issue](https://github.com/harvester/harvester/issues/new/choose).
 
-You can also [Ask Harvester Guru](https://gurubase.io/g/harvester), it is a Harvester-focused AI to answer your questions.
+You can also [ask Harvester Guru](https://gurubase.io/g/harvester) your questions.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Harvester
 [![Go Report Card](https://goreportcard.com/badge/github.com/harvester/harvester)](https://goreportcard.com/report/github.com/harvester/harvester)
 [![Releases](https://img.shields.io/github/release/harvester/harvester.svg)](https://github.com/harvester/harvester/releases)
 [![Slack](https://img.shields.io/badge/slack-join-brightgreen)](https://slack.rancher.io/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Harvester%20Guru-006BFF)](https://gurubase.io/g/harvester)
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. 
 It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Harvester Guru](https://gurubase.io/g/harvester) to Gurubase. Harvester Guru uses the data from this repo and data from the [docs](https://docs.harvesterhci.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Harvester Guru", which highlights that Harvester now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Harvester Guru in Gurubase, just let me know that's totally fine.
