### PR TITLE
Support volume online expand

### DIFF
--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -185,6 +185,15 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - harvesterhci.io
+  resources:
+  - settings
+  verbs:
+  - get
+  - list
+  resourceNames:
+  - csi-online-expand-validation
+- apiGroups:
   - longhorn.io
   resources:
   - volumes

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -68,7 +68,7 @@ kubevirt:
       ## Specify kubevirt feature gates
       vmStateStorageClass: "vmstate-persistence"
       developerConfiguration:
-        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager", "VMPersistentState", "VMLiveUpdateFeatures"]
+        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager", "VMPersistentState", "VMLiveUpdateFeatures", "ExpandDisks"]
 
       vmRolloutStrategy: "LiveUpdate"
 

--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -5,11 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
-
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/rancher/steve/pkg/server"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -46,6 +46,7 @@ var (
 	VipPools                               = NewSetting(VipPoolsConfigSettingName, "")
 	AutoDiskProvisionPaths                 = NewSetting(AutoDiskProvisionPathsSettingName, "")
 	CSIDriverConfig                        = NewSetting(CSIDriverConfigSettingName, `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}`)
+	CSIOnlineExpandValidation              = NewSetting(CSIOnlineExpandValidationSettingName, `{"driver.longhorn.io":true}`)
 	ContainerdRegistry                     = NewSetting(ContainerdRegistrySettingName, "")
 	StorageNetwork                         = NewSetting(StorageNetworkName, "")
 	DefaultVMTerminationGracePeriodSeconds = NewSetting(DefaultVMTerminationGracePeriodSecondsSettingName, "120")
@@ -75,6 +76,7 @@ const (
 	DefaultDashboardUIURL                             = "https://releases.rancher.com/harvester-ui/dashboard/latest/index.html"
 	SupportBundleImageName                            = "support-bundle-image"
 	CSIDriverConfigSettingName                        = "csi-driver-config"
+	CSIOnlineExpandValidationSettingName              = "csi-online-expand-validation"
 	UIIndexSettingName                                = "ui-index"
 	UIPathSettingName                                 = "ui-path"
 	UISourceSettingName                               = "ui-source"

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -55,6 +55,7 @@ func RegisterIndexers(clients *clients.Clients) {
 
 	vmInformer := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmInformer.AddIndexer(indexeresutil.VMByPVCIndex, indexeresutil.VMByPVC)
+	vmInformer.AddIndexer(indexeresutil.VMByHotplugPVCIndex, indexeresutil.VMByHotplugPVC)
 
 	svmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache()
 	svmBackupCache.AddIndexer(ScheduleVMBackupBySourceVM, scheduleVMBackupBySourceVM)

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -54,7 +54,11 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		persistentvolumeclaim.NewValidator(
 			clients.Core.PersistentVolumeClaim().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
-			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache()),
+			clients.KubevirtFactory.Kubevirt().V1().KubeVirt().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
+			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
+			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		keypair.NewValidator(clients.HarvesterFactory.Harvesterhci().V1beta1().KeyPair().Cache()),
 		virtualmachine.NewValidator(
 			clients.Core.Namespace().Cache(),

--- a/pkg/webhook/util/volume.go
+++ b/pkg/webhook/util/volume.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"fmt"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhtypes "github.com/longhorn/longhorn-manager/types"
+	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func CheckOnlineExpand(
+	pvc *corev1.PersistentVolumeClaim,
+	engineCache ctllonghornv1.EngineCache,
+	scCache ctlstoragev1.StorageClassCache,
+	settingCache ctlharvesterv1.SettingCache,
+) (bool, error) {
+	provisioner, err := getPVCProvisioner(pvc, scCache)
+	if err != nil {
+		return false, fmt.Errorf("error determining provisioner for PVC %s/%s: %w", pvc.Namespace, pvc.Name, err)
+	}
+
+	expandable, err := util.GetCSIOnlineExpandValidation(provisioner, settingCache)
+	if err != nil {
+		return false, err
+	}
+
+	if provisioner != lhtypes.LonghornDriverName || !expandable {
+		return expandable, nil
+	}
+
+	return checkLonghornExpandability(pvc, engineCache)
+}
+
+func getPVCProvisioner(pvc *corev1.PersistentVolumeClaim, scCache ctlstoragev1.StorageClassCache) (string, error) {
+	provisioner := util.GetProvisionedPVCProvisioner(pvc, scCache)
+	if provisioner == "" {
+		return "", fmt.Errorf("failed to determine provisioner for PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
+	return provisioner, nil
+}
+
+func checkLonghornExpandability(pvc *corev1.PersistentVolumeClaim, engineCache ctllonghornv1.EngineCache) (bool, error) {
+	if pvc.Spec.VolumeName == "" {
+		return false, fmt.Errorf("PVC %s/%s volume name is empty", pvc.Namespace, pvc.Name)
+	}
+
+	engine, err := GetLHEngine(engineCache, pvc.Spec.VolumeName)
+	if err != nil {
+		return false, fmt.Errorf("error getting Longhorn engine for volume %s: %w", pvc.Spec.VolumeName, err)
+	}
+
+	if engine.Spec.DataEngine == lhv1beta2.DataEngineTypeV2 {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
**Problem:**
Online Resize of Disks/Volumes Attached to Virtual Machines

**Solution:**
Leverage the KubeVirt `ExpandDisks` feature gate to expose volume expansion capabilities to the VM. Since we already support [third-party storage starting from v1.5.0](https://docs.harvesterhci.io/v1.6/advanced/csidriver), it’s also necessary to handle various storage providers with different PVC modes.

**Related Issue:**
#2811

**Test Plan:**

**Prerequisite:**
- Build a Harvester cluster using the ISO from this PR.

**Case 1: Longhorn v1 Block Mode PVC**
- Create a VM with a Longhorn v1 PVC as the root disk.
- Expand the root disk PVC size.
- Verify that the corresponding block device inside the VM reflects the increased size.

**Case 2: Longhorn v2 Block Mode PVC**
- Create a VM with a Longhorn v2 PVC as the root disk.
- Attempt to expand the root disk PVC size.
- Verify that the PVC expansion is denied by the Harvester webhook.

**Case 3: NFS CSI PVC with Filesystem Mode**
- [Deploy the NFS CSI driver on Harvester](https://docs.harvesterhci.io/v1.6/advanced/csidriver/#how-to-deploy-the-nfs-csi-driver).
- Create a VM with an NFS CSI PVC as the root disk.
- Attempt to expand the root disk PVC size.
- Verify that the PVC expansion is denied by the Harvester webhook.
- Enable the CSI-Driver-Validation setting for the NFS CSI driver.
  ```
  apiVersion: harvesterhci.io/v1beta1
  default: '{"driver.longhorn.io":true}'
  kind: Setting
  metadata:
    name: csi-online-expand-validation
  status: {}
  value: '{"nfs.csi.k8s.io":true}'
  ```
- Attempt to expand the root disk PVC size again.
- Verify that the corresponding block device inside the VM reflects the increased size.

**Case 4: TopoLVM PVC as a Hotplug Volume**
- [Deploy the TopoLVM CSI driver on Harvester](https://github.com/topolvm/topolvm).
- Create a VM with the root disk provisioned by any CSI provider.
- Create a PVC using the TopoLVM CSI driver.
- Hotplug the TopoLVM PVC into the running VM.
- Verify that the VM detects the hotplugged volume.
- Enable the CSI-Driver-Validation setting for the TopoLVM CSI driver.
  ```
  apiVersion: harvesterhci.io/v1beta1
  default: '{"driver.longhorn.io":true}'
  kind: Setting
  metadata:
    name: csi-online-expand-validation
  status: {}
  value: '{"nfs.csi.k8s.io":true, "topolvm.io":true}'
  ```
- Expand the size of the TopoLVM PVC.
- Verify that the corresponding block device inside the VM reflects the increased size.

**Additional Context:**
- This PR will [deny online expansion for a filesystem mode PVC that is hotplugged to a running VM](https://github.com/WebberHuang1118/harvester/blob/6af58d85842595fdb03f7268cd9d336006d996ef/pkg/webhook/resources/persistentvolumeclaim/validator.go#L187-L200). 
- This is a corner case where PVC resizing may get stuck waiting for NodeExpand(). For more details, please refer to [this document](https://github.com/WebberHuang1118/harvester-study/blob/master/volume-online-resize/README.md#filesystem-mode-pvc-corner-case).
