### PR TITLE
Fix: Enforce consistent Maintenance Mode Strategy behavior

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -9,16 +9,18 @@ import (
 
 const (
 	vmControllerCreatePVCsFromAnnotationControllerName           = "VMController.CreatePVCsFromAnnotation"
-	vmiControllerReconcileFromHostLabelsControllerName           = "VMIController.ReconcileFromHostLabels"
 	vmControllerSetDefaultManagementNetworkMac                   = "VMController.SetDefaultManagementNetworkMacAddress"
 	vmControllerStoreRunStrategyControllerName                   = "VMController.StoreRunStrategyToAnnotation"
 	vmControllerSyncLabelsToVmi                                  = "VMController.SyncLabelsToVmi"
 	vmControllerSetHaltIfInsufficientResourceQuotaControllerName = "VMController.SetHaltIfInsufficientResourceQuota"
 	vmControllerRemoveDeprecatedFinalizerControllerName          = "VMController.RemoveDeprecatedFinalizer"
-	vmiControllerRemoveDeprecatedFinalizerControllerName         = "VMIController.RemoveDeprecatedFinalizer"
-	vmiControllerSetHaltIfOccurExceededQuotaControllerName       = "VMIController.StopVMIfExceededQuota"
+	vmControllerCleanupPVCAndSnapshotFinalizerName               = "VMController.CleanupPVCAndSnapshot"
 
-	vmControllerCleanupPVCAndSnapshotFinalizerName = "VMController.CleanupPVCAndSnapshot"
+	vmiControllerReconcileFromHostLabelsControllerName     = "VMIController.ReconcileFromHostLabels"
+	vmiControllerRemoveDeprecatedFinalizerControllerName   = "VMIController.RemoveDeprecatedFinalizer"
+	vmiControllerSetHaltIfOccurExceededQuotaControllerName = "VMIController.StopVMIfExceededQuota"
+	vmiControllerSyncHarvesterVMILabelsToPodName           = "VMIController.SyncHarvesterVMILabelsToPod"
+
 	// this finalizer is special one which was added by our controller, not wrangler.
 	// https://github.com/harvester/harvester/blob/78b0f20abb118b5d0fba564e18867b90a1d3c0ee/pkg/controller/master/virtualmachine/vm_controller.go#L97-L101
 	deprecatedHarvesterUnsetOwnerOfPVCsFinalizer = "harvesterhci.io/VMController.UnsetOwnerOfPVCs"
@@ -28,25 +30,29 @@ const (
 
 func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	var (
-		nsCache        = management.CoreFactory.Core().V1().Namespace().Cache()
-		podCache       = management.CoreFactory.Core().V1().Pod().Cache()
-		rqCache        = management.HarvesterCoreFactory.Core().V1().ResourceQuota().Cache()
+		nodeClient     = management.CoreFactory.Core().V1().Node()
+		nodeCache      = nodeClient.Cache()
+		podClient      = management.CoreFactory.Core().V1().Pod()
+		podCache       = podClient.Cache()
 		pvcClient      = management.CoreFactory.Core().V1().PersistentVolumeClaim()
 		pvcCache       = pvcClient.Cache()
 		vmClient       = management.VirtFactory.Kubevirt().V1().VirtualMachine()
 		vmCache        = vmClient.Cache()
-		nodeClient     = management.CoreFactory.Core().V1().Node()
-		nodeCache      = nodeClient.Cache()
 		vmiClient      = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 		vmiCache       = vmiClient.Cache()
 		vmBackupClient = management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup()
 		vmBackupCache  = vmBackupClient.Cache()
-		snapshotClient = management.SnapshotFactory.Snapshot().V1().VolumeSnapshot()
-		vmimCache      = management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache()
-		snapshotCache  = snapshotClient.Cache()
 		crClient       = management.ControllerRevisionFactory.Apps().V1().ControllerRevision()
 		crClientCache  = crClient.Cache()
-		recorder       = management.NewRecorder(vmControllerSetHaltIfInsufficientResourceQuotaControllerName, "", "")
+
+		snapshotClient = management.SnapshotFactory.Snapshot().V1().VolumeSnapshot()
+
+		nsCache       = management.CoreFactory.Core().V1().Namespace().Cache()
+		rqCache       = management.HarvesterCoreFactory.Core().V1().ResourceQuota().Cache()
+		vmimCache     = management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache()
+		snapshotCache = snapshotClient.Cache()
+
+		recorder = management.NewRecorder(vmControllerSetHaltIfInsufficientResourceQuotaControllerName, "", "")
 	)
 
 	// registers the vm controller
@@ -65,38 +71,38 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 
 		vmrCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache),
 	}
-	var virtualMachineClient = management.VirtFactory.Kubevirt().V1().VirtualMachine()
-	virtualMachineClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)
-	virtualMachineClient.OnChange(ctx, vmControllerStoreRunStrategyControllerName, vmCtrl.StoreRunStrategy)
-	virtualMachineClient.OnChange(ctx, vmControllerSyncLabelsToVmi, vmCtrl.SyncLabelsToVmi)
-	virtualMachineClient.OnChange(ctx, vmControllerSetHaltIfInsufficientResourceQuotaControllerName, vmCtrl.SetHaltIfInsufficientResourceQuota)
-	virtualMachineClient.OnChange(ctx, vmControllerRemoveDeprecatedFinalizerControllerName, vmCtrl.removeDeprecatedFinalizer)
-	virtualMachineClient.OnRemove(ctx, vmControllerCleanupPVCAndSnapshotFinalizerName, vmCtrl.cleanupPVCAndSnapshot)
+	vmClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)
+	vmClient.OnChange(ctx, vmControllerStoreRunStrategyControllerName, vmCtrl.StoreRunStrategy)
+	vmClient.OnChange(ctx, vmControllerSyncLabelsToVmi, vmCtrl.SyncLabelsToVmi)
+	vmClient.OnChange(ctx, vmControllerSetHaltIfInsufficientResourceQuotaControllerName, vmCtrl.SetHaltIfInsufficientResourceQuota)
+	vmClient.OnChange(ctx, vmControllerRemoveDeprecatedFinalizerControllerName, vmCtrl.removeDeprecatedFinalizer)
+	vmClient.OnRemove(ctx, vmControllerCleanupPVCAndSnapshotFinalizerName, vmCtrl.cleanupPVCAndSnapshot)
 
 	// registers the vmi controller
-	var virtualMachineCache = virtualMachineClient.Cache()
-	var virtualMachineInstanceClient = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	var vmiCtrl = &VMIController{
+		podClient:           podClient,
+		podCache:            podCache,
 		vmClient:            vmClient,
-		virtualMachineCache: virtualMachineCache,
-		vmiClient:           virtualMachineInstanceClient,
+		virtualMachineCache: vmCache,
+		vmiClient:           vmiClient,
 		nodeCache:           nodeCache,
 		pvcClient:           pvcClient,
 		recorder:            recorder,
 	}
-	virtualMachineInstanceClient.OnChange(ctx, vmiControllerReconcileFromHostLabelsControllerName, vmiCtrl.ReconcileFromHostLabels)
-	virtualMachineInstanceClient.OnChange(ctx, vmiControllerSetHaltIfOccurExceededQuotaControllerName, vmiCtrl.StopVMIfExceededQuota)
-	virtualMachineInstanceClient.OnChange(ctx, vmiControllerRemoveDeprecatedFinalizerControllerName, vmiCtrl.removeDeprecatedFinalizer)
+	vmiClient.OnChange(ctx, vmiControllerReconcileFromHostLabelsControllerName, vmiCtrl.ReconcileFromHostLabels)
+	vmiClient.OnChange(ctx, vmiControllerSetHaltIfOccurExceededQuotaControllerName, vmiCtrl.StopVMIfExceededQuota)
+	vmiClient.OnChange(ctx, vmiControllerRemoveDeprecatedFinalizerControllerName, vmiCtrl.removeDeprecatedFinalizer)
+	vmiClient.OnChange(ctx, vmiControllerSyncHarvesterVMILabelsToPodName, vmiCtrl.SyncHarvesterVMILabelsToPod)
 
 	// register the vm network controller upon the VMI changes
 	var vmNetworkCtl = &VMNetworkController{
 		vmClient:  vmClient,
 		vmCache:   vmCache,
-		vmiClient: virtualMachineInstanceClient,
+		vmiClient: vmiClient,
 		crClient:  crClient,
 		crCache:   crClientCache,
 	}
-	virtualMachineInstanceClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
+	vmiClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
 
 	return nil
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -127,13 +127,25 @@ const (
 
 	RKEControlPlaneRoleLabel = "rke.cattle.io/control-plane-role"
 
-	LabelMaintainModeStrategy                          = prefix + "/maintain-mode-strategy"
-	AnnotationMaintainModeStrategyNodeName             = prefix + "/maintain-mode-strategy-node-name"
+	LabelMaintainModeStrategy              = prefix + "/maintain-mode-strategy"
+	AnnotationMaintainModeStrategyNodeName = prefix + "/maintain-mode-strategy-node-name"
+
 	MaintainModeStrategyMigrate                        = "Migrate"
 	MaintainModeStrategyShutdownAndRestartAfterEnable  = "ShutdownAndRestartAfterEnable"
 	MaintainModeStrategyShutdownAndRestartAfterDisable = "ShutdownAndRestartAfterDisable"
 	MaintainModeStrategyShutdown                       = "Shutdown"
+)
 
+var (
+	ValidMaintenanceModeStrategyValues = []string{
+		MaintainModeStrategyMigrate,
+		MaintainModeStrategyShutdownAndRestartAfterEnable,
+		MaintainModeStrategyShutdownAndRestartAfterDisable,
+		MaintainModeStrategyShutdown,
+	}
+)
+
+const (
 	// s3 backup target constants
 	AWSAccessKey       = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey       = "AWS_SECRET_ACCESS_KEY"

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -145,7 +145,7 @@ func DrainPossible(nodeCache ctlcorev1.NodeCache, node *corev1.Node) error {
 }
 
 func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
-	// Ignore VMs that should not be migrated in maintenance mode. These
+	// Ignore Pods of VMs that should not be migrated in maintenance mode. These
 	// VMs are forcibly shut down when maintenance mode is activated.
 	// They are identified by the maintenance-mode strategy label
 	// `harvesterhci.io/maintain-mode-strategy` having any of these values:
@@ -173,5 +173,7 @@ func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
 	// VMs which don't have the maintenance-mode strategy label set or have it set
 	// to any value other than the ones named above, the behavior will be the same
 	// as the default.
+	// It's ok as well to mark all other pods for deletion here, because if they
+	// shouldn't be deleted, a different filter should mark them to be skipped.
 	return drain.MakePodDeleteStatusOkay()
 }

--- a/pkg/util/patch.go
+++ b/pkg/util/patch.go
@@ -1,0 +1,21 @@
+package util
+
+// Structs for generating Kubernetes PATCH requests with json.Marshal
+// Generating the patch request by serializing a struct guarantees that the JSON
+// data in the request will not be malformed.
+//
+// Utilize like this:
+//
+// op := json.Marshall(
+//   PatchStringValue{
+//     Op:    "replace",
+//     Path:  "/spec/property",
+//     Value: "newValue",
+//   },
+// )
+
+type PatchStringValue struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -79,6 +79,11 @@ func (m *vmMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch
 		return nil, err
 	}
 
+	patchOps, err = m.ensureMaintenanceModeStrategyIsSet(vm, patchOps)
+	if err != nil {
+		return nil, err
+	}
+
 	return patchOps, nil
 }
 
@@ -113,6 +118,11 @@ func (m *vmMutator) Update(_ *types.Request, oldObj runtime.Object, newObj runti
 	}
 
 	patchOps, err = m.patchTerminationGracePeriodSeconds(newVM, patchOps)
+	if err != nil {
+		return nil, err
+	}
+
+	patchOps, err = m.ensureMaintenanceModeStrategyIsSet(newVM, patchOps)
 	if err != nil {
 		return nil, err
 	}
@@ -539,4 +549,58 @@ func hostDevicesOvercommitNeeded(oldVM, newVM *kubevirtv1.VirtualMachine) bool {
 
 func isDedicatedCPU(vm *kubevirtv1.VirtualMachine) bool {
 	return vm.Spec.Template.Spec.Domain.CPU != nil && vm.Spec.Template.Spec.Domain.CPU.DedicatedCPUPlacement
+}
+
+func (m *vmMutator) ensureMaintenanceModeStrategyIsSet(vm *kubevirtv1.VirtualMachine, patchOps types.PatchOps) (types.PatchOps, error) {
+	// If the maintenante-mode strategy label is not set, add it with the default
+	// value of `Migrate`.
+	labels := vm.ObjectMeta.Labels
+	strategy, ok := labels[util.LabelMaintainModeStrategy]
+	if !ok {
+		strategy = util.MaintainModeStrategyMigrate
+		logrus.WithFields(logrus.Fields{
+			"namespace": vm.Namespace,
+			"name":      vm.Name,
+		}).Infof("no maintenance mode strategy specified for VM, applying default strategy `Migrate`")
+		patch, err := json.Marshal(
+			util.PatchStringValue{
+				Op:    "replace",
+				Path:  "/metadata/labels/harvesterhci.io~1maintain-mode-strategy", // `~1` is escaped encoding for `/` in JSON
+				Value: strategy,
+			},
+		)
+		if err != nil {
+			return patchOps, err
+		}
+
+		patchOps = append(patchOps, string(patch[:]))
+	}
+
+	// If the value under .spec.template.metadata.labels does not match the
+	// maintenance mode strategy label, or isn't set, then adjust it to match.
+	templateLabels := vm.Spec.Template.ObjectMeta.Labels
+	templateStrategy, ok := templateLabels[util.LabelMaintainModeStrategy]
+	if ok && strategy != templateStrategy {
+		logrus.WithFields(logrus.Fields{
+			"namespace": vm.Namespace,
+			"name":      vm.Name,
+			"strategy":  strategy,
+		}).Infof("maintenance mode strategy label in template does not match maintenance mode strategy label, applying %v", strategy)
+	}
+
+	if !ok || strategy != templateStrategy {
+		patch, err := json.Marshal(
+			util.PatchStringValue{
+				Op:    "replace",
+				Path:  "/spec/template/metadata/labels/harvesterhci.io~1maintain-mode-strategy",
+				Value: strategy,
+			},
+		)
+		if err != nil {
+			return patchOps, err
+		}
+
+		patchOps = append(patchOps, string(patch[:]))
+	}
+	return patchOps, nil
 }

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -17,6 +17,7 @@ import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
@@ -25,6 +26,102 @@ const (
 	replaceOP        = "replace"
 	nodeAffinityPath = "/spec/template/spec/affinity"
 )
+
+func TestEnsureMaintenanceModeStrategyLabelIsSet(t *testing.T) {
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		templateLabels map[string]string
+		patchOps       types.PatchOps
+	}{
+		{
+			name:           "maintenance mode strategy label is not set, nothing set for template",
+			labels:         map[string]string{},
+			templateLabels: map[string]string{},
+			patchOps: types.PatchOps{
+				`{"op":"replace","path":"/metadata/labels/harvesterhci.io~1maintain-mode-strategy","value":"Migrate"}`,
+				`{"op":"replace","path":"/spec/template/metadata/labels/harvesterhci.io~1maintain-mode-strategy","value":"Migrate"}`,
+			},
+		},
+		{
+			name:   "maintenance mode strategy label is not set, strategy is set for template",
+			labels: map[string]string{},
+			templateLabels: map[string]string{
+				util.LabelMaintainModeStrategy: "foobar",
+			},
+			patchOps: types.PatchOps{
+				`{"op":"replace","path":"/metadata/labels/harvesterhci.io~1maintain-mode-strategy","value":"Migrate"}`,
+				`{"op":"replace","path":"/spec/template/metadata/labels/harvesterhci.io~1maintain-mode-strategy","value":"Migrate"}`,
+			},
+		},
+		{
+			name: "maintenance mode strategy label is set, nothing set for template",
+			labels: map[string]string{
+				util.LabelMaintainModeStrategy: "foobar",
+			},
+			templateLabels: map[string]string{},
+			patchOps: types.PatchOps{
+				`{"op":"replace","path":"/spec/template/metadata/labels/harvesterhci.io~1maintain-mode-strategy","value":"foobar"}`,
+			},
+		},
+		{
+			name: "maintenance mode strategy label is set, strategy is set for template to same value",
+			labels: map[string]string{
+				util.LabelMaintainModeStrategy: "foobar",
+			},
+			templateLabels: map[string]string{
+				util.LabelMaintainModeStrategy: "foobar",
+			},
+			patchOps: types.PatchOps{},
+		},
+		{
+			name: "a maintenance mode strategy label is set, strategy is set for template to different value",
+			labels: map[string]string{
+				util.LabelMaintainModeStrategy: "foobar",
+			},
+			templateLabels: map[string]string{
+				util.LabelMaintainModeStrategy: "barfoo",
+			},
+			patchOps: types.PatchOps{
+				`{"op":"replace","path":"/spec/template/metadata/labels/harvesterhci.io~1maintain-mode-strategy","value":"foobar"}`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			mutator := NewMutator(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+				fakeclients.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions))
+			vm := &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tc.labels,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: tc.templateLabels,
+						},
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Memory: &kubevirtv1.Memory{
+									Guest: resource.NewQuantity(int64(math.Pow(2, 30)), resource.BinarySI), // 1Gi
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// act
+			actual, err := mutator.(*vmMutator).ensureMaintenanceModeStrategyIsSet(vm, types.PatchOps{})
+
+			// assert
+			assert.Nil(t, err, tc.name)
+			assert.Equal(t, tc.patchOps, actual)
+		})
+	}
+}
 
 func TestPatchResourceOvercommit(t *testing.T) {
 	tests := []struct {

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -311,35 +311,35 @@ func (v *vmValidator) checkStorageResourceQuota(vm *kubevirtv1.VirtualMachine, o
 func checkMaintenanceModeStrategyIsValid(newVM, oldVM *kubevirtv1.VirtualMachine) error {
 	labels := newVM.ObjectMeta.Labels
 	newStrategy, ok := labels[util.LabelMaintainModeStrategy]
-	if ok {
-		// Don't deny updates on an existing VM with an invalid maintenance-mode
-		// strategy label, if the label stays the same, but complain with a warning.
-		// If the maintenance-mode strategy label is updated, its new value needs to
-		// be valid regardless.
-		if oldVM != nil {
-			oldVMLabels := oldVM.ObjectMeta.Labels
-			oldStrategy, ok := oldVMLabels[util.LabelMaintainModeStrategy]
-			if ok && oldStrategy == newStrategy {
-				if !slices.Contains(util.ValidMaintenanceModeStrategyValues, oldStrategy) {
-					logrus.WithFields(logrus.Fields{
-						"name":      oldVM.Name,
-						"namespace": oldVM.Namespace,
-					}).Warnf("invalid maintenance-mode strategy for VM, behavior will be equivalent to default `%v`", util.MaintainModeStrategyMigrate)
-
-					return nil
-				}
-			}
-		}
-
-		if !slices.Contains(util.ValidMaintenanceModeStrategyValues, newStrategy) {
-			return werror.NewInvalidError(
-				fmt.Sprintf("invalid maintenance mode strategy: %v", newStrategy),
-				fmt.Sprintf("metadata.labels[%v]", util.LabelMaintainModeStrategy),
-			)
-		}
-	} else {
+	if !ok {
 		return werror.NewInvalidError(
 			fmt.Sprintf("label `%v` not found", util.LabelMaintainModeStrategy),
+			fmt.Sprintf("metadata.labels[%v]", util.LabelMaintainModeStrategy),
+		)
+	}
+
+	// Don't deny updates on an existing VM with an invalid maintenance-mode
+	// strategy label, if the label stays the same, but complain with a warning.
+	// If the maintenance-mode strategy label is updated, its new value needs to
+	// be valid regardless.
+	if oldVM != nil {
+		oldVMLabels := oldVM.ObjectMeta.Labels
+		oldStrategy, ok := oldVMLabels[util.LabelMaintainModeStrategy]
+		if ok && oldStrategy == newStrategy {
+			if !slices.Contains(util.ValidMaintenanceModeStrategyValues, oldStrategy) {
+				logrus.WithFields(logrus.Fields{
+					"name":      oldVM.Name,
+					"namespace": oldVM.Namespace,
+				}).Warnf("invalid maintenance-mode strategy for VM, behavior will be equivalent to default `%v`", util.MaintainModeStrategyMigrate)
+
+				return nil
+			}
+		}
+	}
+
+	if !slices.Contains(util.ValidMaintenanceModeStrategyValues, newStrategy) {
+		return werror.NewInvalidError(
+			fmt.Sprintf("invalid maintenance mode strategy: %v", newStrategy),
 			fmt.Sprintf("metadata.labels[%v]", util.LabelMaintainModeStrategy),
 		)
 	}

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -1,0 +1,187 @@
+package virtualmachine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func TestCheckMaintenanceModeStrategyIsValid(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		expectError bool
+		oldVM       *kubevirtv1.VirtualMachine
+		newVM       *kubevirtv1.VirtualMachine
+	}{
+		{
+			name:        "reject new VM if maintenance mode strategy label is not set",
+			expectError: true,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "reject new VM if maintenance mode strategy label is set to invalid value",
+			expectError: true,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "reject update to VM if maintenance mode strategy label is invalid for new VM",
+			expectError: true,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: util.MaintainModeStrategyMigrate,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This case is crucial, so Harvester can still operate existing VMs with
+			// bogus maintenance-mode strategies (i.e. update their status, shut them
+			// down, etc.)
+			name:        "accept update to VM if maintenance mode strategy label was invalid on old VM",
+			expectError: false,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This case ensures that IF the maintenance-mode label is updated, it is
+			// updated with a valid value
+			name:        "reject update to VM with invalid maintenance-mode strategy label, even if maintenance mode strategy label was invalid on old VM",
+			expectError: true,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "barfoo",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "accept new VM maintenance mode strategy label is set to valid value",
+			expectError: false,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: util.MaintainModeStrategyMigrate,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		err := checkMaintenanceModeStrategyIsValid(tc.newVM, tc.oldVM)
+		if tc.expectError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}


### PR DESCRIPTION
# Problem:

As described in harvester/harvester#6835, there are several problems to be considered here:

1. Ensuring that the maintenance-mode strategy is specified
2. Ensuring that only a valid maintenance-mode strategy can be specified
3. Ensuring that the specified maintenance-mode strategy label is propagated all the way to all resources where it's expected
4. Ensuring that default behavior is applied in all cases where a maintenance-mode strategy either isn't specified or isn't valid

# Solution:

The solution to the problem consists of a modification to the node drain helper and modifications both the mutating admission webhook and the validating admission webhook for the VirtualMachine resource

### The Node Drain Helper

The node drain helper was only marking Pods of VMs which had the maintenance-mode strategy label set to `Migrate` for deletion (i.e. migration off of the node).
This behavior would omit all Pods which didn't have this label set at all, or the ones which had it set to an invalid value. Similarly, Pods of VMs which didn't have one of the three other maintenance-mode strategies set would not be shut down. Thereby any VM without a maintenance-mode strategy, or with an invalid maintenance-mode strategy would be left running, preventing the node from entering the maintenance mode successfully. As a result the node would remain stuck in "Cordoned" state, waiting for an operator to intervene and deal with the VMs.
The new behavior of the drain helper is to migrate any VMs off of the node, if the associated Pod either has no maintenance-mode strategy label, the maintenance-mode strategy label is invalid, or the maintenance-mode strategy is specified as `Migrate`. This is the documented default behavior for VMs.
All other VMs will have a different maintenance-mode strategy specified and they will thus be shut down (and later restarted according to their maintenance-mode strategy).

### Admission Webhook

The admission webhook for the VirtualMachine resource plays a crucial role in making sure that VirtualMachiness have a sane maintenance-mode strategy specified.
First, the mutating webhook ensures that the maintenance-mode strategy label is set on the VirtualMachine resource. If it isn't, it will be set to `Migrate`, which is the default.
Then the mutating webhook ensures that the maintenance-mode strategy label that is set on the VirtualMachine resource is propagated into the `.spec.templates.metadata.labels`, which is to ensure that the label is propagated throughout both the VirtualMachineInstance as well as the Pod belonging to that VirtualMachine.
The mutating webhook will not modify exising maintenance-mode strategy labels on existing VirtualMachine resources. While the node drain helper will apply the default strategy to these virtual machines, this is to ensure that the user will not be faced with inexplicably changing maintenance-mode strategy labels, if they have an invalid value in their cluster.
The webhook will however log an appropriate message, allowing the user to identify VirtualMachine resources affected by invalid values in the maintenance-mode strategy label and correct it.

The validating webhook takes the role of a safe guard, ensuring that no VirtualMachine can be created or updated with an ill-specified maintenance-mode strategy.
It will reject the creation of VirtualMachine resources without a maintenance-mode strategy label or with an invalid value in the maintenance-mode strategy label.
This ensures that the label can not accidentally be filled with bogus data and that the user is informed.

# Related Issue:

- harvester/harvester#6835

# Test plan:

## Scenario 1

Ensure that new VirtualMachines have a valid maintenance-mode strategy. If it's not given, the default should be applied.

### Test 1

No maintenance-mode strategy given.

#### Setup:

Create a new VirtualMachine and specify no maintenance-mode strategy:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/creator: harvester
    harvesterhci.io/os: linux
  name: test
[...]
```

#### Expected Result

The default strategy `Migrate` should have been added by the mutating admission webhook:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: Migrate
    [...]
  name: test
[...]
```

### Test 2

Valid maintenance-mode strategy given.

#### Setup:

Create a new VirtualMachine and specify a valid maintenance-mode strategy:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: Shutdown
    [...]
  name: test
[...]
```

#### Expected Result

The previously specified maintenance-mode strategy should be persisted in the VirtualMachine resource's metadata:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: Shutdown
    [...]
  name: test
[...]
```

## Scenario 2

If an invalid maintenance-mode strategy is specified, the VirtualMachine resource should be rejected.

### Test 1

Invalid maintenance-mode strategy given.

#### Setup:

Create a new VirtualMachine and specify an invalid maintenance-mode strategy:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: foobar
    [...]
  name: test
[...]
```

#### Expected Result

The creation should be rejected with a sensible error message

```
The request is invalid: metadata.labels[harvesterhci.io/maintain-mode-strategy]: invalid maintenance mode strategy: foobar
```

## Scenario 3

The specified maintenance-mode strategy should be propagated to all relevant resources.

### Test 1

The maintenance-mode strategy is propagated to the VirtualMachineInstance and the corresponding Pod, when the VirtualMachine is created

#### Setup

Create a new VirtualMachine and specify a valid maintenance-mode strategy:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: Shutdown
    [...]
  name: test
[...]
```

#### Expected Result

The VirtualMachine resource, the VirtualMachineInstance resource and the belonging Pod resource all have the specified maintenance-mode strategy label.

```
│ ~ │► kubectl get vm,vmi,pod -l harvesterhci.io/maintain-mode-strategy=Shutdown
NAME                              AGE   STATUS    READY
virtualmachine.kubevirt.io/test   10m   Running   True

NAME                                      AGE   PHASE     IP           NODENAME           READY
virtualmachineinstance.kubevirt.io/test   10m   Running   10.52.1.65   harvester-node-1   True

NAME                           READY   STATUS    RESTARTS   AGE
pod/virt-launcher-test-n5tf2   2/2     Running   0          10m
```

### Test 2

The maintenance-mode strategy is updated on the VirtualMachineInstance and on the corresponding Pod, when the maintenance-mode strategy is updated on the VirtualMachine resource.

//TODO

## Scenario 4

In case a VirtualMachine resource, VirtualMachineInstance resource, or a corresponding Pod exists and either has no maintenance-mode strategy label, or the maintenance-mode strategy label has an invalid value, the default behavior (`Migrate`) should be applied.

// TODO