### PR TITLE
untagged network support for storage network

### DIFF
--- a/pkg/controller/master/storagenetwork/storage_network.go
+++ b/pkg/controller/master/storagenetwork/storage_network.go
@@ -277,9 +277,6 @@ func (h *Handler) createNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachm
 	bridgeConfig.Bridge = config.ClusterNetwork + BridgeSuffix
 	bridgeConfig.IPAM.Range = config.Range
 
-	if config.Vlan == 0 {
-		config.Vlan = DefaultPVID
-	}
 	bridgeConfig.Vlan = config.Vlan
 
 	if len(config.Exclude) > 0 {

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1303,9 +1303,14 @@ func (v *settingValidator) checkVCSpansAllNodes(config *storagenetworkctl.Config
 }
 
 func (v *settingValidator) checkStorageNetworkVlanValid(config *storagenetworkctl.Config) error {
-	if config.Vlan < 1 || config.Vlan > 4094 {
-		return fmt.Errorf("The valid value range for VLAN IDs is 1 to 4094")
+	if config.Vlan < 0 || config.Vlan > 4094 {
+		return fmt.Errorf("The valid value range for VLAN IDs is 0 to 4094")
 	}
+
+	if config.Vlan <= 1 && config.ClusterNetwork == mgmtClusterNetwork {
+		return fmt.Errorf("storage network with vlan id %d not allowed on %s cluster", config.Vlan, config.ClusterNetwork)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/harvester/issues/4323#issuecomment-2568639037

**Solution:**
https://github.com/harvester/harvester/issues/4323#issuecomment-2568639037

**Related Issue:**
https://github.com/harvester/harvester/issues/4323

**Test plan:**
1.Select storage network with untagged vlan option from GUI
2.Fill in the ip address range from untagged vlan network and save
3.Verify the following
https://docs.harvesterhci.io/v1.5/advanced/storagenetwork/#after-applying-harvester-storage-network-setting

Refer following steps for GUI configuration
https://github.com/harvester/harvester-ui-extension/pull/119#issue-2841734801

