### PR TITLE
chore: update upgrade-matrix for latest releases

### DIFF
--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,4 +1,8 @@
 versions:
+- name: v1.4.2
+  minUpgradableVersion: v1.4.1
+- name: v1.4.1
+  minUpgradableVersion: v1.4.0
 - name: v1.4.0
   minUpgradableVersion: v1.3.2
 - name: v1.3.2


### PR DESCRIPTION
The image cleanup procedure in Harvester Upgrade indirectly relies on this matrix, so we need to keep it as new as possible. Otherwise, the image cleanup won't happen for people upgrading from v1.4.1/v1.4.2 to master-head.