### PR TITLE
feat: add validating admission policy to prohibit changes to RKE2 CIDR within managed chart

### DIFF
--- a/deploy/charts/harvester/templates/validating-admission-policy.yaml
+++ b/deploy/charts/harvester/templates/validating-admission-policy.yaml
@@ -1,0 +1,58 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: harvester-immutable-promote-cidr
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: ["fleet-local"]
+    resourceRules:
+    - apiGroups:   ["management.cattle.io"]
+      apiVersions: ["v3"]
+      operations:  ["UPDATE"]
+      resources:   ["managedcharts"]
+      resourceNames: ["harvester"]
+      scope: Namespaced
+  matchConditions:
+  - name: "skip-if-upgrading-from-1.4-or-older"
+    expression: "'promote' in oldObject.spec.values"
+  variables:
+  - name: newPodCIDR
+    expression: "'clusterPodCIDR' in object.spec.values.promote ? object.spec.values.promote.clusterPodCIDR : ''"
+  - name: oldPodCIDR
+    expression: "'clusterPodCIDR' in oldObject.spec.values.promote ? oldObject.spec.values.promote.clusterPodCIDR : ''"
+  - name: newServiceCIDR
+    expression: "'clusterServiceCIDR' in object.spec.values.promote ? object.spec.values.promote.clusterServiceCIDR : ''"
+  - name: oldServiceCIDR
+    expression: "'clusterServiceCIDR' in oldObject.spec.values.promote ? oldObject.spec.values.promote.clusterServiceCIDR : ''"
+  - name: newClusterDNS
+    expression: "'clusterDNS' in object.spec.values.promote ? object.spec.values.promote.clusterDNS : ''"
+  - name: oldClusterDNS
+    expression: "'clusterDNS' in oldObject.spec.values.promote ? oldObject.spec.values.promote.clusterDNS : ''"
+  validations:
+  - expression: |-
+      (variables.oldPodCIDR == "" || variables.newPodCIDR == variables.oldPodCIDR) &&
+      (variables.oldServiceCIDR == "" || variables.newServiceCIDR == variables.oldServiceCIDR )&&
+      (variables.oldClusterDNS == "" || variables.newClusterDNS == variables.oldClusterDNS)
+    messageExpression: |-
+      'the promote CIDRs configuration is immutable. ' +
+      'clusterCIDR: ' + variables.oldPodCIDR + ' => ' + variables.newPodCIDR + ', ' +
+      'serviceCIDR:' + variables.oldServiceCIDR + ' => ' + variables.newServiceCIDR + ', ' +
+      'clusterDNS: ' + variables.oldClusterDNS + ' => ' + variables.newClusterDNS
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: harvester-immutable-promote-cidr
+  labels:
+{{ include "harvester.labels" . | indent 4 }}
+spec:
+  policyName: harvester-immutable-promote-cidr
+  validationActions: [Deny]


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Following the completion of #4254, user can now override the RKE2's default pod and service CIDRs. There is nothing prohibiting the user from manipulating Helm to override these settings within the `harvester` managed chart, to alter the values found in the `harvester-system/harvester-helpers` config map. These settings must not be changed post-installation.

Issue: #7196

**Solution:**
Introduce a validating admission policy to prevent the modification of the RKE2 CIDRs within the `harvester` managed chart. 

Per discussion at https://github.com/harvester/harvester/pull/7445#issuecomment-2638181603, the validating admission policy doesn't block attempts to alter the CIDRs that are propagated to the `harvester-system/harvester-helpers`  config map. Since these CIDRs are embedded in a big blob of string within the config map, any unforeseen string change patterns can easily trigger a false positive policy failures. For now, we continue to rely on the existing mechanism of letting the managed chart and bundle error out and block any upgrade, if the config map is changed. Further guardrails to protect the config map will be considered in a future PR.

**Related Issue:**

**Test plan:**

## Base Case - Current behaviour

Without the changes in this PR, user can use `k -n fleet-local edit managedchart harvester` to change the CIDRs defined within the `spec.values.promote` block. This causes the undesirable effect of changing the CIDRs defined in the `harvester-system/harvester-helpers` config map. E.g.,

```sh
# before changing the managed chart
✗ k -n harvester-system get cm harvester-helpers -ojsonpath='{.data.promote\.sh}' | grep -A2 -i "cluster-cidr"
cluster-cidr: 172.16.0.0/16
service-cidr: 172.20.0.0/16
cluster-dns: 172.20.0.10

# after changing the managed chart
✗ k -n harvester-system get cm harvester-helpers -ojsonpath='{.data.promote\.sh}' | grep -A2 -i "cluster-cidr"
cluster-cidr: 172.19.0.0/16
service-cidr: 172.31.0.0/16
cluster-dns: 172.31.0.10
```

## Test Case 1 - Prohibit changes to the promote CIDRs defined in the managed chart

Use `helm template` to render the updated Harvester chart which includes the new `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` resources:

```sh
helm -n harvester-system template harvester ./deploy/charts/harvester
```

Deploy these new Helm-rendered YAML to an existing Harvester cluster:

```sh
$ cat <<EOF | k apply -f -
# Source: harvester/templates/validating-admission-policy.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicy
metadata:
  name: harvester-immutable-promote-cidr
  labels:
    app.kubernetes.io/managed-by: "Helm"
    helm.sh/chart: harvester-0.0.0-dev
    app.kubernetes.io/version: "0.1.x"
    helm.sh/release: harvester
    app.kubernetes.io/part-of: harvester
spec:
  failurePolicy: Fail
  matchConstraints:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values: ["fleet-local"]
    resourceRules:
    - apiGroups:   ["management.cattle.io"]
      apiVersions: ["v3"]
      operations:  ["UPDATE"]
      resources:   ["managedcharts"]
      resourceNames: ["harvester"]
      scope: Namespaced
  matchConditions:
  - name: "skip-if-upgrading-from-1.4-or-older"
    expression: "'promote' in oldObject.spec.values"
  variables:
  - name: newPodCIDR
    expression: "'clusterPodCIDR' in object.spec.values.promote ? object.spec.values.promote.clusterPodCIDR : ''"
  - name: oldPodCIDR
    expression: "'clusterPodCIDR' in oldObject.spec.values.promote ? oldObject.spec.values.promote.clusterPodCIDR : ''"
  - name: newServiceCIDR
    expression: "'clusterServiceCIDR' in object.spec.values.promote ? object.spec.values.promote.clusterServiceCIDR : ''"
  - name: oldServiceCIDR
    expression: "'clusterServiceCIDR' in oldObject.spec.values.promote ? oldObject.spec.values.promote.clusterServiceCIDR : ''"
  - name: newClusterDNS
    expression: "'clusterDNS' in object.spec.values.promote ? object.spec.values.promote.clusterDNS : ''"
  - name: oldClusterDNS
    expression: "'clusterDNS' in oldObject.spec.values.promote ? oldObject.spec.values.promote.clusterDNS : ''"
  validations:
  - expression: |-
      (variables.oldPodCIDR == "" || variables.newPodCIDR == variables.oldPodCIDR) && 
      (variables.oldServiceCIDR == "" || variables.newServiceCIDR == variables.oldServiceCIDR )&& 
      (variables.oldClusterDNS == "" || variables.newClusterDNS == variables.oldClusterDNS)
    messageExpression: |-
      'the promote CIDRs configuration is immutable. ' +
      'clusterCIDR: ' + variables.oldPodCIDR + ' => ' + variables.newPodCIDR + ', ' +
      'serviceCIDR:' + variables.oldServiceCIDR + ' => ' + variables.newServiceCIDR + ', ' +
      'clusterDNS: ' + variables.oldClusterDNS + ' => ' + variables.newClusterDNS
    reason: Invalid
---
# Source: harvester/templates/validating-admission-policy.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicyBinding
metadata:
  name: harvester-immutable-promote-cidr
  labels:
    app.kubernetes.io/managed-by: "Helm"
    helm.sh/chart: harvester-0.0.0-dev
    app.kubernetes.io/version: "0.1.x"
    helm.sh/release: harvester
    app.kubernetes.io/part-of: harvester
spec:
  policyName: harvester-immutable-promote-cidr
  validationActions: [Deny]
EOF
validatingadmissionpolicy.admissionregistration.k8s.io/harvester-immutable-promote-cidr created
validatingadmissionpolicybinding.admissionregistration.k8s.io/harvester-immutable-promote-cidr created
```

Use `k -n fleet-local edit managedchart harvester` to perform the following changes to the CIDRs within the `spec.values.promote` block:

* change the value of the `cluster-cidr` setting
* change the value of the `service-cidr` setting
* change the value of the `cluster-dns` setting
* delete any or all of these CIDRs settings

K8s will reject the changes with the following error:

```sh
#
# managedcharts.management.cattle.io "harvester" was not valid:
# * : ValidatingAdmissionPolicy 'harvester-immutable-promote-cidr' with binding 'harvester-immutable-promote-cidr' denied request: the promote CIDRs configuration is immutable. clusterCIDR: 172.16.0.0/16 => 172.16.0.0/16, serviceCIDR:172.22.0.0/16 => 172.22.0.0/16, clusterDNS: 172.22.0.10 => 172.20.0.10
#
```

## Test Case 2 - Skip policy validation when upgrading from 1.4 or older

Upgrading from Harvester 1.4 or older should not be blocked by the new admission policy. The policy object recognizes that older managed chart in 1.4 or older does not have the promote CIDRs. Hence, it would skip the rules validation.