### PR TITLE
Set node affinity when CPU pinning is set

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -362,7 +362,7 @@ func (m *vmMutator) patchAffinity(vm *kubevirtv1.VirtualMachine, patchOps types.
 	newVMNetworks := vm.Spec.Template.Spec.Networks
 	logrus.Debugf("newNetworks: %+v", newVMNetworks)
 
-	if err := m.addNodeSelectorTerms(vm.Namespace, requiredNodeSelector, newVMNetworks); err != nil {
+	if err := m.addNodeSelectorTerms(vm, requiredNodeSelector, newVMNetworks); err != nil {
 		return patchOps, err
 	}
 
@@ -436,12 +436,12 @@ func makeAffinityFromVMTemplate(template *kubevirtv1.VirtualMachineInstanceTempl
 		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
 	}
 
-	// clear node selector terms whose key contains the prefix "network.harvesterhci.io"
+	// clear node selector terms whose key contains the prefix "network.harvesterhci.io" or equals "cpumanager"
 	nodeSelectorTerms := make([]v1.NodeSelectorTerm, 0, len(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms))
 	for _, term := range affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
 		expressions := make([]v1.NodeSelectorRequirement, 0, len(term.MatchExpressions))
 		for _, expression := range term.MatchExpressions {
-			if !strings.HasPrefix(expression.Key, networkGroup) {
+			if !strings.HasPrefix(expression.Key, networkGroup) && (expression.Key != kubevirtv1.CPUManager) {
 				expressions = append(expressions, expression)
 			}
 		}
@@ -455,9 +455,9 @@ func makeAffinityFromVMTemplate(template *kubevirtv1.VirtualMachineInstanceTempl
 	return affinity
 }
 
-func (m *vmMutator) addNodeSelectorTerms(defaultNamespace string, nodeSelector *v1.NodeSelector, incrementalNetworks []kubevirtv1.Network) error {
+func (m *vmMutator) addNodeSelectorTerms(vm *kubevirtv1.VirtualMachine, nodeSelector *v1.NodeSelector, incrementalNetworks []kubevirtv1.Network) error {
 	for _, network := range incrementalNetworks {
-		nodeSelectorRequirement, err := m.getNodeSelectorRequirementFromNetwork(defaultNamespace, network)
+		nodeSelectorRequirement, err := m.getNodeSelectorRequirementFromNetwork(vm.Namespace, network)
 		if err != nil {
 			return err
 		}
@@ -478,6 +478,27 @@ func (m *vmMutator) addNodeSelectorTerms(defaultNamespace string, nodeSelector *
 			nodeSelector.NodeSelectorTerms = []v1.NodeSelectorTerm{{
 				MatchExpressions: []v1.NodeSelectorRequirement{*nodeSelectorRequirement},
 			}}
+		}
+	}
+
+	if isDedicatedCPU(vm) {
+		requirement := v1.NodeSelectorRequirement{
+			Key:      kubevirtv1.CPUManager,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{"true"},
+		}
+
+		if len(nodeSelector.NodeSelectorTerms) == 0 {
+			nodeSelector.NodeSelectorTerms = []v1.NodeSelectorTerm{{
+				MatchExpressions: []v1.NodeSelectorRequirement{requirement},
+			}}
+		} else {
+			for i, term := range nodeSelector.NodeSelectorTerms {
+				if _, ok := isContainTargetNodeSelectorRequirement(term, requirement); !ok {
+					term.MatchExpressions = append(term.MatchExpressions, requirement)
+					nodeSelector.NodeSelectorTerms[i] = term
+				}
+			}
 		}
 	}
 

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -985,6 +985,49 @@ func TestPatchAffinity(t *testing.T) {
 			},
 		},
 	}
+
+	vm8 := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{
+							DedicatedCPUPlacement: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vm9 := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      kubevirtv1.CPUManager,
+												Operator: v1.NodeSelectorOpIn,
+												Values:   []string{"true"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	net1 := &cniv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "net1",
@@ -1144,6 +1187,32 @@ func TestPatchAffinity(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "add cpu manager affinity",
+			vm:   vm8,
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      kubevirtv1.CPUManager,
+										Operator: v1.NodeSelectorOpIn,
+										Values:   []string{"true"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "remove cpu manager affinity",
+			vm:       vm9,
+			affinity: &v1.Affinity{},
 		},
 	}
 


### PR DESCRIPTION
**Problem:**
The current maintenance mode (with `forced` checkbox is enabled) tries to migrate a VM with `spec.template.spec.cpu.dedicatedCpuPlacement = true` which is not possible when only one node has `CPU Manager` enabled. Because of that the node is stuck at `Cordoned` and the VM is tried to be migrated in a loop.

**Solution:**
~~The [FindNonMigratableVMS](https://github.com/harvester/harvester/blob/f7cfbb51deb2da0ca5dcdf8993bc6f3a9372be86/pkg/controller/master/nodedrain/nodedrain_controller.go#L146) function should identify those VMs with enabled CPU pinning which are not migratable because only one node has `CPU Manager` enabled.
Those VMs are automatically shut down at the beginning of the maintenance mode which seems to be the best solution here to do not block the node to go into maintenance mode.~~

Make sure the node affinity rule
```
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: cpumanager
                operator: In
                values:
                  - true
```
is set via mutator when `spec.template.spec.domain.cpu.dedicatedCpuPlacement` is set.
In that case the existing code base will handle the automatic shutdown or re-scheduling of the VM correctly.

**Related Issue:**
https://github.com/harvester/harvester/issues/6732

**Test plan:**
A cluster with 3 nodes is required.

***Case 1***
- Create two VMs vm01 and vm02. Make sure they are running on the same node.
- Enable `CPU Manager` on the host where the two VMs are running. Make sure only one node has enabled this feature.
- Check the `Enable CPU Pinning` checkbox for vm01 on the `Advanced Settings` page.
- Enable `Maintenance Mode` on the node where the VMs are running. Check the `Force` checkbox and then `Apply`.
- Make sure the node affinity rule is added to the VM.
- The VM vm01 is shut down and NOT migrated. The VM vm02 is migrated to a different node.

In the logs of the harvester-xxx-xxx pods you should find something like this:
```
time="2025-02-10T10:28:24Z" level=info msg="force stopping VM" namespace=default ... virtualmachine_name=vm01
```

***Case 2***
- Create two VMs vm01 and vm02. Make sure they are running on the same node.
- Enable `CPU Manager` on the host where the two VMs are running. Make sure there is another node with `CPU Manager` enabled.
- Check the `Enable CPU Pinning` checkbox for vm01 on the `Advanced Settings` page.
- Enable `Maintenance Mode` on the node where the VMs are running. Check the `Force` checkbox and then `Apply`.
- Make sure the node affinity rule is added to the VM.
- The VM vm01 is NOT shut down; it is migrated to the other node with `CPU Manager` enabled. The VM vm02 is migrated to a different node.

***Case 3***
- Create a VM vm03. Check the `Enable CPU Pinning` checkbox on the `Advanced Settings` page before pressing the `Create` button.
- Press `Apply` to create the VM.
- Choose `Edit YAML` in the action menu.
- Make sure the node affinity rule `spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution` is added to the VM.
```
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: cpumanager
                operator: In
                values:
                  - true
```
- Remove the `dedicatedCpuPlacement` line in the YAML editor.
- Press `Save` button.
- Choose `Edit YAML` in the action menu.
- Make sure the previously added node affinity rule has been removed.

***Case 4***
- Make sure that NO node has `CPU Manager` enabled.
- Create a VM vm05.
- Use the `Edit Config` action menu. Check the `Enable CPU Pinning` checkbox from the `Advanced Settings` page.
- Press `Save` and confirm to restart the VM after saving.
- The VM should not be started. See attached screenshot.

![Bildschirmfoto vom 2025-02-11 17-15-08](https://github.com/user-attachments/assets/cb3315ec-9a02-4202-a022-209beb5b94cd)