### PR TITLE
Skip witness node when pre-drain waits for longhorn

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -450,7 +450,7 @@ wait_longhorn_manager() {
   lm_repo=$(helm get values harvester -n harvester-system -a -o json | jq -r .longhorn.image.longhorn.manager.repository)
   lm_tag=$(helm get values harvester -n harvester-system -a -o json | jq -r .longhorn.image.longhorn.manager.tag)
   lm_image="${lm_repo}:${lm_tag}"
-  node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true,node-role.harvesterhci.io/witness!=true -o json | jq -r '.items | length')
+  local node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true,node-role.harvesterhci.io/witness!=true -o json | jq -r '.items | length')
 
   while [ true ]; do
     lm_ds_ready=0
@@ -469,7 +469,7 @@ wait_longhorn_manager() {
 }
 
 wait_longhorn_instance_manager_aio() {
-  node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true,node-role.harvesterhci.io/witness!=true -o json | jq -r '.items | length')
+  local node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true,node-role.harvesterhci.io/witness!=true -o json | jq -r '.items | length')
   if [ $node_count -lt 2 ]; then
     echo "Skip waiting instance-manager (aio), node count: $node_count"
     return

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -239,7 +239,7 @@ recover_rancher_system_agent() {
 }
 
 wait_longhorn_engines() {
-  node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true -o json | jq -r '.items | length')
+  local node_count=$(kubectl get nodes --selector=harvesterhci.io/managed=true,node-role.harvesterhci.io/witness!=true -o json | jq -r '.items | length')
 
   # For each running engine and its volume
   kubectl get engines.longhorn.io -n longhorn-system -o json |


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

3-node with 1 witness cluster, upgrade stucks on waiting for repo VM's volume to be healty, when SC replica is 3

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Exclude witness node in pre-drain, as what has been done on apply_manifest.

**Related Issue:**
https://github.com/harvester/harvester/issues/7923

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Per issue descrition https://github.com/harvester/harvester/issues/7923