### PR TITLE
Adding a webhook for the validation of CPU pinning

### DIFF
--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -66,7 +66,8 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 			clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache(),
-			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
+			clients.CoreFactory.Core().V1().Node().Cache()),
 		virtualmachineimage.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
 			clients.Core.Pod().Cache(),


### PR DESCRIPTION
**Problem:**
The UI is doing some checks related to CPU pinning/CPU Manager when creating a new VM, but they are only taken into action when the form view is used. The YAML editor does not do the validation. When an existing VM is modified, no validation is done.

**Solution:**
Add a validator webhook that throws an error when the `Enable CPU Pinning` checkbox is enabled in the Advanced Options tab of a VM resource but no node with enabled CPU Manager exists. The check is only done when the VM is running. This allows the user to create VMs with CPU pinning enabled in advance even if the CPU Manager is currently disabled. Trying to start a VM with enabled CPU pinning and no CPU Manager available will fail because the VM is not schedulable due to the node affinity/selector and also that no node is available for the preemption rights.

**Related Issue:**
https://github.com/harvester/harvester/issues/7598

**Test plan:**
A 3 node cluster is required.
***Case 1***
- Disable `CPU Manager` feature on all nodes.
- Create a new VM. Enter all necessary values. Click `Edit as YAML`.
- Add the following:
```
spec:
  template:
    spec:
      domain:
        cpu:
          dedicatedCpuPlacement: true
```
- Press `Create`.
- The creation is aborted and the error message `admission webhook "validator.harvesterhci.io" denied the request: no nodes with CPU Manager enabled found` is displayed.

***Case 2***
- Enable `CPU Manager` feature on one node.
- Create a new VM. Enter all necessary values. Click `Edit as YAML`.
- Add the following:
```
spec:
  template:
    spec:
      domain:
        cpu:
          dedicatedCpuPlacement: true
```
- Press `Create`.
- The VM is created.

***Case 3***
- Enable `CPU Manager` feature on one node.
- Create a new VM.
- Choose `Edit YAML` in the action menu of the VM.
- Add the following:
```
spec:
  template:
    spec:
      domain:
        cpu:
          dedicatedCpuPlacement: true
```
- Press `Save`.
- The VM is modified without errors.

***Case 4***
- Enable `CPU Manager` feature on one node.
- Create a new VM `vm-1`. Do not enable `CPU Pinning`.
- Disable `CPU Manager` feature on all nodes.
- Choose `Edit YAML` in the action menu of the VM `vm-1`.
- Add the following:
```
spec:
  template:
    spec:
      domain:
        cpu:
          dedicatedCpuPlacement: true
```
- Press `Save`.
- The VM is not modified. The error message `admission webhook "validator.harvesterhci.io" denied the request: no nodes with CPU Manager enabled found` is displayed.

***Case 5***
- Disable `CPU Manager` feature on all nodes.
- Create a new VM.
- The VM is started.
- Choose `Edit Config` in the action menu of the VM.
- Go to the `Advanced Options` tab and check the `Enable CPU Pinning` checkbox.
- Press `Save`.
- The save action is aborted and the error message `admission webhook "validator.harvesterhci.io" denied the request: no nodes with CPU Manager enabled found` is displayed.