### PR TITLE
fix: migrate button incorrectly display

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -15,6 +15,7 @@ import (
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/indexeres"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
 )
 
 const (
@@ -73,8 +74,6 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 	resource.AddAction(request, addVolume)
 	resource.AddAction(request, removeVolume)
 	resource.AddAction(request, cloneVM)
-	resource.AddAction(request, migrate)
-	resource.AddAction(request, findMigratableNodes)
 
 	if canEjectCdRom(vm) {
 		resource.AddAction(request, ejectCdRom)
@@ -103,6 +102,11 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 
 	if vf.canUnPause(vmi) {
 		resource.AddAction(request, unpauseVM)
+	}
+
+	if canMigrate(vmi) {
+		resource.AddAction(request, migrate)
+		resource.AddAction(request, findMigratableNodes)
 	}
 
 	if canAbortMigrate(vmi) {
@@ -232,6 +236,18 @@ func isReady(vmi *kubevirtv1.VirtualMachineInstance) bool {
 		}
 	}
 	return false
+}
+
+func canMigrate(vmi *kubevirtv1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return false
+	}
+
+	if err := virtualmachineinstance.ValidateVMMigratable(vmi); err != nil {
+		return false
+	}
+
+	return true
 }
 
 func canAbortMigrate(vmi *kubevirtv1.VirtualMachineInstance) bool {

--- a/pkg/util/virtualmachineinstance/virtualmachineinstance.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance.go
@@ -65,32 +65,32 @@ func ValidateVMMigratable(vmi *kubevirtv1.VirtualMachineInstance) error {
 	vmiNamespacedName := fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)
 
 	if !vmi.IsRunning() {
-		return fmt.Errorf("VM %s considered non-live migratable due to running", vmiNamespacedName)
+		return fmt.Errorf("VM %s is not live migratable as it is not running", vmiNamespacedName)
 	}
 
 	// The VM is already in migrating state
 	if vmi.Annotations[util.AnnotationMigrationUID] != "" {
-		return fmt.Errorf("VM %s considered non-live migratable due to migration state", vmiNamespacedName)
+		return fmt.Errorf("VM %s is not live migratable as it is already in a migrating state", vmiNamespacedName)
 	}
 
 	// Node selectors
 	if vmi.Spec.NodeSelector != nil && vmi.Spec.NodeSelector[corev1.LabelHostname] != "" {
-		return fmt.Errorf("VM %s considered non-live migratable due to node selectors", vmiNamespacedName)
+		return fmt.Errorf("VM %s is not live migratable as node selector is set", vmiNamespacedName)
 	}
 
 	// PCIe devices
 	if len(vmi.Spec.Domain.Devices.HostDevices) != 0 {
-		return fmt.Errorf("VM %s considered non-live migratable due to PCIe or USB devices", vmiNamespacedName)
+		return fmt.Errorf("VM %s is not live migratable as PCIe or USB devices are attached", vmiNamespacedName)
 	}
 
 	// vGPU devices
 	if len(vmi.Spec.Domain.Devices.GPUs) != 0 {
-		return fmt.Errorf("VM %s considered non-live migratable due to vGPU devices", vmiNamespacedName)
+		return fmt.Errorf("VM %s is not live migratable as vGPU devices are attached", vmiNamespacedName)
 	}
 
 	// container-disk or cdrom device
 	if VMContainsCDRomOrContainerDisk(vmi) {
-		return fmt.Errorf("VM %s considered non-live migratable due to CD-ROM or container disk", vmiNamespacedName)
+		return fmt.Errorf("VM %s is not live migratable as CD-ROM or container disk is set", vmiNamespacedName)
 	}
 
 	return nil


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
After https://github.com/harvester/harvester/pull/7137, the migrate and abortMigrate button always shows on the menu.

**Solution:**
We still need to consider the situations mentioned in https://github.com/harvester/harvester/issues/7140#issuecomment-2609293463. So, I prefer to add the canMigrate function back to prevent it from breaking basic function first.

**Related Issue:**
https://github.com/harvester/harvester/issues/7538

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
