### PR TITLE
Add processing of read-message to upgrade controller

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -131,6 +131,12 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 	repo := NewUpgradeRepo(h.ctx, upgrade, h)
 
 	if harvesterv1.UpgradeCompleted.GetStatus(upgrade) == "" {
+		// this label is set by UI when user clicks `dismiss`, the upgrade object is kept but status is reset
+		if upgrade.Labels[util.LabelUpgradeReadMessage] == "true" {
+			logrus.Infof("upgrade %v/%v has %v label, no further processing", upgrade.Namespace, upgrade.Name, util.LabelUpgradeReadMessage)
+			return upgrade, nil
+		}
+
 		logrus.Infof("Initialize upgrade %s/%s", upgrade.Namespace, upgrade.Name)
 
 		if err := h.resetLatestUpgradeLabel(upgrade.Name); err != nil {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
https://github.com/harvester/harvester/issues/7791

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Do not continue upgrade status machine when read-message label is there.

**Related Issue:**
https://github.com/harvester/harvester/issues/7791

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Upgrade v150-v150, enable upgradeLog
2. After upgrade is done, click `dismiss` on UI
3. Check Harvester POD, the log should be like below; not like the ones on issue https://github.com/harvester/harvester/issues/7791

```
...
time="2025-03-10T10:26:38Z" level=info msg="upgrade harvester-system/hvst-upgrade-7xn6v has harvesterhci.io/read-messagelabel, no further processing"
time="2025-03-10T10:26:38Z" level=info msg="upgrade harvester-system/hvst-upgrade-7xn6v has harvesterhci.io/read-message label, no further processing"
....
apiVersion: v1
items:
- apiVersion: harvesterhci.io/v1beta1
  kind: Upgrade
  metadata:
    annotations:
      harvesterhci.io/image-cleanup-plan-completed: "true"
    creationTimestamp: "2025-03-10T10:19:53Z"
    finalizers:
    - wrangler.cattle.io/harvester-upgrade-controller
    generateName: hvst-upgrade-
    generation: 17
    labels:
      harvesterhci.io/latestUpgrade: "true"
      harvesterhci.io/read-message: "true"
      harvesterhci.io/upgradeState: Succeeded
    name: hvst-upgrade-7xn6v
    namespace: harvester-system
    resourceVersion: "28811"
    uid: 50644a47-8e88-43ea-8e0f-90a335663b95
  spec:
    image: ""
    logEnabled: true
    version: v150-fixupglog-upgrade
  status: {}
kind: List
metadata:
  resourceVersion: ""
```