### PR TITLE
chore: Update CI To Use Trivy v0.57.1

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -18,8 +18,9 @@ jobs:
         run: curl -fsSO https://raw.githubusercontent.com/rancher/vexhub/refs/heads/main/reports/rancher.openvex.json
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
+          version: 'v0.57.1'
           scan-type: 'fs'
           ignore-unfixed: true
           format: 'sarif'


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
CI has been failing intermittently due to GHCR rate limiting errors while attempting to pull Trivy in the `trivy-scanning` workflow.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Update the `trivy-scanning` workflow to Trivy v0.57.1. This new version of Trivy supports multiple image registry fallbacks to handle the increase GHCR rate limiting errors.

**Related Issue:**

Fix #7023.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
