### PR TITLE
Remove upgradelog test code from controller

### DIFF
--- a/pkg/controller/master/upgradelog/common.go
+++ b/pkg/controller/master/upgradelog/common.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
@@ -986,4 +987,8 @@ func SetUpgradeLogArchive(upgradeLog *harvesterv1.UpgradeLog, archiveName string
 		Size:          archiveSize,
 		GeneratedTime: generatedTime,
 	}
+}
+
+type ImageGetterInterface interface {
+	GetConsolidatedLoggingImageListFromHelmValues(*kubernetes.Clientset, string, string) (map[string]settings.Image, error)
 }

--- a/pkg/controller/master/upgradelog/controller_test.go
+++ b/pkg/controller/master/upgradelog/controller_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -1053,6 +1054,7 @@ func TestHandler_OnUpgradeLogChange(t *testing.T) {
 			upgradeClient:       fakeclients.UpgradeClient(clientset.HarvesterhciV1beta1().Upgrades),
 			upgradeCache:        fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
 			upgradeLogClient:    fakeclients.UpgradeLogClient(clientset.HarvesterhciV1beta1().UpgradeLogs),
+			imageGetter:         newTestImageGetter(),
 		}
 
 		var actual output
@@ -1159,4 +1161,14 @@ func emptyConditionsTime(conditions []harvesterv1.Condition) {
 		conditions[k].LastTransitionTime = ""
 		conditions[k].LastUpdateTime = ""
 	}
+}
+
+type testImageGetter struct{}
+
+func (i *testImageGetter) GetConsolidatedLoggingImageListFromHelmValues(_ *kubernetes.Clientset, _, _ string) (map[string]settings.Image, error) {
+	return testImages, nil
+}
+
+func newTestImageGetter() *testImageGetter {
+	return &testImageGetter{}
 }

--- a/pkg/controller/master/upgradelog/register.go
+++ b/pkg/controller/master/upgradelog/register.go
@@ -62,6 +62,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		upgradeLogClient:    upgradeLogController,
 		upgradeLogCache:     upgradeLogController.Cache(),
 		clientset:           management.ClientSet,
+		imageGetter:         NewImageGetter(),
 	}
 
 	upgradeLogController.OnChange(ctx, upgradeLogControllerName, handler.OnUpgradeLogChange)


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

A block of test code was added to controller for the convenience of test code.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

It is not easy to simulate a helm chart and release, instead, the imageGetter return the wanted images directly.

Use ImageGetterInterface to abstract and consolidate

**Related Issue:**
https://github.com/harvester/harvester/issues/7860

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. go test on upgrade controller runs successfully
2. upgrade test on real cluster, is done together with PR https://github.com/harvester/harvester/pull/7660#issuecomment-2729515719


Thanks the suggestion from @m-ildefons 