### PR TITLE
fix: use strictAtoi to check string leading with zero

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 
 	// Although we don't use following drivers directly, we need to import them to register drivers.
@@ -1465,7 +1464,7 @@ func validateDefaultVMTerminationGracePeriodSecondsHelper(value string) error {
 		return nil
 	}
 
-	num, err := strconv.ParseInt(value, 10, 64)
+	num, err := webhookUtil.StrictAtoi(value)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -39,6 +39,7 @@ import (
 
 	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester-network-controller/pkg/utils"
+
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/containerd"
 	nodectl "github.com/harvester/harvester/pkg/controller/master/node"
@@ -55,7 +56,7 @@ import (
 	vmUtil "github.com/harvester/harvester/pkg/util/virtualmachine"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
-	webhookutil "github.com/harvester/harvester/pkg/webhook/util"
+	webhookUtil "github.com/harvester/harvester/pkg/webhook/util"
 )
 
 const (
@@ -715,7 +716,7 @@ func validateSupportBundleTimeoutHelper(value string) error {
 		return nil
 	}
 
-	i, err := strconv.Atoi(value)
+	i, err := webhookUtil.StrictAtoi(value)
 	if err != nil {
 		return err
 	}
@@ -745,7 +746,7 @@ func validateSupportBundleExpirationHelper(value string) error {
 		return nil
 	}
 
-	i, err := strconv.Atoi(value)
+	i, err := webhookUtil.StrictAtoi(value)
 	if err != nil {
 		return err
 	}
@@ -775,7 +776,7 @@ func validateSupportBundleNodeCollectionTimeoutHelper(value string) error {
 		return nil
 	}
 
-	i, err := strconv.Atoi(value)
+	i, err := webhookUtil.StrictAtoi(value)
 	if err != nil {
 		return err
 	}
@@ -1447,7 +1448,7 @@ func (v *settingValidator) checkStorageNetworkRangeValid(config *storagenetworkc
 		MinAllocatableIPAddrs = MinAllocatableIPAddrs + 2 + (len(lhNode.Spec.Disks) * 2)
 	}
 
-	count, err := webhookutil.GetUsableIPAddressesCount(config.Range, config.Exclude)
+	count, err := webhookUtil.GetUsableIPAddressesCount(config.Range, config.Exclude)
 	if err != nil {
 		return err
 	}
@@ -1533,7 +1534,7 @@ func validateKubeConfigTTLSettingHelper(value string) error {
 		return nil
 	}
 
-	num, err := strconv.Atoi(value)
+	num, err := webhookUtil.StrictAtoi(value)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/util/string.go
+++ b/pkg/webhook/util/string.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func StrictAtoi(s string) (int, error) {
+	if len(s) > 1 {
+		if s[0] == '0' {
+			return 0, fmt.Errorf("leading zero in input: %s", s)
+		}
+
+<<<<<<< HEAD
+=======
+		if s[0] == '+' {
+			return 0, fmt.Errorf("no allowed symbol in input: %s", s)
+		}
+
+>>>>>>> 9e40a326d (test)
+		if s[0] == '-' && s[1] == '0' {
+			return 0, fmt.Errorf("leading zero in input: %s", s)
+		}
+
+	}
+
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, err
+	}
+	return i, nil
+}

--- a/pkg/webhook/util/string.go
+++ b/pkg/webhook/util/string.go
@@ -11,13 +11,10 @@ func StrictAtoi(s string) (int, error) {
 			return 0, fmt.Errorf("leading zero in input: %s", s)
 		}
 
-<<<<<<< HEAD
-=======
 		if s[0] == '+' {
 			return 0, fmt.Errorf("no allowed symbol in input: %s", s)
 		}
 
->>>>>>> 9e40a326d (test)
 		if s[0] == '-' && s[1] == '0' {
 			return 0, fmt.Errorf("leading zero in input: %s", s)
 		}

--- a/pkg/webhook/util/string_test.go
+++ b/pkg/webhook/util/string_test.go
@@ -1,0 +1,33 @@
+package util
+
+import "testing"
+
+func TestStrictAtoi(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+		hasError bool
+	}{
+		{input: "123", expected: 123, hasError: false},
+		{input: "-123", expected: -123, hasError: false},
+		{input: "0", expected: 0, hasError: false},
+		{input: "+123", expected: 0, hasError: true},
+		{input: "+0", expected: 0, hasError: true},
+		{input: "-0", expected: 0, hasError: true},
+		{input: "001", expected: 0, hasError: true},
+		{input: "+001", expected: 0, hasError: true},
+		{input: "-001", expected: 0, hasError: true},
+		{input: "abc", expected: 0, hasError: true},
+		{input: "", expected: 0, hasError: true},
+	}
+
+	for _, test := range tests {
+		result, err := StrictAtoi(test.input)
+		if (err != nil) != test.hasError {
+			t.Errorf("StrictAtoi(%q) error = %v, wantErr %v", test.input, err, test.hasError)
+		}
+		if result != test.expected {
+			t.Errorf("StrictAtoi(%q) = %v, want %v", test.input, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
#### Problem:
The `strconv.Atoi` treats `"0003"` as normal integer, then convert it to `3`

#### Solution:
However, we don't want string leading with zero. So, we add a new method to validate it. 

The affected settings are:

- SupportBundleTimeout
- SupportBundleExpiration
- SupportBundleNodeCollectionTimeout
- KubeConfigTTLSetting

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5074

#### Test plan:

Use string leading with zero to replace above settings.

![image](https://github.com/user-attachments/assets/929ae366-6f49-4834-9730-65b58a2d4fb8)

![image](https://github.com/user-attachments/assets/5982ab95-5c83-432d-a460-f2d1aba714be)

![image](https://github.com/user-attachments/assets/c0386d89-0cb8-48f3-8337-0cb904888719)

![image](https://github.com/user-attachments/assets/8b30210d-658c-4e84-b603-279cd6afd2d6)