### PR TITLE
fix upgrade matrix and build

### DIFF
--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,29 +1,33 @@
 versions:
-- name: v1.4.0
-  minUpgradableVersion: v1.3.2
-- name: v1.3.2
-  minUpgradableVersion: v1.3.1
-- name: v1.3.1
-  minUpgradableVersion: v1.2.2
-- name: v1.3.0
-  minUpgradableVersion: v1.2.2
-- name: v1.2.2
-  minUpgradableVersion: v1.2.1
-- name: v1.2.1
-  minUpgradableVersion: v1.1.2
-- name: v1.2.0
-  minUpgradableVersion: v1.1.2
-- name: v1.1.3
-  minUpgradableVersion: v1.1.1
-- name: v1.1.2
-  minUpgradableVersion: v1.1.0
-- name: v1.1.1
-  minUpgradableVersion: v1.0.3
-- name: v1.1.0
-  minUpgradableVersion: v1.0.3
-- name: v1.0.3
-  minUpgradableVersion: v1.0.2
-- name: v1.0.2
-  minUpgradableVersion: v1.0.1
-- name: v1.0.1
-  minUpgradableVersion: v1.0.0
+  - name: v1.4.2
+    minUpgradableVersion: v1.4.1
+  - name: v1.4.1
+    minUpgradableVersion: v1.4.0
+  - name: v1.4.0
+    minUpgradableVersion: v1.3.2
+  - name: v1.3.2
+    minUpgradableVersion: v1.3.1
+  - name: v1.3.1
+    minUpgradableVersion: v1.2.2
+  - name: v1.3.0
+    minUpgradableVersion: v1.2.2
+  - name: v1.2.2
+    minUpgradableVersion: v1.2.1
+  - name: v1.2.1
+    minUpgradableVersion: v1.1.2
+  - name: v1.2.0
+    minUpgradableVersion: v1.1.2
+  - name: v1.1.3
+    minUpgradableVersion: v1.1.1
+  - name: v1.1.2
+    minUpgradableVersion: v1.1.0
+  - name: v1.1.1
+    minUpgradableVersion: v1.0.3
+  - name: v1.1.0
+    minUpgradableVersion: v1.0.3
+  - name: v1.0.3
+    minUpgradableVersion: v1.0.2
+  - name: v1.0.2
+    minUpgradableVersion: v1.0.1
+  - name: v1.0.1
+    minUpgradableVersion: v1.0.0


### PR DESCRIPTION
Add entries for v1.4.x releases to the upgrade matrix file. These entries are needed during the build process, without them `make build` will fail since scripts/versions can't determine the minimum version to upgrade from.

**Problem:**

Entries for v1.4.2 and v1.4.1 missing

**Solution:**

Add entries for v1.4.2 and v1.4.1

**Related Issue:**

N/A

**Test plan:**

`make build` should work on `v1.4` branch