### PR TITLE
chore: add actions:write to stale action for cache

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 * * * *'
+    - cron: '30 */4 * * *'
   workflow_dispatch:
     inputs:
       ascending:
@@ -13,6 +13,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   stale:


### PR DESCRIPTION
#7983 

After upgrading to `actions/stale@v9`, I found there is a cache bug, we need to provide `actions: write` to this GA. Since it introduces cache, I decrease frequency.