### PR TITLE
Enable VMPersistentState feature gate for TPM and UEFI persistence

### DIFF
--- a/deploy/charts/harvester/templates/harvester-storageclass.yaml
+++ b/deploy/charts/harvester/templates/harvester-storageclass.yaml
@@ -18,4 +18,16 @@ parameters:
   fromBackup: ""
   baseImage: ""
   migratable: "true"
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: vmstate-persistence
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: "{{ .Values.storageClass.reclaimPolicy }}"
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "{{ .Values.storageClass.replicaCount }}"
+  staleReplicaTimeout: "30"
 {{- end -}}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -60,8 +60,9 @@ kubevirt:
     ##
     configuration:
       ## Specify kubevirt feature gates
+      vmStateStorageClass: "vmstate-persistence"
       developerConfiguration:
-        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager"]
+        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager", "VMPersistentState"]
 
       ## Specify the network configuration of VirtualMachineInstance.
       ##


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Minor changes to enable TPM / UEFI persistence for VM workloads

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
TPM/UEFI persistence needs the `VMPeristentState` feature gate enabled: https://kubevirt.io/user-guide/compute/persistent_tpm_and_uefi_state/ 
It also needs a default storage class to be available for use with VM workloads when tpm/uefi persistence is enabled

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR adds the following
* VMPersistentState feature gate
* Additional vm-state-persistence storage class, which is also configured in kubevirt CR as the default storage class for `vmStateStorageClass`

**Related Issue:** https://github.com/harvester/harvester/issues/6731

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
To test install Harvester with build containing the changes from this PR.
Post install:
* `kubectl get kubevirt kubevirt -n harvester-system -o yaml` should show additional `VMPersistentState` feature gate enabled and `vmStateStorageClass: vmstate-persistence` defined
```
  configuration:
    developerConfiguration:
      featureGates:
      - LiveMigration
      - HotplugVolumes
      - HostDevices
      - GPU
      - CPUManager
      - VMPersistentState
    vmStateStorageClass: vmstate-persistence
```
* additional storage class `vmstate-persistence` is created on the cluster
```
node-1-dhcp:~ # kubectl get sc
NAME                           PROVISIONER          RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
harvester-longhorn (default)   driver.longhorn.io   Delete          Immediate           true                   172m
longhorn                       driver.longhorn.io   Delete          Immediate           true                   171m
longhorn-static                driver.longhorn.io   Delete          Immediate           true                   171m
vmstate-persistence            driver.longhorn.io   Delete          Immediate           true                   172m
```

## test without tpm persistence
* Setup a linux vm on Harvester with tpm enabled
* Add `tpm2-tools` package for your linux distro
* As root run `tpm2_getekcertificate -T device:/dev/tpm0  | openssl x509 -noout -text` and save the certificate for reference
* Restart the VM from Harvester UI or virtctl
* Login post restart, as root run again `tpm2_getekcertificate -T device:/dev/tpm0  | openssl x509 -noout -text` , and observe the certificate has changed across reboots

## test with tpm persistence
* Setup a linux vm on Harvester with tpm and persistence enable. Until UI changes are ready this needs to be done via edit vm yaml option.
```
domain:
        devices:
          tpm:
            persistent: true
```
* Add `tpm2-tools` package for your linux distro
* As root run `tpm2_getekcertificate -T device:/dev/tpm0  | openssl x509 -noout -text` and save the certificate for reference
* Restart the VM from Harvester UI or virtctl
* Login post restart, as root run again `tpm2_getekcertificate -T device:/dev/tpm0  | openssl x509 -noout -text` , and observe the certificate has persisteted across reboots
* An extra pvc for tpm persistence has been created and attached to launcher pod
```
node-1-dhcp:~ # kubectl get pvc
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           VOLUMEATTRIBUTESCLASS   AGE
persistent-state-for-tpm   Bound    pvc-5ee01719-0d70-4a9c-b331-2b0c9b1b2044   10Mi       RWX            vmstate-persistence    <unset>                 17m
```