### PR TITLE
Retry on more DNS errors when upgrade controller gets image list

### DIFF
--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -54,7 +54,8 @@ func IsRetriableNetworkError(err error) bool {
 		return true
 	} else if errors.Is(err, syscall.EHOSTUNREACH) {
 		return true
-	} else if errors.As(err, &dnsError) && dnsError.IsTemporary {
+	} else if errors.As(err, &dnsError) && (dnsError.IsTemporary || dnsError.IsTimeout || dnsError.IsNotFound) {
+		// for in-cluster service based dns name lookup, retry on the above known errors
 		return true
 	}
 	return false


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The DNS lookup error `no such host` may cause old images are not cleaned by upgrade controller.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Retry on those DNS related errors.

**Related Issue:**

https://github.com/harvester/harvester/issues/7891

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. v1.4.1/v1.4.2 -> v1.5.0 upgrade
2. After upgrade, the old container images should be cleaned up not to due to `no such host` error.


** Local test **

The `Trying to get ...` runs until it gets image list

```
time="2025-03-19T09:55:10Z" level=info msg="Try to start repo VM for image pruning"
time="2025-03-19T09:55:10Z" level=info msg="Skip restore VM" name=hvst-upgrade-b5789 namespace=harvester-system
time="2025-03-19T09:55:10Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:55:14Z" level=error msg="Failed to read API for groups map[custom.metrics.k8s.io/v1beta1:stale GroupVersion discovery: custom.metrics.k8s.io/v1beta1 metrics.k8s.io/v1beta1:stale GroupVersion discovery: metrics.k8s.io/v1beta1 subresources.kubevirt.io/v1:stale GroupVersion discovery: subresources.kubevirt.io/v1 subresources.kubevirt.io/v1alpha3:stale GroupVersion discovery: subresources.kubevirt.io/v1alpha3 upload.cdi.kubevirt.io/v1beta1:stale GroupVersion discovery: upload.cdi.kubevirt.io/v1beta1]"
W0319 09:55:15.231519       7 warnings.go:70] kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2.
W0319 09:55:15.239411       7 warnings.go:70] v1 ComponentStatus is deprecated in v1.19+
W0319 09:55:26.638765       7 warnings.go:70] kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2.
W0319 09:55:26.648053       7 warnings.go:70] v1 ComponentStatus is deprecated in v1.19+
time="2025-03-19T09:55:30Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:55:41Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:55:51Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:56:02Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:56:12Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:56:22Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:56:33Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:56:43Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:56:53Z" level=info msg="Trying to get v1.4.2 image list"
time="2025-03-19T09:56:53Z" level=info msg="Trying to get current image list"
time="2025-03-19T09:56:53Z" level=info msg="Diff: [docker.io/rancher/harvester-cluster-repo:v1.4.2 docker.io/longhornio/backing-image-manager:v1.7.2 docker.io/longhornio/csi-provisioner:v4.0.1-20241007 docker.io/rancher/harvester-networkfs-manager:v0.1.2 docker.io/rancher/harvester-node-manager-webhook:v0.3.3 docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 registry.suse.com/suse/sles/15.6/virt-api:1.3.1-150600.5.9.1 docker.io/longhornio/livenessprobe:v2.14.0 docker.io/rancher/harvester-node-disk-
...
```