### PR TITLE
feat: update node promotion helm config to support custom RKE2 CIDRs

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -73,18 +73,20 @@ data:
       echo Waiting for bootstrap object of $CUSTOM_MACHINE...
       sleep 2
     done
+    `}}
 
     VIP=$($KUBECTL get configmap vip -n harvester-system -o=jsonpath='{.data.ip}')
     cat > /host/etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml <<EOF
     cni: multus,canal
-    cluster-cidr: 10.52.0.0/16
-    service-cidr: 10.53.0.0/16
-    cluster-dns: 10.53.0.10
+    cluster-cidr: {{ .Values.promote.clusterPodCIDR }}
+    service-cidr: {{ .Values.promote.clusterServiceCIDR }}
+    cluster-dns: {{ .Values.promote.clusterDNS }}
     tls-san:
       - $VIP
     audit-policy-file: /etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
     EOF
 
+    {{`
     # Disable snapshot-controller related charts because we manage them in Harvester.
     # RKE2 enables these charts by default after v1.25.7 (https://github.com/rancher/rke2/releases/tag/v1.25.7%2Brke2r1)
     cat > /host/etc/rancher/rke2/config.yaml.d/40-disable-charts.yaml <<EOF

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -550,3 +550,11 @@ snapshot-validation-webhook:
 enableLonghornNetworkPolicy: true
 
 enableGoCoverDir: false
+
+# these cluster network configuration are used by node promotion controller.
+# their values must match those provided during Harvester installation, and
+# cannot be modified post-installation.
+promote:
+  clusterPodCIDR: 10.52.0.0/16
+  clusterServiceCIDR: 10.53.0.0/16
+  clusterDNS: 10.53.0.10


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The current hard-coded RKE2 cluster network configuration in the [`promote.sh` script](https://github.com/harvester/harvester/blob/ef97c6c4fa49086a082c12682ef5287d4d3777f5/deploy/charts/harvester/templates/configmap.yaml#L77-L85) doesn't work with the installer's new custom cluster configuration feature introduced in https://github.com/harvester/harvester-installer/pull/886. When a worker node is promoted to be a management node, it would still use the default hard-coded values.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR parameterized the hard-coded RKE2 cluster network configuration using Helm's `Values` structure. As stated in the variables comment, these new variables are used only for node promotion and cannot be changed post-installation.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

### Test Case 1 - Ensure Promoted Node Gets The Overridden Network Configuration

1. Install Harvester using the new ISO built from https://github.com/harvester/harvester-installer/pull/886 with the following cluster network configuration:
   * pod CIDR: 172.17.0.0/16
   * service CIDR: 172.20.0.0/16
   * cluster DNS: 172.20.0.10
1. Expect the installation of the 1st management node to complete successfully
1. Install two more nodes with the `default` role
1. Expect the installation of the 2nd and 3rd nodes to complete successfully
1. Wait for the 2nd and 3rd nodes to be auto-promoted to management nodes
1. Expect their promotion jobs to completed successfully:

```sh
$ k -n harvester-system get job 
NAME                     COMPLETIONS   DURATION   AGE
harvester-promote-dev1   1/1           81s        4m34s
harvester-promote-dev2   1/1           60s        3m12s
```

1. When diff-ing the `harvester-system/harvester-helpers` config map with one from an older installation, expect the `promote.sh` script to include the custom cluster network configuration:

```diff
--- old-promote.sh    2024-12-12 19:36:25.453533253 -0800
+++ new-promote.sh     2024-12-12 16:00:26.129663224 -0800
@@ -57,9 +57,9 @@
 VIP=$($KUBECTL get configmap vip -n harvester-system -o=jsonpath='{.data.ip}')
 cat > /host/etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml <<EOF
 cni: multus,canal
-cluster-cidr: 10.52.0.0/16
-service-cidr: 10.53.0.0/16
-cluster-dns: 10.53.0.10
+cluster-cidr: 172.17.0.0/16
+service-cidr: 172.20.0.0/16
+cluster-dns: 172.20.0.10
 tls-san:
   - $VIP
 audit-policy-file: /etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
```