### PR TITLE
change default setup for multipathd - upgrade path

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -650,11 +650,9 @@ EOF
   if [ ${multiPathEnabled} == false ]
   then
     thirdPartyArgs=$(chroot $HOST_DIR grub2-editenv /oem/grubenv list |grep third_party_kernel_args | awk -F"third_party_kernel_args=" '{print $2}')
-    if [[ ${thirdPartyArgs} != *"rd.multipath=0"* ]]
+    if [[ ${thirdPartyArgs} != *"multipath=off"* ]]
     then
-      thirdPartyArgs="${thirdPartyArgs} rd.multipath=0"
-      # remove multipath=off from thirdPartyArgs that may have been added during 1.4.0 upgrade
-      thirdPartyArgs=$(sed 's/multipath=off//' <<< ${thirdPartyArgs})
+      thirdPartyArgs="${thirdPartyArgs} multipath=off"
       thirdPartyArgs=$(echo ${thirdPartyArgs} | xargs)
       chroot $HOST_DIR grub2-editenv /oem/grubenv set third_party_kernel_args="${thirdPartyArgs}"
     fi
@@ -675,6 +673,13 @@ stages:
          permissions: 0644
          owner: 0
          group: 0
+       - path: /etc/systemd/system/multipathd.service
+         permissions: 420
+         owner: 0
+         group: 0
+         content: W1VuaXRdCkRlc2NyaXB0aW9uPURldmljZS1NYXBwZXIgTXVsdGlwYXRoIERldmljZSBDb250cm9sbGVyCkJlZm9yZT1sdm0yLWFjdGl2YXRpb24tZWFybHkuc2VydmljZQpCZWZvcmU9bG9jYWwtZnMtcHJlLnRhcmdldCBibGstYXZhaWxhYmlsaXR5LnNlcnZpY2Ugc2h1dGRvd24udGFyZ2V0CldhbnRzPXN5c3RlbWQtdWRldmQta2VybmVsLnNvY2tldApBZnRlcj1zeXN0ZW1kLXVkZXZkLWtlcm5lbC5zb2NrZXQKQWZ0ZXI9bXVsdGlwYXRoZC5zb2NrZXQgc3lzdGVtZC1yZW1vdW50LWZzLnNlcnZpY2UKQmVmb3JlPWluaXRyZC1jbGVhbnVwLnNlcnZpY2UKRGVmYXVsdERlcGVuZGVuY2llcz1ubwpDb25mbGljdHM9c2h1dGRvd24udGFyZ2V0CkNvbmZsaWN0cz1pbml0cmQtY2xlYW51cC5zZXJ2aWNlCkNvbmRpdGlvbktlcm5lbENvbW1hbmRMaW5lPSFub21wYXRoCkNvbmRpdGlvblZpcnR1YWxpemF0aW9uPSFjb250YWluZXIKCltTZXJ2aWNlXQpUeXBlPW5vdGlmeQpOb3RpZnlBY2Nlc3M9bWFpbgpFeGVjU3RhcnQ9L3NiaW4vbXVsdGlwYXRoZCAtZCAtcwpFeGVjUmVsb2FkPS9zYmluL211bHRpcGF0aGQgcmVjb25maWd1cmUKVGFza3NNYXg9aW5maW5pdHkKCltJbnN0YWxsXQpXYW50ZWRCeT1zeXNpbml0LnRhcmdldA==
+         encoding: base64
+         ownerstring: ""         
 EOF
   fi
 


### PR DESCRIPTION
tweak multipath behaviour in upgrade path to allow users to subsequently enable multipath post upgrade

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR https://github.com/harvester/harvester-installer/pull/938 changed kernel arguments to disable multipathd during boot. The original idea was to allow end users to still enable multipathd post boot for 3rd party CSI.

However the change seems to have broken boot in kvm when using ide, scsi and sata buses. The same issue has also been noticed on HP DL360's when using a raid controller.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
* PR applies an override to multipathd.service file via /etc/systemd/system, where we drop the condition check for multipath=off during the upgrade path.

**Related Issue:**
https://github.com/harvester/harvester/issues/7622
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
* Install harvester 1.4-head or 1.4.2-rc*
* Upgrade to an iso built with changes from this PR
* Post upgrade all the nodes should have a file /oem/99_disable_lh_multipathd.yaml which sets up multipath exceptions for longhorn volumes and override for multipathd service
* user should be able to enable multipathd on the nodes `systemctl enable multipathd && systemctl start multipathd`