### PR TITLE
Update QA sprint

### DIFF
--- a/.github/workflows/update-issue-sprint.yml
+++ b/.github/workflows/update-issue-sprint.yml
@@ -64,3 +64,27 @@ jobs:
           iteration: current
           new-iteration: next
           statuses: 'New'
+
+      - name: QA Sprint - Clear Sprint
+        uses: derekbit/move-to-next-iteration@master
+        if: steps.check_sprint_build_required.outcome == 'success'
+        with:
+          owner: harvester
+          number: 20
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          iteration-field: Sprint
+          iteration: current
+          new-iteration: none
+          excluded-statuses: "In Review,Done"
+
+      - name: QA Sprint - Move to Next Sprint
+        uses: derekbit/move-to-next-iteration@master
+        if: steps.check_sprint_build_required.outcome == 'success'
+        with:
+          owner: harvester
+          number: 20
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          iteration-field: Sprint
+          iteration: current
+          new-iteration: next
+          statuses: "In Review"


### PR DESCRIPTION
This PR will update QA sprints on completion of a sprint with below rules

- In review items will move to next sprint
- Items in todo and in progress will be removed.
