### PR TITLE
fix: checking storage provider's ability before VM backup/snapshot creation

### DIFF
--- a/pkg/webhook/util/snapshot.go
+++ b/pkg/webhook/util/snapshot.go
@@ -3,14 +3,19 @@ package util
 import (
 	"fmt"
 
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhtypes "github.com/longhorn/longhorn-manager/types"
 	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	longhornutil "github.com/longhorn/longhorn-manager/util"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
+	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 )
@@ -110,5 +115,96 @@ func CheckTotalSnapshotSizeOnNamespace(
 		totalSnapshotUsageQuantity := resource.NewQuantity(totalSnapshotUsage, resource.BinarySI)
 		return werror.NewInvalidError(fmt.Sprintf("total snapshot size limit %s is less than total snapshot usage %s", totalSnapshotSizeQuotaQuantity, totalSnapshotUsageQuantity), "spec.source.name")
 	}
+	return nil
+}
+
+type snapshotBackupAbility struct {
+	snapshot bool
+	backup   bool
+}
+
+func (s snapshotBackupAbility) IsSupported(backupType v1beta1.BackupType) bool {
+	switch backupType {
+	case v1beta1.Backup:
+		return s.backup
+	case v1beta1.Snapshot:
+		return s.snapshot
+	default:
+		return false
+	}
+}
+
+// We currently only defines the snapshot/backup ability for LH v1 and v2,
+// third-party storage get default ability
+// TODO: if we can generate the matrix by leveraging CDI StorageProfile?
+func genAbilityMatrix() map[string]snapshotBackupAbility {
+	return map[string]snapshotBackupAbility{
+		string(lhv1beta2.DataEngineTypeV1) + "." + lhtypes.LonghornDriverName: {true, true},
+		string(lhv1beta2.DataEngineTypeV2) + "." + lhtypes.LonghornDriverName: {false, false},
+	}
+}
+
+func defaultAbility() snapshotBackupAbility {
+	return snapshotBackupAbility{snapshot: true, backup: false}
+}
+
+func getAbilityForProvisioner(provisioner string) snapshotBackupAbility {
+	abilityMatrix := genAbilityMatrix()
+	if ability, exists := abilityMatrix[provisioner]; exists {
+		return ability
+	}
+	return defaultAbility()
+}
+
+func provisionerWrapper(pvc *corev1.PersistentVolumeClaim, engineCache ctllonghornv1.EngineCache) (string, error) {
+	provisioner := util.GetProvisionedPVCProvisioner(pvc)
+	if provisioner != lhtypes.LonghornDriverName {
+		return provisioner, nil
+	}
+
+	engine, err := GetLHEngine(engineCache, pvc.Spec.VolumeName)
+	if err != nil {
+		return "", err
+	}
+
+	return string(engine.Spec.DataEngine) + "." + provisioner, nil
+}
+
+func ValidateProvisionerAndConfig(pvc *corev1.PersistentVolumeClaim,
+	engineCache ctllonghornv1.EngineCache, bt v1beta1.BackupType,
+	cdc map[string]settings.CSIDriverInfo) error {
+
+	// Get wrapper provisioner for checking snapshot/backup ability
+	provisioner, err := provisionerWrapper(pvc, engineCache)
+	if err != nil {
+		return err
+	}
+
+	ability := getAbilityForProvisioner(provisioner)
+	if !ability.IsSupported(bt) {
+		return fmt.Errorf("provisioner %s is not supported for type %s", provisioner, bt)
+	}
+
+	// Get origin provisioner and the CSI configuration
+	provisioner = util.GetProvisionedPVCProvisioner(pvc)
+	c, ok := cdc[provisioner]
+	if !ok {
+		return fmt.Errorf("provisioner %s is not configured in the %s setting", provisioner, settings.CSIDriverConfigSettingName)
+	}
+
+	// Determine which configuration value is required based on the backup type.
+	var requiredValue string
+	switch bt {
+	case v1beta1.Backup:
+		requiredValue = c.BackupVolumeSnapshotClassName
+	case v1beta1.Snapshot:
+		requiredValue = c.VolumeSnapshotClassName
+	}
+
+	if requiredValue == "" {
+		return fmt.Errorf("%s's VolumeSnapshotClassName is not configured for provisioner %s in the %s setting",
+			bt, provisioner, settings.CSIDriverConfigSettingName)
+	}
+
 	return nil
 }


### PR DESCRIPTION
**Problem:**

VM Backup/Snapshot should have the following rules for different storage providers:
- VM with LH v1 volume:
   - Allowing VM snapshot and VM backup
- VM with LH v2 volume
  - Rejecting VM snapshot and VM backup
- VM with third-party storage
  - Allowing VM snapshots and rejecting VM backup

**Solution:**
Improve webhook with the above rules

**Related Issue:**
#7316 

**Test plan:**

**Prerequisite:**
- Building Harvester with master branch `a34d197e5067fc67dd51b5deb8d0c8778de34c6d`
- Updating `harvester-webhook` deployment with this PR

**Case LH v1 volume**:
- Creating a VM with LH v1 volume
- The VM should be able to have backups and snapshots

**Case LH v2 volume**:
- Creating a VM with LH v2 volume
- The VM Backup and snapshot will be rejected

**Case LVM volume**:
- Creating a VM with LH v1 volume
- The VM should be able to have snapshots, but the VM backups will be rejected
