### PR TITLE
update kubevirt image to 1.4.0-150600.5.15.1

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -26,7 +26,7 @@ kubevirt-operator:
     operator:
       image:
         repository: registry.suse.com/suse/sles/15.6/virt-operator
-        tag: &kubevirtVersion 1.4.0-150600.5.12.1
+        tag: &kubevirtVersion 1.4.0-150600.5.15.1
     ## The following images are placeholder for images in use.
     ## They are not used by the kubevirt-operator chart.
     controller:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Current kubevirt arm images are missing a qemu-virtio-gpu package which causes the VMs to fail during boot on ARM clusters.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Update kubevirt images to v1.4.0-150600.5.15.1 which contains the fix

**Related Issue:**
https://github.com/harvester/harvester/issues/7098

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

To test:
* Install harvester arm iso to a node
* check virt operator is using image `registry.suse.com/suse/sles/15.6/virt-operator:1.4.0-150600.5.15.1`
* Create a VM using an arm image
* VM should boot successfully