### PR TITLE
feat: add runStrategy to clone api

### DIFF
--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -40,7 +40,8 @@ type RemoveVolumeInput struct {
 }
 
 type CloneInput struct {
-	TargetVM string `json:"targetVm"`
+	TargetVM    string `json:"targetVm"`
+	RunStrategy string `json:"runStrategy"`
 }
 
 type FindMigratableNodesOutput struct {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Add `runStrategy` field to clone API request body.

**Related Issue:**
https://github.com/harvester/harvester/issues/7871

**Test plan:**
Case 1: The valid value of `runStrategy` is emtpy, `Always`, `Halted`, `Manual`, `RerunOnFailure`, and `Once`. Other value will get error.

Case 2: Clone a VM with empty run strategy. New VM will start with run strategy from original VM.

Case 3: Clone a VM with `Halted` run strategy. New VM will not start automatically.
