### PR TITLE
Update wicked scripts and 90custom with mgmt vlan configured during installation

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -508,6 +508,58 @@ calculateCPUReservedInMilliCPU() {
   echo $reserved
 }
 
+replace_with_mgmtvlan() {
+
+  #files to update
+  SETUPBOND_FILE="/etc/wicked/scripts/setup_bond.sh"
+  SETUPBRIDGE_FILE="/etc/wicked/scripts/setup_bridge.sh"
+  CUSTOM90_FILE="/oem/90_custom.yaml"
+
+  # Get list of interfaces on the host
+  interfaces=$(ip -o link show | awk -F': ' '{print $2}')
+
+  # Derive the mgmt vlan from mgmt-br.vlanid
+  for iface in $interfaces; do
+    if [[ "$iface" =~ ^mgmt-br\.([0-9]+)@mgmt-br$ ]]; then
+      vlan_id="${BASH_REMATCH[1]}"
+      echo "Found VLAN ID: $vlan_id"
+      break
+    fi
+  done
+
+  if [[ -z "$vlan_id" || "$vlan_id" -eq 0 ]]; then
+    echo "VLAN ID: $vlan_id Not found, assign vlan_id=1"
+    vlan_id=1
+  fi
+
+  # Check if the file exists
+  if [[ -f "$SETUPBOND_FILE" ]]; then
+    # Replace the range with the VLAN ID
+    sed -i "s/bridge vlan add vid 2-4094/bridge vlan add vid $vlan_id/" "$SETUPBOND_FILE"
+    echo "Updated $SETUPBOND_FILE with VLAN ID $vlan_id"
+  else
+    echo "File not found: $SETUPBOND_FILE"
+  fi
+
+  # Check if the file exists
+  if [[ -f "$SETUPBRIDGE_FILE" ]]; then
+    # Replace the range with the VLAN ID
+    sed -i "s/bridge vlan add vid 2-4094/bridge vlan add vid $vlan_id/" "$SETUPBRIDGE_FILE"
+    echo "Updated $SETUPBRIDGE_FILE with VLAN ID $vlan_id"
+  else
+    echo "File not found: $SETUPBRIDGE_FILE"
+  fi
+
+  # Check if the file exists
+  if [[ -f "$CUSTOM90_FILE" ]]; then
+    # Replace the range with the VLAN ID
+    sed -i "s/bridge vlan add vid 2-4094/bridge vlan add vid $vlan_id/" "$CUSTOM90_FILE"
+    echo "Updated $CUSTOM90_FILE with VLAN ID $vlan_id"
+  else
+    echo "File not found: $CUSTOM90_FILE"
+  fi
+}
+
 upgrade_os() {
   # The trap will be only effective from this point to the end of the execution
   trap clean_up_tmp_files EXIT
@@ -612,6 +664,9 @@ EOF
 
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
+
+  #replace the range vlans with mgmt vlan in wicked scripts and 90_custom.yaml file before node reboot
+  replace_with_mgmtvlan
 
   reboot_if_job_succeed
 }


### PR DESCRIPTION
#### Problem:
This task is related to https://github.com/harvester/harvester/issues/7650

During Harvester boot, the system attempts to add all VLAN IDs to the management bond/bridge. With Mellanox ConnectX-6 NICs (which support 512 hardware-offloaded VLANs and have hardware VLAN offloading enabled by default), this causes boot log warnings and prevents management VLAN 2301 from being added to the hardware offloaded VLAN list.

https://github.com/harvester/harvester-installer/pull/1026 takes care of adding only user configured vlan to mgmt-br and mgmt-bo interface

when upgrading to v1.6.0 from older versions
This task is created for handling the upgrade path where upgrade to any newer version with the fix from https://github.com/

https://github.com/harvester/harvester-installer/pull/1026 should patch only the vid configured by user for the mgmt-br(during installation)
in wicked scripts of setup_bond.sh and setup_bridge.sh and 90_custom.yaml file.

#### Solution:
This involves replacing the vlan range 2-4094 with vlan id configured during installation in the files /etc/wicked/scripts/setup_bond.sh and /etc/wicked/scripts/setup_bridge.sh
and /oem/90_custom.yaml with during upgrade path.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8041

#### Test plan:
1.Upgrade from v1.5 to latest
2.Check if wicked scripts and /oem/90_custom.yaml shows "bridge vlan <vid> ...." where vid is vlan configured for mgmt br during harvester installation
3.bridge vlan show - shows only the vlans configured for mgmt cluster along with the vlan id configured during installation
mgmt-br - will be part of vlan configured during installation
mgmt-bo - will be part of vlan configured during installation and other user configured vlans under mgmt cluster

#### Additional documentation or context
