### PR TITLE
refactor: use interface harvester server handler to organize with API

### DIFF
--- a/pkg/api/backuptarget/healthy_handler.go
+++ b/pkg/api/backuptarget/healthy_handler.go
@@ -3,19 +3,20 @@ package backuptarget
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	// Although we don't use following drivers directly, we need to import them to register drivers.
 	// NFS Ref: https://github.com/longhorn/backupstore/blob/3912081eb7c5708f0027ebbb0da4934537eb9d72/nfs/nfs.go#L47-L51
 	// S3 Ref: https://github.com/longhorn/backupstore/blob/3912081eb7c5708f0027ebbb0da4934537eb9d72/s3/s3.go#L33-L37
 	_ "github.com/longhorn/backupstore/nfs" //nolint
 	_ "github.com/longhorn/backupstore/s3"  //nolint
+	"github.com/rancher/apiserver/pkg/apierror"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/settings"
-	"github.com/harvester/harvester/pkg/util"
 	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
@@ -33,31 +34,27 @@ func NewHealthyHandler(scaled *config.Scaled) *HealthyHandler {
 	}
 }
 
-func (h *HealthyHandler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
+func (h *HealthyHandler) Do(_ *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
 	backupTargetSetting, err := h.settingCache.Get(settings.BackupTargetSettingName)
 	if err != nil {
-		util.ResponseError(rw, http.StatusInternalServerError, fmt.Errorf("can't get %s setting, error: %w", settings.BackupTargetSettingName, err))
-		return
+		return nil, apierror.NewAPIError(validation.ServerError, fmt.Errorf("can't get %s setting, error: %w", settings.BackupTargetSettingName, err).Error())
 	}
 	if backupTargetSetting.Value == "" {
-		util.ResponseError(rw, http.StatusBadRequest, fmt.Errorf("%s setting is not set", settings.BackupTargetSettingName))
-		return
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, fmt.Errorf("%s setting is not set", settings.BackupTargetSettingName).Error())
 	}
 
 	target, err := settings.DecodeBackupTarget(backupTargetSetting.Value)
 	if err != nil {
-		util.ResponseError(rw, http.StatusInternalServerError, fmt.Errorf("can't decode %s setting %s, error: %w", settings.BackupTargetSettingName, backupTargetSetting.Value, err))
-		return
+		return nil, apierror.NewAPIError(validation.ServerError, fmt.Errorf("can't decode %s setting %s, error: %w", settings.BackupTargetSettingName, backupTargetSetting.Value, err).Error())
 	}
 	if target.IsDefaultBackupTarget() {
-		util.ResponseError(rw, http.StatusBadRequest, fmt.Errorf("can't check the backup target healthy, %s setting is not set", settings.BackupTargetSettingName))
-		return
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, fmt.Errorf("can't check the backup target healthy, %s setting is not set", settings.BackupTargetSettingName).Error())
 	}
 
 	_, err = backuputil.GetBackupStoreDriver(h.secretCache, target)
 	if err != nil {
-		util.ResponseError(rw, http.StatusServiceUnavailable, fmt.Errorf("can't connect to backup target %+v, error: %w", target, err))
-		return
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, fmt.Errorf("can't connect to backup target %+v, error: %w", target, err).Error())
 	}
-	util.ResponseOK(rw)
+
+	return nil, nil
 }

--- a/pkg/api/cluster/schema.go
+++ b/pkg/api/cluster/schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/steve/pkg/server"
 
 	"github.com/harvester/harvester/pkg/config"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 const (
@@ -27,10 +28,10 @@ type Cluster struct {
 // The cluster link handlers allow querying details of device allocation
 // from all nodes in the cluster
 func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
-	handler := Handler{
+	handler := harvesterServer.NewHandler(Handler{
 		nodeCache: scaled.CoreFactory.Core().V1().Node().Cache(),
 		vmCache:   scaled.VirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
-	}
+	})
 
 	fakeClusterStore := &Store{
 		&empty.Store{},

--- a/pkg/api/image/schema.go
+++ b/pkg/api/image/schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harvester/harvester/pkg/image/backingimage"
 	"github.com/harvester/harvester/pkg/image/cdi"
 	"github.com/harvester/harvester/pkg/image/common"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
@@ -35,12 +36,12 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		harvesterv1.VMIBackendCDI:          cdi.GetUploader(ctlcdi, scClient, ctlcdiupload, http.Client{}, vmio),
 	}
 
-	imgHandler := Handler{
+	imgHandler := harvesterServer.NewHandler(Handler{
 		vmiClient:   vmi,
 		vmio:        vmio,
 		downloaders: downloaders,
 		uploaders:   uploaders,
-	}
+	})
 
 	t := schema.Template{
 		ID: "harvesterhci.io.virtualmachineimage",

--- a/pkg/api/keypair/formatter.go
+++ b/pkg/api/keypair/formatter.go
@@ -3,7 +3,6 @@ package keypair
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 
 	"github.com/rancher/apiserver/pkg/apierror"
@@ -13,6 +12,7 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -30,35 +30,24 @@ type KeyGenActionHandler struct {
 	KeyPairCache ctlharvesterv1.KeyPairCache
 }
 
-func (h KeyGenActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if err := h.do(rw, req); err != nil {
-		status := http.StatusInternalServerError
-		if e, ok := err.(*apierror.APIError); ok {
-			status = e.Code.Status
-		}
-		rw.WriteHeader(status)
-		_, _ = rw.Write([]byte(err.Error()))
-		return
-	}
-	rw.WriteHeader(http.StatusOK)
-}
+func (h KeyGenActionHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
+	req, rw := ctx.Req(), ctx.RespWriter()
 
-func (h KeyGenActionHandler) do(rw http.ResponseWriter, req *http.Request) error {
 	input := &harvesterv1.KeyGenInput{}
 	if err := json.NewDecoder(req.Body).Decode(input); err != nil {
-		return apierror.NewAPIError(validation.InvalidBodyContent, fmt.Sprintf("Failed to parse body: %v", err))
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, fmt.Sprintf("Failed to parse body: %v", err))
 	}
 	if input.Name == "" || input.Namespace == "" {
-		return apierror.NewAPIError(validation.InvalidBodyContent, "both name and namespace is required")
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, "both name and namespace is required")
 	}
 	rsaKey, err := util.GeneratePrivateKey(2048)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	privateKey := util.EncodePrivateKeyToPEM(rsaKey)
 	publicKey, err := util.GeneratePublicKey(&rsaKey.PublicKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	keyPair := &harvesterv1.KeyPair{
@@ -72,12 +61,12 @@ func (h KeyGenActionHandler) do(rw http.ResponseWriter, req *http.Request) error
 	}
 
 	if _, err = h.KeyPairs.Create(keyPair); err != nil {
-		return err
+		return nil, err
 	}
 
 	rw.Header().Set("Content-Disposition", "attachment; filename="+input.Name+".pem")
 	rw.Header().Set("Content-Type", "application/octet-stream")
 	rw.Header().Set("Content-Length", strconv.Itoa(len(privateKey)))
 	_, err = rw.Write(privateKey)
-	return err
+	return nil, err
 }

--- a/pkg/api/keypair/schema.go
+++ b/pkg/api/keypair/schema.go
@@ -10,6 +10,7 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 const (
@@ -18,6 +19,10 @@ const (
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 	server.BaseSchemas.MustImportAndCustomize(harvesterv1.KeyGenInput{}, nil)
+	handler := harvesterServer.NewHandler(KeyGenActionHandler{
+		KeyPairs:     scaled.HarvesterFactory.Harvesterhci().V1beta1().KeyPair(),
+		KeyPairCache: scaled.HarvesterFactory.Harvesterhci().V1beta1().KeyPair().Cache(),
+	})
 	t := schema.Template{
 		ID: "harvesterhci.io.keypair",
 		Customize: func(s *types.APISchema) {
@@ -29,10 +34,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 			}
 			s.Formatter = Formatter
 			s.ActionHandlers = map[string]http.Handler{
-				keygen: KeyGenActionHandler{
-					KeyPairs:     scaled.HarvesterFactory.Harvesterhci().V1beta1().KeyPair(),
-					KeyPairCache: scaled.HarvesterFactory.Harvesterhci().V1beta1().KeyPair().Cache(),
-				},
+				keygen: handler,
 			}
 		},
 	}

--- a/pkg/api/namespace/schema.go
+++ b/pkg/api/namespace/schema.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/schemas"
 
 	"github.com/harvester/harvester/pkg/config"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 type UpdateResourceQuotaInput struct {
@@ -18,11 +19,11 @@ type UpdateResourceQuotaInput struct {
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
 
-	handler := &Handler{
+	handler := harvesterServer.NewHandler(&Handler{
 		resourceQuotaClient: scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().ResourceQuota(),
 		clientSet:           *scaled.Management.ClientSet,
 		ctx:                 scaled.Ctx,
-	}
+	})
 
 	nsformatter := nsformatter{
 		clientSet: *scaled.Management.ClientSet,

--- a/pkg/api/node/schema.go
+++ b/pkg/api/node/schema.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 type MaintenanceModeInput struct {
@@ -45,7 +46,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		return err
 	}
 
-	nodeHandler := ActionHandler{
+	nodeHandler := harvesterServer.NewHandler(ActionHandler{
 		jobCache:                    scaled.Management.BatchFactory.Batch().V1().Job().Cache(),
 		nodeClient:                  scaled.Management.CoreFactory.Core().V1().Node(),
 		nodeCache:                   scaled.Management.CoreFactory.Core().V1().Node().Cache(),
@@ -58,7 +59,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		dynamicClient:               dynamicClient,
 		virtSubresourceRestClient:   virtSubresourceClient,
 		ctx:                         scaled.Ctx,
-	}
+	})
 
 	server.BaseSchemas.MustImportAndCustomize(MaintenanceModeInput{}, nil)
 

--- a/pkg/api/uiinfo/ui_info_handler.go
+++ b/pkg/api/uiinfo/ui_info_handler.go
@@ -1,13 +1,12 @@
 package uiinfo
 
 import (
-	"net/http"
 	"os"
 
 	"github.com/harvester/harvester/pkg/config"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/settings"
-	"github.com/harvester/harvester/pkg/util"
 )
 
 type Handler struct {
@@ -20,7 +19,7 @@ func NewUIInfoHandler(scaled *config.Scaled, _ config.Options) *Handler {
 	}
 }
 
-func (h *Handler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
+func (h *Handler) Do(_ *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
 	uiSource := settings.UISource.Get()
 	if uiSource == "auto" {
 		if !settings.IsRelease() {
@@ -29,10 +28,11 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
 			uiSource = "bundled"
 		}
 	}
-	util.ResponseOKWithBody(rw, map[string]string{
+
+	return map[string]string{
 		settings.UISourceSettingName:               uiSource,
 		settings.UIIndexSettingName:                settings.UIIndex.Get(),
 		settings.UIPluginIndexSettingName:          settings.UIPluginIndex.Get(),
 		settings.UIPluginBundledVersionSettingName: os.Getenv(settings.GetEnvKey(settings.UIPluginBundledVersionSettingName)),
-	})
+	}, nil
 }

--- a/pkg/api/upgradelog/schema.go
+++ b/pkg/api/upgradelog/schema.go
@@ -10,10 +10,11 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/schemas"
 
 	"github.com/harvester/harvester/pkg/config"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Options) error {
-	upgradeLogHandler := Handler{
+	upgradeLogHandler := harvesterServer.NewHandler(Handler{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -22,7 +23,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		upgradeCache:     scaled.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),
 		upgradeLogCache:  scaled.HarvesterFactory.Harvesterhci().V1beta1().UpgradeLog().Cache(),
 		upgradeLogClient: scaled.HarvesterFactory.Harvesterhci().V1beta1().UpgradeLog(),
-	}
+	})
 
 	t := schema.Template{
 		ID: "harvesterhci.io.upgradelog",

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -46,6 +46,7 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/drainhelper"
@@ -96,20 +97,9 @@ type vmActionHandler struct {
 	clientSet                 kubernetes.Clientset
 }
 
-func (h vmActionHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if err := h.doAction(rw, req); err != nil {
-		status := http.StatusInternalServerError
-		if e, ok := err.(*apierror.APIError); ok {
-			status = e.Code.Status
-		}
-		rw.WriteHeader(status)
-		_, _ = rw.Write([]byte(err.Error()))
-		return
-	}
-	rw.WriteHeader(http.StatusNoContent)
-}
+func (h *vmActionHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
+	r, rw := ctx.Req(), ctx.RespWriter()
 
-func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(r))
 	action := vars["action"]
 	namespace := vars["namespace"]
@@ -117,178 +107,180 @@ func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) erro
 
 	user, ok := request.UserFrom(r.Context())
 	if !ok {
-		return apierror.NewAPIError(validation.Unauthorized, "failed to get user from request")
+		return nil, apierror.NewAPIError(validation.Unauthorized, "failed to get user from request")
 	}
 
 	switch action {
 	case ejectCdRom:
 		var input EjectCdRomActionInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
 
 		if len(input.DiskNames) == 0 {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter diskNames is empty")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter diskNames is empty")
 		}
 
-		return h.ejectCdRom(r.Context(), name, namespace, input.DiskNames)
+		return nil, h.ejectCdRom(r.Context(), name, namespace, input.DiskNames)
 	case migrate:
 		var input MigrateInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
-		return h.migrate(r.Context(), namespace, name, input.NodeName)
+		return nil, h.migrate(r.Context(), namespace, name, input.NodeName)
 	case abortMigration:
-		return h.abortMigration(namespace, name)
+		return nil, h.abortMigration(namespace, name)
 	case findMigratableNodes:
-		return h.findMigratableNodes(rw, namespace, name)
+		return nil, h.findMigratableNodes(rw, namespace, name)
 	case startVM, restartVM:
 		if err := h.subresourceOperate(r.Context(), vmResource, namespace, name, action); err != nil {
-			return fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
+			return nil, fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
 		}
 	case stopVM:
 		// To align behavior with kubevirt v1.1.1, we set runStrategy to Halted when stopping a VM.
 		if err := h.stopVM(namespace, name); err != nil {
-			return fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
+			return nil, fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
 		}
 	case pauseVM, unpauseVM, softReboot:
 		if err := h.subresourceOperate(r.Context(), vmiResource, namespace, name, action); err != nil {
-			return fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
+			return nil, fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
 		}
 	case backupVM:
 		var input BackupInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
 
 		if input.Name == "" {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter backup name is required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter backup name is required")
 		}
 
 		if err := h.checkBackupTargetConfigured(); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := h.createVMBackup(name, namespace, input); err != nil {
-			return err
+			return nil, err
 		}
-		return nil
+
+		return nil, nil
 	case snapshotVM:
 		// TODO: currently the snapshot CRD creation is handled by UI, we do nothing here.
-		return nil
+		return nil, nil
 	case restoreVM:
 		var input RestoreInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
 
 		if input.Name == "" || input.BackupName == "" {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter name and backupName are required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter name and backupName are required")
 		}
 
 		if err := h.checkBackupTargetConfigured(); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := h.restoreBackup(name, namespace, input); err != nil {
-			return err
+			return nil, err
 		}
-		return nil
+		return nil, nil
 	case createTemplate:
 		var input CreateTemplateInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
 
 		if input.Name == "" {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Template name is required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Template name is required")
 		}
-		return h.createTemplate(namespace, name, input)
+		return nil, h.createTemplate(namespace, name, input)
 	case addVolume:
 		var input AddVolumeInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
 		if input.DiskName == "" || input.VolumeSourceName == "" {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `diskName` and `volumeName` are required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `diskName` and `volumeName` are required")
 		}
-		return h.addVolume(r.Context(), namespace, name, input)
+		return nil, h.addVolume(r.Context(), namespace, name, input)
 	case removeVolume:
 		var input RemoveVolumeInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
 		if input.DiskName == "" {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `volumeName` are required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `volumeName` are required")
 		}
-		return h.removeVolume(r.Context(), namespace, name, input)
+		return nil, h.removeVolume(r.Context(), namespace, name, input)
 	case cloneVM:
 		var input CloneInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
 
 		if input.TargetVM == "" {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Parameter targetVm are required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter targetVm are required")
 		}
 
 		if err := h.cloneVM(name, namespace, input); err != nil {
-			return err
+			return nil, err
 		}
-		return nil
+		return nil, nil
 	case forceStopVM:
 		var gracePeriod int64
 		stopOptions := &kubevirtv1.StopOptions{GracePeriod: &gracePeriod}
 		body, err := json.Marshal(stopOptions)
 		if err != nil {
-			return fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
+			return nil, fmt.Errorf("%s virtual machine %s/%s failed, %v", action, namespace, name, err)
 		}
 		// The request is equal to "virtctl stop my-vm --grace-period 0 --force"
 		if err := h.virtSubresourceRestClient.Put().Namespace(namespace).Resource(vmResource).SubResource(stopVM).Name(name).Body(body).Do(r.Context()).Error(); err != nil {
 			// Kubevirt returns "Halted does not support manual stop requests" error when VM runStrategy is Halted,
 			// but the request will still forcely stop the VM.
 			if strings.Contains(err.Error(), "Halted does not support manual stop requests") {
-				return nil
+				return nil, nil
 			}
-			return err
+			return nil, err
 		}
 	case dismissInsufficientResourceQuota:
-		return h.dismissInsufficientResourceQuota(name, namespace)
+		return nil, h.dismissInsufficientResourceQuota(name, namespace)
 	case updateResourceQuotaAction:
 		if ok, err := apiutil.CanUpdateResourceQuota(h.clientSet, namespace, user.GetName()); err != nil {
-			return apierror.NewAPIError(validation.ServerError, fmt.Sprintf("Failed to check permission: %v", err))
+			return nil, apierror.NewAPIError(validation.ServerError, fmt.Sprintf("Failed to check permission: %v", err))
 		} else if !ok {
-			return apierror.NewAPIError(validation.PermissionDenied, "User does not have permission to update resource quota")
+			return nil, apierror.NewAPIError(validation.PermissionDenied, "User does not have permission to update resource quota")
 		}
 		var updateResourceQuotaInput UpdateResourceQuotaInput
 		if err := json.NewDecoder(r.Body).Decode(&updateResourceQuotaInput); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, fmt.Sprintf("Failed to decode request body: %v ", err))
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, fmt.Sprintf("Failed to decode request body: %v ", err))
 		}
-		return h.updateResourceQuota(namespace, name, updateResourceQuotaInput)
+		return nil, h.updateResourceQuota(namespace, name, updateResourceQuotaInput)
 	case deleteResourceQuotaAction:
 		if ok, err := apiutil.CanUpdateResourceQuota(h.clientSet, namespace, user.GetName()); err != nil {
-			return apierror.NewAPIError(validation.ServerError, fmt.Sprintf("Failed to check permission: %v", err))
+			return nil, apierror.NewAPIError(validation.ServerError, fmt.Sprintf("Failed to check permission: %v", err))
 		} else if !ok {
-			return apierror.NewAPIError(validation.PermissionDenied, "User does not have permission to update resource quota")
+			return nil, apierror.NewAPIError(validation.PermissionDenied, "User does not have permission to update resource quota")
 		}
-		return h.deleteResourceQuota(namespace, name)
+		return nil, h.deleteResourceQuota(namespace, name)
 	case cpuAndMemoryHotplug:
 		vm, err := h.vmCache.Get(namespace, name)
 		if err != nil {
-			return apierror.NewAPIError(validation.ServerError, fmt.Sprintf("Failed to get virtual machine %s/%s: %v", namespace, name, err))
+			return nil, apierror.NewAPIError(validation.ServerError, fmt.Sprintf("Failed to get virtual machine %s/%s: %v", namespace, name, err))
 		}
 		if !canCPUAndMemoryHotplug(vm) {
-			return apierror.NewAPIError(validation.InvalidAction, "CPU and memory hotplug is not supported for this VM")
+			return nil, apierror.NewAPIError(validation.InvalidAction, "CPU and memory hotplug is not supported for this VM")
 		}
 		var input CPUAndMemoryHotplugInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			return apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Failed to decode request body: %v "+err.Error())
 		}
-		return h.cpuAndMemoryHotplug(namespace, name, input)
+		return nil, h.cpuAndMemoryHotplug(namespace, name, input)
 	default:
-		return apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
+		return nil, apierror.NewAPIError(validation.InvalidAction, "Unsupported action")
 	}
-	return nil
+
+	return nil, nil
 }
 
 func (h *vmActionHandler) ejectCdRom(ctx context.Context, name, namespace string, diskNames []string) error {

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
 	virtv1 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/kubevirt.io/v1"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
 const (
@@ -69,7 +70,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	if err != nil {
 		return err
 	}
-	actionHandler := vmActionHandler{
+	actionHandler := harvesterServer.NewHandler(&vmActionHandler{
 		namespace:                 options.Namespace,
 		datavolumeClient:          dataVolumeClient,
 		kubevirtCache:             kubevirtCache,
@@ -98,7 +99,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		storageClassCache:         storageClasses.Cache(),
 		resourceQuotaClient:       resourceQuotas,
 		clientSet:                 *scaled.Management.ClientSet,
-	}
+	})
 
 	vmformatter := vmformatter{
 		pvcCache:      pvcs.Cache(),
@@ -122,28 +123,28 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		ID: vmSchemaID,
 		Customize: func(apiSchema *types.APISchema) {
 			apiSchema.ActionHandlers = map[string]http.Handler{
-				startVM:                          &actionHandler,
-				stopVM:                           &actionHandler,
-				restartVM:                        &actionHandler,
-				softReboot:                       &actionHandler,
-				ejectCdRom:                       &actionHandler,
-				pauseVM:                          &actionHandler,
-				unpauseVM:                        &actionHandler,
-				migrate:                          &actionHandler,
-				abortMigration:                   &actionHandler,
-				findMigratableNodes:              &actionHandler,
-				backupVM:                         &actionHandler,
-				snapshotVM:                       &actionHandler,
-				restoreVM:                        &actionHandler,
-				createTemplate:                   &actionHandler,
-				addVolume:                        &actionHandler,
-				removeVolume:                     &actionHandler,
-				cloneVM:                          &actionHandler,
-				forceStopVM:                      &actionHandler,
-				dismissInsufficientResourceQuota: &actionHandler,
-				updateResourceQuotaAction:        &actionHandler,
-				deleteResourceQuotaAction:        &actionHandler,
-				cpuAndMemoryHotplug:              &actionHandler,
+				startVM:                          actionHandler,
+				stopVM:                           actionHandler,
+				restartVM:                        actionHandler,
+				softReboot:                       actionHandler,
+				ejectCdRom:                       actionHandler,
+				pauseVM:                          actionHandler,
+				unpauseVM:                        actionHandler,
+				migrate:                          actionHandler,
+				abortMigration:                   actionHandler,
+				findMigratableNodes:              actionHandler,
+				backupVM:                         actionHandler,
+				snapshotVM:                       actionHandler,
+				restoreVM:                        actionHandler,
+				createTemplate:                   actionHandler,
+				addVolume:                        actionHandler,
+				removeVolume:                     actionHandler,
+				cloneVM:                          actionHandler,
+				forceStopVM:                      actionHandler,
+				dismissInsufficientResourceQuota: actionHandler,
+				updateResourceQuotaAction:        actionHandler,
+				deleteResourceQuotaAction:        actionHandler,
+				cpuAndMemoryHotplug:              actionHandler,
 			}
 			apiSchema.ResourceActions = map[string]schemas.Action{
 				startVM:    {},

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -48,7 +48,7 @@ type ActionHandler struct {
 	vmCache     ctlkubevirtv1.VirtualMachineCache
 }
 
-func (h *ActionHandler) Do(ctx *harvesterServer.Ctx) (interface{}, error) {
+func (h *ActionHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
 	req := ctx.Req()
 	vars := util.EncodeVars(mux.Vars(req))
 	action := vars["action"]

--- a/pkg/containerd/registry.go
+++ b/pkg/containerd/registry.go
@@ -3,7 +3,6 @@ package containerd
 // File vendored from https://github.com/rancher/wharfie/blob/v0.5.3/pkg/registries/types.go
 // under the Apache 2.0 license. DO NOT EDIT.
 
-
 // Mirror contains the config related to the registry mirror
 type Mirror struct {
 	// Endpoints are endpoints for a namespace. CRI plugin will try the endpoints

--- a/pkg/server/http/ctx.go
+++ b/pkg/server/http/ctx.go
@@ -17,8 +17,14 @@ func newDefaultHarvesterServerCtx(rw http.ResponseWriter, req *http.Request) *Ct
 }
 
 func (ctx *Ctx) SetStatus(statusCode int) { ctx.statusCode = statusCode }
-func (ctx *Ctx) StatusCode() int          { return ctx.statusCode }
-func (ctx *Ctx) Req() *http.Request       { return ctx.req }
+
+// SetStatusOK sets the status code to 200.
+// Some APIs return status code 200 when there is even no response body.
+// So, we open this function for those APIs to invoke.
+func (ctx *Ctx) SetStatusOK() { ctx.statusCode = http.StatusOK }
+
+func (ctx *Ctx) StatusCode() int    { return ctx.statusCode }
+func (ctx *Ctx) Req() *http.Request { return ctx.req }
 func (ctx *Ctx) RespWriter() http.ResponseWriter {
 	return ctx.rw
 }

--- a/pkg/server/http/handler.go
+++ b/pkg/server/http/handler.go
@@ -9,8 +9,12 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 )
 
+// ResponseBody only accepts object which can be marshalled to JSON.
+// if you need to write some custom response, you can use ctx.RespWriter() to write directly to the response.
+type ResponseBody interface{}
+
 type HarvesterServerHandler interface {
-	Do(ctx *Ctx) (interface{}, error)
+	Do(ctx *Ctx) (ResponseBody, error)
 }
 
 type harvesterServerHandler struct {

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harvester/harvester/pkg/api/supportbundle"
 	"github.com/harvester/harvester/pkg/api/uiinfo"
 	"github.com/harvester/harvester/pkg/config"
+	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/server/ui"
 )
 
@@ -48,17 +49,17 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	})
 
 	// Those routes should be above /v1/harvester/{type}, otherwise, the response status code would be 404
-	kcGenerateHandler := kubeconfig.NewGenerateHandler(r.scaled, r.options)
+	kcGenerateHandler := harvesterServer.NewHandler(kubeconfig.NewGenerateHandler(r.scaled, r.options))
 	m.Path("/v1/harvester/kubeconfig").Methods("POST").Handler(kcGenerateHandler)
 
-	uiInfoHandler := uiinfo.NewUIInfoHandler(r.scaled, r.options)
+	uiInfoHandler := harvesterServer.NewHandler(uiinfo.NewUIInfoHandler(r.scaled, r.options))
 	m.Path("/v1/harvester/ui-info").Methods("GET").Handler(uiInfoHandler)
 	m.PathPrefix("/v1/harvester/plugin-assets").Handler(ui.Vue.PluginServeAsset())
 
-	sbDownloadHandler := supportbundle.NewDownloadHandler(r.scaled, r.options.Namespace)
+	sbDownloadHandler := harvesterServer.NewHandler(supportbundle.NewDownloadHandler(r.scaled, r.options.Namespace))
 	m.Path("/v1/harvester/supportbundles/{bundleName}/download").Methods("GET").Handler(sbDownloadHandler)
 
-	btHealthyHandler := backuptarget.NewHealthyHandler(r.scaled)
+	btHealthyHandler := harvesterServer.NewHandler(backuptarget.NewHealthyHandler(r.scaled))
 	m.Path("/v1/harvester/backuptarget/healthz").Methods("GET").Handler(btHealthyHandler)
 	// --- END of preposition routes ---
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Since volumes API structure had been changed, we should modify other APIs structure.

**Solution:**
Use common server handler

**Related Issue:**
https://github.com/harvester/harvester/issues/6558

**Test plan:**

shell: `pytest -k 'not verify_host_maintenance_mode and not host_mgmt_maintenance_mode and not host_reboot_maintenance_mode and not host_poweroff_state and not create_images_using_terraform and not create_keypairs_using_terraform and not create_edit_network and not create_network_using_terraform and not create_volume_using_terraform' --junitxml=result_harvester_api_latest.xml -m 'not delete_host' harvester_e2e_tests/apis --username admin --password {your_harvester_password} --endpoint https://{harvester_vip}`

Run API test. The create_volume_without_name relates to https://github.com/harvester/harvester/issues/7030. It's not a real failed test case, we could skip it.

First Round:

![image](https://github.com/user-attachments/assets/f0b91045-5332-4b32-80ba-695e69160175)

Second Round:

![image](https://github.com/user-attachments/assets/a6f6f26f-2e01-4717-b26e-b2b3b20f5134)

Local Round:

![image](https://github.com/user-attachments/assets/e0516d0f-d1fb-4617-8260-1352925bbae3)
