### PR TITLE
fix(upgrade): disable auto-cleanup-system-generated-snapshot

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -69,6 +69,9 @@ const (
 	replicaReplenishmentAnnotation           = "harvesterhci.io/" + replicaReplenishmentWaitIntervalSetting
 	extendedReplicaReplenishmentWaitInterval = 1800
 
+	autoCleanupSystemGeneratedSnapshotSetting    = "auto-cleanup-system-generated-snapshot"
+	autoCleanupSystemGeneratedSnapshotAnnotation = "harvesterhci.io/" + autoCleanupSystemGeneratedSnapshotSetting
+
 	imageCleanupPlanCompletedAnnotation = "harvesterhci.io/image-cleanup-plan-completed"
 	skipVersionCheckAnnotation          = "harvesterhci.io/skip-version-check"
 	defaultImagePreloadConcurrency      = 1
@@ -234,7 +237,9 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 		if err := h.cleanupImages(upgrade, repo); err != nil {
 			logrus.Warningf("Unable to cleanup images: %s", err.Error())
 			toUpdate := upgrade.DeepCopy()
-			toUpdate.Annotations = make(map[string]string)
+			if toUpdate.Annotations == nil {
+				toUpdate.Annotations = make(map[string]string)
+			}
 			toUpdate.Annotations[imageCleanupPlanCompletedAnnotation] = strconv.FormatBool(true)
 			return h.upgradeClient.Update(toUpdate)
 		}
@@ -357,6 +362,22 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 				}
 			}
 
+			// Disable auto-cleanup-system-generated-snapshot to avoid
+			// https://github.com/harvester/harvester/issues/7679
+			// (skip if it's already disabled)
+			autoCleanupSystemGeneratedSnapshotValue, err := h.getAutoCleanupSystemGeneratedSnapshotValue()
+			if err != nil {
+				return nil, err
+			}
+			if autoCleanupSystemGeneratedSnapshotValue != "false" {
+				if err := h.saveAutoCleanupSystemGeneratedSnapshotToUpgradeAnnotation(toUpdate); err != nil {
+					return nil, err
+				}
+				if err := h.setAutoCleanupSystemGeneratedSnapshotValue("false"); err != nil {
+					return nil, err
+				}
+			}
+
 			// go with RKE2 pre-drain/post-drain hooks
 			logrus.Infof("Start upgrading Kubernetes runtime to %s", info.Release.Kubernetes)
 			if err := h.upgradeKubernetes(info.Release.Kubernetes); err != nil {
@@ -461,9 +482,13 @@ func (h *upgradeHandler) cleanup(upgrade *harvesterv1.Upgrade, cleanJobs bool) e
 		}
 	}
 
-	// restore Longhorn replica-replenishment-wait-interval setting (multi-node cluster only)
+	// restore Longhorn replica-replenishment-wait-interval and
+	// auto-cleanup-system-generated-snapshot settings (multi-node cluster only)
 	if upgrade.Status.SingleNode == "" {
 		if err := h.loadReplicaReplenishmentFromUpgradeAnnotation(upgrade); err != nil {
+			return err
+		}
+		if err := h.loadAutoCleanupSystemGeneratedSnapshotFromUpgradeAnnotation(upgrade); err != nil {
 			return err
 		}
 	}
@@ -749,6 +774,50 @@ func (h *upgradeHandler) setReplicaReplenishmentValue(value int) error {
 	toUpdate := replicaReplenishmentWaitInterval.DeepCopy()
 	toUpdate.Value = strconv.Itoa(value)
 	if !reflect.DeepEqual(toUpdate, replicaReplenishmentWaitInterval) {
+		if _, err := h.lhSettingClient.Update(toUpdate); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *upgradeHandler) getAutoCleanupSystemGeneratedSnapshotValue() (string, error) {
+	autoCleanupSystemGeneratedSnapshot, err := h.lhSettingCache.Get(util.LonghornSystemNamespaceName, autoCleanupSystemGeneratedSnapshotSetting)
+	if err != nil {
+		return "", err
+	}
+	return autoCleanupSystemGeneratedSnapshot.Value, nil
+}
+
+func (h *upgradeHandler) saveAutoCleanupSystemGeneratedSnapshotToUpgradeAnnotation(upgrade *harvesterv1.Upgrade) error {
+	autoCleanupSystemGeneratedSnapshotValue, err := h.getAutoCleanupSystemGeneratedSnapshotValue()
+	if err != nil {
+		return err
+	}
+	if upgrade.Annotations == nil {
+		upgrade.Annotations = make(map[string]string)
+	}
+	upgrade.Annotations[autoCleanupSystemGeneratedSnapshotAnnotation] = autoCleanupSystemGeneratedSnapshotValue
+	return nil
+}
+
+func (h *upgradeHandler) loadAutoCleanupSystemGeneratedSnapshotFromUpgradeAnnotation(upgrade *harvesterv1.Upgrade) error {
+	value, ok := upgrade.Annotations[autoCleanupSystemGeneratedSnapshotAnnotation]
+	if !ok {
+		logrus.Warnf("no original %s value set", autoCleanupSystemGeneratedSnapshotSetting)
+		return nil
+	}
+	return h.setAutoCleanupSystemGeneratedSnapshotValue(value)
+}
+
+func (h *upgradeHandler) setAutoCleanupSystemGeneratedSnapshotValue(value string) error {
+	autoCleanupSystemGeneratedSnapshot, err := h.lhSettingCache.Get(util.LonghornSystemNamespaceName, autoCleanupSystemGeneratedSnapshotSetting)
+	if err != nil {
+		return err
+	}
+	toUpdate := autoCleanupSystemGeneratedSnapshot.DeepCopy()
+	toUpdate.Value = value
+	if !reflect.DeepEqual(toUpdate, autoCleanupSystemGeneratedSnapshot) {
 		if _, err := h.lhSettingClient.Update(toUpdate); err != nil {
 			return err
 		}


### PR DESCRIPTION
**Problem:**
When live migrating VMs during upgrade, it's possible to hit a case where a replica is being rebuilt at _just_ the wrong time such that an automatic snapshot purge results in I/O errors for the VM on the target node.

**Solution:**
Disabling auto-cleanup-system-generated-snapshot for the duration of the upgrade prevents snapshot purge at that time and thus avoids the issue.

This commit also incidentally fixes a problem where the replica-replenishment-wait-interval setting value wasn't reverted after upgrade completion due to the upgrade CR's annotations being forcibly set to an empty map.

**Related Issue:**
https://github.com/harvester/harvester/issues/7679

**Test plan:**
- Install v1.4.1 with at least two nodes.
- Initiate an upgrade to a version which includes this fix.
- Check `kubectl -n longhorn-system get settings.longhorn.io/auto-cleanup-system-generated-snapshot` - it should show the value as `true`
- Once the upgrade gets through updating system services, but before the nodes are drained, the value of `auto-cleanup-system-generated-snapshot` should automatically change to `false` (try `watch -d 'kubectl -n longhorn-system get settings.longhorn.io/auto-cleanup-system-generated-snapshot'` in a terminal).
- Once the upgrade is complete, the value should return to `true`.