### PR TITLE
feat: deprecated minFreeDiskSpaceGB and add skipGarbageCollectionThresholdCheck

### DIFF
--- a/pkg/webhook/resources/version/validator.go
+++ b/pkg/webhook/resources/version/validator.go
@@ -18,7 +18,7 @@ var (
 )
 
 const (
-	MinFreeDiskSpaceGBAnnotation = "harvesterhci.io/minFreeDiskSpaceGB"
+	SkipGarbageCollectionThreadholdCheckAnnotation = "harvesterhci.io/skipGarbageCollectionThresholdCheck"
 )
 
 func NewValidator() types.Validator {
@@ -49,10 +49,10 @@ func (v *versionValidator) Create(_ *types.Request, newObj runtime.Object) error
 }
 
 func checkAnnotations(version *v1beta1.Version) error {
-	if value, ok := version.Annotations[MinFreeDiskSpaceGBAnnotation]; ok {
-		_, err := strconv.ParseUint(value, 10, 64)
+	if value, ok := version.Annotations[SkipGarbageCollectionThreadholdCheckAnnotation]; ok {
+		_, err := strconv.ParseBool(value)
 		if err != nil {
-			return werror.NewBadRequest(fmt.Sprintf("invalid value %s for annotation %s", value, MinFreeDiskSpaceGBAnnotation))
+			return werror.NewBadRequest(fmt.Sprintf("invalid value %s for annotation %s", value, SkipGarbageCollectionThreadholdCheckAnnotation))
 		}
 	}
 	return nil


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The `minFreeDiskSpaceGB` is not useful now, because we have limit for disk to have at least 250GB when installing harvester. The default garbage collection threshold is 15%. That means the disk must have 37.5 GB to continue the upgrade. The default `minFreeDiskSpaceGB` is 30GB. It's lower then garbage collection threshold check.

**Solution:**
Deprecate `minFreeDiskSpaceGB`. Add `harvesterhci.io/skipGarbageCollectionThresholdCheck` annotation.

**Related Issue:**
https://github.com/harvester/harvester/issues/7131

**Test plan:**
1. Create a harvester cluster.
2. Make one node disk full. Like `dd if=/dev/random of=/usr/local/test.img bs=1G count=100`
3. Create a test version.

```yaml
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: 1.5.0-head
  namespace: harvester-system
spec:
  isoURL: http://192.168.0.181:8000/harvester-1.5.0-head-amd64.iso
  minUpgradableVersion: 1.3.2
  releaseDate: "20241231"
```

4. Click upgrade on the dashboard. We should get an error message.

<img width="845" alt="Screenshot 2024-12-11 at 3 22 45 PM" src="https://github.com/user-attachments/assets/324765a9-67b6-476e-9416-d28ef07fd6db">


5. Add annotation `harvesterhci.io/skipGarbageCollectionThresholdCheck: true` to the version.
6. Click upgrade on the dashboard. It should pass.