### PR TITLE
feat: use common func to detect vm is migratable or not

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -73,6 +73,8 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 	resource.AddAction(request, addVolume)
 	resource.AddAction(request, removeVolume)
 	resource.AddAction(request, cloneVM)
+	resource.AddAction(request, migrate)
+	resource.AddAction(request, findMigratableNodes)
 
 	if canEjectCdRom(vm) {
 		resource.AddAction(request, ejectCdRom)
@@ -101,11 +103,6 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 
 	if vf.canUnPause(vmi) {
 		resource.AddAction(request, unpauseVM)
-	}
-
-	if canMigrate(vmi) {
-		resource.AddAction(request, migrate)
-		resource.AddAction(request, findMigratableNodes)
 	}
 
 	if canAbortMigrate(vmi) {
@@ -223,28 +220,6 @@ func (vf *vmformatter) canStop(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.Vi
 		default:
 			// skip to other condition
 		}
-	}
-
-	return true
-}
-
-func canMigrate(vmi *kubevirtv1.VirtualMachineInstance) bool {
-	if vmi == nil {
-		return false
-	}
-
-	if !vmi.IsRunning() {
-		return false
-	}
-
-	// The VM is already in migrating state
-	if vmi.Annotations[util.AnnotationMigrationUID] != "" {
-		return false
-	}
-
-	// The VM is set to run on a specific node
-	if vmi.Spec.NodeSelector != nil && vmi.Spec.NodeSelector[corev1.LabelHostname] != "" {
-		return false
 	}
 
 	return true

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -405,13 +405,9 @@ func (h *vmActionHandler) migrate(ctx context.Context, namespace, vmName string,
 	if !isReady(vmi) {
 		return errors.New("Can't migrate the VM, the VM is not in ready status")
 	}
-	if !canMigrate(vmi) {
-		return errors.New("The VM is not migratable")
-	}
 
-	// functions in formatter only return bool, the disk.Name is also needed, check them directly here
-	if virtualmachineinstance.VMContainsCDRomOrContainerDisk(vmi) {
-		return fmt.Errorf("VM %s contains CD-ROM or container disk, needs to be ejected before migration", vmName)
+	if err := virtualmachineinstance.ValidateVMMigratable(vmi); err != nil {
+		return err
 	}
 
 	if ok, err := h.isMigratableNode(nodeName, vmi); err != nil {
@@ -512,8 +508,8 @@ func (h *vmActionHandler) findMigratableNodes(rw http.ResponseWriter, namespace,
 		return err
 	}
 
-	if !canMigrate(vmi) {
-		return errors.New("The VM is not migratable")
+	if err := virtualmachineinstance.ValidateVMMigratable(vmi); err != nil {
+		return err
 	}
 
 	nodes, err := h.findMigratableNodesByVMI(vmi)

--- a/pkg/util/virtualmachineinstance/virtualmachineinstance.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance.go
@@ -79,8 +79,13 @@ func ValidateVMMigratable(vmi *kubevirtv1.VirtualMachineInstance) error {
 	}
 
 	// PCIe devices
-	if vmi.Spec.Domain.Devices.HostDevices != nil {
-		return fmt.Errorf("VM %s considered non-live migratable due to pcie or usb devices", vmiNamespacedName)
+	if len(vmi.Spec.Domain.Devices.HostDevices) != 0 {
+		return fmt.Errorf("VM %s considered non-live migratable due to PCIe or USB devices", vmiNamespacedName)
+	}
+
+	// vGPU devices
+	if len(vmi.Spec.Domain.Devices.GPUs) != 0 {
+		return fmt.Errorf("VM %s considered non-live migratable due to vGPU devices", vmiNamespacedName)
 	}
 
 	// container-disk or cdrom device


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
When we try to migrate a VM with an attached PCI or USB device, the GUI initially shows the Migrate button. However, after clicking it, an error message appears. After that, the Migrate button disappears from the menu.

**Solution:**
We should still display Migrate button, and show the error message after clicking it.

**Related Issue:**
https://github.com/harvester/harvester/issues/6806

**Test plan:**

#### Host Device

1. Start a VM attached with an attached PCI or USB device.
2. After clicking live migration, we should show the specific error message for pci/usb device.

![image](https://github.com/user-attachments/assets/de5a1531-6b3a-4761-ac62-85b341119307)


#### CD-ROM

1. Start a VM with CD-ROM
2. After clicking live migration, we should show the specific error message for CD-ROM.

![image](https://github.com/user-attachments/assets/89ca8724-7e3a-40e9-ba74-f1e664f9b4a9)
