### PR TITLE
Patch upgradeLog on the upgrade path

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -573,54 +573,54 @@ EOF
 
 upgrade_harvester_upgradelog_with_patch_loggingref()
 {
-  local namespace=$UPGRADE_NAMESPACE
-  local upgradelogname=$(kubectl get upgrades.harvesterhci.io $HARVESTER_UPGRADE_NAME -n $UPGRADE_NAMESPACE -ojsonpath="{.status.upgradeLog}")
+  local namespace="${UPGRADE_NAMESPACE}"
+  local upgradelogname=$(kubectl get upgrades.harvesterhci.io "${HARVESTER_UPGRADE_NAME}" -n "${UPGRADE_NAMESPACE}" -ojsonpath="{.status.upgradeLog}")
   local loggingref="harvester-upgradelog"
 
-  if [[ -z "$upgradelogname" ]]; then
-    echo "upgradelog is not found from upgrade $HARVESTER_UPGRADE_NAME, nothing to do"
+  if [[ -z "${upgradelogname}" ]]; then
+    echo "upgradelog is not found from upgrade ${HARVESTER_UPGRADE_NAME}, nothing to do"
     return 0
   fi
 
   # patch_clusteroutput
-  echo "patch clusteroutput $upgradelogname-clusteroutput"
+  echo "patch clusteroutput ${upgradelogname}-clusteroutput"
   local patchfile="patch_clusteroutput.yaml"
-  cat > $patchfile <<EOF
+  cat > "${patchfile}" <<EOF
 spec:
-  loggingRef: "$loggingref"
+  loggingRef: "${loggingref}"
 EOF
-  kubectl patch clusteroutput -n $namespace $upgradelogname-clusteroutput --patch-file ./$patchfile --type merge || echo "failed to patch upgradeLog clusteroutput"
-  rm -rf ./$patchfile
+  kubectl patch clusteroutput -n "${namespace}" "${upgradelogname}"-clusteroutput --patch-file ./"${patchfile}" --type merge || echo "failed to patch upgradeLog clusteroutput"
+  rm -rf ./"${patchfile}"
 
   # patch_clusterflow
-  echo "patch clusterflow $upgradelogname-clusterflow"
+  echo "patch clusterflow ${upgradelogname}-clusterflow"
   patchfile="patch_clusterflow.yaml"
-  cat > $patchfile <<EOF
+  cat > "${patchfile}" <<EOF
 spec:
-  loggingRef: "$loggingref"
+  loggingRef: "${loggingref}"
 EOF
-  kubectl patch clusterflow -n $namespace $upgradelogname-clusterflow --patch-file ./$patchfile --type merge || echo "failed to patch upgradeLog clusterflow"
-  rm -rf ./$patchfile
+  kubectl patch clusterflow -n "${namespace}" "${upgradelogname}"-clusterflow --patch-file ./"${patchfile}" --type merge || echo "failed to patch upgradeLog clusterflow"
+  rm -rf ./"${patchfile}"
 
   # patch logging
-  echo "patch logging $upgradelogname-infra"
+  echo "patch logging ${upgradelogname}-infra"
   patchfile="patch_logging.yaml"
-  cat > $patchfile <<EOF
+  cat > "${patchfile}" <<EOF
 spec:
-  loggingRef: "$loggingref"
+  loggingRef: "${loggingref}"
 EOF
-  kubectl patch logging -n $namespace $upgradelogname-infra --patch-file ./$patchfile --type merge || echo "failed to patch upgradeLog logging"
-  rm -rf ./$patchfile
+  kubectl patch logging -n "${namespace}" "${upgradelogname}"-infra --patch-file ./"${patchfile}" --type merge || echo "failed to patch upgradeLog logging"
+  rm -rf ./"${patchfile}"
 
   # patch the may be existing logging operator-root
-  echo "patch logging $upgradelogname-operator-root"
+  echo "patch logging ${upgradelogname}-operator-root"
   patchfile="patch_logging.yaml"
-  cat > $patchfile <<EOF
+  cat > "${patchfile}" <<EOF
 spec:
   loggingRef: "harvester-upgradelog-operator-root"
 EOF
-  kubectl patch logging -n $namespace $upgradelogname-operator-root --patch-file ./$patchfile --type merge || echo "failed to patch upgradeLog logging operator-root"
-  rm -rf ./$patchfile
+  kubectl patch logging -n "${namespace}" "${upgradelogname}"-operator-root --patch-file ./"${patchfile}" --type merge || echo "failed to patch upgradeLog logging operator-root or it is not existing"
+  rm -rf ./"${patchfile}"
 }
 
 upgrade_nvidia_driver_toolkit_addon()

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1124,6 +1124,15 @@ upgrade_addon_rancher_logging()
   fi
 }
 
+# NOTE: review in each release, add corresponding process
+upgrade_harvester_upgradelog() {
+  echo "upgrade harvester upgradelog"
+  # in v1.5.0, new rancher-logging is bumped
+  if [ "$REPO_LOGGING_CHART_VERSION" = "105.2.0+up4.10.0" ]; then
+    upgrade_harvester_upgradelog_with_patch_loggingref $REPO_LOGGING_CHART_VERSION
+  fi
+}
+
 upgrade_addons()
 {
   wait_for_addons_crd
@@ -1135,6 +1144,8 @@ upgrade_addons()
   # those 2 addons have flexible user-configurable fields, only upgrade harvester related e.g. new image tag
   # from v1.2.0, they are upgraded per following
   upgrade_addon_rancher_monitoring
+  # the upgradelog may be affected by the bumped rancher-logging
+  upgrade_harvester_upgradelog
   upgrade_addon_rancher_logging
   upgrade_nvidia_driver_toolkit_addon
 }

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1128,8 +1128,8 @@ upgrade_addon_rancher_logging()
 upgrade_harvester_upgradelog() {
   echo "upgrade harvester upgradelog"
   # in v1.5.0, new rancher-logging is bumped
-  if [ "$REPO_LOGGING_CHART_VERSION" = "105.2.0+up4.10.0" ]; then
-    upgrade_harvester_upgradelog_with_patch_loggingref $REPO_LOGGING_CHART_VERSION
+  if [ "${REPO_LOGGING_CHART_VERSION}" = "105.2.0+up4.10.0" ]; then
+    upgrade_harvester_upgradelog_with_patch_loggingref "${REPO_LOGGING_CHART_VERSION}"
   fi
 }
 

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1150,13 +1150,15 @@ upgrade_addons()
     upgrade_addon $addon "harvester-system"
   done
 
-  # those 2 addons have flexible user-configurable fields, only upgrade harvester related e.g. new image tag
+  # the rancher-monitoring and rancher-logging addon have flexible user-configurable fields
   # from v1.2.0, they are upgraded per following
   upgrade_addon_rancher_monitoring
-  # the upgradelog may be affected by the bumped rancher-logging
+  # the upgradelog may be affected by the new rancher-logging
   upgrade_harvester_upgradelog_loggingref
   upgrade_addon_rancher_logging
+  # after rancher-logging is upgraded, upgrade upgradelog if necessary
   upgrade_harvester_upgradelog_logging_fluentd_fluentbit
+
   upgrade_nvidia_driver_toolkit_addon
 }
 

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1124,12 +1124,21 @@ upgrade_addon_rancher_logging()
   fi
 }
 
-# NOTE: review in each release, add corresponding process
-upgrade_harvester_upgradelog() {
-  echo "upgrade harvester upgradelog"
-  # in v1.5.0, new rancher-logging is bumped
+# NOTE: review in each release, add corresponding process, runs before rancher-logging is bumped
+upgrade_harvester_upgradelog_loggingref() {
+  echo "upgrade harvester upgradelog loggingref"
+  # in v1.5.0, new rancher-logging is bumped, loggingref is required
   if [ "${REPO_LOGGING_CHART_VERSION}" = "105.2.0+up4.10.0" ]; then
     upgrade_harvester_upgradelog_with_patch_loggingref "${REPO_LOGGING_CHART_VERSION}"
+  fi
+}
+
+# adapt upgradeLog to new logging stack requirements, runs after rancher-logging is bumped
+upgrade_harvester_upgradelog_logging_fluentd_fluentbit() {
+  echo "upgrade harvester upgradelog logging fluend fluentbit"
+  # in v1.5.0, new rancher-logging is bumped, fluentbitagent and others are required
+  if [ "${REPO_LOGGING_CHART_VERSION}" = "105.2.0+up4.10.0" ]; then
+    upgrade_harvester_upgradelog_with_patch_logging_fluentd_fluentbit "${REPO_LOGGING_CHART_VERSION}"
   fi
 }
 
@@ -1145,8 +1154,9 @@ upgrade_addons()
   # from v1.2.0, they are upgraded per following
   upgrade_addon_rancher_monitoring
   # the upgradelog may be affected by the bumped rancher-logging
-  upgrade_harvester_upgradelog
+  upgrade_harvester_upgradelog_loggingref
   upgrade_addon_rancher_logging
+  upgrade_harvester_upgradelog_logging_fluentd_fluentbit
   upgrade_nvidia_driver_toolkit_addon
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The upstream logging has some enhancements, the upgradeLog needs to adapt to them.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR and https://github.com/harvester/harvester/pull/7653 enhance the upgradeLog in v1.5.0

**Related Issue:**
https://github.com/harvester/harvester/issues/7652
https://github.com/harvester/harvester/issues/7654

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Upgrade v1.4.*->v1.5.0, ugpradeLog should work properly, no matter rancher-logging addon is enabled or not


local test log:
```
run the same test script several times

...
patch clusteroutput hvst-upgrade-b2f59-upgradelog-clusteroutput
clusteroutput.logging.banzaicloud.io/hvst-upgrade-b2f59-upgradelog-clusteroutput patched (no change)
patch clusterflow hvst-upgrade-b2f59-upgradelog-clusterflow
clusterflow.logging.banzaicloud.io/hvst-upgrade-b2f59-upgradelog-clusterflow patched (no change)
patch logging hvst-upgrade-b2f59-upgradelog-infra
logging.logging.banzaicloud.io/hvst-upgrade-b2f59-upgradelog-infra patched (no change)
patch logging hvst-upgrade-b2f59-upgradelog-operator-root
logging.logging.banzaicloud.io/hvst-upgrade-b2f59-upgradelog-operator-root patched


NAME                                          LOGGINGREF                           CONTROLNAMESPACE        WATCHNAMESPACES   PROBLEMS
hvst-upgrade-b2f59-upgradelog-infra           harvester-upgradelog                 harvester-system                          
hvst-upgrade-b2f59-upgradelog-operator-root   harvester-upgradelog-operator-root   cattle-logging-system            

```

v141->v150 upgrade test, with addon rancher-logging disabled, the upgradeLog works well

![image](https://github.com/user-attachments/assets/e417682c-d225-4f55-b7b4-eb3d17ad3ca5)


another test with updated code:
```
$ kubectl get upgrade.harvesterhci -A
NAMESPACE          NAME                 AGE
harvester-system   hvst-upgrade-ttggs   5m46s

$ kubectl get upgradelog -A
NAMESPACE          NAME                            UPGRADE
harvester-system   hvst-upgrade-ttggs-upgradelog   hvst-upgrade-ttggs



$ ./patch.sh 
patch clusteroutput hvst-upgrade-ttggs-upgradelog-clusteroutput
clusteroutput.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-clusteroutput patched
patch clusterflow hvst-upgrade-ttggs-upgradelog-clusterflow
clusterflow.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-clusterflow patched
patch logging hvst-upgrade-ttggs-upgradelog-infra
logging.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-infra patched
patch logging hvst-upgrade-ttggs-upgradelog-operator-root
logging.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-operator-root patched
...
$ ./patch.sh 
patch clusteroutput hvst-upgrade-ttggs-upgradelog-clusteroutput
clusteroutput.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-clusteroutput patched (no change)
patch clusterflow hvst-upgrade-ttggs-upgradelog-clusterflow
clusterflow.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-clusterflow patched (no change)
patch logging hvst-upgrade-ttggs-upgradelog-infra
logging.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-infra patched (no change)
patch logging hvst-upgrade-ttggs-upgradelog-operator-root
logging.logging.banzaicloud.io/hvst-upgrade-ttggs-upgradelog-operator-root patched (no change)
harv21:/home/rancher # 

```