### PR TITLE
feat: add refreshIntervalInSeconds to backup target

### DIFF
--- a/pkg/controller/master/backup/backup_target.go
+++ b/pkg/controller/master/backup/backup_target.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -26,6 +27,10 @@ import (
 
 const (
 	backupTargetControllerName = "harvester-backup-target-controller"
+
+	longhornBackupTargetSettingName            = "backup-target"
+	longhornBackupTargetSecretSettingName      = "backup-target-credential-secret"
+	longhornBackupstorePollIntervalSettingName = "backupstore-poll-interval"
 )
 
 // RegisterBackupTarget register the setting controller and reconsile longhorn setting when backup target changed
@@ -95,7 +100,9 @@ func (h *TargetHandler) OnBackupTargetChange(_ string, setting *harvesterv1.Sett
 			return h.setConfiguredCondition(setting, "", err)
 		}
 
-		return h.reUpdateBackupTargetSettingSecret(setting, target)
+		if setting, err = h.reUpdateBackupTargetSettingSecret(setting, target); err != nil {
+			return h.setConfiguredCondition(setting, "", err)
+		}
 
 	case settings.NFSBackupType:
 		if err = h.updateLonghornTarget(target); err != nil {
@@ -127,6 +134,12 @@ func (h *TargetHandler) OnBackupTargetChange(_ string, setting *harvesterv1.Sett
 		}
 
 		return h.setConfiguredCondition(setting, "", fmt.Errorf("Invalid backup target type:%s or parameter", target.Type))
+	}
+
+	if target.RefreshIntervalInSeconds > 0 {
+		if err = h.updateLonghornPollIntervalSetting(target); err != nil {
+			return h.setConfiguredCondition(setting, "", err)
+		}
 	}
 
 	if len(setting.Status.Conditions) == 0 || harvesterv1.SettingConfigured.IsFalse(setting) {
@@ -285,4 +298,33 @@ func (h *TargetHandler) setConfiguredCondition(setting *harvesterv1.Setting, rea
 	// SetError with nil error will cleanup message in condition and set the status to true
 	harvesterv1.SettingConfigured.SetError(settingCpy, reason, err)
 	return h.settings.Update(settingCpy)
+}
+
+func (h *TargetHandler) updateLonghornPollIntervalSetting(backupTarget *settings.BackupTarget) error {
+	setting, err := h.longhornSettingCache.Get(util.LonghornSystemNamespaceName, longhornBackupstorePollIntervalSettingName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		if _, err := h.longhornSettings.Create(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      longhornBackupstorePollIntervalSettingName,
+				Namespace: util.LonghornSystemNamespaceName,
+			},
+			Value: strconv.FormatInt(backupTarget.RefreshIntervalInSeconds, 10),
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	settingCpy := setting.DeepCopy()
+	settingCpy.Value = strconv.FormatInt(backupTarget.RefreshIntervalInSeconds, 10)
+
+	if !reflect.DeepEqual(setting, settingCpy) {
+		_, err := h.longhornSettings.Update(settingCpy)
+		return err
+	}
+	return nil
 }

--- a/pkg/controller/master/backup/util.go
+++ b/pkg/controller/master/backup/util.go
@@ -1,9 +1,12 @@
 package backup
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 	"time"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -223,4 +226,10 @@ func getSecretRefName(vmName string, secretName string) string {
 
 func getVMBackupMetadataFilePath(vmBackupNamespace, vmBackupName string) string {
 	return filepath.Join(vmBackupMetadataFolderPath, vmBackupNamespace, fmt.Sprintf("%s.cfg", vmBackupName))
+}
+
+func getBackupTargetHash(value string) string {
+	hash := sha256.New224()
+	io.Copy(hash, io.MultiReader(strings.NewReader(value)))
+	return fmt.Sprintf("%x", hash.Sum(nil))
 }

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -17,14 +17,15 @@ const (
 )
 
 type BackupTarget struct {
-	Type               TargetType `json:"type"`
-	Endpoint           string     `json:"endpoint"`
-	AccessKeyID        string     `json:"accessKeyId"`
-	SecretAccessKey    string     `json:"secretAccessKey"`
-	BucketName         string     `json:"bucketName"`
-	BucketRegion       string     `json:"bucketRegion"`
-	Cert               string     `json:"cert"`
-	VirtualHostedStyle bool       `json:"virtualHostedStyle"`
+	Type                     TargetType `json:"type"`
+	Endpoint                 string     `json:"endpoint"`
+	AccessKeyID              string     `json:"accessKeyId"`
+	SecretAccessKey          string     `json:"secretAccessKey"`
+	BucketName               string     `json:"bucketName"`
+	BucketRegion             string     `json:"bucketRegion"`
+	Cert                     string     `json:"cert"`
+	VirtualHostedStyle       bool       `json:"virtualHostedStyle"`
+	RefreshIntervalInSeconds int64      `json:"refreshIntervalInSeconds"`
 }
 
 type VMForceResetPolicy struct {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -28,6 +28,7 @@ const (
 	AnnotationStorageClassName          = prefix + "/storageClassName"
 	AnnotationStorageProvisioner        = prefix + "/storageProvisioner"
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
+	AnnotationLastRefreshTime           = prefix + "/lastRefreshTime"
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
 

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -500,6 +500,10 @@ func (v *settingValidator) validateBackupTarget(setting *v1beta1.Setting) error 
 		return nil
 	}
 
+	if target.RefreshIntervalInSeconds < 0 {
+		return werror.NewInvalidError("Refresh interval should be greater than or equal to 0", settings.KeywordValue)
+	}
+
 	// when target is from internal re-update, allow fast pass
 	if v.isUpdatedS3BackupTarget(target) {
 		return nil


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Currently, the system can sync data from backup target to the cluster when we setup backup target setting first time. It will not get any new data from backup target after it.

**Solution:**
Add a new field `refreshIntervalInSeconds` to backup target setting, so users can control when to get data from backup target to the cluster. The value `0` disables the feature.

**Related Issue:**
https://github.com/harvester/harvester/issues/7083

**Test plan:**
1. Setup two cluster - `cluster1` and `cluster2`.
2. Setup the same backup target on each cluster.
3. On `cluster2`, set `refreshIntervalInSeconds` as `60` seconds.
4. Create a VMImage, VM, and VMBackup on the `cluster1`.
5. After the data is on the backup target, wait around 1 minute. We can see the data is synced to `cluster2`.
6. Create a new VM and VMBakcup on the `cluster2`.
7.  After the data is on the backup target, wait around 1 minuter. The data is not in `cluster1`, because default `refreshIntervalInSeconds` is `0` which disables the feature.
8. Change `refreshIntervalInSeconds` from `0` to `60` on the `cluster1`. We can see new VMBackup is on the `cluster1`.
