### PR TITLE
allow storage network config on mgmt cluster

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -64,6 +64,7 @@ const (
 	labelAppNameValueGrafana          = "grafana"
 	labelAppNameValueImportController = "harvester-vm-import-controller"
 	maxTTLDurationMinutes             = 52560000 //specifies max duration allowed for kubeconfig TTL setting, and corresponds to 100 years
+	mgmtClusterNetwork                = "mgmt"
 )
 
 var certs = getSystemCerts()
@@ -1210,6 +1211,11 @@ func (v *settingValidator) checkStorageNetworkValueVaild() error {
 }
 
 func (v *settingValidator) checkVlanStatusReady(config *storagenetworkctl.Config) error {
+	//mgmt cluster
+	if config.ClusterNetwork == mgmtClusterNetwork {
+		return nil
+	}
+
 	_, err := v.cnCache.Get(config.ClusterNetwork)
 	if err != nil {
 		return fmt.Errorf("cluster network %s not found because %v", config.ClusterNetwork, err)
@@ -1249,6 +1255,11 @@ func getMatchNodes(vc *networkv1.VlanConfig) ([]string, error) {
 }
 
 func (v *settingValidator) checkVCSpansAllNodes(config *storagenetworkctl.Config) error {
+	//mgmt cluster
+	if config.ClusterNetwork == mgmtClusterNetwork {
+		return nil
+	}
+
 	matchedNodes := mapset.NewSet[string]()
 
 	vcs, err := v.vcCache.List(labels.Set{


### PR DESCRIPTION

**Problem:**
1.4 restricts to configure storage network  using mgmt cluster because of the vlan status check introduced from
https://github.com/harvester/harvester/issues/2995

**Solution:**
skip checking vlan status for mgmt cluster

**Related Issue:**
https://github.com/harvester/harvester/issues/7212

**Test plan:**
1.Prepare a Harvester v1.4.0 cluster
2.Edit the storage-network setting
3.add vlan-id, Ensure the mgmt cluster network is selected and give an ip range
5.The configuration should be successful and LH pods must be allocated a secondary network in the ip range provided.
