### PR TITLE
fine tune drain helper to skip hot plug volumes

### DIFF
--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -27,7 +27,7 @@ const (
 	// combination of recommendations from longhorn and kubevirt docs
 	// https://kubevirt.io/user-guide/operations/node_maintenance/
 	//https://longhorn.io/docs/1.3.1/volumes-and-nodes/maintenance/#updating-the-node-os-or-container-runtime
-	defaultSkipPodLabels      = "app!=csi-attacher,app!=csi-provisioner"
+	defaultSkipPodLabels      = "app!=csi-attacher,app!=csi-provisioner,kubevirt.io!=hotplug-disk"
 	defaultGracePeriodSeconds = 180
 	defaultTimeOut            = 240 * time.Second
 	DrainAnnotation           = "harvesterhci.io/drain-requested"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Current implementation of node drain helper triggers drain while skipping csi pods only. 
The hot plug volume is not covered by the kubvirt managed pdb, which only targets the launcher pod

```
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  creationTimestamp: "2024-12-10T22:55:48Z"
  generateName: kubevirt-disruption-budget-
  generation: 3
  name: kubevirt-disruption-budget-h5pln
  namespace: default
  ownerReferences:
  - apiVersion: kubevirt.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: VirtualMachineInstance
    name: test-vm
    uid: 80022fff-623d-436b-b222-57d51e4362fb
  resourceVersion: "413438"
  uid: 80830c92-a88d-4c03-9a70-d0f6884d7ccd
spec:
  minAvailable: 1
  selector:
    matchLabels:
      kubevirt.io/created-by: 80022fff-623d-436b-b222-57d51e4362fb
status:
  conditions:
  - lastTransitionTime: "2024-12-10T22:55:48Z"
    message: ""
    observedGeneration: 3
    reason: InsufficientPods
    status: "False"
    type: DisruptionAllowed
  currentHealthy: 1
  desiredHealthy: 1
  disruptionsAllowed: 0
  expectedPods: 1
  observedGeneration: 3
```

The hot plug volume is skipped due to lack of `kubevirt.io/created-by` label selector and matching value.

```
k get pod hp-volume-szjzr -o yaml | yq .metadata.labels
kubevirt.io: hotplug-disk
kubevirt.io/migrationJobUID: edc50b15-c3cf-4be4-a347-c5cb9cf6d6b5
```


This results in IO issues for VM's with hot plug volumes when a node maintenance operation is performed as the hot plug pod is destroyed before the VM has been migrated to new destination node.
 
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
fine tune the drain helper to skip hot plug volumes using the label filter
This ensures that the hot plug pod is skipped during maintenance and its lifecycle is managed by kubevirt as part of the VM migration

**Related Issue:**
https://github.com/harvester/harvester/issues/7128
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
