### PR TITLE
[Backport v1.3] Fix crash on invalid JSON data

### DIFF
--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/rancher/steve/pkg/server"
@@ -127,7 +129,15 @@ func VMTemplateVersionByImageID(obj *harvesterv1.VirtualMachineTemplateVersion) 
 
 	var volumeClaimTemplates []corev1.PersistentVolumeClaim
 	if err := json.Unmarshal([]byte(volumeClaimTemplateStr), &volumeClaimTemplates); err != nil {
-		return []string{}, fmt.Errorf("can't unmarshal %s, err: %w", util.AnnotationVolumeClaimTemplates, err)
+		// an IndexFunc should never return an error as this would cause the cache
+		// to panic. Therefore we just log the error and return an empty result.
+		logrus.WithFields(logrus.Fields{
+			"annotation": util.AnnotationVolumeClaimTemplates,
+			"name":       obj.Name,
+			"namespace":  obj.Namespace,
+			"err":        err.Error(),
+		}).Error("can't unmarshal JSON data")
+		return []string{}, nil
 	}
 
 	imageIDs := []string{}


### PR DESCRIPTION
Fix crash on invalid JSON data in volume claim template annotation of a VM template version.
The indexer function for the VM template version may not return an error when it fails to parse the JSON data in the volume claim template annotation of an object, as otherwise the cache would panic and cause a crash.
To fix this, just log the error and return an empty result.

Additionally, the admission webhook verifies that invalid JSON data can not be contained in the volume claim template annotation of the VM template version. This prevents the indexer function from failing to parse the object.

related-to: harvester/harvester#7051
backport-of: https://github.com/harvester/harvester/pull/7102