### PR TITLE
Enhance upgradeLog

### DIFF
--- a/pkg/controller/master/upgradelog/common.go
+++ b/pkg/controller/master/upgradelog/common.go
@@ -25,6 +25,8 @@ import (
 const (
 	defaultDeploymentReplicas   int32 = 1
 	defaultLogArchiveVolumeSize       = "1Gi"
+
+	upgradeLogLoggingRef = "harvester-upgradelog"
 )
 
 func upgradeLogReference(upgradeLog *harvesterv1.UpgradeLog) metav1.OwnerReference {
@@ -84,6 +86,8 @@ func prepareLogging(upgradeLog *harvesterv1.UpgradeLog, images map[string]Image)
 			},
 		},
 		Spec: loggingv1.LoggingSpec{
+			// without this field, it may cause: "Other logging resources exist with the same loggingRef: rancher-logging-root"
+			LoggingRef:              upgradeLogLoggingRef,
 			ControlNamespace:        upgradeLog.Namespace,
 			FlowConfigCheckDisabled: true,
 			FluentbitSpec: &loggingv1.FluentbitSpec{

--- a/pkg/controller/master/upgradelog/common.go
+++ b/pkg/controller/master/upgradelog/common.go
@@ -26,6 +26,8 @@ const (
 	defaultDeploymentReplicas   int32 = 1
 	defaultLogArchiveVolumeSize       = "1Gi"
 
+	// this is used to differentiate separate fluentbit&fluentd group
+	// all the none-root logging/clusterflow/clusteroutput objects need this reference
 	upgradeLogLoggingRef = "harvester-upgradelog"
 )
 
@@ -170,6 +172,7 @@ func prepareClusterFlow(upgradeLog *harvesterv1.UpgradeLog) *loggingv1.ClusterFl
 			},
 		},
 		Spec: loggingv1.ClusterFlowSpec{
+			LoggingRef: upgradeLogLoggingRef,
 			Filters: []loggingv1.Filter{
 				{
 					TagNormaliser: &filter.TagNormaliser{},
@@ -264,6 +267,7 @@ func prepareClusterOutput(upgradeLog *harvesterv1.UpgradeLog) *loggingv1.Cluster
 		},
 		Spec: loggingv1.ClusterOutputSpec{
 			OutputSpec: loggingv1.OutputSpec{
+				LoggingRef: upgradeLogLoggingRef,
 				FileOutput: &output.FileOutputConfig{
 					Path:     "/archive/logs/${tag}",
 					Compress: "gzip",


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
https://github.com/harvester/harvester/issues/7652
https://github.com/harvester/harvester/issues/7654

The controller checks `upgradeLog.DeletionTimestamp != nil`

https://github.com/harvester/harvester/blob/9b46493d505dfc4e9d0402ad57de43752dfcc9f8/pkg/controller/master/upgradelog/controller.go#L94

The `stopCollect` has no chance to be called here.

https://github.com/harvester/harvester/blob/9b46493d505dfc4e9d0402ad57de43752dfcc9f8/pkg/controller/master/upgradelog/controller.go#L298

The onRemove needs to call `stopCollect` anyway. (or check the related conditions first)

https://github.com/harvester/harvester/blob/9b46493d505dfc4e9d0402ad57de43752dfcc9f8/pkg/controller/master/upgradelog/controller.go#L317

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

(1) Add the required loggingRef field
(2) Cleanup resources when upgrade is manually deleted

**Related Issue:**
https://github.com/harvester/harvester/issues/7652
https://github.com/harvester/harvester/issues/7654

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. without enabling rancher-logging,  trigger upgrade, enable upgradelog, delete upgrade after a while

All related resources are cleand up.

```
$kubectl get logging -A
NAME                                          LOGGINGREF             CONTROLNAMESPACE        WATCHNAMESPACES   PROBLEMS
hvst-upgrade-cjhgj-upgradelog-infra           harvester-upgradelog   harvester-system                          
hvst-upgrade-cjhgj-upgradelog-operator-root                          cattle-logging-system                     

...
$kubectl get clusterflow -A
No resources found
$kubectl  get clusteroutput -A
No resources found
$kubectl kk get logging -A
No resources found

$kubectl  get managedchart -A
NAMESPACE     NAME                                      AGE
fleet-local   harvester                                 28m
fleet-local   harvester-crd                             28m
fleet-local   local-managed-system-upgrade-controller   28m
fleet-local   rancher-logging-crd                       28m
fleet-local   rancher-monitoring-crd                    28m


...
time="2025-02-19T09:26:12Z" level=info msg="Update upgradeLog harvester-system/hvst-upgrade-cjhgj-upgradelog"
time="2025-02-19T09:26:12Z" level=info msg="Stop collecting logs"
time="2025-02-19T09:26:12Z" level=info msg="Tearing down the logging infrastructure for upgrade procedure"
time="2025-02-19T09:26:12Z" level=info msg="Delete UpgradeLog harvester-system/hvst-upgrade-cjhgj-upgradelog"
time="2025-02-19T09:26:12Z" level=info msg="Removing all other related resources"
time="2025-02-19T09:26:12Z" level=info msg="Tearing down the logging infrastructure for upgrade procedure"
```

2. with enabling rancher-logging,  trigger upgrade, enable upgradelog, delete upgrade after a while

No resources are left


```
...
$kubectl  get logging -A
NAME                                  LOGGINGREF                     CONTROLNAMESPACE        WATCHNAMESPACES   PROBLEMS
hvst-upgrade-9xjkb-upgradelog-infra   harvester-upgradelog           harvester-system                          
rancher-logging-kube-audit            harvester-kube-audit-log-ref   cattle-logging-system                     
rancher-logging-root                                                 cattle-logging-system                     


$kubectl get logging -A
NAME                         LOGGINGREF                     CONTROLNAMESPACE        WATCHNAMESPACES   PROBLEMS
rancher-logging-kube-audit   harvester-kube-audit-log-ref   cattle-logging-system                     
rancher-logging-root                                        cattle-logging-system                     
...
```