### PR TITLE
VMBuilder: expose network interface boot order

### DIFF
--- a/pkg/builder/network.go
+++ b/pkg/builder/network.go
@@ -44,7 +44,7 @@ func (v *VMBuilder) Network(interfaceName, networkName string) *VMBuilder {
 	return v
 }
 
-func (v *VMBuilder) Interface(interfaceName, interfaceModel, interfaceMACAddress string, interfaceType string) *VMBuilder {
+func (v *VMBuilder) Interface(interfaceName, interfaceModel, interfaceMACAddress, interfaceType string) *VMBuilder {
 	interfaces := v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces
 	networkInterface := kubevirtv1.Interface{
 		Name:       interfaceName,
@@ -66,6 +66,20 @@ func (v *VMBuilder) Interface(interfaceName, interfaceModel, interfaceMACAddress
 	}
 	interfaces = append(interfaces, networkInterface)
 	v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces = interfaces
+	return v
+}
+
+func (v *VMBuilder) SetNetworkInterfaceBootOrder(interfaceName string, bootOrder uint) *VMBuilder {
+	interfaces := v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces
+
+	for i, iface := range interfaces {
+		if iface.Name == interfaceName {
+			ifaceCopy := iface.DeepCopy()
+			ifaceCopy.BootOrder = func() *uint { v := uint(bootOrder); return &v }()
+			v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces[i] = *ifaceCopy
+		}
+	}
+
 	return v
 }
 

--- a/pkg/builder/network.go
+++ b/pkg/builder/network.go
@@ -75,7 +75,7 @@ func (v *VMBuilder) SetNetworkInterfaceBootOrder(interfaceName string, bootOrder
 	for i, iface := range interfaces {
 		if iface.Name == interfaceName {
 			ifaceCopy := iface.DeepCopy()
-			ifaceCopy.BootOrder = func() *uint { v := uint(bootOrder); return &v }()
+			ifaceCopy.BootOrder = &bootOrder
 			v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces[i] = *ifaceCopy
 		}
 	}

--- a/pkg/builder/network_test.go
+++ b/pkg/builder/network_test.go
@@ -1,0 +1,28 @@
+package builder
+
+import "testing"
+
+func TestSetNetworkInterfaceBootOrder(t *testing.T) {
+	builder := NewVMBuilder("test")
+	builder.NetworkInterface("eth0", "virtio", "00:00:00:00:00:00", NetworkInterfaceTypeBridge, "testnet")
+	builder.NetworkInterface("eth1", "virtio", "00:00:00:00:00:01", NetworkInterfaceTypeBridge, "testnet")
+
+	if builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces[0].BootOrder != nil {
+		t.Error("Boot order set on network interface eth0")
+	}
+
+	if builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces[1].BootOrder != nil {
+		t.Error("Boot order set on network interface eth1")
+	}
+
+	builder.SetNetworkInterfaceBootOrder("eth1", 3)
+
+	if builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces[0].BootOrder != nil {
+		t.Error("Boot order set on network interface eth0")
+	}
+
+	if builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces[1].BootOrder == nil ||
+		*builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces[1].BootOrder != 3 {
+		t.Error("Failed to set boot order on network interface eth1")
+	}
+}


### PR DESCRIPTION
Expose a function that allows setting the boot order property of network interfaces in the VMBuilder.

The main use case for this is the Terraform provider, which utilizes the VMBuilder to generate VM structures.

Exposing this property as its own method rather than modifying the existing `Interface` method keeps compatibility for other users of the VMBuilder.

related-to: https://github.com/harvester/harvester/issues/7695

**Problem:**
The VMBuilder is used by the Harvester Terraform provider to generate the structure of a VirtualMachine object from the specifications in the Terraform manifest. To allow creating VMs, which can do network/PXE booting with the Terraform provider, the provider must be able to set the boot order property on a network interface of a VM structure.

**Solution:**
Add an additional method to the VMBuilder, which allows setting the boot order property of a specific network interface.

**Related Issue:**
https://github.com/harvester/harvester/issues/7695

**Test plan:**
Unit tests included
