### PR TITLE
api: add new checking mechanism for snapshot

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -169,6 +169,9 @@ func (h *vmActionHandler) doAction(rw http.ResponseWriter, r *http.Request) erro
 			return err
 		}
 		return nil
+	case snapshotVM:
+		// TODO: currently the snapshot CRD creation is handled by UI, we do nothing here.
+		return nil
 	case restoreVM:
 		var input RestoreInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -100,6 +100,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	vmformatter := vmformatter{
 		pvcCache:      pvcs.Cache(),
 		vmiCache:      vmis.Cache(),
+		scCache:       storageClasses.Cache(),
 		vmBackupCache: backups.Cache(),
 		clientSet:     *scaled.Management.ClientSet,
 	}
@@ -127,6 +128,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				abortMigration:                   &actionHandler,
 				findMigratableNodes:              &actionHandler,
 				backupVM:                         &actionHandler,
+				snapshotVM:                       &actionHandler,
 				restoreVM:                        &actionHandler,
 				createTemplate:                   &actionHandler,
 				addVolume:                        &actionHandler,
@@ -144,6 +146,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				softReboot: {},
 				pauseVM:    {},
 				unpauseVM:  {},
+				snapshotVM: {},
 				migrate: {
 					Input: "migrateInput",
 				},

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -413,7 +413,7 @@ func (h *ActionHandler) snapshot(_ context.Context, pvcNamespace, pvcName, snaps
 		return err
 	}
 
-	provisioner := util.GetProvisionedPVCProvisioner(pvc)
+	provisioner := util.GetProvisionedPVCProvisioner(pvc, h.scCache)
 	csiDriverInfo, err := settings.GetCSIDriverInfo(provisioner)
 	if err != nil {
 		return err

--- a/pkg/api/volume/schema.go
+++ b/pkg/api/volume/schema.go
@@ -40,6 +40,10 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 
 	handler := harvesterServer.NewHandler(actionHandler)
 
+	formatter := &volFormatter{
+		scCache: scaled.StorageFactory.Storage().V1().StorageClass().Cache(),
+	}
+
 	t := schema.Template{
 		ID: pvcSchemaID,
 		Customize: func(s *types.APISchema) {
@@ -62,7 +66,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 				actionSnapshot:     handler,
 			}
 		},
-		Formatter: Formatter,
+		Formatter: formatter.Formatter,
 	}
 	server.SchemaFactory.AddTemplate(t)
 	return nil

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -664,7 +664,7 @@ func (h *Handler) createVolumeSnapshot(vmBackup *harvesterv1.VirtualMachineBacku
 		}
 		sourceStorageClassName = *pvc.Spec.StorageClassName
 		sourceImageID = pvc.Annotations[util.AnnotationImageID]
-		sourceProvisioner = util.GetProvisionedPVCProvisioner(pvc)
+		sourceProvisioner = util.GetProvisionedPVCProvisioner(pvc, h.storageClassCache)
 		volumeSnapshotSource.PersistentVolumeClaimName = &volumeBackup.PersistentVolumeClaim.ObjectMeta.Name
 	}
 

--- a/pkg/webhook/resources/volumesnapshot/validator.go
+++ b/pkg/webhook/resources/volumesnapshot/validator.go
@@ -5,6 +5,7 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,12 +29,14 @@ const (
 func NewValidator(
 	pvcCache ctlcorev1.PersistentVolumeClaimCache,
 	engineCache ctllonghornv1.EngineCache,
+	scCache ctlstoragev1.StorageClassCache,
 	resourceQuotaCache ctlharvesterv1.ResourceQuotaCache,
 	vmCache ctlkubevirtv1.VirtualMachineCache,
 ) types.Validator {
 	return &volumeSnapshotValidator{
 		pvcCache:           pvcCache,
 		engineCache:        engineCache,
+		scCache:            scCache,
 		resourceQuotaCache: resourceQuotaCache,
 		vmCache:            vmCache,
 	}
@@ -44,6 +47,7 @@ type volumeSnapshotValidator struct {
 
 	pvcCache           ctlcorev1.PersistentVolumeClaimCache
 	engineCache        ctllonghornv1.EngineCache
+	scCache            ctlstoragev1.StorageClassCache
 	resourceQuotaCache ctlharvesterv1.ResourceQuotaCache
 	vmCache            ctlkubevirtv1.VirtualMachineCache
 }
@@ -90,12 +94,12 @@ func (v *volumeSnapshotValidator) Create(_ *types.Request, newObj runtime.Object
 		}
 	} else if len(vms) > 0 {
 		vm := vms[0]
-		if err = webhookutil.CheckTotalSnapshotSizeOnVM(v.pvcCache, v.engineCache, vm, resourceQuota.Spec.SnapshotLimit.VMTotalSnapshotSizeQuota[vm.Name]); err != nil {
+		if err = webhookutil.CheckTotalSnapshotSizeOnVM(v.pvcCache, v.engineCache, v.scCache, vm, resourceQuota.Spec.SnapshotLimit.VMTotalSnapshotSizeQuota[vm.Name]); err != nil {
 			return err
 		}
 	}
 
-	if err = webhookutil.CheckTotalSnapshotSizeOnNamespace(v.pvcCache, v.engineCache, newVolumeSnapshot.Namespace, resourceQuota.Spec.SnapshotLimit.NamespaceTotalSnapshotSizeQuota); err != nil {
+	if err = webhookutil.CheckTotalSnapshotSizeOnNamespace(v.pvcCache, v.engineCache, v.scCache, newVolumeSnapshot.Namespace, resourceQuota.Spec.SnapshotLimit.NamespaceTotalSnapshotSizeQuota); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -98,6 +98,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 			clients.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
+			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().ResourceQuota().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache(),
 		),
@@ -155,6 +156,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		volumesnapshot.NewValidator(
 			clients.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
+			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().ResourceQuota().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 		),


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The VM snapshot cannot be executed because we disable the backup with 3rd-party storage solution.
We need to redefine the flow of VM snapshots.

**Solution:**
We reuse the backup checking mechanism for the snapshot capability. After v1.5.0, we should split it out to ensure the snapshot can be executed once the corresponding CSI driver has the snapshot capability.

**Related Issue:**
https://github.com/harvester/harvester/issues/7944

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
