### PR TITLE
chore: change the rule of creating e2e issue and remove it when unlabeling

### DIFF
--- a/.github/workflows/bot/action_label.py
+++ b/.github/workflows/bot/action_label.py
@@ -2,11 +2,13 @@ import time
 import random
 from bot.label_action.create_gui_issue import CreateGUIIssue
 from bot.label_action.create_backport import CreateBackport
+from bot.label_action.create_e2e import CreateE2EIssue
 from bot.action import Action
 
 ALL_LABEL_ACTIONS = [
     CreateBackport,
-    CreateGUIIssue
+    CreateGUIIssue,
+    CreateE2EIssue
 ]
 
 class ActionLabel(Action):

--- a/.github/workflows/bot/action_project.py
+++ b/.github/workflows/bot/action_project.py
@@ -43,4 +43,3 @@ class ActionProject(Action):
         
         it = IssueTransfer(issue["number"])
         it.create_comment_if_not_exist()
-        it.create_e2e_issue()

--- a/.github/workflows/bot/issue_transfer.py
+++ b/.github/workflows/bot/issue_transfer.py
@@ -3,8 +3,7 @@ import logging
 
 from flask import render_template
 
-from bot import repo, repo_test, \
-    GITHUB_OWNER, GITHUB_REPOSITORY, GITHUB_REPOSITORY_TEST
+from bot import repo
 
 
 template_re = re.compile('---\n.*?---\n', re.DOTALL)
@@ -28,35 +27,3 @@ class IssueTransfer:
         if not found:
             logging.info('pre-merge checklist does not exist, creating a new one')
             self.__issue.create_comment(render_template('pre-merge.md'))
-
-    def create_e2e_issue(self):
-        require_e2e = True
-        labels = self.__issue.get_labels()
-        for label in labels:
-            if label.name == 'not-require/test-plan':
-                require_e2e = False
-                break
-        if require_e2e:
-            found = False
-            for comment in self.__comments:
-                if comment.body.startswith('Automation e2e test issue:'):
-                    logging.info('Automation e2e test issue already exists, not creating a new one')
-                    found = True
-                    break
-            if not found:
-                logging.info('Automation e2e test issue does not exist, creating a new one')
-
-                issue_link = '{}/{}#{}'.format(GITHUB_OWNER, GITHUB_REPOSITORY, self.__issue.number)
-                issue_test_title = '[e2e] {}'.format(self.__issue.title)
-                issue_test_template_content = repo_test.get_contents(
-                    ".github/ISSUE_TEMPLATE/test.md").decoded_content.decode()
-                issue_test_body = template_re.sub("\n", issue_test_template_content, count=1)
-                issue_test_body += '\nrelated issue: {}'.format(issue_link)
-                issue_test = repo_test.create_issue(title=issue_test_title, body=issue_test_body)
-
-                issue_test_link = '{}/{}#{}'.format(GITHUB_OWNER, GITHUB_REPOSITORY_TEST, issue_test.number)
-
-                # link test issue in Harvester issue
-                self.__issue.create_comment('Automation e2e test issue: {}'.format(issue_test_link))
-        else:
-            logging.info('label require/automation-e2e does not exists, not creating test issue')

--- a/.github/workflows/bot/label_action/create_e2e.py
+++ b/.github/workflows/bot/label_action/create_e2e.py
@@ -1,0 +1,57 @@
+from bot import repo
+from bot.action import LabelAction
+import re
+import logging
+from bot import repo, repo_test, \
+    GITHUB_OWNER, GITHUB_REPOSITORY, GITHUB_REPOSITORY_TEST
+    
+template_re = re.compile('---\n.*?---\n', re.DOTALL)
+
+target_label = 'require/auto-e2e-test'
+
+class CreateE2EIssue(LabelAction):
+    def __init__(self):
+        pass
+    
+    def isMatched(self, request):
+        for label in request['issue']['labels']:
+            if label['name'] == target_label:
+                return True
+        return False
+    
+    def action(self, request):
+        require_e2e = False
+        issue = repo.get_issue(request['issue']['number'])
+        
+        labels = issue.get_labels()
+        comments = issue.get_comments() 
+        
+        for label in labels:
+            if label.name == target_label:
+                require_e2e = True
+                break
+
+        if require_e2e:
+            found = False
+            for comment in comments:
+                if comment.body.startswith('Automation e2e test issue:'):
+                    logging.info('Automation e2e test issue already exists, not creating a new one')
+                    found = True
+                    break
+            if not found:
+                logging.info('Automation e2e test issue does not exist, creating a new one')
+
+                issue_link = '{}/{}#{}'.format(GITHUB_OWNER, GITHUB_REPOSITORY, issue.number)
+                issue_test_title = '[e2e] {}'.format(issue.title)
+                issue_test_template_content = repo_test.get_contents(
+                    ".github/ISSUE_TEMPLATE/test.md").decoded_content.decode()
+                issue_test_body = template_re.sub("\n", issue_test_template_content, count=1)
+                issue_test_body += '\nrelated issue: {}'.format(issue_link)
+                issue_test = repo_test.create_issue(title=issue_test_title, body=issue_test_body)
+
+                issue_test_link = '{}/{}#{}'.format(GITHUB_OWNER, GITHUB_REPOSITORY_TEST, issue_test.number)
+
+                # link test issue in Harvester issue
+                issue.create_comment('Automation e2e test issue: {}'.format(issue_test_link))
+        else:
+            logging.info('label {} does not exist, not creating test issue'.format(target_label))

--- a/.github/workflows/issue-management-close-issue.yaml
+++ b/.github/workflows/issue-management-close-issue.yaml
@@ -48,8 +48,10 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+      with:
+        repository: harvester/tests
     
-    - name: Find and Close E2E Issue
+    - name: Find and Close E2E Issue in harvester/tests
       run: |
         # Search for e2e issues with matching title using major.minor version
         E2E_ISSUE=$(gh issue list --search "[e2e] ${{ github.event.issue.title }}" --json number --jq '.[0].number')

--- a/.github/workflows/issue-management-close-issue.yaml
+++ b/.github/workflows/issue-management-close-issue.yaml
@@ -42,3 +42,24 @@ jobs:
         fi
       env:
         GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+  e2e:
+    runs-on: ubuntu-latest
+    if: contains(github.event.label.name, 'require/auto-e2e-test')
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    
+    - name: Find and Close E2E Issue
+      run: |
+        # Search for e2e issues with matching title using major.minor version
+        E2E_ISSUE=$(gh issue list --search "[e2e] ${{ github.event.issue.title }}" --json number --jq '.[0].number')
+
+        if [ -n "$E2E_ISSUE" ]; then
+          echo "Closing e2e issue #$E2E_ISSUE"
+          gh issue close $E2E_ISSUE --reason "not planned"
+          gh issue edit $E2E_ISSUE --add-label "wontfix"
+        else
+          echo "No matching e2e issue found for version ${{ env.MAJOR_MINOR_VERSION }}"
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}

--- a/.github/workflows/issue-management-create-issue-by-label.yaml
+++ b/.github/workflows/issue-management-create-issue-by-label.yaml
@@ -11,7 +11,10 @@ concurrency:
 jobs:
   create-issue:
     name: Create Issue
-    if: contains(join(github.event.issue.labels.*.name, ', '), 'backport-needed/') || contains(join(github.event.issue.labels.*.name, ', '), 'require-ui/')
+    if: 
+      contains(join(github.event.issue.labels.*.name, ', '), 'backport-needed/') || 
+      contains(join(github.event.issue.labels.*.name, ', '), 'require-ui/') || 
+      contains(join(github.event.issue.labels.*.name, ', '), 'require/auto-e2e-test')
     runs-on: ubuntu-latest
     env:
       EVENT: ${{ toJson(github.event) }}
@@ -36,5 +39,10 @@ jobs:
       
       - name: Create GUI Issue
         if: contains(join(github.event.issue.labels.*.name, ', '), 'require-ui/')
+        run: |
+          python .github/workflows/bot.py "$EVENT"
+      
+      - name: Create E2E Issue
+        if: contains(join(github.event.issue.labels.*.name, ', '), 'require/auto-e2e-test')
         run: |
           python .github/workflows/bot.py "$EVENT"


### PR DESCRIPTION
#8134 

I just reused our python script, we could move it to common lib one day. But, for now, reusing is a quick way. 

Now, after moving issue to Review or Ready for Testing, bot won't create an e2e test issue. It's triggered by label.

Test: https://github.com/JackTestHook/test/issues/236