### PR TITLE
Auto merge backports

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -32,20 +32,24 @@ pull_request_rules:
       assignees:
         - "{{ author }}"
 
-- name: Automatically merge Renovate PRs
+- name: Automatically merge Renovate/Backport PRs
   conditions:
   - check-success="Build binaries (x64)"
   - check-success="Build binaries (arm64)"
-  - author = renovate[bot]
+  - or:
+    - author = renovate[bot]
+    - author = mergify[bot]
   actions:
     merge:
       method: rebase
 
-- name: Automatically approve Renovate PRs
+- name: Automatically approve Renovate/Backport PRs
   conditions:
   - check-success="Build binaries (x64)"
   - check-success="Build binaries (arm64)"
-  - author = renovate[bot]
+  - or:
+    - author = renovate[bot]
+    - author = mergify[bot]
   actions:
     review:
       type: APPROVE

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,4 +1,15 @@
 pull_request_rules:
+- name: Automatically open v1.5 backport PR
+  conditions:
+    - base=master
+    - label="backport-to/v1.5"
+  actions:
+    backport:
+      branches:
+        - v1.5
+      assignees:
+        - "{{ author }}"
+
 - name: Automatically open v1.4 backport PR
   conditions:
     - base=master
@@ -18,17 +29,6 @@ pull_request_rules:
     backport:
       branches:
         - v1.3
-      assignees:
-        - "{{ author }}"
-
-- name: Automatically open v1.2 backport PR
-  conditions:
-    - base=master
-    - label="backport-to/v1.2"
-  actions:
-    backport:
-      branches:
-        - v1.2
       assignees:
         - "{{ author }}"
 


### PR DESCRIPTION
Mergify automation
- Create a v1.5 backport PR if there is a `backport-to/v1.5` label.
- Remove v1.2 backport automation.
- Approve a backport PR if CI passes.
- Merge a backport PR if approvals meet the repo's configuration.