### PR TITLE
fix(upgrade): clean up image with crictl

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -37,14 +37,14 @@ HOST_DIR="${HOST_DIR:-/host}"
 export CONTAINER_RUNTIME_ENDPOINT=unix:///$HOST_DIR/run/k3s/containerd/containerd.sock
 export CONTAINERD_ADDRESS=$HOST_DIR/run/k3s/containerd/containerd.sock
 
-CTR="$HOST_DIR/$(readlink $HOST_DIR/var/lib/rancher/rke2/bin)/ctr"
-if [ -z "$CTR" ];then
-	echo "Fail to get host ctr binary."
+CRICTL="$HOST_DIR/$(readlink $HOST_DIR/var/lib/rancher/rke2/bin)/crictl"
+if [ -z "$CRICTL" ];then
+	echo "Fail to get host crictl binary."
 	exit 0
 fi
 
 ret=0
-"$CTR" -n k8s.io i rm $IMAGES || ret=$?
+"$CRICTL" rmi $IMAGES || ret=$?
 
 if [ "$ret" -ne 0 ]; then
 	echo "Fail to remove images"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

We used `ctr` to remove container images initially. But that's not thorough.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Replace the use of `ctr i rm` with `crictl rmi`.

**Related Issue:**

#6691 

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster in v1.4.0
2. Prepare a customized build of Harvester ISO image containing this fix (for QAs, please use the master-head ISO image)
3. Get the before-upgrade image list on each node with `crictl images`
4. Upgrade the cluster with the ISO image
5. After the upgrade succeed, collect the after-upgrade image list on each node
6. Besides, the result of `crictl images` should not contain bunch of `<none>` lines (please refer to https://github.com/harvester/harvester/issues/6691#issue-2560988813 for example)
7. Compare the two lists. Images exist in v1.4.0 but not in the customized build should be removed.