### PR TITLE
Selectively update SC harvester-longhorn default SC annotation

### DIFF
--- a/deploy/charts/harvester/templates/_helpers.tpl
+++ b/deploy/charts/harvester/templates/_helpers.tpl
@@ -123,3 +123,35 @@ Get Support-bundle-kit image environment for updating the default values per cur
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Get a dynamic storageclass.kubernetes.io/is-default-class value for harvester-longhorn storageclass.
+*/}}
+{{- define "harvester.annotations.defaultstorageclass" -}}
+{{- if .Values.storageClass.defaultStorageClass }}
+ {{- $allscs := (lookup "storage.k8s.io/v1" "StorageClass" "" "") -}}
+ {{- if eq (len $allscs ) 0 -}}
+storageclass.kubernetes.io/is-default-class: "true"
+ {{- else -}}
+ {{- $scname := "" -}}
+ {{- range $index, $cursc := $allscs.items -}}
+ {{- range $k, $v := $cursc.metadata.annotations -}}
+ {{- if eq $k "storageclass.kubernetes.io/is-default-class" -}}
+ {{- if eq $v "true" -}}
+ {{- $scname = $cursc.metadata.name -}}
+ {{- end -}}
+ {{- end -}}
+ {{- end -}}
+ {{- end -}}
+ {{- if eq $scname "" }}
+storageclass.kubernetes.io/is-default-class: "true"
+ {{- else if eq $scname "harvester-longhorn" -}}
+storageclass.kubernetes.io/is-default-class: "true"
+ {{- else -}}
+storageclass.kubernetes.io/is-default-class: "false"
+ {{- end }}
+ {{- end }}
+{{- else -}}
+storageclass.kubernetes.io/is-default-class: "false"
+{{- end }}
+{{- end }}

--- a/deploy/charts/harvester/templates/harvester-storageclass.yaml
+++ b/deploy/charts/harvester/templates/harvester-storageclass.yaml
@@ -5,9 +5,7 @@ metadata:
   name: harvester-longhorn
   annotations:
     harvesterhci.io/is-reserved-storageclass: "true"
-{{- if .Values.storageClass.defaultStorageClass }}
-    storageclass.kubernetes.io/is-default-class: "true"
-{{- end }}
+{{ include "harvester.annotations.defaultstorageclass" . | indent 4 }}
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: "{{ .Values.storageClass.reclaimPolicy }}"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

When harvester managedchart is updated, it may update the default sc, but denied by webhook

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. If `storageclass.kubernetes.io/is-default-class: "true"` is not set on any sc, respect the chart value
2. If `storageclass.kubernetes.io/is-default-class: "true"` is on Harvester-longhorn, keep it true.
3. If `storageclass.kubernetes.io/is-default-class: "true"` is set on other SC, set it to false on harvester-longhorn, do not follow the chart value.

**Related Issue:**
https://github.com/harvester/harvester/issues/7375

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

See solution.

**Note**
There has been a block of code to process the default SC on upgrade script:
https://github.com/harvester/harvester/blob/41d3e1b5b1b5d3e9d3a91568638ab8c5b4071f8b/package/upgrade/upgrade_manifests.sh#L893C1-L896C5
```
  local sc=$(kubectl get sc -o json | jq '.items[] | select(.metadata.annotations."storageclass.kubernetes.io/is-default-class" == "true" and .metadata.name != "harvester-longhorn")')
  if [ -n "$sc" ] && [ "$UPGRADE_PREVIOUS_VERSION" != "v1.0.3" ]; then
      yq e '.spec.values.storageClass.defaultStorageClass = false' -i harvester.yaml
  fi
```