### PR TITLE
feat: remove guest cluster if related namespace is removed in Harvester

### DIFF
--- a/pkg/controller/master/rancher/namespace.go
+++ b/pkg/controller/master/rancher/namespace.go
@@ -1,0 +1,108 @@
+package rancher
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func (h *Handler) onNamespaceRemoved(_ string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+	if namespace == nil {
+		return namespace, nil
+	}
+
+	value := settings.RancherCluster.Get()
+	if value == "" {
+		return namespace, nil
+	}
+
+	rancherClusterConfig, err := settings.DecodeConfig[settings.RancherClusterConfig](value)
+	if err != nil {
+		return namespace, err
+	}
+
+	if !rancherClusterConfig.RemoveUpstreamClusterWhenNamespaceIsDeleted {
+		return namespace, nil
+	}
+
+	secret, err := h.SecretCache.Get(util.HarvesterSystemNamespaceName, util.RancherClusterConfigSecretName)
+	if err != nil {
+		return nil, err
+	}
+
+	if secret.Data == nil || len(secret.Data["kubeConfig"]) == 0 {
+		return nil, fmt.Errorf("kubeConfig is empty in secret %s/%s", util.HarvesterSystemNamespaceName, util.RancherClusterConfigSecretName)
+	}
+
+	kc, err := clientcmd.RESTConfigFromKubeConfig(secret.Data["kubeConfig"])
+	if err != nil {
+		return nil, err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(kc)
+	if err != nil {
+		return nil, err
+	}
+
+	harvesterConfigsGroupVersion := k8sschema.GroupVersionResource{Group: "rke-machine-config.cattle.io", Version: "v1", Resource: "harvesterconfigs"}
+	provisioningClusterGroupVersion := k8sschema.GroupVersionResource{Group: "provisioning.cattle.io", Version: "v1", Resource: "clusters"}
+	harvesterConfigs, err := dynamicClient.Resource(harvesterConfigsGroupVersion).Namespace("fleet-default").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		logrus.WithError(err).Error("Fail to list harvesterConfigs")
+		return nil, err
+	}
+
+	for _, harvesterConfig := range harvesterConfigs.Items {
+		vmNamespace, ok := harvesterConfig.Object["vmNamespace"].(string)
+		if !ok {
+			continue
+		}
+		if vmNamespace == namespace.Name {
+			metadata, ok := harvesterConfig.Object["metadata"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ownerReferences, ok := metadata["ownerReferences"].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, o := range ownerReferences {
+				ownerReference, ok := o.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				clusterName, ok := ownerReference["name"].(string)
+				if !ok {
+					continue
+				}
+
+				logrus.WithFields(logrus.Fields{
+					"harvester.namespace": namespace.Name,
+					"cluster":             clusterName,
+				}).Info("Namespace is removed, removing upstream cluster")
+				err = dynamicClient.Resource(provisioningClusterGroupVersion).Namespace("fleet-default").Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return namespace, nil
+					}
+					logrus.WithError(err).WithFields(logrus.Fields{
+						"harvester.namespace": namespace.Name,
+						"cluster":             clusterName,
+					}).Info("Fail to remove upstream cluster")
+					return nil, err
+				}
+			}
+		}
+	}
+	return namespace, nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -54,6 +54,7 @@ var (
 	KubeconfigTTL                          = NewSetting(KubeconfigDefaultTokenTTLMinutesSettingName, "0") // "0" is default value to ensure token does not expire
 	LonghornV2DataEngineEnabled            = NewSetting(LonghornV2DataEngineSettingName, "false")
 	AdditionalGuestMemoryOverheadRatio     = NewSetting(AdditionalGuestMemoryOverheadRatioName, AdditionalGuestMemoryOverheadRatioDefault)
+	RancherCluster                         = NewSetting(RancherClusterSettingName, "{}")
 	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
 	HarvesterCSICCMVersion = NewSetting(HarvesterCSICCMSettingName, `{"harvester-cloud-provider":">=0.0.1 <0.3.0","harvester-csi-provider":">=0.0.1 <0.3.0"}`)
 	NTPServers             = NewSetting(NTPServersSettingName, "")
@@ -109,6 +110,7 @@ const (
 	DefaultStorageClassSettingName                    = "default-storage-class"
 	MaxHotplugRatioSettingName                        = "max-hotplug-ratio"
 	VMMigrationNetworkSettingName                     = "vm-migration-network"
+	RancherClusterSettingName                         = "rancher-cluster"
 
 	// settings have `default` and `value` string used in many places, replace them with const
 	KeywordDefault = "default"

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -241,3 +241,7 @@ func ValidateAdditionalGuestMemoryOverheadRatioHelper(value string) error {
 	_, err := NewAdditionalGuestMemoryOverheadRatioConfig(value)
 	return err
 }
+
+type RancherClusterConfig struct {
+	RemoveUpstreamClusterWhenNamespaceIsDeleted bool `json:"removeUpstreamClusterWhenNamespaceIsDeleted"`
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -90,6 +90,7 @@ const (
 	RancherMonitoringAlertmanager       = "rancher-monitoring-alertmanager"
 	RancherMonitoring                   = "rancher-monitoring"
 	RancherMonitoringGrafana            = "rancher-monitoring-grafana"
+	RancherClusterConfigSecretName      = "rancher-cluster-config"
 	CattleLoggingSystemNamespaceName    = "cattle-logging-system"
 	HarvesterUpgradeImageRepository     = "rancher/harvester-upgrade"
 	GrafanaPVCName                      = "rancher-monitoring-grafana"

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -1172,7 +1172,7 @@ func Test_validateStorageNetworkConfig(t *testing.T) {
 	}
 
 	clientset := fake.NewSimpleClientset()
-	v := NewValidator(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	v := NewValidator(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1253,7 +1253,7 @@ func Test_validateMaxHotplugRatio(t *testing.T) {
 		},
 	}
 
-	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -138,6 +138,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterNetworkFactory.Network().V1beta1().VlanConfig().Cache(),
 			clients.HarvesterNetworkFactory.Network().V1beta1().VlanStatus().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta2().Node().Cache(),
+			clients.Core.Secret().Cache(),
 		),
 		templateversion.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate().Cache(),


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Remove guest cluster in Rancher if related namespace is removed in Harvester

**Related Issue:**
https://github.com/harvester/harvester/issues/7136

**Test plan:**
1. Create a harvester cluster.
2. Import the harvester cluster to a rancher cluster.
3. Copy rancher kubeconfig and save to a file like:

```yaml
apiVersion: v1
kind: Config
clusters:
- name: "local"
  cluster:
    server: "https://192.168.0.181:6443/k8s/clusters/local"
    certificate-authority-data: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJ2VENDQ\
      VdPZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQkdNUnd3R2dZRFZRUUtFeE5rZVc1aGJXbGoKY\
      kdsemRHVnVaWEl0YjNKbk1TWXdKQVlEVlFRRERCMWtlVzVoYldsamJHbHpkR1Z1WlhJdFkyRkFNV\
      GN6TXprdwpNRE0xTmpBZUZ3MHlOREV5TVRFd05qVTVNVFphRncwek5ERXlNRGt3TmpVNU1UWmFNR\
      Vl4SERBYUJnTlZCQW9UCkUyUjVibUZ0YVdOc2FYTjBaVzVsY2kxdmNtY3hKakFrQmdOVkJBTU1IV\
      1I1Ym1GdGFXTnNhWE4wWlc1bGNpMWoKWVVBeE56TXpPVEF3TXpVMk1Ga3dFd1lIS29aSXpqMENBU\
      VlJS29aSXpqMERBUWNEUWdBRTZFVHlrSnExQStwSgpoNXRzUno4Um9mbGVBZlJyaVBXaFd2V3Vhc\
      1loL0M2S0lCaFMrT0pFRmU2ZTFKZ2hBaUpNcmRwWUgyaUl6Y2xwCmhjTUtHUjlCRzZOQ01FQXdEZ\
      1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGR\
      XRWcGlIcDVxRmIwUys0cXY4RkNmeTc1RWRFTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSVFEUgpLc\
      jFJekdHUWIzcFlnOURxaG9md0EzQTAranlUdkRwa0UwY29WNmZLeXdJZ1d4UmRQSnkrSlBZMGJLZ\
      EdmSzUyCm85ZE1sRUZZV2poa3orYU9YeXRJMjZVPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t"

users:
- name: "local"
  user:
    token: "kubeconfig-user-qjg5lxq42q:9qttqjmkzf2n6t7jfbmswg6z6vbzcgbhlqws5nx7dsnndjfql49vpz"


contexts:
- name: "local"
  context:
    user: "local"
    cluster: "local"

current-context: "local"
```

4. Use base64 to encode the kubeconfig:

```
base64 test.config -w 0
```

5. Save the output to a secret `harvester-system/rancher-cluster-config` in harvester like:

```yaml
apiVersion: v1
data:
  kubeConfig: YXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnCmNsdXN0ZXJzOgotIG5hbWU6ICJsb2NhbCIKICBjbHVzdGVyOgogICAgc2VydmVyOiAiaHR0cHM6Ly8xOTIuMTY4LjAuMTgxOjY0NDMvazhzL2NsdXN0ZXJzL2xvY2FsIgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6ICJMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKMlZFTkRRXAogICAgICBWZFBaMEYzU1VKQlowbENRVVJCUzBKblozRm9hMnBQVUZGUlJFRnFRa2ROVW5kM1IyZFpSRlpSVVV0RmVFNXJaVmMxYUdKWGJHb0tZXAogICAgICBrZHNlbVJIVm5WYVdFbDBZak5LYmsxVFdYZEtRVmxFVmxGUlJFUkNNV3RsVnpWb1lsZHNhbUpIYkhwa1IxWjFXbGhKZEZreVJrRk5WXAogICAgICBHTjZUWHByZHdwTlJFMHhUbXBCWlVaM01IbE9SRVY1VFZSRmQwNXFWVFZOVkZwaFJuY3dlazVFUlhsTlJHdDNUbXBWTlUxVVdtRk5SXAogICAgICBWbDRTRVJCWVVKblRsWkNRVzlVQ2tVeVVqVmliVVowWVZkT2MyRllUakJhVnpWc1kya3hkbU50WTNoS2FrRnJRbWRPVmtKQlRVMUlWXAogICAgICAxSTFZbTFHZEdGWFRuTmhXRTR3V2xjMWJHTnBNV29LV1ZWQmVFNTZUWHBQVkVGM1RYcFZNazFHYTNkRmQxbElTMjlhU1hwcU1FTkJVXAogICAgICBWbEpTMjlhU1hwcU1FUkJVV05FVVdkQlJUWkZWSGxyU25FeFFTdHdTZ3BvTlhSelVubzRVbTltYkdWQlpsSnlhVkJYYUZkMlYzVmhjXAogICAgICAxbG9MME0yUzBsQ2FGTXJUMHBGUm1VMlpURktaMmhCYVVwTmNtUndXVWd5YVVsNlkyeHdDbWhqVFV0SFVqbENSelpPUTAxRlFYZEVaXAogICAgICAxbEVWbEl3VUVGUlNDOUNRVkZFUVdkTGEwMUJPRWRCTVZWa1JYZEZRaTkzVVVaTlFVMUNRV1k0ZDBoUldVUUtWbEl3VDBKQ1dVVkdSXAogICAgICBYUldjR2xJY0RWeFJtSXdVeXMwY1hZNFJrTm1lVGMxUldSRlRVRnZSME5EY1VkVFRUUTVRa0ZOUTBFd1owRk5SVlZEU1ZGRVVncExjXAogICAgICBqRkpla2RIVVdJemNGbG5PVVJ4YUc5bWQwRXpRVEFyYW5sVWRrUndhMFV3WTI5V05tWkxlWGRKWjFkNFVtUlFTbmtyU2xCWk1HSkxaXAogICAgICBFZG1TelV5Q204NVpFMXNSVVpaVjJwb2Ezb3JZVTlZZVhSSk1qWlZQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHQiCgp1c2VyczoKLSBuYW1lOiAibG9jYWwiCiAgdXNlcjoKICAgIHRva2VuOiAia3ViZWNvbmZpZy11c2VyLXFqZzVsOGpoYmw6enFsY212bWJjcTV0YmJzamxidzVqdDY4OXFucHR4NWx6YmxqYzd0NmZybGZmNzJiamZmdnNuIgoKCmNvbnRleHRzOgotIG5hbWU6ICJsb2NhbCIKICBjb250ZXh0OgogICAgdXNlcjogImxvY2FsIgogICAgY2x1c3RlcjogImxvY2FsIgoKY3VycmVudC1jb250ZXh0OiAibG9jYWwiCg==
kind: Secret
metadata:
  name: rancher-cluster-config
  namespace: harvester-system
type: secret
```

6. Set `rancher-cluster` setting with following value:

```
'{"removeUpstreamClusterWhenNamespaceIsDeleted":true}'
```

7. Create a new namespace `thisistest` in harvester.
8. Create a new VMImage / VLAN network under `thisistest` namespace.
9. Create a guest cluster and set the pool namespace as `thisistest`.
10. After the guest cluster is ready, remove `thisistest` namespace in harvester. Check the guest cluster is removed.