### PR TITLE
Move storagenetwork consts to Harvester util for public usage

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -177,4 +177,17 @@ const (
 	NodeSchedulingRequirementsNotMetKey = "NodeSchedulingRequirementsNotMet"
 	MaintainModeStrategyKey             = "MaintainModeStrategy"
 	LastHealthyReplicaKey               = "LastHealthyReplica"
+
+	// moved from storage_network for public usage
+	StorageNetworkAnnotation        = "storage-network.settings.harvesterhci.io"
+	ReplicaStorageNetworkAnnotation = StorageNetworkAnnotation + "/replica"
+	PausedStorageNetworkAnnotation  = StorageNetworkAnnotation + "/paused"
+	HashStorageNetworkAnnotation    = StorageNetworkAnnotation + "/hash"
+	NadStorageNetworkAnnotation     = StorageNetworkAnnotation + "/net-attach-def"
+	OldNadStorageNetworkAnnotation  = StorageNetworkAnnotation + "/old-net-attach-def"
+
+	HashStorageNetworkLabel = HashStorageNetworkAnnotation
+
+	StorageNetworkNetAttachDefPrefix    = "storagenetwork-"
+	StorageNetworkNetAttachDefNamespace = HarvesterSystemNamespaceName
 )


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Storagenetwork does not put consts on Harvester public util package.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Move them to public.

Also for https://github.com/harvester/network-controller-harvester/pull/149

**Related Issue:**
https://github.com/harvester/harvester/issues/4355
https://github.com/harvester/harvester/issues/4752

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
