### PR TITLE
Fix incorrect unit in cpu usage dashboard

### DIFF
--- a/package/upgrade/migrations/upgrade_manifests/v1.4.0/pre-hook.sh
+++ b/package/upgrade/migrations/upgrade_manifests/v1.4.0/pre-hook.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -x
+
+patch_harvester_vm_dashboard()
+{
+    echo "Patch configmap/harvester-vm-dashboard..."
+    local patch_json=$( \
+        kubectl get -n cattle-dashboards configmap harvester-vm-dashboard -o json | \
+            jq '.data."harvester_vm_dashboard.json" | fromjson | .panels |=
+                map(
+                    if .title == "CPU Usage" then
+                        .yaxes |= map(
+                            if .format == "percentunit" then
+                                .format = "percent"
+                            else
+                                .
+                            end
+                    )
+                    else
+                        .
+                    end
+                )' |
+        jq -r .
+    )
+
+    if [ -z "$patch_json" ]; then
+        echo "Something goes wrong, the patch json is empty... skip this patch"
+        return 1
+    fi
+
+    patch_json=$(echo '{"data":{"harvester_vm_dashboard.json": ""}}' | jq --arg arg "$patch_json" '.data."harvester_vm_dashboard.json"=$arg')
+    kubectl patch -n cattle-dashboards configmap harvester-vm-dashboard --type merge -p "$patch_json"
+}
+
+patch_harvester_vm_detail_dashboard()
+{
+    echo "Patch configmap/harvester-vm-detail-dashboard..."
+    local patch_json=$( \
+        kubectl get -n cattle-dashboards configmap harvester-vm-detail-dashboard -o json | \
+            jq '.data."harvester_vm_info_details.json" | fromjson | .panels |=
+                map(
+                    if .title == "CPU Usage" then
+                        .fieldConfig.defaults.unit = "percent"
+                    else
+                        .
+                    end
+                )'
+    )
+
+    if [ -z "$patch_json" ]; then
+        echo "Something goes wrong, the patch json is empty... skip this patch"
+        return 1
+    fi
+
+    patch_json=$(echo '{"data":{"harvester_vm_info_details.json": ""}}' | jq --arg arg "$patch_json" '.data."harvester_vm_info_details.json"=$arg')
+    kubectl patch -n cattle-dashboards configmap harvester-vm-detail-dashboard --type merge -p "$patch_json"
+}
+
+# Fix incorrect unit in CPU Usage dashboard https://github.com/harvester/harvester/issues/7086
+patch_harvester_vm_dashboard
+patch_harvester_vm_detail_dashboard


### PR DESCRIPTION
**Problem:**
Prometheus VM Metrics are not accurate whatsoever where cpu usage metrics at a percentage level are exceeding 200000% within the Harvester UI VM metrics.

**Solution:**
fix incorrect cpu usage unit, this PR aim to fix issue in the upgrade path. harvester-installer pr is here: https://github.com/harvester/harvester-installer/pull/908

**Related Issue:**
https://github.com/harvester/harvester/issues/7086

**Test plan:**
- Prepare a single node v1.4.0 harvester  (easy to test)
- Upgrade harvestester to the version with this patch
- Enable rancher-monitoring addon
- Prepare some VMs (e.g. 3 VM)
- Goto Grafana UI and wait for a couple of minutes
- Check the value of cpu usage should fall in range [0, 100] in both `Harvester VM Dashboard` and `Harvester VM Info Detail` dashboards (during vm startup, the cpu usage may slightly go over 100%, after a while it should dramatically drop to a low value, like 2%)

<image src=https://github.com/user-attachments/assets/1b6e6d2c-bb8a-4364-aab5-a00a6f00910d width=500 />
<image src=https://github.com/user-attachments/assets/4df795d5-c996-4f97-9923-f68e8ae6d41a width=500 />

