### PR TITLE
feat: add cpu / memory hotplug config

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -68,7 +68,9 @@ kubevirt:
       ## Specify kubevirt feature gates
       vmStateStorageClass: "vmstate-persistence"
       developerConfiguration:
-        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager", "VMPersistentState"]
+        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager", "VMPersistentState", "VMLiveUpdateFeatures"]
+
+      vmRolloutStrategy: "LiveUpdate"
 
       ## Specify the network configuration of VirtualMachineInstance.
       ##
@@ -108,6 +110,10 @@ kubevirt:
           resourceName: virt-handler
           resourceType: DaemonSet
           type: strategic
+
+    workloadUpdateStrategy:
+      workloadUpdateMethods:
+        - LiveMigrate
 
 ###########################################################################
 ###########################################################################
@@ -430,7 +436,7 @@ harvester-networkfs-manager:
 
   image:
     repository: rancher/harvester-networkfs-manager
-    pullPolicy: IfNotPresent 
+    pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: main-head
 
@@ -447,7 +453,7 @@ harvester-node-disk-manager:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: master-head
-  
+
   webhook:
     image:
       repository: rancher/harvester-node-disk-manager-webhook

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -268,6 +269,12 @@ func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) erro
 			return apierror.NewAPIError(validation.PermissionDenied, "User does not have permission to update resource quota")
 		}
 		return h.deleteResourceQuota(namespace, name)
+	case cpuAndMemoryHotplug:
+		var input CPUAndMemoryHotplugInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+		}
+		return h.cpuAndMemoryHotplug(namespace, name, input)
 	default:
 		return apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
 	}
@@ -1526,4 +1533,37 @@ func (h *vmActionHandler) deleteResourceQuota(namespace, name string) error {
 		return err
 	}
 	return nil
+}
+
+func (h *vmActionHandler) cpuAndMemoryHotplug(namespace, name string, input CPUAndMemoryHotplugInput) error {
+	if input.Sockets == 0 && input.Memory == "" {
+		return nil
+	}
+
+	patchOps := []string{}
+	if input.Sockets != 0 {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/cpu/sockets", "value": %d}`, input.Sockets))
+	}
+
+	if input.Memory != "" {
+		memory, err := resource.ParseQuantity(input.Memory)
+		if err != nil {
+			return fmt.Errorf("failed to parse memory quantity: %v", err)
+		}
+
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/memory/guest", "value": "%s"}`, memory.String()))
+	}
+
+	if len(patchOps) == 0 {
+		return nil
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"namespace": namespace,
+		"name":      name,
+		"patchOps":  patchOps,
+	}).Info("patch cpu and memory hotplug")
+	patchData := fmt.Sprintf("[%s]", strings.Join(patchOps, ","))
+	_, err := h.vms.Patch(namespace, name, k8stypes.JSONPatchType, []byte(patchData))
+	return err
 }

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -36,6 +36,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	server.BaseSchemas.MustImportAndCustomize(AddVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(RemoveVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(CloneInput{}, nil)
+	server.BaseSchemas.MustImportAndCustomize(CPUAndMemoryHotplugInput{}, nil)
 
 	dataVolumeClient := scaled.CdiFactory.Cdi().V1beta1().DataVolume()
 	vms := scaled.VirtFactory.Kubevirt().V1().VirtualMachine()
@@ -138,6 +139,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				dismissInsufficientResourceQuota: &actionHandler,
 				updateResourceQuotaAction:        &actionHandler,
 				deleteResourceQuotaAction:        &actionHandler,
+				cpuAndMemoryHotplug:              &actionHandler,
 			}
 			apiSchema.ResourceActions = map[string]schemas.Action{
 				startVM:    {},
@@ -179,6 +181,9 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 					Input: "updateResourceQuotaInput",
 				},
 				deleteResourceQuotaAction: {},
+				cpuAndMemoryHotplug: {
+					Input: "cpuAndMemoryHotplugInput",
+				},
 			}
 		},
 		Formatter: vmformatter.formatter,

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -51,3 +51,8 @@ type FindMigratableNodesOutput struct {
 type UpdateResourceQuotaInput struct {
 	TotalSnapshotSizeQuota string `json:"totalSnapshotSizeQuota"`
 }
+
+type CPUAndMemoryHotplugInput struct {
+	Sockets uint32 `json:"sockets"`
+	Memory  string `json:"memory"`
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Solution:**
KubeVirt 1.2 supports CPU / Memory hotplug to dynamically update cpu / memory claims for VMs at runtime. Harvester should leverage this feature to have flexible and efficient resource management.

**Related Issue:**
https://github.com/harvester/harvester/issues/5835

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

### Mac Address

1. Create a VM.
2. Check there is `harvesterhci.io/mac-address` annotation on the VM and the value keeps mac address of different interfaces in VMI.

```yaml
# vm
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  annotations:
    harvesterhci.io/mac-address: '{"default":"be:40:c3:88:75:7c"}'
```

```yaml
# vmi
status:
  interfaces:
  - infoSource: domain, guest-agent
    interfaceName: enp1s0
    ipAddress: 10.52.2.19
    ipAddresses:
    - 10.52.2.19
    mac: be:40:c3:88:75:7c
    name: default
    queueCount: 1
```

3. Stop / Restart VM and check the mac address is updated to VM devices.

```yaml
# vm
spec:
  template:
    spec:
      domain:
          interfaces:
          - macAddress: be:40:c3:88:75:7c
            masquerade: {}
            model: virtio
            name: default
```

### CPU / Memory hotplug

Since we need some update from UI, we can't create VM from UI currently.

1. Create a VMImage.

```yaml
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineImage
metadata:
  name: focal-image
  namespace: default
spec:
  checksum: ""
  displayName: focal-server-cloudimg-amd64.img
  pvcName: ""
  pvcNamespace: ""
  retry: 3
  sourceType: download
  storageClassParameters:
    migratable: "true"
    numberOfReplicas: "3"
    staleReplicaTimeout: "30"
    dataLocality: "strict-local"
  url: http://192.168.0.181:8000/focal-server-cloudimg-amd64.img
```

2. Create cloudinit secret.

```yaml
apiVersion: v1
data:
  networkdata: ""
  userdata: I2Nsb3VkLWNvbmZpZwpwYWNrYWdlX3VwZGF0ZTogdHJ1ZQpwYWNrYWdlczoKICAtIHFlbXUtZ3Vlc3QtYWdlbnQKcnVuY21kOgogIC0gLSBzeXN0ZW1jdGwKICAgIC0gZW5hYmxlCiAgICAtIC0tbm93CiAgICAtIHFlbXUtZ3Vlc3QtYWdlbnQuc2VydmljZQpwYXNzd29yZDogdGVzdApjaHBhc3N3ZDoKICBleHBpcmU6IGZhbHNlCnNzaF9wd2F1dGg6IHRydWUK
kind: Secret
metadata:
  labels:
    harvesterhci.io/cloud-init-template: harvester
  name: cloudinit-with-default-password
  namespace: default
type: secret
```

3. Create VM with 1 CPU and 1Gi memory.

```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  annotations:
    harvesterhci.io/vmRunStrategy: RerunOnFailure
    harvesterhci.io/volumeClaimTemplates: '[{"metadata":{"name":"vm1-disk-0-tioib","annotations":{"harvesterhci.io/imageId":"default/focal-image"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"longhorn-focal-image"}}]'
  labels:
    harvesterhci.io/creator: harvester
  name: vm1
  namespace: default
spec:
  runStrategy: RerunOnFailure
  template:
    metadata:
      annotations:
        harvesterhci.io/sshNames: '[]'
      creationTimestamp: null
      labels:
        harvesterhci.io/vmName: vm1
    spec:
      affinity: {}
      architecture: amd64
      domain:
        cpu:
          cores: 1
          sockets: 1
          threads: 1
        memory:
          guest: 1Gi
        devices:
          disks:
          - bootOrder: 1
            disk:
              bus: virtio
            name: disk-0
          - disk:
              bus: virtio
            name: cloudinitdisk
          inputs:
          - bus: usb
            name: tablet
            type: tablet
          interfaces:
          - masquerade: {}
            model: virtio
            name: default
        features:
          acpi:
            enabled: true
        machine:
          type: q35
      evictionStrategy: LiveMigrate
      hostname: vm1
      networks:
      - name: default
        pod: {}
      terminationGracePeriodSeconds: 120
      volumes:
      - name: disk-0
        persistentVolumeClaim:
          claimName: vm1-disk-0-tioib
      - cloudInitNoCloud:
          networkDataSecretRef:
            name: cloudinit-with-default-password
          secretRef:
            name: cloudinit-with-default-password
        name: cloudinitdisk
```

4. Do CPU hotplug.

```
> kubectl patch vm vm1 --type='json' \
-p='[{"op": "replace", "path": "/spec/template/spec/domain/cpu/sockets", "value": 2}]'
```

5. Check the CPU sockets on VMI is `2`. The vCPU in KubeVirt is cores * sockets * threads.

```yaml
# vmi
spec:
  domain:
    cpu:
      cores: 1
      maxSockets: 4
      model: host-model
      sockets: 2
      threads: 1
```

6. Do memory hotplug.

```
> kubectl patch vm vm1 -p='[{"op": "replace", "path": "/spec/template/spec/domain/memory/guest", "value": "2Gi"}]' --type='json'
```

7. Check the Memory on VMI is `2Gi`.

```yaml
# vmi
spec:
  domain:
    memory:
      guest: 2Gi
      maxGuest: 4Gi
```