### PR TITLE
Refine clone vm failed error message

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1153,7 +1153,7 @@ func (h *vmActionHandler) cloneVM(name string, namespace string, input CloneInpu
 
 	newVM.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = string(newPVCsString)
 	if newVM, err = h.vms.Create(newVM); err != nil {
-		return fmt.Errorf("cannot create newVM %+v, err: %w", newVM, err)
+		return fmt.Errorf("cannot create new VM %s/%s, err: %w", newVM.Namespace, newVM.Name, err)
 	}
 
 	for oldSecretName, newSecretName := range secretNameMap {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The error message for clone vm failure is too long since it contains the whole VM CR.

**Solution:**
Replace the VM CR content with vm namespace and name.

**Related Issue:**
https://github.com/harvester/harvester/issues/7827

**Test plan:**
- Prepare a harvester cluster that contains this patch, also include the ui change https://github.com/harvester/harvester-ui-extension/pull/203
- Create one VM
- Clone the VM named `vm_clone`, the error message pop up like the below screenshot. 
![image](https://github.com/user-attachments/assets/0cd6c119-0ce9-4e18-a1b9-d5db53734030)