### PR TITLE
improve machine type lookup based on processor architecture

### DIFF
--- a/pkg/api/cluster/formatter.go
+++ b/pkg/api/cluster/formatter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"runtime"
 
 	corev1 "k8s.io/api/core/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -14,7 +15,10 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/gorilla/mux"
+
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 type Handler struct {
@@ -35,15 +39,21 @@ func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusNoContent)
 }
 
-func (h Handler) do(rw http.ResponseWriter, _ *http.Request) error {
+func (h Handler) do(rw http.ResponseWriter, req *http.Request) error {
 
-	nodeDeviceAvailability, err := h.generateDeviceAvailability()
-	if err != nil {
-		return err
+	vars := util.EncodeVars(mux.Vars(req))
+	link := vars["link"]
+	var result []byte
+	var err error
+	switch link {
+	case deviceCapacity:
+		result, err = h.generateDeviceAvailabilityResponse()
+	case machineTypes:
+		result, err = generateMachineTypes()
 	}
-	result, err := json.Marshal(nodeDeviceAvailability)
+
 	if err != nil {
-		return fmt.Errorf("unable to marshal node device capacity: %v", err)
+		return fmt.Errorf("unable to marshal api response: %v", err)
 	}
 	_, err = rw.Write(result)
 	return err
@@ -90,4 +100,26 @@ func calculateAllocation(nodes []*corev1.Node, vms []*kubevirtv1.VirtualMachine)
 		}
 	}
 	return nodeDeviceAvailability
+}
+
+// generateDeviceAvailabilityResponse is a wrapper around
+func (h Handler) generateDeviceAvailabilityResponse() ([]byte, error) {
+	nodeDeviceAvailability, err := h.generateDeviceAvailability()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(nodeDeviceAvailability)
+}
+
+// generateMachineTypes is a helper to return machineTypes for UI to render machine types possible
+func generateMachineTypes() ([]byte, error) {
+	var machineTypes []string
+	switch runtime.GOARCH {
+	case "amd64":
+		machineTypes = append(machineTypes, "pc", "q53")
+	case "arm64":
+		machineTypes = append(machineTypes, "virt")
+	}
+
+	return json.Marshal(machineTypes)
 }

--- a/pkg/api/cluster/schema.go
+++ b/pkg/api/cluster/schema.go
@@ -13,6 +13,7 @@ import (
 const (
 	deviceCapacity   = "deviceCapacity"
 	localClusterName = "local"
+	machineTypes     = "machineTypes"
 )
 
 type Cluster struct {
@@ -40,6 +41,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 		schema.CollectionMethods = []string{"GET"}
 		schema.LinkHandlers = map[string]http.Handler{
 			deviceCapacity: handler,
+			machineTypes:   handler,
 		}
 	})
 	return nil


### PR DESCRIPTION


**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently the `Machine Type` definition in harvester VM `Advanced Options` page is harcoded to `q35`

This breaks VM's on ARM clusters where the only supported type is `virt`



**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces a new api handler on the local cluster which returns valid machine types based on underlying node arch lookup. The response is an array of valid machine types.

On amd64 hosts the machine types returned are `q35` and `pc`

https://kubevirt.io/user-guide/compute/virtual_hardware/#machine-type

On arm64 hosts the only supported machine type is `virt`
https://kubevirt.io/user-guide/cluster_admin/virtual_machines_on_Arm64/#machine-type

A UI change is needed to ensure the `Machine Types` is populated from the api call to `"${URL}/v1/harvester/cluster/local?link=machineType"`

A similar lookup already exists to find `deviceCapacity` to track vGPU allocation details

**Related Issue:**
https://github.com/harvester/harvester/issues/5364
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

From backend to test
### AMD64 Cluster
* deploy new harvester build to an amd64 node.
* Run the following commands against newly provisioned cluster
```
export APITOKEN="token"
export URL="url"
curl -sk -u $APITOKEN "${URL}/v1/harvester/cluster/local?link=machineTypes"
```
* machine types returned should be `["pc","q53"]`
### ARM64 Cluster
* deploy new harvester build to an arm64 node.
* Run the following commands against newly provisioned cluster
```
export APITOKEN="token"
export URL="url"
curl -sk -u $APITOKEN "${URL}/v1/harvester/cluster/local?link=machineTypes"
```
* machine types returned should be `["virt"]`