### PR TITLE
Fix crash on invalid JSON data

### DIFF
--- a/pkg/webhook/resources/templateversion/validator.go
+++ b/pkg/webhook/resources/templateversion/validator.go
@@ -21,7 +21,7 @@ const (
 	fieldTemplateID                     = "spec.templateId"
 	fieldKeyPairIDs                     = "spec.keyPairIds"
 	fieldResourcesLimits                = "spec.vm.spec.template.spec.domain.resources.limits"
-	fieldVolumeClaimTemplatesAnnotation = "spec.vm.metadata.annoataions[\"harvesterhci.io/volumeClaimTemplates\"]"
+	fieldVolumeClaimTemplatesAnnotation = "spec.vm.metadata.annotations[\"harvesterhci.io/volumeClaimTemplates\"]"
 )
 
 func NewValidator(templateCache ctlharvesterv1.VirtualMachineTemplateCache, templateVersionCache ctlharvesterv1.VirtualMachineTemplateVersionCache, keypairs ctlharvesterv1.KeyPairCache) types.Validator {

--- a/pkg/webhook/resources/templateversion/validator_test.go
+++ b/pkg/webhook/resources/templateversion/validator_test.go
@@ -1,0 +1,100 @@
+package templateversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func Test_validateVolumeClaimTemplateString(t *testing.T) {
+	var testCases = []struct {
+		name               string
+		expectError        bool
+		newTemplateVersion *harvesterv1.VirtualMachineTemplateVersion
+	}{
+		{
+			name:        "no volume claim template string annotation",
+			expectError: false,
+			newTemplateVersion: &harvesterv1.VirtualMachineTemplateVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foobar-no-volume-claim-template-annotation",
+				},
+				Spec: harvesterv1.VirtualMachineTemplateVersionSpec{
+					VM: harvesterv1.VirtualMachineSourceSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "empty JSON data in volume claim template string annotation",
+			expectError: false,
+			newTemplateVersion: &harvesterv1.VirtualMachineTemplateVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foobar-empty-json",
+				},
+				Spec: harvesterv1.VirtualMachineTemplateVersionSpec{
+					VM: harvesterv1.VirtualMachineSourceSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								util.AnnotationVolumeClaimTemplates: "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "valid JSON data in volume claim template string annotation",
+			expectError: false,
+			newTemplateVersion: &harvesterv1.VirtualMachineTemplateVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foobar-valid-json",
+				},
+				Spec: harvesterv1.VirtualMachineTemplateVersionSpec{
+					VM: harvesterv1.VirtualMachineSourceSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								util.AnnotationVolumeClaimTemplates: "[]",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "invalid JSON data in volume claim template string annotation",
+			expectError: true,
+			newTemplateVersion: &harvesterv1.VirtualMachineTemplateVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foobar-invalid-json",
+				},
+				Spec: harvesterv1.VirtualMachineTemplateVersionSpec{
+					VM: harvesterv1.VirtualMachineSourceSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								util.AnnotationVolumeClaimTemplates: "[{}]}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validateVolumeClaimTemplateString(tc.newTemplateVersion)
+		if tc.expectError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}


### PR DESCRIPTION
# Problem

Harvester container crashes when a VirtualMachineTemplateVersion with bogus JSON data in `.spec.vm.metadata.annotations.harvesterhci.io/volumeClaimTemplates` is created
As a result of the Harvester container crashing, Harvester web UI becomes unavailable.
See also: harvester/harvester#7051

# Proposed Solution

Fix crash on invalid JSON data in volume claim template annotation of a VM template version.
The indexer function for the VM template version may not return an error when it fails to parse the JSON data in the volume claim template annotation of an object, as otherwise the cache would panic and cause a crash.
To fix this, just log the error and return an empty result.

```
[...]
time="2024-12-05T12:07:14Z" level=error msg="can't unmarshal JSON data" annotation=harvesterhci.io/volumeClaimTemplates err="invalid character '}' after top-level value" name=windows-raw-image-base-version-2 namespace=harvester-public
time="2024-12-05T12:07:14Z" level=error msg="error syncing 'harvester-public/windows-raw-image-base-version-2': handler template-version-controller: can't unmarshal harvesterhci.io/volumeClaimTemplates annotation, err: invalid character '}' after top-level value, requeuing"
time="2024-12-05T12:07:14Z" level=error msg="error syncing 'harvester-public/windows-raw-image-base-version-2': handler template-version-controller: can't unmarshal harvesterhci.io/volumeClaimTemplates annotation, err: invalid character '}' after top-level value, requeuing"
time="2024-12-05T12:07:14Z" level=error msg="error syncing 'harvester-public/windows-raw-image-base-version-2': handler template-version-controller: can't unmarshal harvesterhci.io/volumeClaimTemplates annotation, err: invalid character '}' after top-level value, requeuing"
time="2024-12-05T12:07:14Z" level=error msg="can't unmarshal JSON data" annotation=harvesterhci.io/volumeClaimTemplates err="invalid character '}' after top-level value" name=windows-raw-image-base-version-2 namespace=harvester-public
[...]
```

Additionally, the admission webhook verifies that invalid JSON data can not be contained in the volume claim template annotation of the VM template version. This prevents the indexer function from failing to parse the object.
When trying to create a new `VirtualMachineTemplateVersion`, which contains invalid JSON data in the annotation, the admission webhook will deny the request with a reasonable error message:

```
│ ~ │► kubectl apply -f ./template.yaml 
The request is invalid: spec.vm.metadata.annoataions["harvesterhci.io/volumeClaimTemplates"]: Invalid JSON data in annotation harvesterhci.io/volumeClaimTemplates
```

# Related Issue

harvester/harvester#7051

# Test plan

To test the validity of the proposed fix, two functionalities must be individually checked.
The order isn't mandatory, but it's advisable to first test the admission webhook, because testing the fix for the crash requires modification of the admission webhook configuration.
Assuming a clean Harvester cluster with default configuration, the admission webhook can be tested by simply trying to apply a problematic manifest to the cluster. This should fail with a meaningful error message.
The fix of the crash can be tested by disabling the admission webhook and creating a problematic resource. The creation should succeed and the Harvester Pod should continue to run. It is expected to find error message in the logs of the Harvester Pod, which point to the problematic resource.

## Validating Webhook

1. Try to create a `VirtualMachineTemplateVersion` with bogus JSON data in annotation:

```
│ ~ │► cat template.yaml 
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineTemplateVersion
metadata:
  labels:
    template.harvesterhci.io/templateID: windows-raw-image-base-template
  name: windows-raw-image-base-version-2
  namespace: harvester-public
  ownerReferences:
    - apiVersion: harvesterhci.io/v1beta1
      blockOwnerDeletion: true
      controller: true
      kind: VirtualMachineTemplate
      name: windows-raw-image-base-template
      uid: b92d77a2-0313-451f-92b6-364f566a5fd3
spec:
  templateId: harvester-public/windows-raw-image-base-template
  vm:
    metadata:
      annotations:
        harvesterhci.io/reservedMemory: 256Mi
        harvesterhci.io/volumeClaimTemplates: |-
          [{
            "metadata": {
              "name": "pvc-rootdisk",
              "annotations": {
                "harvesterhci.io/imageId": ""
              }
            },
            "spec":{
              "accessModes": ["ReadWriteMany"],
              "resources":{
                "requests":{
                  "storage": "32Gi"
                }
              },
              "volumeMode": "Block"
            }
          }]}
      creationTimestamp: null
      labels:
        harvesterhci.io/os: windows
    spec:
      runStrategy: RerunOnFailure
      template:
        metadata:
          creationTimestamp: null
        spec:
          domain:
            cpu:
              cores: 1
            devices:
              disks:
                - bootOrder: 1
                  disk:
                    bus: virtio
                  name: rootdisk
              interfaces:
                - masquerade: {}
                  model: virtio
                  name: default
            features:
              acpi:
                enabled: true
            resources:
              limits:
                cpu: '1'
                memory: 2Gi
          evictionStrategy: LiveMigrateIfPossible
          networks:
            - name: default
              pod: {}
          volumes:
            - name: rootdisk
              persistentVolumeClaim:
                claimName: pvc-rootdisk
│ ~ │► kubectl apply -f ./template.yaml 
The request is invalid: spec.vm.metadata.annoataions["harvesterhci.io/volumeClaimTemplates"]: Invalid JSON data in annotation harvesterhci.io/volumeClaimTemplates
```

2. Confirm that the creation is denied with a meaningful error message

## Fix of the panic and crash of the Harvester container:

1. Disable the admission webhook for the `VirtualMachineTemplateVersion`
```
│ ~ │► kubectl -n harvester-system edit validatingwebhookconfigurations.admissionregistration.k8s.io harvester-validator
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  annotations:
    objectset.rio.cattle.io/applied: H4sIAAAAAAAA/8yXz27jNhDGX6WYs2Jb0Ra7K6CHjeMUcINF1o5zSJDDiBxbrClSJUcKAsPvXtD/CttR1t62Xh/FAef7zachR5pBQYwSGSGdARpjGVlZ48Ojzf4kwZ645ZRtCWTW1FK2rSSkAFFj3L4YcheTegoptOs4+uUPZeRvQxKO+LvbDBYEKeToavJM7uKFstza6YXAg/b6EsV2Av/qmQqYRyAcLaq7VwV5xqKE1FRaR6AxI/1uzTn6HFIYy4+ESdbBS7qM48tMJBkm8Wf6RB8Jf01o/DmR1BEY1PYqqVEriWxdiK7K8pA+zQBlobxX1gyoVvTyQM4vX8IT1DFEUMcZMcbwHIHQigx3rRmrSQAWeFUZqYPS7bDDt8O4OxjJ/r26uh489EfD0WP/W+dmNFjEOtydxv3hqH856H29/vYg7x47N8lw1L967OguRODJ1Sr4N9vHXxHDsrJGnyMokfPlq2+v9rRXpStrQtw6hvTDh2Q+j2CMSleO7qxW4hVSuEGlYWPexrLWRicXqqUsROAqTSv7SvW7s1W5MCyYhKXa8fA5AluSWzf3E4zurr/c98K6I28rJxa5wFhJPqx6YctA0NVVUIV59GM6173b3n0PoibBMuz3TIZrq6uChEZVbBF8Xbst9yF2XXmLadM622DdQe/Le2BTei1RuYNRplVGtXLchHE8QchWoS5Q5MqQD+dge6XtGbn6GWZF6/f6PrMqcEIn5WvAqsqJQ3lalOOsylBMg/jZAjrybN15WeiJWZnJYRfW6S1jKkqNTPVa40DrCjQ4oYIM/zOB38JNGq/bXa5lRilydHwwxlgTfYcgRl3mbznWwJEtZvXPJ5BUavsaHD6YJXQ/Tqg1/eR//Ipv7uRldqHR+/92ADcN+nWpJz88uyQo5RFn438EOfaYeoOlzy23/k1r7EEsvoLWqc/BlvXDX5VlPK/rX+QkK011ceT0PO7bdX/qhD+5RrGwrCT1xuPwJxWC1hDMn+d/BwAA//8TqO3mbQ4AAA
    objectset.rio.cattle.io/id: ""
    objectset.rio.cattle.io/owner-gvk: /v1, Kind=Secret
    objectset.rio.cattle.io/owner-name: harvester-webhook-ca
    objectset.rio.cattle.io/owner-namespace: harvester-system
  creationTimestamp: "2024-12-05T11:52:54Z"
  generation: 2
  labels:
    objectset.rio.cattle.io/hash: fd7ea3b0a2e2112bc3ba319e8e7ea53ef93de0ca
  name: harvester-validator
  resourceVersion: "16926"
  uid: 9aafc116-332e-4ad4-b17b-001488c39100
webhooks:
- admissionReviewVersions:
  - v1
  - v1beta1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJ2RENDQVdPZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQkdNUnd3R2dZRFZRUUtFeE5rZVc1aGJXbGoKYkdsemRHVnVaWEl0YjNKbk1TWXdKQVlEVlFRRERCMWtlVzVoYldsamJHbHpkR1Z1WlhJdFkyRkFNVGN6TXpNNQpPVFEzT0RBZUZ3MHlOREV5TURVeE1UVXhNVGhhRncwek5ERXlNRE14TVRVeE1UaGFNRVl4SERBYUJnTlZCQW9UCkUyUjVibUZ0YVdOc2FYTjBaVzVsY2kxdmNtY3hKakFrQmdOVkJBTU1IV1I1Ym1GdGFXTnNhWE4wWlc1bGNpMWoKWVVBeE56TXpNems1TkRjNE1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRXpUdTVRWW1oUUV5LwpaYTJKYTJVbTJoa1lIcjJkVUJjcTBWdXBZZmQ1ZTFhMytac3dxNnJqYml0STdsN0tCMzVqdFJWRGUwMzNzdEZMCmRydmg0a0tXQzZOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGRFgzRERNWG9xZnk0NnN2K3NRY05OVXlVOXJVTUFvR0NDcUdTTTQ5QkFNQ0EwY0FNRVFDSUJtcgowL0hvZUp0R09hWE4rVTJQZEhDU0NjYjdBNDFGbkdhYmNNMWZqbGRQQWlCWTd0WHUrK1RKRk5QSzJORWFNLzZLCjB6Zk9MSWVhSXJqZ01MMWpTVHV0V3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
    service:
      name: harvester-webhook
      namespace: harvester-system
      path: /v1/webhook/validation
      port: 443
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: validator.harvesterhci.io
  namespaceSelector: {}
  objectSelector: {}
  rules:
[...]
  - apiGroups:
    - harvesterhci.io
    apiVersions:
    - v1beta1
    operations:
    - CREATE  # <--- delete this line
    - UPDATE
    - DELETE
    resources:
    - virtualmachinetemplateversions
    scope: Namespaced
[...]
```

2. Create a `VirtualMachineTemplateVersion` with bogus JSON data in the annotation:
```
│ ~ │► cat template.yaml 
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineTemplateVersion
metadata:
  labels:
    template.harvesterhci.io/templateID: windows-raw-image-base-template
  name: windows-raw-image-base-version-2
  namespace: harvester-public
  ownerReferences:
    - apiVersion: harvesterhci.io/v1beta1
      blockOwnerDeletion: true
      controller: true
      kind: VirtualMachineTemplate
      name: windows-raw-image-base-template
      uid: b92d77a2-0313-451f-92b6-364f566a5fd3
spec:
  templateId: harvester-public/windows-raw-image-base-template
  vm:
    metadata:
      annotations:
        harvesterhci.io/reservedMemory: 256Mi
        harvesterhci.io/volumeClaimTemplates: |-
          [{
            "metadata": {
              "name": "pvc-rootdisk",
              "annotations": {
                "harvesterhci.io/imageId": ""
              }
            },
            "spec":{
              "accessModes": ["ReadWriteMany"],
              "resources":{
                "requests":{
                  "storage": "32Gi"
                }
              },
              "volumeMode": "Block"
            }
          }]}
      creationTimestamp: null
      labels:
        harvesterhci.io/os: windows
    spec:
      runStrategy: RerunOnFailure
      template:
        metadata:
          creationTimestamp: null
        spec:
          domain:
            cpu:
              cores: 1
            devices:
              disks:
                - bootOrder: 1
                  disk:
                    bus: virtio
                  name: rootdisk
              interfaces:
                - masquerade: {}
                  model: virtio
                  name: default
            features:
              acpi:
                enabled: true
            resources:
              limits:
                cpu: '1'
                memory: 2Gi
          evictionStrategy: LiveMigrateIfPossible
          networks:
            - name: default
              pod: {}
          volumes:
            - name: rootdisk
              persistentVolumeClaim:
                claimName: pvc-rootdisk
│ ~ │► kubectl apply -f ./template.yaml               
virtualmachinetemplateversion.harvesterhci.io/windows-raw-image-base-version-2 created  
```

3. Confirm that the Harvester Pod only logs the error and does not crash
```
│ ~ │► kubectl -n harvester-system get pods harvester-5b8bc5bd6b-prd82 
NAME                         READY   STATUS    RESTARTS   AGE
harvester-5b8bc5bd6b-prd82   1/1     Running   0          22m
│ ~ │► kubectl -n harvester-system logs harvester-5b8bc5bd6b-prd82
[...]
time="2024-12-05T12:07:14Z" level=error msg="can't unmarshal JSON data" annotation=harvesterhci.io/volumeClaimTemplates err="invalid character '}' after top-level value" name=windows-raw-image-base-version-2 namespace=harvester-public
time="2024-12-05T12:07:14Z" level=error msg="error syncing 'harvester-public/windows-raw-image-base-version-2': handler template-version-controller: can't unmarshal harvesterhci.io/volumeClaimTemplates annotation, err: invalid character '}' after top-level value, requeuing"
time="2024-12-05T12:07:14Z" level=error msg="error syncing 'harvester-public/windows-raw-image-base-version-2': handler template-version-controller: can't unmarshal harvesterhci.io/volumeClaimTemplates annotation, err: invalid character '}' after top-level value, requeuing"
time="2024-12-05T12:07:14Z" level=error msg="error syncing 'harvester-public/windows-raw-image-base-version-2': handler template-version-controller: can't unmarshal harvesterhci.io/volumeClaimTemplates annotation, err: invalid character '}' after top-level value, requeuing"
time="2024-12-05T12:07:14Z" level=error msg="can't unmarshal JSON data" annotation=harvesterhci.io/volumeClaimTemplates err="invalid character '}' after top-level value" name=windows-raw-image-base-version-2 namespace=harvester-public
[...]
```