### PR TITLE
image/download: ensure the VM Image is imported before download

### DIFF
--- a/pkg/image/backingimage/download.go
+++ b/pkg/image/backingimage/download.go
@@ -27,6 +27,9 @@ func GetDownloader(biCache ctllhv1.BackingImageCache, httpClient http.Client, vm
 }
 
 func (bid *Downloader) DoDownload(vmi *harvesterv1.VirtualMachineImage, rw http.ResponseWriter, req *http.Request) error {
+	if !bid.vmio.IsImported(vmi) {
+		return fmt.Errorf("please wait until the image has been imported")
+	}
 	if bid.vmio.IsEncryptOperation(vmi) {
 		return fmt.Errorf("encrypted image is not supported for download")
 	}

--- a/pkg/image/cdi/download.go
+++ b/pkg/image/cdi/download.go
@@ -33,6 +33,10 @@ func GetDownloader(vmImageDownloaderClient v1beta1.VirtualMachineImageDownloader
 }
 
 func (cd *Downloader) DoDownload(vmImg *harvesterv1.VirtualMachineImage, rw http.ResponseWriter, req *http.Request) error {
+	if !cd.vmio.IsImported(vmImg) {
+		return fmt.Errorf("please wait until the image has been imported")
+	}
+
 	vmImgName := cd.vmio.GetName(vmImg)
 	vmImgNamespace := cd.vmio.GetNamespace(vmImg)
 	imageDownloader, err := cd.vmImageDownloaderClient.Get(vmImgNamespace, vmImgName, metav1.GetOptions{})


### PR DESCRIPTION
#### Problem:
The download will get the incomplete image since the image is not ready

#### Solution:
check the image status should be imported before download

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8027

#### Test plan:
Please refer to the reproduce steps on above issue

#### Additional documentation or context
