### PR TITLE
Use storage class name from annotation `harvesterhci.io/storageClassName`

### DIFF
--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -73,7 +73,11 @@ func GetImageStorageClassName(image *harvesterv1.VirtualMachineImage) string {
 	if image.Spec.Backend == harvesterv1.VMIBackendCDI {
 		return image.Spec.TargetStorageClassName
 	}
-	return fmt.Sprintf("longhorn-%s", image.Name)
+	prefix := "longhorn"
+	if annotationStorageClassName, ok := image.Annotations[AnnotationStorageClassName]; ok {
+		prefix = annotationStorageClassName
+	}
+	return fmt.Sprintf("%s-%s", prefix, image.Name)
 }
 
 func GetImageStorageClassParameters(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (map[string]string, error) {


### PR DESCRIPTION
... in helper function `GetImageStorageClassName` and use the previous value `longhorn` as fallback.

**Problem:**
The helper function GetImageStorageClassName is hardcoding the prefix of the returned StorageClass name with `longhorn` which might cause confusion if you are using using a custom StorageClass.

**Solution:**
Make use of the `harvesterhci.io/storageClassName` annotation if available. Alternatively fall back to `longhorn` or anything else that needs to be discussed.

**Related Issue:**
https://github.com/harvester/harvester/issues/8019

**Test plan:**
Check `Reproduce` in https://github.com/harvester/harvester/issues/8019.
