### PR TITLE
Add resourcequota controller to scale resource on demand

### DIFF
--- a/pkg/controller/master/migration/register.go
+++ b/pkg/controller/master/migration/register.go
@@ -25,16 +25,19 @@ func Register(ctx context.Context, management *config.Management, options config
 	pods := management.CoreFactory.Core().V1().Pod()
 	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	vmims := management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration()
+	settingCache := management.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()
+
 	handler := &Handler{
-		namespace:  options.Namespace,
-		rqs:        rqs,
-		rqCache:    rqs.Cache(),
-		vmiCache:   vmis.Cache(),
-		vms:        vms,
-		vmCache:    vms.Cache(),
-		pods:       pods,
-		podCache:   pods.Cache(),
-		restClient: virtv1Client.RESTClient(),
+		namespace:    options.Namespace,
+		rqs:          rqs,
+		rqCache:      rqs.Cache(),
+		vmiCache:     vmis.Cache(),
+		vms:          vms,
+		vmCache:      vms.Cache(),
+		pods:         pods,
+		podCache:     pods.Cache(),
+		settingCache: settingCache,
+		restClient:   virtv1Client.RESTClient(),
 	}
 
 	vmis.OnChange(ctx, vmiControllerName, handler.OnVmiChanged)

--- a/pkg/controller/master/migration/vmi_controller.go
+++ b/pkg/controller/master/migration/vmi_controller.go
@@ -13,21 +13,23 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	ctlharvcorev1 "github.com/harvester/harvester/pkg/generated/controllers/core/v1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlvirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/util"
 )
 
 // Handler resets vmi annotations and nodeSelector when a migration completes
 type Handler struct {
-	namespace  string
-	rqs        ctlharvcorev1.ResourceQuotaClient
-	rqCache    ctlharvcorev1.ResourceQuotaCache
-	vmiCache   ctlvirtv1.VirtualMachineInstanceCache
-	vms        ctlvirtv1.VirtualMachineClient
-	vmCache    ctlvirtv1.VirtualMachineCache
-	podCache   ctlcorev1.PodCache
-	pods       ctlcorev1.PodClient
-	restClient rest.Interface
+	namespace    string
+	rqs          ctlharvcorev1.ResourceQuotaClient
+	rqCache      ctlharvcorev1.ResourceQuotaCache
+	vmiCache     ctlvirtv1.VirtualMachineInstanceCache
+	vms          ctlvirtv1.VirtualMachineClient
+	vmCache      ctlvirtv1.VirtualMachineCache
+	podCache     ctlcorev1.PodCache
+	pods         ctlcorev1.PodClient
+	settingCache ctlharvesterv1.SettingCache
+	restClient   rest.Interface
 }
 
 func (h *Handler) OnVmiChanged(_ string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {

--- a/pkg/controller/master/migration/vmim_controller_test.go
+++ b/pkg/controller/master/migration/vmim_controller_test.go
@@ -3,6 +3,8 @@
 package migration
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +13,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakecore "k8s.io/client-go/kubernetes/fake"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	kubevirtservices "kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	ctlharvcorev1 "github.com/harvester/harvester/pkg/generated/controllers/core/v1"
@@ -21,14 +24,41 @@ import (
 
 const (
 	resourceQuotaNamespace = "rs"
-	resourceQuotaName
-	uid
+	resourceQuotaName      = "rq1"
+	uid                    = "6afcf4d9-b8a7-464a-a4e9-abe81fc7eacd"
+
+	longVMIName = "a-very-long-name-exceeds-the-63-length-and-it-reports-error-in-old-version"
+
+	memory1Gi = 1 * 1024 * 1024 * 1024
+
+	// the vm limits.memory is dynamically computed, avoid to use hard coded number
+	vmResourceLimitStr = "{\"limits.cpu\":\"1\",\"limits.memory\":\"%v\"}"
 
 	errMockTrackerAdd = "mock resource should add into fake controller tracker"
 	errMockTrackerGet = "mock resource should get into fake controller tracker"
 )
 
 func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
+	// compute the dynamic overhead per kubevirt
+	getMemWithOverhead := func(memLimit int64) int64 {
+		vmi := kubevirtv1.VirtualMachineInstance{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "vm1",
+				Namespace: resourceQuotaNamespace,
+			},
+			Spec: kubevirtv1.VirtualMachineInstanceSpec{
+				Domain: kubevirtv1.DomainSpec{
+					Resources: kubevirtv1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: *resource.NewQuantity(memLimit, resource.BinarySI),
+						},
+					},
+				},
+			},
+		}
+		overhead := kubevirtservices.GetMemoryOverhead(&vmi, runtime.GOARCH, util.GetAdditionalGuestMemoryOverheadRatioWithoutError(nil)) // use default ratio 1.5
+		return overhead.Value() + memLimit
+	}
 
 	type fields struct {
 		rqs      ctlharvcorev1.ResourceQuotaClient
@@ -62,7 +92,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					Spec: corev1.ResourceQuotaSpec{
 						Hard: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-							corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
 						},
 					},
 				},
@@ -70,13 +100,14 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
+						UID:       uid,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
 							Resources: kubevirtv1.ResourceRequirements{
 								Limits: map[corev1.ResourceName]resource.Quantity{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
 								},
 							},
 						},
@@ -97,7 +128,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 			want: &corev1.ResourceQuota{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"1266Mi"}`,
+						util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi)),
 					},
 					Namespace: resourceQuotaNamespace,
 					Name:      resourceQuotaName,
@@ -106,13 +137,76 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI), // will be updated by rq controller later
-						corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
 					},
 				},
 			},
 		},
 		{
-			name:   "Succeeded", // Equivalent to Failed
+			name:   "In Pending with a long VMI name, the UID based key is used in newer version",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      longVMIName,
+						Namespace: resourceQuotaNamespace,
+						UID:       uid,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: longVMIName},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi)),
+					},
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI), // will be updated by rq controller later
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name:   "Succeeded, name based annotation key is deleted from ResourceQuota",
 			fields: fields{},
 			args: args{
 				rq: &corev1.ResourceQuota{
@@ -120,14 +214,14 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 						Namespace: resourceQuotaNamespace,
 						Name:      resourceQuotaName,
 						Annotations: map[string]string{
-							util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"1364Mi"}`,
+							util.GenerateAnnotationKeyMigratingVMName("vm1"): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi)),
 						},
 						Labels: map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
 					},
 					Spec: corev1.ResourceQuotaSpec{
 						Hard: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
-							corev1.ResourceLimitsMemory: *resource.NewQuantity(2727694336, resource.BinarySI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2+getMemWithOverhead(memory1Gi), resource.BinarySI),
 						},
 					},
 				},
@@ -141,7 +235,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 							Resources: kubevirtv1.ResourceRequirements{
 								Limits: map[corev1.ResourceName]resource.Quantity{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
 								},
 							},
 						},
@@ -168,8 +262,72 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				},
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI), // will be updated by rq controller later
-						corev1.ResourceLimitsMemory: *resource.NewQuantity(2727694336, resource.BinarySI),
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2+getMemWithOverhead(memory1Gi), resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name:   "Succeeded, UID based annotation key is deleted from ResourceQuota",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi)),
+						},
+						Labels: map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2+getMemWithOverhead(memory1Gi), resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vm1",
+						Namespace: resourceQuotaNamespace,
+						UID:       uid,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationSucceeded,
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace:   resourceQuotaNamespace,
+					Name:        resourceQuotaName,
+					Annotations: map[string]string{},
+					Labels:      map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2+getMemWithOverhead(memory1Gi), resource.BinarySI),
 					},
 				},
 			},
@@ -186,7 +344,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					Spec: corev1.ResourceQuotaSpec{
 						Hard: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-							corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
 						},
 					},
 				},
@@ -200,7 +358,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 							Resources: kubevirtv1.ResourceRequirements{
 								Limits: map[corev1.ResourceName]resource.Quantity{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
 								},
 							},
 						},
@@ -226,7 +384,64 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-						corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name:   "RQ is not in the target namespace, skip scaling",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "random",
+						Name:      resourceQuotaName,
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vm1",
+						Namespace: resourceQuotaNamespace,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "random",
+					Name:      resourceQuotaName,
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
 					},
 				},
 			},
@@ -243,7 +458,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					Spec: corev1.ResourceQuotaSpec{
 						Hard: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-							corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
 						},
 					},
 				},
@@ -257,7 +472,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 							Resources: kubevirtv1.ResourceRequirements{
 								Limits: map[corev1.ResourceName]resource.Quantity{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
 								},
 							},
 						},
@@ -283,7 +498,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-						corev1.ResourceLimitsMemory: *resource.NewQuantity(1297436672, resource.BinarySI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
 					},
 				},
 			},
@@ -312,7 +527,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 							Resources: kubevirtv1.ResourceRequirements{
 								Limits: map[corev1.ResourceName]resource.Quantity{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi, resource.BinarySI),
 								},
 							},
 						},

--- a/pkg/controller/master/resourcequota/register.go
+++ b/pkg/controller/master/resourcequota/register.go
@@ -10,7 +10,7 @@ const (
 	resourceQuotaControllerName = "resourceQuotaController"
 )
 
-func Register(ctx context.Context, management *config.Management, options config.Options) error {
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	rqs := management.HarvesterCoreFactory.Core().V1().ResourceQuota()
 	handler := &Handler{
 		rqs:     rqs,

--- a/pkg/controller/master/resourcequota/register.go
+++ b/pkg/controller/master/resourcequota/register.go
@@ -12,7 +12,9 @@ const (
 
 func Register(ctx context.Context, management *config.Management, _ config.Options) error {
 	rqs := management.HarvesterCoreFactory.Core().V1().ResourceQuota()
+	nsCache := management.CoreFactory.Core().V1().Namespace().Cache()
 	handler := &Handler{
+		nsCache: nsCache,
 		rqs:     rqs,
 		rqCache: rqs.Cache(),
 	}

--- a/pkg/controller/master/resourcequota/register.go
+++ b/pkg/controller/master/resourcequota/register.go
@@ -1,0 +1,21 @@
+package resourcequota
+
+import (
+	"context"
+
+	"github.com/harvester/harvester/pkg/config"
+)
+
+const (
+	resourceQuotaControllerName = "resourceQuotaController"
+)
+
+func Register(ctx context.Context, management *config.Management, options config.Options) error {
+	rqs := management.HarvesterCoreFactory.Core().V1().ResourceQuota()
+	handler := &Handler{
+		rqs:     rqs,
+		rqCache: rqs.Cache(),
+	}
+	rqs.OnChange(ctx, resourceQuotaControllerName, handler.OnResourceQuotaChanged)
+	return nil
+}

--- a/pkg/controller/master/resourcequota/resourcequota_controller.go
+++ b/pkg/controller/master/resourcequota/resourcequota_controller.go
@@ -1,78 +1,97 @@
 package resourcequota
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	ctlv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 
 	ctlharvcorev1 "github.com/harvester/harvester/pkg/generated/controllers/core/v1"
 	"github.com/harvester/harvester/pkg/util"
-
 	rqutils "github.com/harvester/harvester/pkg/util/resourcequota"
 )
 
 type Handler struct {
+	nsCache ctlv1.NamespaceCache
 	rqs     ctlharvcorev1.ResourceQuotaClient
 	rqCache ctlharvcorev1.ResourceQuotaCache
 }
 
 var errSkipScaling = errors.New("skip scaling")
 
+// When Harvester is scaling resourcequota per vmim, the resourcequota can also be reset by Rancher
+// Luckily Rancher only resets it when Rancher related POD starts, it does not monitor and reset it all the time
+// Harvester controller calculates the resourcequota per Rancher annotation and Harvester annotation
+// If someday Rancher keeps resetting it, this controller needs an enhancement to avoid looping update resourcequota with Rancher
 func (h *Handler) OnResourceQuotaChanged(_ string, rq *corev1.ResourceQuota) (*corev1.ResourceQuota, error) {
-	// not a target rq
-	if rq == nil || rq.DeletionTimestamp != nil || rq.Annotations == nil || rq.Labels == nil || rq.Labels[util.LabelManagementDefaultResourceQuota] != "true" {
+	// not a target resourcequota
+	if rq == nil || rq.DeletionTimestamp != nil || rq.Labels == nil || rq.Labels[util.LabelManagementDefaultResourceQuota] != "true" {
 		return rq, nil
 	}
 
+	// for debugging or manually disabling this feature
+	if rq.Annotations[util.AnnotationSkipResourceQuotaAutoScaling] == "true" {
+		logrus.Debugf("resourcequota %s/%s annotation %s is set, skip auto scaling", rq.Namespace, rq.Name, util.AnnotationSkipResourceQuotaAutoScaling)
+		return rq, nil
+	}
+
+	// check namespace ResourceQuota annotation
+	ns, err := h.nsCache.Get(rq.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("can't find resourcequota %s/%s related namespace, error %w", rq.Namespace, rq.Name, err)
+	}
+
 	rqCopy := rq.DeepCopy()
-	update, err := scaleResourceOnDemand(rqCopy)
+	update, err := scaleResourceQuotaOnDemand(rqCopy, ns.Annotations[util.CattleAnnotationResourceQuota])
 	if err != nil {
 		if errors.Is(err, errSkipScaling) {
 			return rq, nil
 		}
 		return rq, err
 	}
-
 	if update {
+		logrus.Debugf("resourcequota %s/%s is updated from %+v to %+v", rq.Namespace, rq.Name, rq.Spec, rqCopy.Spec)
 		return h.rqs.Update(rqCopy)
 	}
 
 	return rq, nil
 }
 
-func scaleResourceOnDemand(rq *corev1.ResourceQuota) (bool, error) {
-	// below data is only related to rq itself, if error happens and run reconciller, it will fall into error looping
+func scaleResourceQuotaOnDemand(rq *corev1.ResourceQuota, rqStr string) (bool, error) {
 	update := false
-	if rqutils.IsEmptyResourceQuota(rq) {
-		logrus.Warnf("resourcequota %s/%s has 0 quota, skip scaling", rq.Namespace, rq.Name)
+	if rqStr == "" {
+		logrus.Debugf("resourcequota %s/%s related namespace has empty %s annotation, skip scaling", rq.Namespace, rq.Name, util.CattleAnnotationResourceQuota)
 		return update, errSkipScaling
+	}
+	var rqBase *v3.NamespaceResourceQuota
+	if err := json.Unmarshal([]byte(rqStr), &rqBase); err != nil {
+		logrus.Warnf("resourcequota %s/%s related namespace has invalid %s annotation %s, skip scaling, error %s", rq.Namespace, rq.Name, util.CattleAnnotationResourceQuota, rqStr, err.Error())
+		return update, err
 	}
 
-	carq, _ := rq.Annotations[util.CattleAnnotationResourceQuota]
-	// NamespaceResourceQuota
-	rqBase, err := rqutils.GetRancherNamespaceResourceQuotaFromRQAnnotations(rq)
-	if err != nil {
-		logrus.Warnf("resourcequota %s/%s has invalid %s annotation %s, skip scaling, error %s", rq.Namespace, rq.Name, util.CattleAnnotationResourceQuota, carq, err.Error())
-		return update, errSkipScaling
-	}
-	if rqBase == nil {
-		logrus.Warnf("resourcequota %s/%s has no %s annotation, skip scaling", rq.Namespace, rq.Name, util.CattleAnnotationResourceQuota)
+	// if both CPU and memory have no limits
+	if rqutils.IsEmptyResourceQuota(rq) {
+		logrus.Debugf("resourcequota %s/%s has 0 quota, skip scaling", rq.Namespace, rq.Name)
 		return update, errSkipScaling
 	}
 
 	rCPULimit, rMemoryLimit, err := rqutils.GetCPUMemoryLimitsFromRancherNamespaceResourceQuota(rqBase)
 	if err != nil {
-		logrus.Warnf("resourcequota %s/%s can't get valid Quantity values from rancher %s annotations %s, skip scaling, error %s", rq.Namespace, rq.Name, util.CattleAnnotationResourceQuota, carq, err.Error())
+		logrus.Warnf("resourcequota %s/%s can't get valid Quantity values from Rancher %s annotations %s, skip scaling, error %s", rq.Namespace, rq.Name, util.CattleAnnotationResourceQuota, rqStr, err.Error())
 		return update, errSkipScaling
 	}
 
 	cpuDelta, memDelta, _, err := rqutils.GetVMIMResourcesFromRQAnnotation(rq)
 	if err != nil {
-		logrus.Warnf("resourcequota %s/%s can't get valid Quantity values from harvester vm annotations, skip scaling, error %s", rq.Namespace, rq.Name, err.Error())
+		logrus.Warnf("resourcequota %s/%s can't get valid Quantity values from Harvester vm annotations, skip scaling, error %s", rq.Namespace, rq.Name, err.Error())
 		return update, errSkipScaling
 	}
 
-	update = rqutils.CalculateNewResourceQuotaFromBaseDelta(rq, rCPULimit, rMemoryLimit, cpuDelta, memDelta)
+	// note: if any base has no limit, the delta is not added
+	rq, update = rqutils.CalculateNewResourceQuotaFromBaseDelta(rq, rCPULimit, rMemoryLimit, cpuDelta, memDelta)
 	return update, nil
 }

--- a/pkg/controller/master/resourcequota/resourcequota_controller_test.go
+++ b/pkg/controller/master/resourcequota/resourcequota_controller_test.go
@@ -1,0 +1,399 @@
+//go:build linux && amd64
+
+package resourcequota
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctlharvcorev1 "github.com/harvester/harvester/pkg/generated/controllers/core/v1"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	resourceQuotaNamespace = "test"
+	resourceQuotaName      = "rq1"
+	uid
+
+	memory1Gi = 1 * 1024 * 1024 * 1024
+	cpuCore1  = 1
+	cpuCore2  = 2
+	cpuCore3  = 3
+)
+
+func TestHandler_OnResourceQuotaChanged(t *testing.T) {
+
+	type fields struct {
+		rqs ctlharvcorev1.ResourceQuotaClient
+	}
+	type args struct {
+		rq *corev1.ResourceQuota
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		want    *corev1.ResourceQuota
+	}{
+		{
+			name:   "Resourcequota has limits value zero, skip scalling ",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(0, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(0, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "No RancherNamespaceResourceQuota annotation, skip scalling ",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "Invalid RancherNamespaceResourceQuota annotation, skip scalling ",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace:   resourceQuotaNamespace,
+						Name:        resourceQuotaName,
+						Labels:      map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"10000m invalid\"}}"},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "Invalid Harvester VM migration annotation, skip scalling",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10240Mi\"}}",
+							util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi invalid"}`,
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "No pending scaling, RQ is based on Rancher annotation",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10240Mi\"}}",
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10240Mi\"}}",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.DecimalSI),
+					},
+				},
+			},
+		},
+		{
+			name:   "Scaling up per vmim resources annotations",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+							util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+						util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name:   "Scaling up further per vmim resources annotations",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+							util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							util.AnnotationMigratingPrefix + "vm2": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore2, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+						util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.AnnotationMigratingPrefix + "vm2": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore3, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(14*memory1Gi, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name:   "Scaling down per vmim resources annotations",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+							// util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`, // vm1 finished the migration
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name:   "Scaling is finished per vmim resources annotations",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+							util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							util.AnnotationMigratingPrefix + "vm2": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore3, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(14*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+						util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.AnnotationMigratingPrefix + "vm2": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore3, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(14*memory1Gi, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name:   "Rancher resets RQ, scaling is rebased",
+			fields: fields{},
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"20Gi\"}}", // Rancher resets the base from 10Gi to 20Gi
+							util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							util.AnnotationMigratingPrefix + "vm2": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(20*memory1Gi, resource.BinarySI), // Rancher resets the base from 10Gi to 20Gi
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota:     "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"20Gi\"}}",
+						util.AnnotationMigratingPrefix + "vm1": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.AnnotationMigratingPrefix + "vm2": `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore3, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(24*memory1Gi, resource.BinarySI), // Harvester adds the 4Gi to new base
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.args.rq == nil {
+				return
+			}
+
+			_, err := scaleResourceOnDemand(tt.args.rq)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("scaleResourceOnDemand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			assert.Equal(t, tt.want, tt.args.rq, "case %q", tt.name)
+		})
+	}
+}

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/controller/master/nodedrain"
 	"github.com/harvester/harvester/pkg/controller/master/rancher"
+	"github.com/harvester/harvester/pkg/controller/master/resourcequota"
 	"github.com/harvester/harvester/pkg/controller/master/schedulevmbackup"
 	"github.com/harvester/harvester/pkg/controller/master/setting"
 	"github.com/harvester/harvester/pkg/controller/master/storagenetwork"
@@ -57,6 +58,7 @@ var registerFuncs = []registerFunc{
 	nodedrain.Register,
 	mcmsettings.Register,
 	schedulevmbackup.Register,
+	resourcequota.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -46,6 +46,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		snapshotCache  = snapshotClient.Cache()
 		crClient       = management.ControllerRevisionFactory.Apps().V1().ControllerRevision()
 		crClientCache  = crClient.Cache()
+		settingCache   = management.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()
 		recorder       = management.NewRecorder(vmControllerSetHaltIfInsufficientResourceQuotaControllerName, "", "")
 	)
 
@@ -61,9 +62,10 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		vmBackupCache:  vmBackupCache,
 		snapshotClient: snapshotClient,
 		snapshotCache:  snapshotCache,
+		settingCache:   settingCache,
 		recorder:       recorder,
 
-		vmrCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache),
+		vmrCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache, settingCache),
 	}
 	var virtualMachineClient = management.VirtFactory.Kubevirt().V1().VirtualMachine()
 	virtualMachineClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)

--- a/pkg/controller/master/virtualmachine/vm_controller.go
+++ b/pkg/controller/master/virtualmachine/vm_controller.go
@@ -40,6 +40,7 @@ type VMController struct {
 	vmBackupCache  ctlharvesterv1.VirtualMachineBackupCache
 	snapshotClient ctlsnapshotv1.VolumeSnapshotClient
 	snapshotCache  ctlsnapshotv1.VolumeSnapshotCache
+	settingCache   ctlharvesterv1.SettingCache
 	recorder       record.EventRecorder
 
 	vmrCalculator *rqutils.Calculator

--- a/pkg/util/annotationkey.go
+++ b/pkg/util/annotationkey.go
@@ -1,0 +1,9 @@
+package util
+
+func GenerateAnnotationKeyMigratingVMName(vmName string) string {
+	return AnnotationMigratingNamePrefix + vmName
+}
+
+func GenerateAnnotationKeyMigratingVMUID(vmUID string) string {
+	return AnnotationMigratingUIDPrefix + vmUID
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -31,9 +31,19 @@ const (
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
 
-	// AnnotationMigratingPrefix is used to store the migrating vm in the annotation of ResourceQuota
+	// AnnotationSkipResourceQuotaAutoScaling is used to disable to resourcequota auto scaling
+	AnnotationSkipResourceQuotaAutoScaling = prefix + "/skipResourceQuotaAutoScaling"
+
+	// AnnotationMigratingNamePrefix is used to store the migrating vm in the annotation of ResourceQuota
 	// eg: harvesterhci.io/migrating-vm1: jsonOfResourceList, harvesterhci.io/migrating-vm2: jsonOfResourceList
-	AnnotationMigratingPrefix = prefix + "/migrating-"
+	// will be removed after v1.5.0
+	AnnotationMigratingNamePrefix = prefix + "/migrating-"
+
+	// replace AnnotationMigratingNamePrefix from v1.5.0
+	AnnotationMigratingUIDPrefix = prefix + "/migratingUID-"
+
+	// AnnotationMigratingPrefix is replaced by AnnotationMigratingNamePrefix, and is kept for compatibility
+	AnnotationMigratingPrefix = AnnotationMigratingNamePrefix
 
 	// AnnotationInsufficientResourceQuota is indicated the resource is insufficient of Namespace
 	AnnotationInsufficientResourceQuota = prefix + "/insufficient-resource-quota"

--- a/pkg/util/resourcequota/calculator.go
+++ b/pkg/util/resourcequota/calculator.go
@@ -238,7 +238,7 @@ func GetVMIMResourcesFromRQAnnotation(rq *corev1.ResourceQuota) (cpu, mem, stora
 }
 
 // Get Rancher NamespaceResourceQuota LimitsCPU and LimitsMemory
-func GetCpuMemoryLimitsFromRancherNamespaceResourceQuota(nrq *v3.NamespaceResourceQuota) (cpu, mem resource.Quantity, err error) {
+func GetCPUMemoryLimitsFromRancherNamespaceResourceQuota(nrq *v3.NamespaceResourceQuota) (cpu, mem resource.Quantity, err error) {
 	if cpu, err = resource.ParseQuantity(nrq.Limit.LimitsCPU); err != nil {
 		return
 	}
@@ -363,23 +363,25 @@ func CalculateScaleResourceQuotaWithVMI(
 	}
 
 	rl = corev1.ResourceList{}
-	currentCPULimit, cpuOK := rq.Spec.Hard[corev1.ResourceLimitsCPU]
+	//currentCPULimit, cpuOK := rq.Spec.Hard[corev1.ResourceLimitsCPU]
+	_, cpuOK := rq.Spec.Hard[corev1.ResourceLimitsCPU]
 	if !vmiLimits.Cpu().IsZero() && cpuOK {
-		currentCPULimit.Add(vmiLimits[corev1.ResourceCPU])
+		//currentCPULimit.Add(vmiLimits[corev1.ResourceCPU])
 		rl[corev1.ResourceLimitsCPU] = vmiLimits[corev1.ResourceCPU]
 
-		rq.Spec.Hard[corev1.ResourceLimitsCPU] = currentCPULimit
+		//rq.Spec.Hard[corev1.ResourceLimitsCPU] = currentCPULimit
 	}
 
-	currentMemoryLimit, memOK := rq.Spec.Hard[corev1.ResourceLimitsMemory]
+	//currentMemoryLimit, memOK := rq.Spec.Hard[corev1.ResourceLimitsMemory]
+	_, memOK := rq.Spec.Hard[corev1.ResourceLimitsMemory]
 	if !vmiLimits.Memory().IsZero() && memOK {
 		mem := vmiLimits[corev1.ResourceMemory]
 		mem.Add(kubevirtservices.GetMemoryOverhead(vmi, runtime.GOARCH, nil))
 
-		currentMemoryLimit.Add(mem)
+		//currentMemoryLimit.Add(mem)
 		rl[corev1.ResourceLimitsMemory] = mem
 
-		rq.Spec.Hard[corev1.ResourceLimitsMemory] = currentMemoryLimit
+		//rq.Spec.Hard[corev1.ResourceLimitsMemory] = currentMemoryLimit
 	}
 
 	return true, rq, rl

--- a/pkg/util/resourcequota/calculator.go
+++ b/pkg/util/resourcequota/calculator.go
@@ -15,6 +15,7 @@ import (
 	kubevirtservices "kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	ctlharvestercorev1 "github.com/harvester/harvester/pkg/generated/controllers/core/v1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
@@ -28,23 +29,26 @@ var resourceQuotaConversion = map[string]string{
 }
 
 type Calculator struct {
-	nsCache   ctlv1.NamespaceCache
-	podCache  ctlv1.PodCache
-	rqCache   ctlharvestercorev1.ResourceQuotaCache
-	vmimCache ctlkubevirtv1.VirtualMachineInstanceMigrationCache
+	nsCache      ctlv1.NamespaceCache
+	podCache     ctlv1.PodCache
+	rqCache      ctlharvestercorev1.ResourceQuotaCache
+	vmimCache    ctlkubevirtv1.VirtualMachineInstanceMigrationCache
+	settingCache ctlharvesterv1.SettingCache
 }
 
 func NewCalculator(
 	nsCache ctlv1.NamespaceCache,
 	podCache ctlv1.PodCache,
 	rqCache ctlharvestercorev1.ResourceQuotaCache,
-	vmimCache ctlkubevirtv1.VirtualMachineInstanceMigrationCache) *Calculator {
+	vmimCache ctlkubevirtv1.VirtualMachineInstanceMigrationCache,
+	settingCache ctlharvesterv1.SettingCache) *Calculator {
 
 	return &Calculator{
-		nsCache:   nsCache,
-		podCache:  podCache,
-		rqCache:   rqCache,
-		vmimCache: vmimCache,
+		nsCache:      nsCache,
+		podCache:     podCache,
+		rqCache:      rqCache,
+		vmimCache:    vmimCache,
+		settingCache: settingCache,
 	}
 }
 
@@ -89,7 +93,7 @@ func (c *Calculator) CheckIfVMCanStartByResourceQuota(vm *kubevirtv1.VirtualMach
 		return err
 	}
 	if nrq == nil {
-		logrus.Debugf("CheckIfVMCanStartByResourceQuota: skipping check, resource quota not found in the namespace %s", vm.Namespace)
+		logrus.Debugf("CheckIfVMCanStartByResourceQuota: resource quota is not found in the namespace %s, skip check", vm.Namespace)
 		return nil
 	}
 
@@ -98,7 +102,7 @@ func (c *Calculator) CheckIfVMCanStartByResourceQuota(vm *kubevirtv1.VirtualMach
 	if err != nil {
 		return err
 	} else if len(rqs) == 0 {
-		logrus.Debugf("CheckIfVMCanStartByResourceQuota: no found any default resource quota in the namespace %s", vm.Namespace)
+		logrus.Debugf("CheckIfVMCanStartByResourceQuota: default resource quota is not found in the namespace %s, skip check", vm.Namespace)
 		return nil
 	}
 
@@ -127,17 +131,6 @@ func (c *Calculator) getNamespaceResourceQuota(vm *kubevirtv1.VirtualMachine) (*
 	return resourceQuota, nil
 }
 
-func GetRancherNamespaceResourceQuotaFromRQAnnotations(rq *corev1.ResourceQuota) (*v3.NamespaceResourceQuota, error) {
-	var resourceQuota *v3.NamespaceResourceQuota
-	if rqStr, ok := rq.Annotations[util.CattleAnnotationResourceQuota]; !ok {
-		return nil, nil
-	} else if err := json.Unmarshal([]byte(rqStr), &resourceQuota); err != nil {
-		return nil, fmt.Errorf("failed to Unmarshal %s annotation error %w", util.CattleAnnotationResourceQuota, err)
-	}
-
-	return resourceQuota, nil
-}
-
 func (c *Calculator) getResourceQuota(vm *kubevirtv1.VirtualMachine) ([]*corev1.ResourceQuota, error) {
 	selector := labels.Set{util.LabelManagementDefaultResourceQuota: "true"}.AsSelector()
 	rqs, err := c.rqCache.List(vm.Namespace, selector)
@@ -161,6 +154,7 @@ func (c *Calculator) containsEnoughResourceQuotaToStartVM(
 	usedCPU := rq.Status.Used.Name(corev1.ResourceLimitsCPU, resource.DecimalSI)
 	usedMem := rq.Status.Used.Name(corev1.ResourceLimitsMemory, resource.BinarySI)
 	// calculate vm actual used resource
+	// note: this calculation is not 100% accurate as the lifecycles of RQ and VMIM are different
 	usedCPU.Sub(vmimsCPU)
 	usedMem.Sub(vmimsMem)
 
@@ -176,7 +170,9 @@ func (c *Calculator) containsEnoughResourceQuotaToStartVM(
 	actualCPU := actualRq.Name(corev1.ResourceLimitsCPU, resource.DecimalSI)
 	actualMem := actualRq.Name(corev1.ResourceLimitsMemory, resource.BinarySI)
 
-	// check if vms actual used resource is less than namespace resource quota limits
+	logrus.Debugf("%s/%s CPU: used %v, vmim %v vm %v actual %v, memory: used %v, vmim %v vm %v actual %v", vm.Namespace, vm.Name, usedCPU.MilliValue(), vmimsCPU.MilliValue(), vmCPU.MilliValue(), actualCPU.MilliValue(), usedMem.Value(), vmimsMem.Value(), vmMem.Value(), actualMem.Value())
+
+	// check if remaining quotas on namespace are sufficient to run this VM
 	// if not, return insufficient resource error
 	if !actualCPU.IsZero() {
 		actualCPU.Sub(*usedCPU)
@@ -209,7 +205,7 @@ func (c *Calculator) calculateVMActualOverhead(vm *kubevirtv1.VirtualMachine) *r
 		},
 	}
 
-	memoryOverhead := kubevirtservices.GetMemoryOverhead(vmi, runtime.GOARCH, nil)
+	memoryOverhead := kubevirtservices.GetMemoryOverhead(vmi, runtime.GOARCH, util.GetAdditionalGuestMemoryOverheadRatioWithoutError(c.settingCache))
 	return &memoryOverhead
 }
 
@@ -218,7 +214,7 @@ func (c *Calculator) getRunningVMIMResources(rq *corev1.ResourceQuota) (cpu, mem
 }
 
 func getVMIMResourcesFromRQAnnotation(rq *corev1.ResourceQuota) (cpu, mem, storage resource.Quantity, err error) {
-	vms, err := GetResourceListFromMigratingVMs(rq)
+	vms, err := getResourceListFromMigratingVMs(rq)
 	if err != nil {
 		return cpu, mem, storage, err
 	}
@@ -239,12 +235,20 @@ func GetVMIMResourcesFromRQAnnotation(rq *corev1.ResourceQuota) (cpu, mem, stora
 
 // Get Rancher NamespaceResourceQuota LimitsCPU and LimitsMemory
 func GetCPUMemoryLimitsFromRancherNamespaceResourceQuota(nrq *v3.NamespaceResourceQuota) (cpu, mem resource.Quantity, err error) {
-	if cpu, err = resource.ParseQuantity(nrq.Limit.LimitsCPU); err != nil {
-		return
+	if nrq.Limit.LimitsCPU == "" {
+		cpu = *resource.NewQuantity(0, resource.DecimalSI)
+	} else {
+		if cpu, err = resource.ParseQuantity(nrq.Limit.LimitsCPU); err != nil {
+			return
+		}
 	}
 
-	if mem, err = resource.ParseQuantity(nrq.Limit.LimitsMemory); err != nil {
-		return
+	if nrq.Limit.LimitsMemory == "" {
+		mem = *resource.NewQuantity(0, resource.BinarySI)
+	} else {
+		if mem, err = resource.ParseQuantity(nrq.Limit.LimitsMemory); err != nil {
+			return
+		}
 	}
 	return
 }
@@ -355,6 +359,7 @@ func convertNamespaceResourceLimitToResourceList(limit *v3.ResourceQuotaLimit) (
 func CalculateScaleResourceQuotaWithVMI(
 	rq *corev1.ResourceQuota,
 	vmi *kubevirtv1.VirtualMachineInstance,
+	ratio *string,
 ) (needUpdate bool, toUpdate *corev1.ResourceQuota, rl corev1.ResourceList) {
 
 	vmiLimits := vmi.Spec.Domain.Resources.Limits
@@ -363,25 +368,17 @@ func CalculateScaleResourceQuotaWithVMI(
 	}
 
 	rl = corev1.ResourceList{}
-	//currentCPULimit, cpuOK := rq.Spec.Hard[corev1.ResourceLimitsCPU]
+
 	_, cpuOK := rq.Spec.Hard[corev1.ResourceLimitsCPU]
 	if !vmiLimits.Cpu().IsZero() && cpuOK {
-		//currentCPULimit.Add(vmiLimits[corev1.ResourceCPU])
 		rl[corev1.ResourceLimitsCPU] = vmiLimits[corev1.ResourceCPU]
-
-		//rq.Spec.Hard[corev1.ResourceLimitsCPU] = currentCPULimit
 	}
 
-	//currentMemoryLimit, memOK := rq.Spec.Hard[corev1.ResourceLimitsMemory]
 	_, memOK := rq.Spec.Hard[corev1.ResourceLimitsMemory]
 	if !vmiLimits.Memory().IsZero() && memOK {
 		mem := vmiLimits[corev1.ResourceMemory]
-		mem.Add(kubevirtservices.GetMemoryOverhead(vmi, runtime.GOARCH, nil))
-
-		//currentMemoryLimit.Add(mem)
+		mem.Add(kubevirtservices.GetMemoryOverhead(vmi, runtime.GOARCH, ratio))
 		rl[corev1.ResourceLimitsMemory] = mem
-
-		//rq.Spec.Hard[corev1.ResourceLimitsMemory] = currentMemoryLimit
 	}
 
 	return true, rq, rl
@@ -415,23 +412,28 @@ func CalculateRestoreResourceQuotaWithVMI(
 	return true, rq
 }
 
-func CalculateNewResourceQuotaFromBaseDelta(rq *corev1.ResourceQuota, cpuBase, memBase, cpuDelta, memDelta resource.Quantity) bool {
-	cpuBase.Add(cpuDelta)
-	memBase.Add(memDelta)
+// If base is zero, delta is not added
+func CalculateNewResourceQuotaFromBaseDelta(rq *corev1.ResourceQuota, cpuBase, memBase, cpuDelta, memDelta resource.Quantity) (*corev1.ResourceQuota, bool) {
 	needUpdate := false
-	if !rq.Spec.Hard[corev1.ResourceLimitsCPU].Equal(cpuBase) {
-		needUpdate = true
-		rq.Spec.Hard[corev1.ResourceLimitsCPU] = cpuBase
+	if !cpuBase.IsZero() {
+		cpuBase.Add(cpuDelta)
+		if !rq.Spec.Hard[corev1.ResourceLimitsCPU].Equal(cpuBase) {
+			needUpdate = true
+			rq.Spec.Hard[corev1.ResourceLimitsCPU] = cpuBase
+		}
 	}
-	if !rq.Spec.Hard[corev1.ResourceLimitsMemory].Equal(memBase) {
-		needUpdate = true
-		rq.Spec.Hard[corev1.ResourceLimitsMemory] = memBase
+	if !memBase.IsZero() {
+		memBase.Add(memDelta)
+		if !rq.Spec.Hard[corev1.ResourceLimitsMemory].Equal(memBase) {
+			needUpdate = true
+			rq.Spec.Hard[corev1.ResourceLimitsMemory] = memBase
+		}
 	}
-	return needUpdate
+	return rq, needUpdate
 }
 
 func checkResourceQuotaAndVMI(rq *corev1.ResourceQuota, limits corev1.ResourceList) bool {
-	if isEmptyQuota(rq) {
+	if isEmpty(rq) {
 		return false
 	}
 
@@ -441,7 +443,7 @@ func checkResourceQuotaAndVMI(rq *corev1.ResourceQuota, limits corev1.ResourceLi
 	return true
 }
 
-func isEmptyQuota(rq *corev1.ResourceQuota) bool {
+func isEmpty(rq *corev1.ResourceQuota) bool {
 	if rq == nil {
 		return true
 	}
@@ -455,7 +457,7 @@ func isEmptyQuota(rq *corev1.ResourceQuota) bool {
 }
 
 func IsEmptyResourceQuota(rq *corev1.ResourceQuota) bool {
-	return isEmptyQuota(rq)
+	return isEmpty(rq)
 }
 
 func calculateVMStorageQuantity(vm *kubevirtv1.VirtualMachine) (resource.Quantity, error) {

--- a/pkg/util/resourcequota/calculator_test.go
+++ b/pkg/util/resourcequota/calculator_test.go
@@ -8,6 +8,7 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corefake "k8s.io/client-go/kubernetes/fake"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -41,6 +42,12 @@ const (
 	namespaceCPUExist    = "cpu-exist"
 	namespaceMemoryExist = "memory-exist"
 	namespaceNoneExist   = "none-exist"
+
+	uid1 = "1afcf4d9-b8a7-464a-a4e9-abe81fc7eacd"
+	uid2 = "2afcf4d9-b8a7-464a-a4e9-abe81fc7eacd"
+
+	memory1Gi = 1 * 1024 * 1024 * 1024
+	testNS    = "default"
 )
 
 func Test_vmValidator_checkResourceQuota(t *testing.T) {
@@ -122,6 +129,7 @@ func Test_vmValidator_checkResourceQuota(t *testing.T) {
 				fakeclients.NamespaceCache(coreclientset.CoreV1().Namespaces),
 				nil,
 				nil,
+				nil,
 				nil)
 
 			got, err := c.getNamespaceResourceQuota(tt.args.vm)
@@ -162,4 +170,302 @@ func serializeNamespaceResourceQuota(quota *v3.NamespaceResourceQuota) (string, 
 	}
 
 	return string(data), nil
+}
+
+func Test_vmValidator_containsEnoughResourceQuotaToStartVM(t *testing.T) {
+	generateRQ := func(cpu, mem int64) kubevirtv1.ResourceRequirements {
+		return kubevirtv1.ResourceRequirements{
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceMemory: *resource.NewQuantity(mem*memory1Gi, resource.DecimalSI),
+				corev1.ResourceCPU:    *resource.NewQuantity(cpu, resource.DecimalSI),
+			},
+		}
+	}
+
+	nsrq := v3.NamespaceResourceQuota{
+		Limit: v3.ResourceQuotaLimit{
+			LimitsCPU:    "4000m",
+			LimitsMemory: "10240Mi",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		vm      *kubevirtv1.VirtualMachine
+		nsrq    *v3.NamespaceResourceQuota
+		rq      *corev1.ResourceQuota
+		wantErr bool
+	}{
+		{
+			name: "VM can start as quota is enough",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: testNS,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Resources: generateRQ(1, 1),
+							},
+						},
+					},
+				},
+			},
+			nsrq: &nsrq,
+			rq: &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNS,
+					Name:      "rq1",
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"4\", \"limitsMemory\":\"10240Mi\"}}",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.DecimalSI),
+					},
+				},
+				Status: corev1.ResourceQuotaStatus{
+					Used: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(2*memory1Gi, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "VM can't start due to insufficient memory",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: testNS,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Resources: generateRQ(1, 1), // with overhead, the VM requires > 1Gi memory
+							},
+						},
+					},
+				},
+			},
+			nsrq: &nsrq,
+			rq: &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNS,
+					Name:      "rq1",
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"4\", \"limitsMemory\":\"10240Mi\"}}",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.DecimalSI),
+					},
+				},
+				Status: corev1.ResourceQuotaStatus{
+					Used: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(9*memory1Gi, resource.DecimalSI), // only 1Gi memory is available
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "VM can't start due to insufficient cpu",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: testNS,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Resources: generateRQ(1, 1),
+							},
+						},
+					},
+				},
+			},
+			nsrq: &nsrq,
+			rq: &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNS,
+					Name:      "rq1",
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"4\", \"limitsMemory\":\"10240Mi\"}}",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.DecimalSI),
+					},
+				},
+				Status: corev1.ResourceQuotaStatus{
+					Used: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(2*memory1Gi, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "VM can start and RQ is also scaled",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: testNS,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Resources: generateRQ(1, 1),
+							},
+						},
+					},
+				},
+			},
+			nsrq: &nsrq,
+			rq: &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNS,
+					Name:      "rq1",
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota:             "{\"limit\":{\"limitsCpu\":\"4\", \"limitsMemory\":\"10240Mi\"}}",
+						util.GenerateAnnotationKeyMigratingVMUID(uid1): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.GenerateAnnotationKeyMigratingVMUID(uid2): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(6, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(14.5*memory1Gi, resource.DecimalSI), // already scaled
+					},
+				},
+				Status: corev1.ResourceQuotaStatus{
+					Used: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(8*memory1Gi, resource.DecimalSI),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "VM can't start and RQ is also scaled",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: testNS,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Resources: generateRQ(1, 1),
+							},
+						},
+					},
+				},
+			},
+			nsrq: &nsrq,
+			rq: &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNS,
+					Name:      "rq1",
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota:             "{\"limit\":{\"limitsCpu\":\"4\", \"limitsMemory\":\"10240Mi\"}}",
+						util.GenerateAnnotationKeyMigratingVMUID(uid1): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.GenerateAnnotationKeyMigratingVMUID(uid2): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(6, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(14.5*memory1Gi, resource.DecimalSI),
+					},
+				},
+				Status: corev1.ResourceQuotaStatus{
+					Used: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(13*memory1Gi, resource.DecimalSI), // 10 - ( 13 - 2 -2 ) = 1, does not meet the VM's requirement
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "VM can start and RQ is also scaled",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vm1",
+					Namespace: testNS,
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Resources: generateRQ(1, 1),
+							},
+						},
+					},
+				},
+			},
+			nsrq: &nsrq,
+			rq: &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNS,
+					Name:      "rq1",
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.CattleAnnotationResourceQuota:                          "{\"limit\":{\"limitsCpu\":\"4\", \"limitsMemory\":\"10240Mi\"}}",
+						util.GenerateAnnotationKeyMigratingVMName("vminmigration1"): `{"limits.cpu":"1","limits.memory":"2Gi"}`, // name based key still works
+						util.GenerateAnnotationKeyMigratingVMName("vminmigration2"): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(6, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(14.5*memory1Gi, resource.DecimalSI),
+					},
+				},
+				Status: corev1.ResourceQuotaStatus{
+					Used: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.DecimalSI), // 10 - ( 12 - 2 -2 ) = 2, meets the VM's requirement
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCalculator(
+				nil,
+				nil,
+				nil,
+				nil,
+				nil)
+
+			err := c.containsEnoughResourceQuotaToStartVM(tt.vm, tt.nsrq, tt.rq)
+			assert.Equalf(t, tt.wantErr, err != nil, "case %s containsEnoughResourceQuotaToStartVM(%v) failed", tt.name, tt.vm.Name)
+		})
+	}
 }

--- a/pkg/util/resourcequota/utils.go
+++ b/pkg/util/resourcequota/utils.go
@@ -2,6 +2,7 @@ package resourcequota
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -80,7 +81,7 @@ func GetResourceListFromMigratingVMs(rq *corev1.ResourceQuota) (map[string]corev
 
 			var rl corev1.ResourceList
 			if err := json.Unmarshal([]byte(rq.Annotations[k]), &rl); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to unmarshal vm %v quantity %v %w", k, rq.Annotations[k], err)
 			}
 			vms[strings.TrimPrefix(k, util.AnnotationMigratingPrefix)] = rl
 		}

--- a/pkg/util/resourcequota/utils.go
+++ b/pkg/util/resourcequota/utils.go
@@ -16,14 +16,17 @@ func HasMigratingVM(rq *corev1.ResourceQuota) bool {
 	}
 
 	for k := range rq.Annotations {
-		if strings.HasPrefix(k, util.AnnotationMigratingPrefix) {
+		if strings.HasPrefix(k, util.AnnotationMigratingUIDPrefix) {
+			return true
+		}
+		if strings.HasPrefix(k, util.AnnotationMigratingNamePrefix) {
 			return true
 		}
 	}
 	return false
 }
 
-func UpdateMigratingVM(rq *corev1.ResourceQuota, vmName string, rl corev1.ResourceList) error {
+func AddMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string, rl corev1.ResourceList) error {
 	rlb, err := json.Marshal(rl)
 	if err != nil {
 		return err
@@ -32,58 +35,61 @@ func UpdateMigratingVM(rq *corev1.ResourceQuota, vmName string, rl corev1.Resour
 	if rq.Annotations == nil {
 		rq.Annotations = make(map[string]string)
 	}
-	rq.Annotations[util.AnnotationMigratingPrefix+vmName] = string(rlb)
+
+	// name key may exceed 63 chars, but it does not affect the delete function
+	delete(rq.Annotations, util.GenerateAnnotationKeyMigratingVMName(vmName))     // remove the may existing old key
+	rq.Annotations[util.GenerateAnnotationKeyMigratingVMUID(vmUID)] = string(rlb) // add UID based key, value
 	return nil
 }
 
-// remove the may existing VM Miration, return true if it exists
-func RemoveMigratingVMFromRQAnnotation(rq *corev1.ResourceQuota, vmName string) bool {
+// delete the may existing VM Miration, return true if it exists
+func DeleteMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string) bool {
 	if rq.Annotations == nil {
 		return false
 	}
 	len1 := len(rq.Annotations)
-	delete(rq.Annotations, util.AnnotationMigratingPrefix+vmName)
+	delete(rq.Annotations, util.GenerateAnnotationKeyMigratingVMName(vmName))
+	delete(rq.Annotations, util.GenerateAnnotationKeyMigratingVMUID(vmUID))
 	len2 := len(rq.Annotations)
 	return len1 != len2
 }
 
-func ContainsMigratingVM(rq *corev1.ResourceQuota, vmName string) bool {
+func ContainsMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string) bool {
 	if rq.Annotations == nil {
 		return false
 	}
-	if _, ok := rq.Annotations[util.AnnotationMigratingPrefix+vmName]; ok {
+	// check both possible keys
+	if _, ok := rq.Annotations[util.GenerateAnnotationKeyMigratingVMName(vmName)]; ok {
+		return true
+	}
+	if _, ok := rq.Annotations[util.GenerateAnnotationKeyMigratingVMUID(vmUID)]; ok {
 		return true
 	}
 	return false
 }
 
-func GetResourceListFromMigratingVM(rq *corev1.ResourceQuota, vmName string) (corev1.ResourceList, error) {
-	if rq.Annotations != nil {
-		if v, ok := rq.Annotations[util.AnnotationMigratingPrefix+vmName]; ok {
-			var rl corev1.ResourceList
-			if err := json.Unmarshal([]byte(v), &rl); err != nil {
-				return nil, err
-			}
-			return rl, nil
-		}
-	}
-	return nil, nil
-}
-
-func GetResourceListFromMigratingVMs(rq *corev1.ResourceQuota) (map[string]corev1.ResourceList, error) {
+// check both possible keys
+func getResourceListFromMigratingVMs(rq *corev1.ResourceQuota) (map[string]corev1.ResourceList, error) {
 	vms := make(map[string]corev1.ResourceList)
 	if rq.Annotations == nil {
 		return vms, nil
 	}
 
 	for k := range rq.Annotations {
-		if strings.HasPrefix(k, util.AnnotationMigratingPrefix) {
+		if strings.HasPrefix(k, util.AnnotationMigratingUIDPrefix) {
 
 			var rl corev1.ResourceList
 			if err := json.Unmarshal([]byte(rq.Annotations[k]), &rl); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal vm %v quantity %v %w", k, rq.Annotations[k], err)
 			}
-			vms[strings.TrimPrefix(k, util.AnnotationMigratingPrefix)] = rl
+			vms[strings.TrimPrefix(k, util.AnnotationMigratingUIDPrefix)] = rl
+		} else if strings.HasPrefix(k, util.AnnotationMigratingNamePrefix) {
+
+			var rl corev1.ResourceList
+			if err := json.Unmarshal([]byte(rq.Annotations[k]), &rl); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal vm %v quantity %v %w", k, rq.Annotations[k], err)
+			}
+			vms[strings.TrimPrefix(k, util.AnnotationMigratingNamePrefix)] = rl
 		}
 	}
 	return vms, nil

--- a/pkg/util/resourcequota/utils.go
+++ b/pkg/util/resourcequota/utils.go
@@ -35,11 +35,15 @@ func UpdateMigratingVM(rq *corev1.ResourceQuota, vmName string, rl corev1.Resour
 	return nil
 }
 
-func RemoveMigratingVM(rq *corev1.ResourceQuota, vmName string) {
+// remove the may existing VM Miration, return true if it exists
+func RemoveMigratingVMFromRQAnnotation(rq *corev1.ResourceQuota, vmName string) bool {
 	if rq.Annotations == nil {
-		return
+		return false
 	}
+	len1 := len(rq.Annotations)
 	delete(rq.Annotations, util.AnnotationMigratingPrefix+vmName)
+	len2 := len(rq.Annotations)
+	return len1 != len2
 }
 
 func ContainsMigratingVM(rq *corev1.ResourceQuota, vmName string) bool {

--- a/pkg/util/setting.go
+++ b/pkg/util/setting.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"fmt"
+
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+
+	"github.com/harvester/harvester/pkg/settings"
+)
+
+// get the value of AdditionalGuestMemoryOverheadRatio, if failed, return the default ratio
+func GetAdditionalGuestMemoryOverheadRatioWithoutError(settingCache ctlharvesterv1.SettingCache) *string {
+	value := settings.AdditionalGuestMemoryOverheadRatioDefault
+	if settingCache == nil {
+		return &value
+	}
+	s, err := settingCache.Get(settings.AdditionalGuestMemoryOverheadRatioName)
+	if err != nil || s == nil {
+		return &value
+	}
+	value = s.Value
+	if value == "" {
+		value = s.Default
+		if value == "" {
+			value = settings.AdditionalGuestMemoryOverheadRatioDefault
+			return &value
+		}
+	}
+	agmorc, err := settings.NewAdditionalGuestMemoryOverheadRatioConfig(value)
+	if err != nil {
+		value = settings.AdditionalGuestMemoryOverheadRatioDefault
+		return &value
+	}
+	if agmorc.IsEmpty() {
+		return nil
+	}
+	value = agmorc.Value()
+	return &value
+}
+
+func GetAdditionalGuestMemoryOverheadRatio(settingCache ctlharvesterv1.SettingCache) (*string, error) {
+	value := ""
+	if settingCache == nil {
+		return nil, fmt.Errorf("The settingCache is empty, can't get the setting")
+	}
+	s, err := settingCache.Get(settings.AdditionalGuestMemoryOverheadRatioName)
+	if err != nil {
+		return nil, err
+	}
+	value = s.Value
+	if value == "" {
+		value = s.Default
+	}
+	agmorc, err := settings.NewAdditionalGuestMemoryOverheadRatioConfig(value)
+	if err != nil {
+		return nil, err
+	}
+	if agmorc.IsEmpty() {
+		return nil, nil
+	}
+	value = agmorc.Value()
+	return &value, nil
+}

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -39,6 +39,7 @@ func NewValidator(
 	vmCache ctlkubevirtv1.VirtualMachineCache,
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
 	nadCache ctlcniv1.NetworkAttachmentDefinitionCache,
+	settingCache ctlharvesterv1.SettingCache,
 ) types.Validator {
 	return &vmValidator{
 		pvcCache:      pvcCache,
@@ -47,7 +48,7 @@ func NewValidator(
 		vmiCache:      vmiCache,
 		nadCache:      nadCache,
 
-		rqCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache),
+		rqCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache, settingCache),
 	}
 }
 
@@ -58,8 +59,8 @@ type vmValidator struct {
 	vmCache       ctlkubevirtv1.VirtualMachineCache
 	vmiCache      ctlkubevirtv1.VirtualMachineInstanceCache
 	nadCache      ctlcniv1.NetworkAttachmentDefinitionCache
-
-	rqCalculator *resourcequota.Calculator
+	settingCache  ctlharvesterv1.SettingCache
+	rqCalculator  *resourcequota.Calculator
 }
 
 func (v *vmValidator) Resource() types.Resource {

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -650,7 +650,7 @@ func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
 	fakeVMCache := fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines)
 	fakeNadCache := fakeclients.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
 
-	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache).(*vmValidator)
+	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache, nil).(*vmValidator)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -60,7 +60,7 @@ func NewValidator(
 		snapshotClass:                     snapshotClass,
 		networkAttachmentDefinitionsCache: networkAttachmentDefinitionsCache,
 
-		vmrCalculator: resourcequota.NewCalculator(nss, pods, rqs, vmims),
+		vmrCalculator: resourcequota.NewCalculator(nss, pods, rqs, vmims, setting),
 	}
 }
 

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -64,7 +64,8 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
-			clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache()),
+			clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		virtualmachineimage.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
 			clients.Core.PersistentVolumeClaim().Cache(),


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

[note]: PR is not finished yet.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Per description on 
https://github.com/harvester/harvester/issues/7178
https://github.com/harvester/harvester/issues/7464
https://github.com/harvester/harvester/issues/7585  (fixed via another PR https://github.com/harvester/harvester/pull/7614)

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Add a resourcequota controller, it computes the RQ dynamically per Rancher annotation and Harvester scalling annotation, make sure the real RQ is the total of them.

If Rancher re-initialize the RQ base or set with another value, the controller will just re-compute the new value per Rancher base + Harvester scaling.

The RQ computing will never decrease from the RQ real value.

2. The VMIM controller is only responsible for adding/removing self information into/from RQ annotation

3. Use new UID based annotation key to replace original VM name based (issue https://github.com/harvester/harvester/issues/7464) , and keep compatiable with existing name based key

4. Support to manually stop the auto scalling on namespaces

5. Use the v1.4.0 added setting `additional-guest-memory-overhead-ratio` to compute VM overhead, instead of `nil` (default to 1) 

**Related Issue:**
https://github.com/harvester/harvester/issues/7178
https://github.com/harvester/harvester/issues/7464

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Refer: https://github.com/harvester/harvester/issues/7178#issuecomment-2649172176