### PR TITLE
Add upgrade path processing of issue 7442

### DIFF
--- a/package/upgrade/migrations/managed_charts/v1.4.0.sh
+++ b/package/upgrade/migrations/managed_charts/v1.4.0.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_snapshot_validation_webhook_tls()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "v1" and
+                   .kind == "Secret" and
+                   .name == "snapshot-validation-webhook-tls")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "name": "snapshot-validation-webhook-tls",
+      "jsonPointers":["/data"]}]' $manifest -i
+  fi
+}
+
+patch_harvester_snapshot_validation_webhook()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "admissionregistration.k8s.io/v1" and
+                   .kind == "ValidatingWebhookConfiguration" and
+                   .name == "harvester-snapshot-validation-webhook")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "admissionregistration.k8s.io/v1",
+      "kind": "ValidatingWebhookConfiguration",
+      "name": "harvester-snapshot-validation-webhook",
+      "jsonPointers":["/webhooks"]}]' $manifest -i
+  fi
+}
+
+patch_ignoring_resources()
+{
+  # add ignoring resources
+  patch_snapshot_validation_webhook_tls $CHART_MANIFEST
+  patch_harvester_snapshot_validation_webhook $CHART_MANIFEST
+}
+
+case $CHART_NAME in
+  harvester)
+    patch_ignoring_resources
+    ;;
+esac

--- a/package/upgrade/migrations/managed_charts/v1.4.1.sh
+++ b/package/upgrade/migrations/managed_charts/v1.4.1.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_snapshot_validation_webhook_tls()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "v1" and
+                   .kind == "Secret" and
+                   .name == "snapshot-validation-webhook-tls")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "name": "snapshot-validation-webhook-tls",
+      "jsonPointers":["/data"]}]' $manifest -i
+  fi
+}
+
+patch_harvester_snapshot_validation_webhook()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "admissionregistration.k8s.io/v1" and
+                   .kind == "ValidatingWebhookConfiguration" and
+                   .name == "harvester-snapshot-validation-webhook")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "admissionregistration.k8s.io/v1",
+      "kind": "ValidatingWebhookConfiguration",
+      "name": "harvester-snapshot-validation-webhook",
+      "jsonPointers":["/webhooks"]}]' $manifest -i
+  fi
+}
+
+patch_ignoring_resources()
+{
+  # add ignoring resources
+  patch_snapshot_validation_webhook_tls $CHART_MANIFEST
+  patch_harvester_snapshot_validation_webhook $CHART_MANIFEST
+}
+
+case $CHART_NAME in
+  harvester)
+    patch_ignoring_resources
+    ;;
+esac

--- a/package/upgrade/migrations/managed_charts/v1.4.2.sh
+++ b/package/upgrade/migrations/managed_charts/v1.4.2.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_snapshot_validation_webhook_tls()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "v1" and
+                   .kind == "Secret" and
+                   .name == "snapshot-validation-webhook-tls")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "name": "snapshot-validation-webhook-tls",
+      "jsonPointers":["/data"]}]' $manifest -i
+  fi
+}
+
+patch_harvester_snapshot_validation_webhook()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "admissionregistration.k8s.io/v1" and
+                   .kind == "ValidatingWebhookConfiguration" and
+                   .name == "harvester-snapshot-validation-webhook")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "admissionregistration.k8s.io/v1",
+      "kind": "ValidatingWebhookConfiguration",
+      "name": "harvester-snapshot-validation-webhook",
+      "jsonPointers":["/webhooks"]}]' $manifest -i
+  fi
+}
+
+patch_ignoring_resources()
+{
+  # add ignoring resources
+  patch_snapshot_validation_webhook_tls $CHART_MANIFEST
+  patch_harvester_snapshot_validation_webhook $CHART_MANIFEST
+}
+
+case $CHART_NAME in
+  harvester)
+    patch_ignoring_resources
+    ;;
+esac

--- a/package/upgrade/migrations/managed_charts/v1.4.3.sh
+++ b/package/upgrade/migrations/managed_charts/v1.4.3.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -ex
+
+CHART_NAME=$1
+CHART_MANIFEST=$2
+
+patch_snapshot_validation_webhook_tls()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "v1" and
+                   .kind == "Secret" and
+                   .name == "snapshot-validation-webhook-tls")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "name": "snapshot-validation-webhook-tls",
+      "jsonPointers":["/data"]}]' $manifest -i
+  fi
+}
+
+patch_harvester_snapshot_validation_webhook()
+{
+  local manifest=$1
+
+  result=$(yq '.spec.diff.comparePatches[] |
+                 select(
+                   .apiVersion == "admissionregistration.k8s.io/v1" and
+                   .kind == "ValidatingWebhookConfiguration" and
+                   .name == "harvester-snapshot-validation-webhook")' $manifest 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    yq e '.spec.diff.comparePatches += [{
+      "apiVersion": "admissionregistration.k8s.io/v1",
+      "kind": "ValidatingWebhookConfiguration",
+      "name": "harvester-snapshot-validation-webhook",
+      "jsonPointers":["/webhooks"]}]' $manifest -i
+  fi
+}
+
+patch_ignoring_resources()
+{
+  # add ignoring resources
+  patch_snapshot_validation_webhook_tls $CHART_MANIFEST
+  patch_harvester_snapshot_validation_webhook $CHART_MANIFEST
+}
+
+case $CHART_NAME in
+  harvester)
+    patch_ignoring_resources
+    ;;
+esac


### PR DESCRIPTION
**Problem:**

Harvester managedchart is marked as harvester-snapshot-validation-webhook modified

**Solution:**

Add those dynamic resources (updated each time chart is updated) to diff path of managedchart.

**Related Issue:**
https://github.com/harvester/harvester/issues/7442

**Test plan:**

Update harvester managedchart, observe the managedchart is not complained.

code PR:  https://github.com/harvester/harvester-installer/pull/939
backport v1.4 https://github.com/harvester/harvester-installer/pull/947
backport v1.5 https://github.com/harvester/harvester-installer/pull/946

note: this PR assumes there are v1.4.0, v1.4.1, v1.4.2, v1.4.3 releases, both v1.5 and v1.4.3(latest) can add this PR