### PR TITLE
feat: check existing vmbackup

### DIFF
--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -612,6 +612,18 @@ func (h *Handler) reconcileVolumeSnapshots(vmBackup *harvesterv1.VirtualMachineB
 			}
 		}
 
+		if volumeBackup.LonghornBackupName != nil {
+			if err := checkLHBackup(h.lhbackupCache, *volumeBackup.LonghornBackupName); err != nil {
+				logrus.WithError(err).WithFields(logrus.Fields{
+					"name":           vmBackupCpy.Name,
+					"namespace":      vmBackupCpy.Namespace,
+					"volumeBackup":   *volumeBackup.Name,
+					"longhornBackup": *volumeBackup.LonghornBackupName,
+				}).Warn("Longhorn backup is not ready")
+			}
+			return nil
+		}
+
 		if volumeSnapshot.Status != nil {
 			vmBackupCpy.Status.VolumeBackups[i].ReadyToUse = volumeSnapshot.Status.ReadyToUse
 			vmBackupCpy.Status.VolumeBackups[i].CreationTime = volumeSnapshot.Status.CreationTime


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
If data in backup-target is removed, the vmbackup cannot work as expected. Currently, users cannot know whether a VMBackup is healthy. They need to restore it and find whether it's broken.

**Solution:**
Check the existing VMBackup regularly. If data is missing, set it as non-ready.

**Related Issue:**
https://github.com/harvester/harvester/issues/7692

**Test plan:**
1. Create a cluster and setup backup target with non-zero `refreshIntervalInSeconds`.
2. Create a VMBackup.
3. Get into backup target and move LH data to other places. For example:
```
> cd /opt/backupstore/
> mv backupstore/volumes/97/e3/pvc-b1f62a1d-f364-4e5a-9406-7db6106e59ee/ ../../../../
```
4. Wait for refresh interval, we can see the VMBackup is marked as non-ready and `readyToUse` of related volume backup is false. 
5. Get into backup target and move the data back.
6. Wait for refresh interval, we can see the VMBackup is marked as ready again.
