### PR TITLE
Fix6844 Backfill VMI MAC to VM and sync VM generation

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -10,8 +10,7 @@ import (
 const (
 	vmControllerCreatePVCsFromAnnotationControllerName           = "VMController.CreatePVCsFromAnnotation"
 	vmiControllerReconcileFromHostLabelsControllerName           = "VMIController.ReconcileFromHostLabels"
-	vmiControllerSetDefaultManagementNetworkMac                  = "VMIController.SetDefaultManagementNetworkMacAddress"
-	vmiControllerSyncControllerRevision                          = "VMIController.SyncControllerRevision"
+	vmiControllerSyncMacAddressAndControllerRevision             = "VMIController.SyncMacAddressAndControllerRevision"
 	vmControllerStoreRunStrategyControllerName                   = "VMController.StoreRunStrategyToAnnotation"
 	vmControllerSyncLabelsToVmi                                  = "VMController.SyncLabelsToVmi"
 	vmControllerSetHaltIfInsufficientResourceQuotaControllerName = "VMController.SetHaltIfInsufficientResourceQuota"
@@ -92,14 +91,13 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	// register the vmi network controller upon the VMI changes
 	var virtualMachineInstanceController = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	var vmNetworkCtl = &VMNetworkController{
-		vmClient: vmClient,
-		vmCache:  vmCache,
-		//vmiClient:     virtualMachineInstanceController,
+		vmClient:      vmClient,
+		vmCache:       vmCache,
 		crClient:      crClient,
 		crCache:       crClientCache,
 		vmiController: virtualMachineInstanceController,
 	}
-	virtualMachineInstanceController.OnChange(ctx, vmiControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SyncMacAddressAndControllerRevision)
+	virtualMachineInstanceController.OnChange(ctx, vmiControllerSyncMacAddressAndControllerRevision, vmNetworkCtl.SyncMacAddressAndControllerRevision)
 
 	return nil
 }

--- a/pkg/controller/master/virtualmachine/vmi_network_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller.go
@@ -30,50 +30,51 @@ func (h *VMNetworkController) SyncMacAddressAndControllerRevision(id string, vmi
 	}
 
 	// ensure vmi mac is backfilled to vm
-	var retryvmi = false
-	var err error = nil
-	if vmi, err = h.syncNetworkDynamicMacAddress(vmi, &retryvmi); err != nil {
+	retryvmi := false
+	if vmi, err := h.syncNetworkDynamicMacAddress(vmi, &retryvmi); err != nil {
 		return vmi, err
 	}
 
 	// ensure vmi mac is backfilled to rc
-	var retryrc = false
-	if vmi, err = h.syncControllerRevisionFromVmi(vmi, &retryrc); err != nil {
+	retrycr := false
+	if vmi, err := h.syncControllerRevision(vmi, &retrycr); err != nil {
 		return vmi, err
 	}
 
 	// vmi may end onChange, but vm/rc is not synced yet
-	if retryvmi || retryrc {
+	if retryvmi || retrycr {
 		h.vmiController.EnqueueAfter(vmi.Namespace, vmi.Name, time.Second*1)
 		return vmi, nil
 	}
 
-	// last step: if vm did not sync with rc, update it
-
-	return h.updateVm(vmi)
+	// last step: if vm still did not sync with rc, update it
+	return h.updateVM(vmi)
 }
 
-// when user does not specify mac address when creating a VM
+// if user does not specify mac address when creating a VM
 // guest OS will use the initial allocated mac address from its DHCP config
-// when VM restarts that mac address may change, and related IP is not persistant
-// SyncNetworkDynamicMacAddress saves the dynamic mac address observed from the the VMI status,
+// when VM restarts that mac address may change, and related IP is not persistent
+// syncNetworkDynamicMacAddress saves the dynamic mac address observed from the the VMI status to vm
 func (h *VMNetworkController) syncNetworkDynamicMacAddress(vmi *kubevirtv1.VirtualMachineInstance, retry *bool) (*kubevirtv1.VirtualMachineInstance, error) {
 	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
 		return vmi, err
 	}
 
+	if vm == nil || vm.DeletionTimestamp != nil {
+		return vmi, nil
+	}
+
 	vmCopy := vm.DeepCopy()
 	vmiInterfaces := getVmiInterfaceMacs(vmi)
-
 	updated := false
 	for i, vmIface := range vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces {
 		if vmIface.Name == "" || vmIface.MacAddress != "" {
 			continue
 		}
 		if macAddress := vmiInterfaces[vmIface.Name]; macAddress != "" {
-			// only set the network mac address when it is empty
-			logrus.Debugf("set VM %s management network %s macAddress to %s", vm.Name, vmIface.Name, macAddress)
+			// only backfill the network mac address when it is empty
+			logrus.Infof("set VM %s network %s macAddress to %s", vm.Name, vmIface.Name, macAddress)
 			vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = macAddress
 			updated = true
 		}
@@ -83,13 +84,13 @@ func (h *VMNetworkController) syncNetworkDynamicMacAddress(vmi *kubevirtv1.Virtu
 	}
 	*retry = true
 	if _, err := h.vmClient.Update(vmCopy); err != nil {
-		return vmi, err
+		return vmi, fmt.Errorf("failed to update vmi mac to vm: %w", err)
 	}
 
 	return vmi, nil
 }
 
-func getVmInterfaceMacs(vm *kubevirtv1.VirtualMachine) map[string]string {
+func getVMInterfaceMacs(vm *kubevirtv1.VirtualMachine) map[string]string {
 	vmInterfaceMacs := make(map[string]string, len(vm.Spec.Template.Spec.Domain.Devices.Interfaces))
 	for _, vmIface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
 		if vmIface.MacAddress != "" {
@@ -109,10 +110,14 @@ func getVmiInterfaceMacs(vmi *kubevirtv1.VirtualMachineInstance) map[string]stri
 	return vmiInterfaces
 }
 
-func (h *VMNetworkController) syncControllerRevisionFromVmi(vmi *kubevirtv1.VirtualMachineInstance, retry *bool) (*kubevirtv1.VirtualMachineInstance, error) {
+func (h *VMNetworkController) syncControllerRevision(vmi *kubevirtv1.VirtualMachineInstance, retry *bool) (*kubevirtv1.VirtualMachineInstance, error) {
 	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
 		return vmi, err
+	}
+
+	if vm == nil || vm.DeletionTimestamp != nil {
+		return vmi, nil
 	}
 
 	// already synced
@@ -130,19 +135,18 @@ func (h *VMNetworkController) syncControllerRevisionFromVmi(vmi *kubevirtv1.Virt
 func (h *VMNetworkController) regenerateControllerRevision(vmi *kubevirtv1.VirtualMachineInstance, vm *kubevirtv1.VirtualMachine, retry *bool) error {
 	crObj, err := h.crCache.Get(vmi.Namespace, vmi.Status.VirtualMachineRevisionName)
 	if err != nil {
-		return fmt.Errorf("error fetch controller revision object for vmi %s-%s: %v", vmi.Name, vmi.Namespace, err)
+		// controllerRevision has a different name than vm name, essential to log it's name in error
+		return fmt.Errorf("failed to fetch controllerRevision %s/%s: %w", vmi.Namespace, vmi.Status.VirtualMachineRevisionName, err)
 	}
 
 	revisionSpec := &vmwatch.VirtualMachineRevisionData{}
 	if err = json.Unmarshal(crObj.Data.Raw, revisionSpec); err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal controllerRevision %s/%s: %w", crObj.Namespace, crObj.Name, err)
 	}
+
 	revisionSpecCopy := revisionSpec
-
-	//var vmInterfaceMacs map[string]string = getVmInterfaceMacs(vm)
-	var vmInterfaceMacs = getVmInterfaceMacs(vm)
-	var vmiInterfaceMacs = getVmiInterfaceMacs(vmi)
-
+	vmInterfaceMacs := getVMInterfaceMacs(vm)
+	vmiInterfaceMacs := getVmiInterfaceMacs(vmi)
 	updated := false
 	for i, rcIface := range revisionSpec.Spec.Template.Spec.Domain.Devices.Interfaces {
 		// only backfill when saved MAC is empty
@@ -162,23 +166,26 @@ func (h *VMNetworkController) regenerateControllerRevision(vmi *kubevirtv1.Virtu
 	}
 
 	crObjCopy := crObj.DeepCopy()
-	patch, patchGenError := patchVMRevisionViaVmSpec(&revisionSpecCopy.Spec)
+	patch, patchGenError := patchVMRevisionViaVMSpec(&revisionSpecCopy.Spec)
 	if patchGenError != nil {
-		return fmt.Errorf("error during patch generation for vmi %s-%s: %v", vmi.Name, vmi.Name, patchGenError)
+		return fmt.Errorf("failed to generate a patch for controllerRevision %s/%s: %w", crObj.Namespace, crObj.Name, patchGenError)
 	}
 	if deletionErr := h.crClient.Delete(vmi.Namespace, crObj.Name, &metav1.DeleteOptions{}); deletionErr != nil {
-		return fmt.Errorf("error during deletion of controllerRevision for vmi %s-%s: %v", vmi.Name, vmi.Name, deletionErr)
+		return fmt.Errorf("failed to delete controllerRevision %s/%s: %w", crObj.Namespace, crObj.Name, deletionErr)
 	}
 	*retry = true
-	logrus.Debugf("VM %s/%s delete and create new cr object %v to patch generation: vm.Generation %v, vm.Status.ObservedGeneration %v", vm.Namespace, vm.Name, crObj.Name, vm.Generation, vm.Status.ObservedGeneration)
+	logrus.Infof("VM %s/%s delete and create new controllerRevision %v to sync generation: vm.Generation %v, vm.Status.ObservedGeneration %v", vm.Namespace, vm.Name, crObj.Name, vm.Generation, vm.Status.ObservedGeneration)
 	crObjCopy.Data.Raw = patch
 	crObjCopy.ResourceVersion = ""
-	_, err = h.crClient.Create(crObjCopy)
+	if _, err = h.crClient.Create(crObjCopy); err != nil {
+		return fmt.Errorf("failed to create controllerRevision %s/%s: %w", crObjCopy.Namespace, crObjCopy.Name, err)
+	}
 
-	return err
+	return nil
 }
 
 // copied from kubevirt.io/kubevirt/pkg/virt-controller/watch as this is a private method
+/*
 func patchVMRevision(vm *kubevirtv1.VirtualMachine) ([]byte, error) {
 	vmBytes, err := json.Marshal(vm)
 	if err != nil {
@@ -195,9 +202,10 @@ func patchVMRevision(vm *kubevirtv1.VirtualMachine) ([]byte, error) {
 	patch, err := json.Marshal(objCopy)
 	return patch, err
 }
+*/
 
 // clone of patchVMRevision but works upon VirtualMachineSpec
-func patchVMRevisionViaVmSpec(vmSpec *kubevirtv1.VirtualMachineSpec) ([]byte, error) {
+func patchVMRevisionViaVMSpec(vmSpec *kubevirtv1.VirtualMachineSpec) ([]byte, error) {
 	vmBytes, err := json.Marshal(vmSpec)
 	if err != nil {
 		return nil, err
@@ -213,10 +221,14 @@ func patchVMRevisionViaVmSpec(vmSpec *kubevirtv1.VirtualMachineSpec) ([]byte, er
 	return patch, err
 }
 
-func (h *VMNetworkController) updateVm(vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+func (h *VMNetworkController) updateVM(vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
 	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
 		return vmi, err
+	}
+
+	if vm == nil || vm.DeletionTimestamp != nil {
+		return vmi, nil
 	}
 
 	// already synced
@@ -226,15 +238,15 @@ func (h *VMNetworkController) updateVm(vmi *kubevirtv1.VirtualMachineInstance) (
 
 	crObj, err := h.crCache.Get(vmi.Namespace, vmi.Status.VirtualMachineRevisionName)
 	if err != nil {
-		return vmi, fmt.Errorf("error fetch controller revision object for vmi %s-%s: %v", vmi.Name, vmi.Namespace, err)
+		return vmi, fmt.Errorf("failed to fetch controllerRevision %s/%s: %w", vmi.Namespace, vmi.Status.VirtualMachineRevisionName, err)
 	}
 
 	revisionSpec := &vmwatch.VirtualMachineRevisionData{}
 	if err = json.Unmarshal(crObj.Data.Raw, revisionSpec); err != nil {
-		return vmi, err
+		return vmi, fmt.Errorf("failed to unmarshal controllerRevision %s/%s: %w", crObj.Namespace, crObj.Name, err)
 	}
 
-	// if there are other changes than MAC, just skip
+	// if there are other changes than MAC, skip
 	if !equality.Semantic.DeepEqual(revisionSpec.Spec, vm.Spec) {
 		return vmi, nil
 	}
@@ -247,7 +259,7 @@ func (h *VMNetworkController) updateVm(vmi *kubevirtv1.VirtualMachineInstance) (
 	vmCopy.Annotations[util.AnnotationTimestamp] = time.Now().Format(time.RFC3339)
 	logrus.Debugf("VM %s/%s is forcely updated to sync vm.Generation %v, vm.Status.ObservedGeneration %v", vm.Namespace, vm.Name, vm.Generation, vm.Status.ObservedGeneration)
 	if _, err := h.vmClient.Update(vmCopy); err != nil {
-		return vmi, err
+		return vmi, fmt.Errorf("failed to update vm %s to sync generation: %w", util.AnnotationTimestamp, err)
 	}
 
 	return vmi, nil

--- a/pkg/controller/master/virtualmachine/vmi_network_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller.go
@@ -3,6 +3,7 @@ package virtualmachine
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -12,80 +13,121 @@ import (
 
 	ctlappsv1 "github.com/harvester/harvester/pkg/generated/controllers/apps/v1"
 	vmv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	util "github.com/harvester/harvester/pkg/util"
 )
 
 type VMNetworkController struct {
-	vmCache   vmv1.VirtualMachineCache
-	vmClient  vmv1.VirtualMachineClient
-	vmiClient vmv1.VirtualMachineInstanceClient
-	crCache   ctlappsv1.ControllerRevisionCache
-	crClient  ctlappsv1.ControllerRevisionClient
+	vmCache       vmv1.VirtualMachineCache
+	vmClient      vmv1.VirtualMachineClient
+	crCache       ctlappsv1.ControllerRevisionCache
+	crClient      ctlappsv1.ControllerRevisionClient
+	vmiController vmv1.VirtualMachineInstanceController
 }
 
-// SetDefaultNetworkMacAddress set the default mac address of networks using the initial allocated mac address from the VMI status,
-// since the most guest OS will use the initial allocated mac address of its DHCP config, and on Kubevirt the VM restart it will re-allocate
-// a new mac address which will lead the original network unreachable.
-func (h *VMNetworkController) SetDefaultNetworkMacAddress(id string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
-	if id == "" || vmi == nil || vmi.DeletionTimestamp != nil {
+func (h *VMNetworkController) SyncMacAddressAndControllerRevision(id string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+	if id == "" || vmi == nil || vmi.DeletionTimestamp != nil || vmi.Status.Phase != kubevirtv1.Running || len(vmi.Status.Interfaces) == 0 {
 		return vmi, nil
 	}
 
-	if vmi.Status.Phase != kubevirtv1.Running {
+	// ensure vmi mac is backfilled to vm
+	var retryvmi = false
+	var err error = nil
+	if vmi, err = h.syncNetworkDynamicMacAddress(vmi, &retryvmi); err != nil {
+		return vmi, err
+	}
+
+	// ensure vmi mac is backfilled to rc
+	var retryrc = false
+	if vmi, err = h.syncControllerRevisionFromVmi(vmi, &retryrc); err != nil {
+		return vmi, err
+	}
+
+	// vmi may end onChange, but vm/rc is not synced yet
+	if retryvmi || retryrc {
+		h.vmiController.EnqueueAfter(vmi.Namespace, vmi.Name, time.Second*1)
 		return vmi, nil
 	}
 
-	if len(vmi.Status.Interfaces) == 0 {
-		return vmi, nil
-	}
+	// last step: if vm did not sync with rc, update it
 
-	err := h.updateVMDefaultNetworkMacAddress(vmi)
+	return h.updateVm(vmi)
+}
+
+// when user does not specify mac address when creating a VM
+// guest OS will use the initial allocated mac address from its DHCP config
+// when VM restarts that mac address may change, and related IP is not persistant
+// SyncNetworkDynamicMacAddress saves the dynamic mac address observed from the the VMI status,
+func (h *VMNetworkController) syncNetworkDynamicMacAddress(vmi *kubevirtv1.VirtualMachineInstance, retry *bool) (*kubevirtv1.VirtualMachineInstance, error) {
+	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
+		return vmi, err
+	}
+
+	vmCopy := vm.DeepCopy()
+	vmiInterfaces := getVmiInterfaceMacs(vmi)
+
+	updated := false
+	for i, vmIface := range vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces {
+		if vmIface.Name == "" || vmIface.MacAddress != "" {
+			continue
+		}
+		if macAddress := vmiInterfaces[vmIface.Name]; macAddress != "" {
+			// only set the network mac address when it is empty
+			logrus.Debugf("set VM %s management network %s macAddress to %s", vm.Name, vmIface.Name, macAddress)
+			vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = macAddress
+			updated = true
+		}
+	}
+	if !updated {
+		return vmi, nil
+	}
+	*retry = true
+	if _, err := h.vmClient.Update(vmCopy); err != nil {
 		return vmi, err
 	}
 
 	return vmi, nil
 }
 
-func (h *VMNetworkController) updateVMDefaultNetworkMacAddress(vmi *kubevirtv1.VirtualMachineInstance) error {
-	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
-	if err != nil {
-		return err
+func getVmInterfaceMacs(vm *kubevirtv1.VirtualMachine) map[string]string {
+	vmInterfaceMacs := make(map[string]string, len(vm.Spec.Template.Spec.Domain.Devices.Interfaces))
+	for _, vmIface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
+		if vmIface.MacAddress != "" {
+			vmInterfaceMacs[vmIface.Name] = vmIface.MacAddress
+		}
 	}
+	return vmInterfaceMacs
+}
 
-	vmCopy := vm.DeepCopy()
-	var length = len(vmi.Status.Interfaces)
-	var vmiInterfaces = make(map[string]string, length)
+func getVmiInterfaceMacs(vmi *kubevirtv1.VirtualMachineInstance) map[string]string {
+	var vmiInterfaces = make(map[string]string, len(vmi.Status.Interfaces))
 	for _, iface := range vmi.Status.Interfaces {
-		if iface.MAC != "" && iface.Name != "" {
+		if iface.Name != "" && iface.MAC != "" {
 			vmiInterfaces[iface.Name] = iface.MAC
 		}
 	}
-
-	for i, vmIface := range vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces {
-		macAddress, ok := vmiInterfaces[vmIface.Name]
-		// only set the network mac address when it has no existing value
-		if ok && vmIface.MacAddress == "" {
-			logrus.Debugf("set VM %s management network %s macAddress to %s", vm.Name, vmIface.Name, macAddress)
-			vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = macAddress
-		}
-	}
-
-	// note: this function is related to vm/vmi, should always run on vmi change
-	if err := h.regenerateControllerRevision(vmi, vm); err != nil {
-		return err
-	}
-
-	if equality.Semantic.DeepEqual(vmCopy.Spec.Template.Spec.Domain.Devices, vm.Spec.Template.Spec.Domain.Devices) {
-		return nil
-	}
-	if _, err := h.vmClient.Update(vmCopy); err != nil {
-		return err
-	}
-
-	return nil
+	return vmiInterfaces
 }
 
-func (h *VMNetworkController) regenerateControllerRevision(vmi *kubevirtv1.VirtualMachineInstance, vm *kubevirtv1.VirtualMachine) error {
+func (h *VMNetworkController) syncControllerRevisionFromVmi(vmi *kubevirtv1.VirtualMachineInstance, retry *bool) (*kubevirtv1.VirtualMachineInstance, error) {
+	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return vmi, err
+	}
+
+	// already synced
+	if vm.Generation == vm.Status.ObservedGeneration {
+		return vmi, nil
+	}
+
+	if err := h.regenerateControllerRevision(vmi, vm, retry); err != nil {
+		return vmi, err
+	}
+
+	return vmi, nil
+}
+
+func (h *VMNetworkController) regenerateControllerRevision(vmi *kubevirtv1.VirtualMachineInstance, vm *kubevirtv1.VirtualMachine, retry *bool) error {
 	crObj, err := h.crCache.Get(vmi.Namespace, vmi.Status.VirtualMachineRevisionName)
 	if err != nil {
 		return fmt.Errorf("error fetch controller revision object for vmi %s-%s: %v", vmi.Name, vmi.Namespace, err)
@@ -95,19 +137,43 @@ func (h *VMNetworkController) regenerateControllerRevision(vmi *kubevirtv1.Virtu
 	if err = json.Unmarshal(crObj.Data.Raw, revisionSpec); err != nil {
 		return err
 	}
-	if !equality.Semantic.DeepEqual(revisionSpec.Spec.Template, vm.Spec.Template) && vm.Generation != vm.Status.ObservedGeneration {
-		patch, patchGenError := patchVMRevision(vm)
-		if patchGenError != nil {
-			return fmt.Errorf("error during patch generation for vmi %s-%s: %v", vmi.Name, vmi.Name, patchGenError)
+	revisionSpecCopy := revisionSpec
+
+	//var vmInterfaceMacs map[string]string = getVmInterfaceMacs(vm)
+	var vmInterfaceMacs = getVmInterfaceMacs(vm)
+	var vmiInterfaceMacs = getVmiInterfaceMacs(vmi)
+
+	updated := false
+	for i, rcIface := range revisionSpec.Spec.Template.Spec.Domain.Devices.Interfaces {
+		// only backfill when saved MAC is empty
+		if rcIface.Name == "" || rcIface.MacAddress != "" {
+			continue
 		}
-		if deletionErr := h.crClient.Delete(vmi.Namespace, crObj.Name, &metav1.DeleteOptions{}); deletionErr != nil {
-			return fmt.Errorf("error during deletion of controllerRevision for vmi %s-%s: %v", vmi.Name, vmi.Name, deletionErr)
+		vmMacAddress := vmInterfaceMacs[rcIface.Name]
+		vmiMacAddress := vmiInterfaceMacs[rcIface.Name]
+		// on the safe path to update revision
+		if vmMacAddress != "" && vmMacAddress == vmiMacAddress {
+			revisionSpecCopy.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = vmMacAddress
+			updated = true
 		}
-		logrus.Debugf("VM %s/%s delete and create new cr object to patch generation: %s", vm.Namespace, vm.Name, patch)
-		crObj.Data.Raw = patch
-		crObj.ResourceVersion = ""
-		_, err = h.crClient.Create(crObj)
 	}
+	if !updated {
+		return nil
+	}
+
+	crObjCopy := crObj.DeepCopy()
+	patch, patchGenError := patchVMRevisionViaVmSpec(&revisionSpecCopy.Spec)
+	if patchGenError != nil {
+		return fmt.Errorf("error during patch generation for vmi %s-%s: %v", vmi.Name, vmi.Name, patchGenError)
+	}
+	if deletionErr := h.crClient.Delete(vmi.Namespace, crObj.Name, &metav1.DeleteOptions{}); deletionErr != nil {
+		return fmt.Errorf("error during deletion of controllerRevision for vmi %s-%s: %v", vmi.Name, vmi.Name, deletionErr)
+	}
+	*retry = true
+	logrus.Debugf("VM %s/%s delete and create new cr object %v to patch generation: vm.Generation %v, vm.Status.ObservedGeneration %v", vm.Namespace, vm.Name, crObj.Name, vm.Generation, vm.Status.ObservedGeneration)
+	crObjCopy.Data.Raw = patch
+	crObjCopy.ResourceVersion = ""
+	_, err = h.crClient.Create(crObjCopy)
 
 	return err
 }
@@ -128,4 +194,61 @@ func patchVMRevision(vm *kubevirtv1.VirtualMachine) ([]byte, error) {
 	objCopy["spec"] = spec
 	patch, err := json.Marshal(objCopy)
 	return patch, err
+}
+
+// clone of patchVMRevision but works upon VirtualMachineSpec
+func patchVMRevisionViaVmSpec(vmSpec *kubevirtv1.VirtualMachineSpec) ([]byte, error) {
+	vmBytes, err := json.Marshal(vmSpec)
+	if err != nil {
+		return nil, err
+	}
+	var raw map[string]interface{}
+	err = json.Unmarshal(vmBytes, &raw)
+	if err != nil {
+		return nil, err
+	}
+	objCopy := make(map[string]interface{})
+	objCopy["spec"] = raw
+	patch, err := json.Marshal(objCopy)
+	return patch, err
+}
+
+func (h *VMNetworkController) updateVm(vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return vmi, err
+	}
+
+	// already synced
+	if vm.Generation == vm.Status.ObservedGeneration {
+		return vmi, nil
+	}
+
+	crObj, err := h.crCache.Get(vmi.Namespace, vmi.Status.VirtualMachineRevisionName)
+	if err != nil {
+		return vmi, fmt.Errorf("error fetch controller revision object for vmi %s-%s: %v", vmi.Name, vmi.Namespace, err)
+	}
+
+	revisionSpec := &vmwatch.VirtualMachineRevisionData{}
+	if err = json.Unmarshal(crObj.Data.Raw, revisionSpec); err != nil {
+		return vmi, err
+	}
+
+	// if there are other changes than MAC, just skip
+	if !equality.Semantic.DeepEqual(revisionSpec.Spec, vm.Spec) {
+		return vmi, nil
+	}
+
+	// forcely update vm, then upstream controller will sync the Generation and ObservedGeneration
+	vmCopy := vm.DeepCopy()
+	if vmCopy.Annotations == nil {
+		vmCopy.Annotations = make(map[string]string, 1)
+	}
+	vmCopy.Annotations[util.AnnotationTimestamp] = time.Now().Format(time.RFC3339)
+	logrus.Debugf("VM %s/%s is forcely updated to sync vm.Generation %v, vm.Status.ObservedGeneration %v", vm.Namespace, vm.Name, vm.Generation, vm.Status.ObservedGeneration)
+	if _, err := h.vmClient.Update(vmCopy); err != nil {
+		return vmi, err
+	}
+
+	return vmi, nil
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

vm, vmi, ControllerRevision are not well synced randomly

1. When VMI MAC is backfilled to VM, the Generation and ObservedGeneration are different;
2. In race case, the backfilled MAC may overwrite VM addtional changes (other than MAC) to controllerRevision.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Make sure those vm, vmi and controllerRevision are well synced
2. Only backfill MAC, avoid to overwrite other data

**Related Issue:**
https://github.com/harvester/harvester/issues/6844

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Test cases:
1. Create a VM without setting any MACs, VMI will get dynamic MACs and sync back to VM
3. Restore a saved VM, it is simlary to 1, VMI will get new dynamic MAC and sync back to VM
4. Create a VM with setting all interfaces with MACs, VMI inheriate them

vm Generation is same as ObservedGeneration, UI does not show generation difference

5. Create a VM witout setting any MACs, when VMI is starting, edit VM yaml to set one/all interfaces with MAC and do not restart VM, the still-empty MAC interface will be synced back, finally the Generation & ObservedGeneration are different

![image](https://github.com/user-attachments/assets/7b4350cb-3316-4f2e-87f6-d60da9cfc8d0)
while MAC is backfilling, the VM spec is modified; VM shows both updates
![image](https://github.com/user-attachments/assets/dcfcb1c1-29cf-4645-94fa-35d6bd66618d)
controllerrevision is updated with the vmi's MAC
![image](https://github.com/user-attachments/assets/3113301d-c7bf-4e97-86fe-0355a636c307)

VMI MAC is backfilled, but the new annotation on VM is not synced to ControllerRevision; which requres a VM rebooting

6. Create  a VM witout setting any MACs, , when VMI is starting, edit VM yaml to set other fields and do not restart VM, the still-empty MAC interface will be synced back, finally the Generation & ObservedGeneration are different
7. Create a VM witout setting any MACs, when VMI is starting, edit VM yaml to set all interfaces with MAC and do not restart VM, finally the Generation & ObservedGeneration are different