### PR TITLE
Replace annotation with AppArmor profile within security context

### DIFF
--- a/deploy/charts/harvester/templates/deployment.yaml
+++ b/deploy/charts/harvester/templates/deployment.yaml
@@ -32,8 +32,6 @@ spec:
 {{ include "harvester.labels" . | indent 8 }}
         app.kubernetes.io/name: harvester
         app.kubernetes.io/component: apiserver
-      annotations:
-        container.apparmor.security.beta.kubernetes.io/apiserver: unconfined
     spec:
       serviceAccountName: harvester
       affinity:
@@ -43,6 +41,8 @@ spec:
           image: {{ .Values.containers.apiserver.image.repository }}:{{ .Values.containers.apiserver.image.tag }}
           imagePullPolicy: {{ .Values.containers.apiserver.image.imagePullPolicy }}
           securityContext:
+            appArmorProfile:
+              type: Unconfined
             capabilities:
               add: ["SYS_ADMIN"]
 {{- if .Values.containers.apiserver.command }}
@@ -159,8 +159,6 @@ spec:
 {{ include "harvester.labels" . | indent 8 }}
         app.kubernetes.io/name: harvester
         app.kubernetes.io/component: webhook-server
-      annotations:
-        container.apparmor.security.beta.kubernetes.io/harvester-webhook: unconfined
     spec:
       serviceAccountName: harvester
       affinity:
@@ -193,6 +191,8 @@ spec:
         args: []
         imagePullPolicy: {{ .Values.webhook.image.imagePullPolicy }}
         securityContext:
+          appArmorProfile:
+            type: Unconfined
           capabilities:
             add: ["SYS_ADMIN"]
         ports:


### PR DESCRIPTION
#### Problem:
I got a warning message when patching the `harvester` and `harvester-webhook` deployment.
```
Warning: spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/apiserver]: deprecated since v1.30; use the "appArmorProfile" field instead
```
```
Warning: spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/harvester-webhook]: deprecated since v1.30; use the "appArmorProfile" field instead
```

#### Solution:
Specify the `appArmorProfile` on the container's `securityContext`.

References:
- https://kubernetes.io/docs/tutorials/security/apparmor/
- https://kubernetes.io/docs/tutorials/security/apparmor/#specifying-apparmor-confinement

NOTE, this changes require Kubernetes >= v1.30. So take care when this is planned to be backported.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8116

#### Test plan:
Run the following commands in one of the Harvester nodes:
```
# docker ps | grep docker.io/rancher/harvester
# docker inspect <container-id> | grep Pid
# cat /proc/<pid>/attr/current
```
```
# docker ps | grep docker.io/rancher/harvester-webhook
# docker inspect <container-id> | grep Pid
# cat /proc/<pid>/attr/current
```
Both should look like
```
# cat /proc/25930/attr/current
unconfined
```
