### PR TITLE
[WIP] Ensure the vm is synced when vmim has changes

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -236,7 +236,7 @@ func isReady(vmi *kubevirtv1.VirtualMachineInstance) bool {
 
 func canAbortMigrate(vmi *kubevirtv1.VirtualMachineInstance) bool {
 	if vmi != nil &&
-		vmi.Annotations[util.AnnotationMigrationState] == migration.StateMigrating {
+		vmi.Annotations[util.AnnotationMigrationState] == migration.StateMigrating || vmi.Annotations[util.AnnotationMigrationState] == migration.StatePending {
 		return true
 	}
 	return false

--- a/pkg/controller/master/migration/vmi_controller.go
+++ b/pkg/controller/master/migration/vmi_controller.go
@@ -1,8 +1,6 @@
 package migration
 
 import (
-	"context"
-
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +20,7 @@ type Handler struct {
 	namespace  string
 	rqs        ctlharvcorev1.ResourceQuotaClient
 	rqCache    ctlharvcorev1.ResourceQuotaCache
+	vmis       ctlvirtv1.VirtualMachineInstanceClient
 	vmiCache   ctlvirtv1.VirtualMachineInstanceCache
 	vms        ctlvirtv1.VirtualMachineClient
 	vmCache    ctlvirtv1.VirtualMachineCache
@@ -73,7 +72,7 @@ func (h *Handler) resetHarvesterMigrationStateInVMI(vmi *kubevirtv1.VirtualMachi
 		delete(toUpdate.Spec.NodeSelector, corev1.LabelHostname)
 	}
 
-	if err := util.VirtClientUpdateVmi(context.Background(), h.restClient, h.namespace, vmi.Namespace, vmi.Name, toUpdate); err != nil {
+	if _, err := h.vmis.Update(toUpdate); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/master/migration/vmim_controller_test.go
+++ b/pkg/controller/master/migration/vmim_controller_test.go
@@ -4,7 +4,9 @@ package migration
 
 import (
 	"testing"
+	"time"
 
+	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -21,11 +23,13 @@ import (
 
 const (
 	resourceQuotaNamespace = "rs"
-	resourceQuotaName
-	uid
+	resourceQuotaName      = "rq1"
 
 	errMockTrackerAdd = "mock resource should add into fake controller tracker"
 	errMockTrackerGet = "mock resource should get into fake controller tracker"
+
+	vmName       = "vm1"
+	migrationUID = "f560ca71-7ecb-4c0e-8614-b63111ef92c4"
 )
 
 func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
@@ -33,148 +37,246 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 	type fields struct {
 		rqs      ctlharvcorev1.ResourceQuotaClient
 		rqCache  ctlharvcorev1.ResourceQuotaCache
-		vmiCache ctlvirtv1.VirtualMachineInstanceCache
+		vms      ctlvirtv1.VirtualMachineClient
 		vmCache  ctlvirtv1.VirtualMachineCache
+		vmis     ctlvirtv1.VirtualMachineInstanceClient
+		vmiCache ctlvirtv1.VirtualMachineInstanceCache
+		podCache ctlcorev1.PodCache
 	}
 	type args struct {
 		rq   *corev1.ResourceQuota
+		vm   *kubevirtv1.VirtualMachine
 		vmi  *kubevirtv1.VirtualMachineInstance
 		vmim *kubevirtv1.VirtualMachineInstanceMigration
 	}
 
+	getOriginRQ := func() *corev1.ResourceQuota {
+		return &corev1.ResourceQuota{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: resourceQuotaNamespace,
+				Name:      resourceQuotaName,
+				Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+			},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+					corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
+				},
+			},
+		}
+	}
+
+	getScaledRQ := func() *corev1.ResourceQuota {
+		return &corev1.ResourceQuota{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: map[string]string{
+					util.AnnotationMigratingPrefix + vmName: `{"limits.cpu":"1","limits.memory":"1266Mi"}`,
+				},
+				Namespace: resourceQuotaNamespace,
+				Name:      resourceQuotaName,
+				Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+			},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+					corev1.ResourceLimitsMemory: *resource.NewQuantity(2624933888, resource.BinarySI),
+				},
+			},
+		}
+	}
+
+	getNormalVMI := func() *kubevirtv1.VirtualMachineInstance {
+		return &kubevirtv1.VirtualMachineInstance{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      vmName,
+				Namespace: resourceQuotaNamespace,
+			},
+			Spec: kubevirtv1.VirtualMachineInstanceSpec{
+				Domain: kubevirtv1.DomainSpec{
+					Resources: kubevirtv1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+						},
+					},
+				},
+			},
+		}
+	}
+
+	getMigrationSucceededVMI := func() *kubevirtv1.VirtualMachineInstance {
+		return &kubevirtv1.VirtualMachineInstance{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      vmName,
+				Namespace: resourceQuotaNamespace,
+				Annotations: map[string]string{
+					util.AnnotationMigrationUID: migrationUID,
+				},
+			},
+			Spec: kubevirtv1.VirtualMachineInstanceSpec{
+				Domain: kubevirtv1.DomainSpec{
+					Resources: kubevirtv1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+						},
+					},
+				},
+			},
+			Status: kubevirtv1.VirtualMachineInstanceStatus{
+				MigrationState: &kubevirtv1.VirtualMachineInstanceMigrationState{
+					MigrationUID: migrationUID,
+					Completed:    true,
+				},
+			},
+		}
+	}
+
+	/*
+		getMigrationAbortedVMI := func() *kubevirtv1.VirtualMachineInstance {
+			return &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      vmName,
+					Namespace: resourceQuotaNamespace,
+					Annotations: map[string]string{
+						util.AnnotationMigrationUID: migrationUID,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Resources: kubevirtv1.ResourceRequirements{
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+								corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+							},
+						},
+					},
+				},
+				Status: kubevirtv1.VirtualMachineInstanceStatus{
+					MigrationState: &kubevirtv1.VirtualMachineInstanceMigrationState{
+						MigrationUID: migrationUID,
+						Completed: true,
+						AbortStatus: kubevirtv1.MigrationAbortSucceeded,
+					},
+				},
+			}
+		}
+	*/
+
+	getArgs := func(vmimPhase kubevirtv1.VirtualMachineInstanceMigrationPhase, vmi *kubevirtv1.VirtualMachineInstance, rq *corev1.ResourceQuota) *args {
+		return &args{
+			rq: rq,
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      vmName,
+					Namespace: resourceQuotaNamespace,
+				},
+			},
+			vmi: vmi,
+			vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      vmName,
+					Namespace: resourceQuotaNamespace,
+					UID:       "f560ca71-7ecb-4c0e-8614-b63111ef92c4",
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: vmName},
+				Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+					Phase: vmimPhase,
+				},
+			},
+		}
+	}
+
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		want    *corev1.ResourceQuota
+		name            string
+		fields          fields
+		args            *args
+		wantErr         bool
+		want            *corev1.ResourceQuota
+		wantVMTsUpdated bool
+		baseVMTs        string
+		onChangeVMI     bool
+		wantVMIErr      bool
+		abort           bool
 	}{
 		{
-			name:   "In Pending",
-			fields: fields{},
-			args: args{
-				rq: &corev1.ResourceQuota{
-					ObjectMeta: v1.ObjectMeta{
-						Namespace: resourceQuotaNamespace,
-						Name:      resourceQuotaName,
-						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
-					},
-					Spec: corev1.ResourceQuotaSpec{
-						Hard: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-							corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
-						},
-					},
-				},
-				vmi: &kubevirtv1.VirtualMachineInstance{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "vm1",
-						Namespace: resourceQuotaNamespace,
-					},
-					Spec: kubevirtv1.VirtualMachineInstanceSpec{
-						Domain: kubevirtv1.DomainSpec{
-							Resources: kubevirtv1.ResourceRequirements{
-								Limits: map[corev1.ResourceName]resource.Quantity{
-									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
-								},
-							},
-						},
-					},
-				},
-				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "vmim1",
-						Namespace: resourceQuotaNamespace,
-					},
-					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
-					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
-						Phase: kubevirtv1.MigrationPending,
-					},
-				},
-			},
-			wantErr: false,
-			want: &corev1.ResourceQuota{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"1266Mi"}`,
-					},
-					Namespace: resourceQuotaNamespace,
-					Name:      resourceQuotaName,
-					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
-				},
-				Spec: corev1.ResourceQuotaSpec{
-					Hard: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
-						corev1.ResourceLimitsMemory: *resource.NewQuantity(2624933888, resource.BinarySI),
-					},
-				},
-			},
+			name:            "In Pending",
+			fields:          fields{},
+			args:            getArgs(kubevirtv1.MigrationPending, getNormalVMI(), getOriginRQ()),
+			wantErr:         false,
+			want:            getScaledRQ(),
+			wantVMTsUpdated: true,
+			baseVMTs:        time.Now().Format(time.RFC3339),
+			onChangeVMI:     false,
+			wantVMIErr:      false,
+			abort:           true,
 		},
 		{
-			name:   "Succeeded", // Equivalent to Failed
-			fields: fields{},
-			args: args{
-				rq: &corev1.ResourceQuota{
-					ObjectMeta: v1.ObjectMeta{
-						Namespace: resourceQuotaNamespace,
-						Name:      resourceQuotaName,
-						Annotations: map[string]string{
-							util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"1364Mi"}`,
-						},
-						Labels: map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
-					},
-					Spec: corev1.ResourceQuotaSpec{
-						Hard: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
-							corev1.ResourceLimitsMemory: *resource.NewQuantity(2727694336, resource.BinarySI),
-						},
-					},
-				},
-				vmi: &kubevirtv1.VirtualMachineInstance{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "vm1",
-						Namespace: resourceQuotaNamespace,
-					},
-					Spec: kubevirtv1.VirtualMachineInstanceSpec{
-						Domain: kubevirtv1.DomainSpec{
-							Resources: kubevirtv1.ResourceRequirements{
-								Limits: map[corev1.ResourceName]resource.Quantity{
-									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
-								},
-							},
-						},
-					},
-				},
-				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "vmim1",
-						Namespace: resourceQuotaNamespace,
-					},
-					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
-					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
-						Phase: kubevirtv1.MigrationSucceeded,
-					},
-				},
-			},
-			wantErr: false,
-			want: &corev1.ResourceQuota{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace:   resourceQuotaNamespace,
-					Name:        resourceQuotaName,
-					Annotations: map[string]string{},
-					Labels:      map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
-				},
-				Spec: corev1.ResourceQuotaSpec{
-					Hard: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-						corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
-					},
-				},
-			},
+			name:            "In Scheduling",
+			fields:          fields{},
+			args:            getArgs(kubevirtv1.MigrationScheduling, getNormalVMI(), getScaledRQ()),
+			wantErr:         false,
+			want:            getScaledRQ(),
+			wantVMTsUpdated: true,
+			baseVMTs:        time.Now().Format(time.RFC3339),
+			onChangeVMI:     false,
+			wantVMIErr:      false,
+			abort:           true,
 		},
+		{
+			name:            "Scheduled",
+			fields:          fields{},
+			args:            getArgs(kubevirtv1.MigrationScheduled, getNormalVMI(), getScaledRQ()),
+			wantErr:         false,
+			want:            getScaledRQ(),
+			wantVMTsUpdated: false, // VM is not expected to be forcely synced
+			baseVMTs:        time.Now().Format(time.RFC3339),
+			onChangeVMI:     false,
+			wantVMIErr:      false,
+			abort:           true,
+		},
+		{
+			name:            "Running",
+			fields:          fields{},
+			args:            getArgs(kubevirtv1.MigrationRunning, getNormalVMI(), getScaledRQ()),
+			wantErr:         false,
+			want:            getScaledRQ(),
+			wantVMTsUpdated: false, // VM is not expected to be forcely synced
+			baseVMTs:        time.Now().Format(time.RFC3339),
+			onChangeVMI:     false,
+			wantVMIErr:      false,
+			abort:           true,
+		},
+		{
+			name:            "Succeeded",
+			fields:          fields{},
+			args:            getArgs(kubevirtv1.MigrationSucceeded, getMigrationSucceededVMI(), getScaledRQ()),
+			wantErr:         false,
+			want:            getOriginRQ(),
+			wantVMTsUpdated: true,
+			baseVMTs:        time.Now().Format(time.RFC3339),
+			onChangeVMI:     true,
+			wantVMIErr:      false,
+			abort:           false,
+		},
+		// There is no podCache ATM, leave this case TBD.
+		/*
+			{
+				name:   "Aborted",
+				fields: fields{},
+				args: getArgs(kubevirtv1.MigrationFailed, getMigrationAbortedVMI(), getScaledRQ()),
+				wantErr: false,
+				want: getOriginRQ(),
+				wantVMTsUpdated: true,
+				baseVMTs:        time.Now().Format(time.RFC3339),
+				onChangeVMI: true,
+				wantVMIErr: false,
+				abort: false,
+			},
+		*/
 	}
+	// ensure timestamp can be compared
+	time.Sleep(1 * time.Second)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var clientset = fakecore.NewSimpleClientset()
@@ -182,6 +284,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 
 			if tt.args.rq != nil {
 				err := clientset.Tracker().Add(tt.args.rq)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+			if tt.args.vm != nil {
+				err := harvFakeClient.Tracker().Add(tt.args.vm)
 				assert.Nil(t, err, errMockTrackerAdd)
 			}
 			if tt.args.vmi != nil {
@@ -196,6 +302,9 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 			h := &Handler{
 				rqs:      fakeclients.ResourceQuotaClient(clientset.CoreV1().ResourceQuotas),
 				rqCache:  fakeclients.ResourceQuotaCache(clientset.CoreV1().ResourceQuotas),
+				vms:      fakeclients.VirtualMachineClient(harvFakeClient.KubevirtV1().VirtualMachines),
+				vmCache:  fakeclients.VirtualMachineCache(harvFakeClient.KubevirtV1().VirtualMachines),
+				vmis:     fakeclients.VirtualMachineInstanceClient(harvFakeClient.KubevirtV1().VirtualMachineInstances),
 				vmiCache: fakeclients.VirtualMachineInstanceCache(harvFakeClient.KubevirtV1().VirtualMachineInstances),
 			}
 
@@ -205,9 +314,28 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				return
 			}
 
+			// in successed/aborted cases, vmi onChange will further sync VM
+			if tt.onChangeVMI {
+				_, err := h.OnVmiChanged("", tt.args.vmi)
+				if (err != nil) != tt.wantVMIErr {
+					t.Errorf("OnVmiChanged() error = %v, wantErr %v", err, tt.wantVMIErr)
+					return
+				}
+			}
+
 			rq, err := clientset.Tracker().Get(corev1.SchemeGroupVersion.WithResource("resourcequotas"), tt.args.rq.Namespace, tt.args.rq.Name)
 			assert.Nil(t, err, errMockTrackerGet)
 			assert.Equal(t, tt.want, rq, "case %q", tt.name)
+
+			// vmim change will cause vm is updated thus the UI can render proper migrate button
+			obj, err := harvFakeClient.Tracker().Get(kubevirtv1.SchemeGroupVersion.WithResource("virtualmachines"), tt.args.vm.Namespace, tt.args.vm.Name)
+			assert.Nil(t, err, errMockTrackerGet)
+			vm, ok := obj.(*kubevirtv1.VirtualMachine)
+			assert.Equal(t, ok, true, "case %q", tt.name)
+			if tt.wantVMTsUpdated {
+				assert.True(t, len(vm.Annotations) == 1, "case %q", tt.name)
+				assert.True(t, vm.Annotations[util.AnnotationTimestamp] > tt.baseVMTs, tt.name)
+			}
 		})
 	}
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -8,6 +8,7 @@ const (
 	AnnotationMigrationTarget           = prefix + "/migrationTargetNodeName"
 	AnnotationMigrationUID              = prefix + "/migrationUID"
 	AnnotationMigrationState            = prefix + "/migrationState"
+	AnnotationMigrationStateTimestamp   = prefix + "/migrationStateTimestamp" // timestamp when entering this state
 	AnnotationTimestamp                 = prefix + "/timestamp"
 	AnnotationVolumeClaimTemplates      = prefix + "/volumeClaimTemplates"
 	AnnotationUpgradePatched            = prefix + "/upgrade-patched"

--- a/pkg/util/resourcequota/utils.go
+++ b/pkg/util/resourcequota/utils.go
@@ -40,6 +40,9 @@ func RemoveMigratingVM(rq *corev1.ResourceQuota, vmName string) {
 		return
 	}
 	delete(rq.Annotations, util.AnnotationMigratingPrefix+vmName)
+	if len(rq.Annotations) == 0 {
+		rq.Annotations = nil
+	}
 }
 
 func ContainsMigratingVM(rq *corev1.ResourceQuota, vmName string) bool {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Migration UI menu is not properly rendered when VMIM has changes.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Sync on all cases.

When a controller updates several objects in a row, there is always time-sequences related issues. Should be carefully processed.

BTW: The code is not fully finished & tested.

**Related Issue:**

https://github.com/harvester/harvester/issues/7180

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

(1) Setup a 2+ nodes cluster
(2) Create 4+ VMs, schedule them to one node
(3) Maintain this node, all VMs are put into migration automatically
(4) In general, 2 VMs will run migration at first, another 2 are on pending
(5) Those 2 pending migration VMs, should have `abort` menu, and allow to be aborted; the other running migration VMs should also be same.
...

TBD: Check the behaivour of UI and kubectl, if kubectl deletes a vmim successfully, UI should also allow, either from `Abort` menu, or from the `delete` menu.

TBD: Confirm the `Abort` allowed status from kubevirt source code.
...