### PR TITLE
remove emulated machine types

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -84,11 +84,6 @@ kubevirt:
         ##
         permitBridgeInterfaceOnPodNetwork: true
 
-      ## Specify the machine type regex for validating the emulation of VirtualMachineInstance,
-      ## defaults to discover automatically, "pseries*" if arch is ppc64le, otherwise "q35, pc-g35*, pc, pc-i440fx*".
-      ##
-      emulatedMachines: ["q35", "pc-q35*", "pc", "pc-i440fx*"]
-
     customizeComponents:
       patches:
         - patch: '{"webhooks":[{"name":"kubevirt-validator.kubevirt.io","failurePolicy":"Ignore"},{"name":"kubevirt-update-validator.kubevirt.io","failurePolicy":"Ignore"}]}'


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The `emulatedMachineTypes` defined in the harvester chart definition break the harvester arm builds.

```
Stop harvester-system/upgrade-repo-hvst-upgrade-hghk4
+ echo 'Stop harvester-system/upgrade-repo-hvst-upgrade-hghk4'
+ virtctl stop upgrade-repo-hvst-upgrade-hghk4 -n harvester-system
You are using a client virtctl version that is different from the KubeVirt version running in the cluster
Client Version: v1.3.1
Server Version: v1.4.0
Error stopping VirtualMachine Internal error occurred: admission webhook "virtualmachine-validator.kubevirt.io" denied the request: spec.template.spec.domain.machine.type is not supported: virt (allowed values: [q35 pc-q35* pc pc-i440fx*])
```
The error is reported from the virt-api validating webhook when vmi is created

https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go#L970

As part of the current arm builds we patched the harvester chart to remove the `emulatedMachineConfiguration` along with image information.

This is no longer needed since we have sles based multi-arch kubevirt builds available for kubevirt 1.4.x and higher.

We we will be removing the harvester arm specific patching in the installer https://github.com/harvester/harvester-installer/pull/957

Kubevirt already calculates the valid emulatedMachine types based on system architecture: https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-config/virt-config.go#L177

Our specifying the `emulatedMachineTypes` overrides the arch specific lookup as kubevirt merges the arch specific lookup with the values present from kubevirt CR, and overrides the defaults.
https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-config/configuration.go#L295

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
We do not need the `emulatedMachineTypes` as this can be calculated at runtime by kubevirt

https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-config/virt-config.go#L55
https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-config/virt-config.go#L53

**Related Issue:**
https://github.com/harvester/harvester/issues/7098

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
## Test Case 1
* Install Harvester v1.5 build on a amd64 based node
* Post install validate kubevirt CR does not contain emulatedMachineTypes
* Attempt to create a machine of type not supported by arch should fail, for example `pc-i440fx`


## Test Case 2
* Install Harvester v1.5 build on a arm64 based node
* Post install validate kubevirt CR does not contain emulatedMachineTypes
* Attempt to create a machine of type not supported by arch should fail, for example `pc` or `pc-q35`