### PR TITLE
fix: improve VM Backup/Restore backward and forward compatibility during source VM has third-party storage

### DIFF
--- a/pkg/controller/master/backup/backup_metadata.go
+++ b/pkg/controller/master/backup/backup_metadata.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/longhorn/backupstore"
-
 	// Although we don't use following drivers directly, we need to import them to register drivers.
 	// NFS Ref: https://github.com/longhorn/backupstore/blob/3912081eb7c5708f0027ebbb0da4934537eb9d72/nfs/nfs.go#L47-L51
 	// S3 Ref: https://github.com/longhorn/backupstore/blob/3912081eb7c5708f0027ebbb0da4934537eb9d72/s3/s3.go#L33-L37
@@ -487,7 +486,12 @@ func (h *MetadataHandler) checkDependentStorageClassExist(backupMetadata *Virtua
 func (h *MetadataHandler) checkDependentLonghornBackupExist(target *settings.BackupTarget, backupMetadata *VirtualMachineBackupMetadata) bool {
 	for _, vb := range backupMetadata.VolumeBackups {
 		if vb.LonghornBackupName == nil {
-			continue
+			logrus.WithFields(logrus.Fields{
+				"namespace":    backupMetadata.Namespace,
+				"name":         backupMetadata.Name,
+				"volumeBackup": vb.Name,
+			}).Warn("skip creating vm backup, because the volume is not from LH")
+			return false
 		}
 
 		volumeName := vb.PersistentVolumeClaim.Spec.VolumeName

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -270,6 +270,11 @@ func (v *restoreValidator) checkVMBackupType(vmRestore *v1beta1.VirtualMachineRe
 	switch vmBackup.Spec.Type {
 	case v1beta1.Backup:
 		err = v.checkBackup(vmRestore, vmBackup)
+		if err == nil {
+			// Because of the misleading items https://github.com/harvester/harvester/issues/7755#issue-2896409886,
+			// User may have VMBackups with non-LH source volume. We should prevent this VMBackup from restoring
+			err = webhookutil.IsLHBackupRelated(vmBackup)
+		}
 	case v1beta1.Snapshot:
 		err = v.checkSnapshot(vmRestore, vmBackup)
 	}

--- a/pkg/webhook/util/snapshot.go
+++ b/pkg/webhook/util/snapshot.go
@@ -208,3 +208,17 @@ func ValidateProvisionerAndConfig(pvc *corev1.PersistentVolumeClaim,
 
 	return nil
 }
+
+// While we try to recover a VMBackup remote, if the volumeBackup has no LonghornBackupName,
+// it can be the volume backup is not completed or the volume backup is from third-party storage
+// from the misleading items https://github.com/harvester/harvester/issues/7755#issue-2896409886.
+// We should reject to recover such VMBackups
+func IsLHBackupRelated(vmb *v1beta1.VirtualMachineBackup) error {
+	for _, vb := range vmb.Status.VolumeBackups {
+		if vb.LonghornBackupName == nil || *vb.LonghornBackupName == "" {
+			return fmt.Errorf("vmbackup %s/%s vb %s not from LH, it can't be recovered",
+				vmb.Namespace, vmb.Name, *vb.Name)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**Problem:**
Improve VM Backup/Restore backward and forward compatibility during source VM has third-party storage

**Solution:**
- Not restoring a VMBackup, if there is a non-LH source volume
- Not discovering an existing VMBackup on remote, if there is a non-LH source volume

**Related Issue:**
#7755 

**Test plan:**

**Prerequisite:**
- Building Harvester with master branch `51fa44d402bd57f2dadf231ab621dd9068424c04`
- Updating `harvester-webhook` deployment with this PR
- Updating `harvester` deployment with this PR

**Case Restore the VMBackup has third-party storage:**
- Creating a VM `vm-1` which uses third-party volume
- Creating a VMBackup `vm-b1` for `vm1`
- Restoring `vm-b1`, it will be rejected by webook
  -  With the message `vmbackup <vmbackup namespace>/<vmbackup name> vb <volumeBackup name> not from LH, it can't be recovered`

**Case Discovering existing VMBackup on remote, and the source VM has third-party storage:**
- Creating a VM `vm-1` which uses third-party volume
- Creating a VMBackup `vm-b1` for `vm1`
- Disconnecting backup target
- Removing `vm1` and `vm-b1`
- Reconnecting backup target
- `vm1-b` should not be recovered
  - Harvester deployment has log `skip creating vm backup, because the volume is not from LH`
