### PR TITLE
Added default nodePlacement in kubevirt cr

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -56,6 +56,12 @@ kubevirt:
   ## Specify the specification of KubeVirt resource.
   ##
   spec:
+    ## Specify default placement of infra components
+    ## based on logic https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-operator/resource/apply/reconcile.go#L127
+    ## an empty nodePlacement struct is enough to continue existing behaviour of allowing kubevirt controlplane 
+    ## components to be scheduled to any node in the cluster
+    infra:
+      nodePlacement: {}
     ## Specify the default configuration of KubeVirt virtual machine.
     ##
     configuration:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Kubevirt v1.3 has added logic to schedule kubevirt infra components to controlplane nodes.

This breaks 2 node harvester upgrades are broken since controlplane node cannot be drained successfully.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
To avoid this the PR adds an empty `nodePlacement` struct to the kubevirt CR to allow scheduling of kubevirt controplane components to any node in the cluster.

**Related Issue:**
https://github.com/harvester/harvester/issues/7647
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
