### PR TITLE
chore: check all PRs and tag team when marking PR as stale [skip ci]

### DIFF
--- a/.github/workflows/issue-management-stale.yml
+++ b/.github/workflows/issue-management-stale.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/stale@v9
       with:
         stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-        stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+        stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 5 days. Please review it as soon as possible. cc @harvester/dev '
         close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
         close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
         days-before-stale: 30
@@ -34,7 +34,7 @@ jobs:
         ascending: ${{ inputs.ascending }}
         stale-issue-label: 'status/stale'
         stale-pr-label: 'status/stale'
-        exempt-all-assignees: true
-        exempt-issue-labels: 'kind/enhancement,kind/feature,require/investigate,require/pm-review'
+        exempt-all-assignees: false
+        exempt-issue-labels: 'require/pm-review'
         exempt-draft-pr: true
         exempt-all-milestones: true


### PR DESCRIPTION
#7983 

- Stale all issues/PRs with/without assignees.
- Tag team when marking PR stale.