### PR TITLE
feat(webhook): add certs check

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -71,7 +71,7 @@ type Handler struct {
 	longhornSettingCache ctllhv1.SettingCache
 	configmaps           ctlcorev1.ConfigMapClient
 	configmapCache       ctlcorev1.ConfigMapCache
-	serviceCache         ctlcorev1.ServiceCache
+	endpointCache        ctlcorev1.EndpointsCache
 	apps                 catalogv1.AppClient
 	managedCharts        ctlmgmtv3.ManagedChartClient
 	managedChartCache    ctlmgmtv3.ManagedChartCache

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -20,7 +20,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	clusters := management.ProvisioningFactory.Provisioning().V1().Cluster()
 	deployments := management.AppsFactory.Apps().V1().Deployment()
 	configmaps := management.CoreFactory.Core().V1().ConfigMap()
-	services := management.CoreFactory.Core().V1().Service()
+	endpoints := management.CoreFactory.Core().V1().Endpoints()
 	lhs := management.LonghornFactory.Longhorn().V1beta2().Setting()
 	apps := management.CatalogFactory.Catalog().V1().App()
 	managedCharts := management.RancherManagementFactory.Management().V3().ManagedChart()
@@ -49,7 +49,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		longhornSettingCache: lhs.Cache(),
 		configmaps:           configmaps,
 		configmapCache:       configmaps.Cache(),
-		serviceCache:         services.Cache(),
+		endpointCache:        endpoints.Cache(),
 		apps:                 apps,
 		managedCharts:        managedCharts,
 		managedChartCache:    managedCharts.Cache(),

--- a/pkg/util/certs.go
+++ b/pkg/util/certs.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"github.com/sirupsen/logrus"
+)
+
+func GetAddrEarliestExpiringCert(addr string) (*x509.Certificate, error) {
+	conf := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	conn, err := tls.Dial("tcp", addr, conf)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"addr": addr,
+			"conf": conf,
+		}).WithError(err).Error("tls.Dial")
+		return nil, err
+	}
+	defer conn.Close()
+
+	var earliestExpiringCert *x509.Certificate
+	certs := conn.ConnectionState().PeerCertificates
+	for _, cert := range certs {
+		if earliestExpiringCert == nil || earliestExpiringCert.NotAfter.After(cert.NotAfter) {
+			earliestExpiringCert = cert
+		}
+	}
+
+	return earliestExpiringCert, nil
+}
+
+func GetAddrsEarliestExpiringCert(addrs []string) (*x509.Certificate, error) {
+	var earliestExpiringCert *x509.Certificate
+	for _, addr := range addrs {
+		cert, err := GetAddrEarliestExpiringCert(addr)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"addr": addr,
+			}).WithError(err).Error("GetEarliestExpiringCert")
+			continue
+		}
+
+		if earliestExpiringCert == nil || earliestExpiringCert.NotAfter.After(cert.NotAfter) {
+			earliestExpiringCert = cert
+		}
+	}
+
+	return earliestExpiringCert, nil
+}

--- a/pkg/util/endpoint.go
+++ b/pkg/util/endpoint.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetKubernetesIps(endpointCache ctlcorev1.EndpointsCache) ([]string, error) {
+	endpoints, err := endpointCache.Get(metav1.NamespaceDefault, "kubernetes")
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"namespace": metav1.NamespaceDefault,
+			"name":      "kubernetes",
+		}).WithError(err).Error("endpointCache.Get")
+		return nil, err
+	}
+
+	var ips []string
+	for _, subset := range endpoints.Subsets {
+		for _, address := range subset.Addresses {
+			ips = append(ips, address.IP+":6443")
+		}
+	}
+
+	return ips, nil
+}

--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/docker/go-units"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -16,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
@@ -46,6 +48,8 @@ const (
 	defaultNewImageSize                uint64 = 13 * 1024 * 1024 * 1024 // 13GB, this value aggregates all tarball image sizes. It may change in the future.
 	defaultImageGCHighThresholdPercent        = 85.0                    // default value in kubelet config
 	freeSystemPartitionMsg                    = "df -h '/usr/local/'"
+	minCertsExpirationInDayAnnotation         = "harvesterhci.io/minCertsExpirationInDay"
+	defaultMinCertsExpirationInDay            = 7
 )
 
 func NewValidator(
@@ -59,6 +63,7 @@ func NewValidator(
 	vmBackupCache ctlharvesterv1.VirtualMachineBackupCache,
 	svmbackupCache ctlharvesterv1.ScheduleVMBackupCache,
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
+	endpointCache v1.EndpointsCache,
 	httpClient *http.Client,
 	bearToken string,
 ) types.Validator {
@@ -73,6 +78,7 @@ func NewValidator(
 		vmBackupCache:     vmBackupCache,
 		svmbackupCache:    svmbackupCache,
 		vmiCache:          vmiCache,
+		endpointCache:     endpointCache,
 		httpClient:        httpClient,
 		bearToken:         bearToken,
 	}
@@ -91,6 +97,7 @@ type upgradeValidator struct {
 	vmBackupCache     ctlharvesterv1.VirtualMachineBackupCache
 	svmbackupCache    ctlharvesterv1.ScheduleVMBackupCache
 	vmiCache          ctlkubevirtv1.VirtualMachineInstanceCache
+	endpointCache     v1.EndpointsCache
 	httpClient        *http.Client
 	bearToken         string
 }
@@ -191,7 +198,11 @@ func (v *upgradeValidator) checkResources(version *v1beta1.Version) error {
 		return err
 	}
 
-	return v.checkNonLiveMigratableVMs()
+	if err := v.checkNonLiveMigratableVMs(); err != nil {
+		return err
+	}
+
+	return v.checkCerts(version)
 }
 
 func (v *upgradeValidator) hasDegradedVolume() (bool, error) {
@@ -513,4 +524,39 @@ func (v *upgradeValidator) getKubeletStatsSummary(nodeName, kubeletURL string) (
 		return nil, werror.NewInternalError(fmt.Sprintf("node %s, can't parse json response %s, err: %+v", nodeName, string(body), err))
 	}
 	return summary, nil
+}
+
+func (v *upgradeValidator) checkCerts(version *v1beta1.Version) error {
+	kubernetesIPs, err := util.GetKubernetesIps(v.endpointCache)
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("can't get list of kubernetes ip, err: %+v", err))
+	}
+	if len(kubernetesIPs) == 0 {
+		err = fmt.Errorf("cluster ip is empty")
+		logrus.WithFields(logrus.Fields{
+			"namespace": metav1.NamespaceDefault,
+			"name":      "kubernetes",
+		}).WithError(err).Error("cluster ip is empty in the endpoints")
+		return werror.NewInternalError(fmt.Sprintf("can't get kubernetes ip, err: %+v", err))
+	}
+
+	earliestExpiringCert, err := util.GetAddrsEarliestExpiringCert(kubernetesIPs)
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("can't get earliest expiring cert, err: %+v", err))
+	}
+
+	minCertsExpirationInDay := defaultMinCertsExpirationInDay
+	if value, ok := version.Annotations[minCertsExpirationInDayAnnotation]; ok {
+		minCertsExpirationInDay, err = strconv.Atoi(value)
+		if err != nil {
+			return werror.NewBadRequest(fmt.Sprintf("invalid value %s for annotation %s", value, minCertsExpirationInDayAnnotation))
+		}
+	}
+
+	expirationDate := time.Now().AddDate(0, 0, minCertsExpirationInDay)
+	if earliestExpiringCert.NotAfter.Before(expirationDate) {
+		return werror.NewBadRequest(fmt.Sprintf(
+			"earliest expiring cert for default/kubernetes ClusterIP is %s, it will expire in %s days. Please rotate RKE2 certificates.", earliestExpiringCert.NotAfter, strconv.Itoa(minCertsExpirationInDay)))
+	}
+	return nil
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -83,6 +83,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
+			clients.Core.Endpoints().Cache(),
 			&http.Client{
 				Transport: transport,
 				Timeout:   time.Second * 20,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
During upgrade, if some RKE2 certs are expiration, the node upgrade may be stuck.

**Solution:**
Add certs expiration validation when users create a Upgrade CR.

**Related Issue:**
https://github.com/harvester/harvester/issues/7056

**Test plan:**
### Certs is expired in 365 days.
1. Create a version.
```
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  annotations:
    harvesterhci.io/minFreeDiskSpaceGB: "5"
    harvesterhci.io/minCertsExpirationInDay: "365"
  name: master-head
  namespace: harvester-system
spec:
  isoURL: http://192.168.0.181:8000/harvester-master-amd64.iso
  minUpgradableVersion: v1.4.0
  releaseDate: "202401231"
```
2. Create an upgrade with the version. The webhook should deny the request, because the certification will be expired in 365 days.

<img width="668" alt="Screenshot 2024-11-28 at 4 20 45 PM" src="https://github.com/user-attachments/assets/b9cecacc-0d3f-49e3-a10b-f7a4cf98d0d0">

### Certs is not expired in 7 days
1. Create a new cluster.
2. Create a version.
```
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  annotations:
    harvesterhci.io/minFreeDiskSpaceGB: "5"
  name: master-head
  namespace: harvester-system
spec:
  isoURL: http://192.168.0.181:8000/harvester-master-amd64.iso
  minUpgradableVersion: v1.4.0
  releaseDate: "202401231"
```
3. Create an upgrade with the version. It should not get any error.