### PR TITLE
Bump virtctl to v1.4.0

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -10,7 +10,7 @@ ENV KUBECTL_VERSION v1.29.9
 RUN curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
-RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.3.1/virtctl-v1.3.1-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
+RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.4.0/virtctl-v1.4.0-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.8/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Following log is observed when testing upgrade.
```
You are using a client virtctl version that is different from the KubeVirt version running in the cluster
Client Version: v1.3.1
Error starting VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "upgrade-repo-hvst-upgrade-lfd2d": VM is already running
Server Version: v1.4.0
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Bump virtctl version.

**Related Issue:**
https://github.com/harvester/harvester/issues/7648

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Per https://github.com/harvester/harvester/issues/7648 issue description