### PR TITLE
fix(upgrade): set repo vm cpu model to host-passthru

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_repo.go
+++ b/pkg/controller/master/upgrade/upgrade_repo.go
@@ -204,6 +204,7 @@ func (r *Repo) createVM(image *harvesterv1.VirtualMachineImage) (*kubevirtv1.Vir
 							Cores:   1,
 							Sockets: 1,
 							Threads: 1,
+							Model:   kubevirtv1.CPUModeHostPassthrough,
 						},
 						Firmware: &kubevirtv1.Firmware{
 							Bootloader: &kubevirtv1.Bootloader{


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The default CPU model for virtual machines is `host-model`. It was used since we did not specify the CPU model for the upgrade repo VM.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Per suggested in https://github.com/harvester/harvester/issues/7373#issuecomment-2636027816, explicitly specify the model to be `host-passthrough`.

**Related Issue:**

#7373

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster with at least two nodes using the built ISO image from this PR (for QAs, please use the master-head ISO image)
2. Trigger the upgrade with the same ISO image
3. Monitor the upgrade progress and the upgrade repo VM
4. The upgrade should succeed without the upgrade repo VM being shut down during the time
