### PR TITLE
Save and restore fleet-controller configmap

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -114,7 +114,6 @@ wait_cluster_local_and_fleet() {
   wait_cluster_local_is_imported
   wait_fleet_agent_is_redeployed
   wait_cluster_local_is_ready
-  #wait_apiServerURL_in_fleet_controller_configmap
 }
 
 debug_cluster_local_and_fleet() {
@@ -322,7 +321,7 @@ save_fleet_controller_configmap()
     return 0
   fi
 
-  # local var will escape yq filed none-exsting error
+  # local var will escape yq field none-exsting error
   local apiServerURL=$(yq -e '.apiServerURL' $valuesfile)
   local apiServerCA=$(yq -e '.apiServerCA' $valuesfile)
   FLEET_APISERVERURL=$apiServerURL
@@ -352,10 +351,9 @@ restore_fleet_controller_configmap()
     return 0
   fi
 
-  # local var will escape yq filed none-exsting error
+  # local var will escape yq field none-exsting error
   local apiServerURL=$(yq -e '.apiServerURL' $valuesfile)
   local apiServerCA=$(yq -e '.apiServerCA' $valuesfile)
-
   local patchURL=false
   local patchCA=false
   if [[ ! -z "$FLEET_APISERVERURL" && "$apiServerURL" != "$FLEET_APISERVERURL" ]]; then
@@ -396,24 +394,6 @@ EOF
   rm -f ./$patchfile
   echo "sleep 20s for fleet-controller to work on new configmap"
   sleep 20
-}
-
-wait_apiServerURL_in_fleet_controller_configmap() {
-  while [ true ]; do
-    local configmap=$(kubectl get configmap fleet-controller -n cattle-fleet-system -ojsonpath="{.data.config}")
-    local apiServerField="apiServerURL"
-
-    if [ -n "$(echo "$configmap" | yq -e ".${apiServerField}")" ]; then
-      echo "apiServerURL field is not empty in cattle-fleet-system/fleet-controller configmap"
-      break
-    else
-      echo "apiServerURL field is empty in cattle-fleet-system/fleet-controller configmap"
-      sleep 2
-    fi
-
-    unset configmap
-    unset apiServerField
-  done
 }
 
 wait_capi_cluster() {

--- a/pkg/controller/master/mcmsettings/fleetcontroller.go
+++ b/pkg/controller/master/mcmsettings/fleetcontroller.go
@@ -64,6 +64,7 @@ func (h *mcmSettingsHandler) reconcileInternalCASetting(setting *mgmtv3.Setting,
 
 	var patchedConfigMap *corev1.ConfigMap
 	if currentVal != encodedCA {
+		logrus.Infof("patch fleet-controller configmap %v from %v to %v", util.APIServerCAKey, currentVal, encodedCA)
 		patchedConfigMap, err = patchConfigMap(fleetControllerConfig, util.APIServerCAKey, encodedCA)
 		if err != nil {
 			return setting, err
@@ -85,6 +86,7 @@ func (h *mcmSettingsHandler) reconcileInternalServerURLSetting(setting *mgmtv3.S
 
 	var patchedConfigMap *corev1.ConfigMap
 	if currentVal != apiServerURL {
+		logrus.Infof("patch fleet-controller configmap %v from %v to %v", util.APIServerURLKey, currentVal, apiServerURL)
 		patchedConfigMap, err = patchConfigMap(fleetControllerConfig, util.APIServerURLKey, apiServerURL)
 		if err != nil {
 			return setting, err


### PR DESCRIPTION
To avoid unexpected re-deployment of fleet-agent
as harvester-contrller will set configmap later

That may cause the Harvester managedchart upgrade
is disrupted and rolled back by the new fleet-agent

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
https://github.com/harvester/harvester/issues/6851
https://github.com/harvester/harvester/pull/7004#pullrequestreview-2442398649

From the test log https://github.com/harvester/harvester/pull/7022#issuecomment-2485725232, old harvester POD should update the configmap just after Rancher is upgraded by Helm. But in rare cases, it does not and until the new harvester POD (v1.4.0) is up.

This PR checks the configmap in upgrade script, if the configmap is not updated then update it with the saved values.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Break the potential race, run the controller related work on upgarde script in advance, avoid re-deployment of fleet-agent later.

**Related Issue:**
https://github.com/harvester/harvester/issues/6851
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->


**Local Test.**

my local env did not reproduce the error, the log showed the configmap had the desired value

```
...
wait rollout -n cattle-fleet-local-system statefulset fleet-agent
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
partitioned roll out complete: 1 new pods have been updated...
new field agentTLSMode is found in clusters.fleet.cattle.io crd
new field agentTLSMode is found in cattle-fleet-system/fleet-controller configmap
apiServerURL https://10.53.198.41 and apiServerCA LS0tLS1..== have already been same with saved values
wait until cluster.fleet local is Imported after fleet-controller is upgraded
NAME                                READY   STATUS    RESTARTS   AGE
fleet-controller-8569c5ccd9-jb94l   3/3     Running   0          69s

```

harvester-controller debug change:

when `setting.management internal-server-url` changes, Harvester-controller will detect and log:
```
time="2024-11-19T12:05:03Z" level=info msg="patch fleet-controller configmap apiServerURL from https://10.53.47.173 to https://10.53.47.174"
```
fleet-controller log:
```
time="2024-11-19T12:05:03Z" level=info msg="API server config changed, trigger cluster import for cluster fleet-local/local"
time="2024-11-19T12:05:03Z" level=info msg="Cluster import for 'fleet-local/local'. Deployed new agent"
````