### PR TITLE
Double check the POD when VM is denied by ResourceQuota

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -30,6 +30,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	var (
 		nsCache        = management.CoreFactory.Core().V1().Namespace().Cache()
 		podCache       = management.CoreFactory.Core().V1().Pod().Cache()
+		podClient      = management.CoreFactory.Core().V1().Pod()
 		rqCache        = management.HarvesterCoreFactory.Core().V1().ResourceQuota().Cache()
 		pvcClient      = management.CoreFactory.Core().V1().PersistentVolumeClaim()
 		pvcCache       = pvcClient.Cache()
@@ -51,6 +52,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 
 	// registers the vm controller
 	var vmCtrl = &VMController{
+		podClient:      podClient,
 		pvcClient:      pvcClient,
 		pvcCache:       pvcCache,
 		vmClient:       vmClient,

--- a/pkg/controller/master/virtualmachine/vm_controller.go
+++ b/pkg/controller/master/virtualmachine/vm_controller.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	kubevirt "kubevirt.io/api/core"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 var syncLabelsToVmi = []string{util.LabelMaintainModeStrategy}
 
 type VMController struct {
+	podClient      v1.PodClient
 	pvcClient      v1.PersistentVolumeClaimClient
 	pvcCache       v1.PersistentVolumeClaimCache
 	vmClient       ctlkubevirtv1.VirtualMachineClient
@@ -291,6 +293,23 @@ func (h *VMController) SetHaltIfInsufficientResourceQuota(_ string, vm *kubevirt
 		return nil, err
 	}
 
+	// Refer: https://github.com/harvester/harvester/issues/7585
+	// When VM is detected as insufficient resource, there is one race case:
+	//  the VM's POD is created and the ResourceQuota is updated, but vmrCalculator's local cache does not have this POD yet
+	// Re-check POD on ApiServer when insufficient resource happens
+	exist, err1 := h.isVMPodExistingOnAPIServer(vm)
+	if err1 != nil {
+		errNew := fmt.Errorf("SetHaltIfInsufficientResourceQuota: VM %s/%s reports error %w, but failed to recheck POD, error %w", vm.Namespace, vm.Name, err, err1)
+		logrus.Debugf("%s", err.Error())
+		return nil, errNew
+	}
+	if exist {
+		logrus.Infof("SetHaltIfInsufficientResourceQuota: VM %s/%s reports error %s, but the POD is existing, enqueue to re-check", vm.Namespace, vm.Name, err.Error())
+		// next time, the CheckIfVMCanStartByResourceQuota will get the already existing POD
+		h.vmController.EnqueueAfter(vm.Namespace, vm.Name, 1*time.Second)
+		return vm, nil
+	}
+
 	return vm, h.stopVM(vm, err.Error())
 }
 
@@ -368,4 +387,20 @@ func (h *VMController) removeDeprecatedFinalizer(_ string, vm *kubevirtv1.Virtua
 		return h.vmClient.Update(vmObj)
 	}
 	return vm, nil
+}
+
+// List the VM related POD on APIServer instead of local cache
+// Note: this is slower than query from cache, call it when really necessary
+func (h *VMController) isVMPodExistingOnAPIServer(vm *kubevirtv1.VirtualMachine) (bool, error) {
+	pods, err := h.podClient.List(vm.Namespace, metav1.ListOptions{
+		LabelSelector: labels.Set{
+			util.LabelVMName: vm.Name,
+		}.String(),
+	})
+	if err != nil {
+		return false, err
+	} else if len(pods.Items) == 0 {
+		return false, nil
+	}
+	return true, nil
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Sometimes, the VM is denied by ResourceQuota but there is enough free quota. This is caused by a rare race case: the VM's POD is created and the ResourceQuota's `used` statistics is updated, but the VM Controller does not have this new POD in local cache, the ResourceQuota calculator assumes there is no space.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

When ResourceQuota denies the VM, double check if the POD is existing on ApiServer, if it is there, rerun the process.

**Related Issue:**

When testing PR https://github.com/harvester/harvester/pull/7504 for issue https://github.com/harvester/harvester/issues/7178,  https://github.com/harvester/harvester/issues/7585 is observed.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Per issue https://github.com/harvester/harvester/issues/7585#issue-2845091345 `To Reproduce` section

Local test:
without this fix:

```
time="2025-02-11T18:42:31Z" level=info msg="test5-ns/test5-vm1 usedCPU 0, vmimCPU 0 vmCPU 2000 actual CPU 2500"
time="2025-02-11T18:42:31Z" level=info msg="test5-ns/test5-vm1 usedCPU 0, vmimCPU 0 vmCPU 2000 actual CPU 2500"
time="2025-02-11T18:42:31Z" level=info msg="test5-ns/test5-vm1 usedCPU 0, vmimCPU 0 vmCPU 2000 actual CPU 2500"

// the current POD occupies the resources, and it is counted as used
time="2025-02-11T18:42:31Z" level=info msg="test5-ns/test5-vm1 usedCPU 2015, vmimCPU 0 vmCPU 2000 actual CPU 2500"

time="2025-02-11T18:42:31Z" level=debug msg="stop the VM test5-vm1 in namespace test5-ns due to insufficient resource quota: cpu insufficient resources due to resource quota"
time="2025-02-11T18:42:31Z" level=info msg="Event(v1.ObjectReference{Kind:\"VirtualMachine\", Namespace:\"test5-ns\", Name:\"test5-vm1\", UID:\"f09f6d21-2233-48df-820a-8ed78b712ced\", APIVersion:\"kubevirt.io/v1\", ResourceVersion:\"370371\", FieldPath:\"\"}): type: 'Warning' reason: 'InsufficientResourceQuota' Set runStrategy to Halted: cpu insufficient resources due to resource quota"
time="2025-02-11T18:42:31Z" level=debug msg="CheckIfVMCanStartByResourceQuota: VM test5-ns/test5-vm1 is halted, skip check"
time="2025-02-11T18:42:31Z" level=debug msg="skip cleaning up insufficient resource annotation, VM test5-vm1 in namespace test5-ns is halted."
```


with this fix & https://github.com/harvester/harvester/pull/7504

```
time="2025-02-12T13:07:59Z" level=debug msg="test7-ns/test7-vm1 CPU: used 0, vmim 0 vm 2000 actual 2500, memory: used 0, vmim 0 vm 2540699648 actual 3221225472"
time="2025-02-12T13:07:59Z" level=debug msg="test7-ns/test7-vm1 CPU: used 0, vmim 0 vm 2000 actual 2500, memory: used 0, vmim 0 vm 2540699648 actual 3221225472"
time="2025-02-12T13:07:59Z" level=debug msg="VM test7-vm1 in namespace test7-ns is starting"

// resource quota is updated
time="2025-02-12T13:07:59Z" level=debug msg="test7-ns/test7-vm1 CPU: used 2015, vmim 0 vm 2000 actual 2500, memory: used 2604893169, vmim 0 vm 2540699648 actual 3221225472"

// below log was taken from the previous code, but it worked
time="2025-02-12T13:07:59Z" level=debug msg="CheckIfVMCanStartByResourceQuota: VM test7-ns/test7-vm1 has insufficient resource cpu insufficient resources due to resource quota, but the POD is existing, re-check"

time="2025-02-12T13:07:59Z" level=debug msg="CheckIfVMCanStartByResourceQuota: VM test7-ns/test7-vm1 has running pod, skip check"
time="2025-02-12T13:07:59Z" level=debug msg="VM test7-vm1 in namespace test7-ns is starting"
time="2025-02-12T13:08:00Z" level=debug msg="CheckIfVMCanStartByResourceQuota: VM test7-ns/test7-vm1 has running pod, skip check"
time="2025-02-12T13:08:00Z" level=debug msg="VM test7-vm1 in namespace test7-ns is starting"
```

only with this fix:
```
time="2025-02-13T09:18:26Z" level=debug msg="Wrote ping"

// denied, but identified and retry
time="2025-02-13T09:18:29Z" level=info msg="SetHaltIfInsufficientResourceQuota: VM testns/vm1 reports error cpu insufficient resources due to resource quota, but the POD is existing, enqueue to re-check"

time="2025-02-13T09:18:30Z" level=debug msg="CheckIfVMCanStartByResourceQuota: VM testns/vm1 has running pod, skip check"
time="2025-02-13T09:18:30Z" level=debug msg="CheckIfVMCanStartByResourceQuota: VM testns/vm1 has running pod, skip check"
time="2025-02-13T09:18:30Z" level=debug msg="CheckIfVMCanStartByResourceQuota: VM testns/vm1 has running pod, skip check"
```

Also refer: https://github.com/harvester/harvester/issues/7585#issuecomment-2655921035 about the reproduce on old version.