### PR TITLE
ci: avoid creating duplicate releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,7 +385,11 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release create ${{ github.ref_name }} --draft --notes "Draft release for ${{ github.ref_name }}"
+        if gh release view ${{ github.ref_name }} > /dev/null; then
+          echo ${{ github.ref_name }} release exists
+        else
+          gh release create ${{ github.ref_name }} --draft --notes "Draft release for ${{ github.ref_name }}"
+        fi
         gh release upload ${{ github.ref_name }} dist/artifacts/harvester*initrd-${{ env.arch }}
         gh release upload ${{ github.ref_name }} dist/artifacts/harvester*vmlinuz-${{ env.arch }}
         gh release upload ${{ github.ref_name }} dist/artifacts/harvester*images-list-${{ env.arch }}.txt


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The workflow triggered by tag events will create duplicate releases because we use matrix for x64 and arm64 architectures.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Check the release's existence before creating one.

**Related Issue:**

N/A

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Test using act with tag events:

```
cat <<EOF > event.json
{
  "ref": "refs/tags/test-tag"
}
EOF

act push --secret-file secret.txt --container-architecture linux/amd64 --eventpath event.json
```