### PR TITLE
Restore non-migratible VMs back to running state after node upgrade

### DIFF
--- a/cmd/upgradehelper/cmd/vmlivemigratedetector/vmlivemigratedetector.go
+++ b/cmd/upgradehelper/cmd/vmlivemigratedetector/vmlivemigratedetector.go
@@ -13,7 +13,9 @@ import (
 )
 
 var (
-	shutdown bool
+	shutdown  bool
+	restoreVM bool
+	upgrade   string
 )
 
 var vmLiveMigrateDetectorCmd = &cobra.Command{
@@ -31,6 +33,8 @@ If there is no place to go, it can optionally shut down the VMs.
 			KubeConfigPath: cmd.KubeConfigPath,
 			KubeContext:    cmd.KubeContext,
 			Shutdown:       shutdown,
+			RestoreVM:      restoreVM,
+			Upgrade:        upgrade,
 			NodeName:       args[0],
 		}
 		if err := run(ctx, options); err != nil {
@@ -42,6 +46,8 @@ If there is no place to go, it can optionally shut down the VMs.
 
 func init() {
 	vmLiveMigrateDetectorCmd.Flags().BoolVar(&shutdown, "shutdown", false, "Shutdown non-migratable VMs")
+	vmLiveMigrateDetectorCmd.Flags().BoolVar(&restoreVM, "restore-vm", false, "Add restoreVM annotation to upgrade CR, must be used with --upgrade={upgrade-name}")
+	vmLiveMigrateDetectorCmd.Flags().StringVar(&upgrade, "upgrade", "", "Upgrade CR name")
 
 	cmd.RootCmd.AddCommand(vmLiveMigrateDetectorCmd)
 }

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -289,7 +289,11 @@ command_pre_drain() {
   wait_longhorn_engines
 
   # Shut down non-live migratable VMs
-  upgrade-helper vm-live-migrate-detector "$HARVESTER_UPGRADE_NODE_NAME" --shutdown
+  local upgrade_helper_args="--shutdown"
+  if [ "$HARVESTER_UPGRADE_RESTORE_VM" = "true" ]; then
+    upgrade_helper_args="$upgrade_helper_args --restore-vm --upgrade $HARVESTER_UPGRADE_NAME"
+  fi
+  upgrade-helper vm-live-migrate-detector "$HARVESTER_UPGRADE_NODE_NAME" $upgrade_helper_args
 
   # Live migrate VMs
   kubectl taint node $HARVESTER_UPGRADE_NODE_NAME --overwrite kubevirt.io/drain=draining:NoSchedule
@@ -723,8 +727,12 @@ command_single_node_upgrade() {
   NEW_OS_SQUASHFS_IMAGE_FILE=$(mktemp -p $UPGRADE_TMP_DIR)
   download_file "$UPGRADE_REPO_SQUASHFS_IMAGE" "$NEW_OS_SQUASHFS_IMAGE_FILE"
 
-  # Stop all VMs
-  shutdown_all_vms
+  # Shut down non-live migratable VMs
+  local upgrade_helper_args="--shutdown"
+  if [ "$HARVESTER_UPGRADE_RESTORE_VM" = "true" ]; then
+    upgrade_helper_args="$upgrade_helper_args --restore-vm --upgrade $HARVESTER_UPGRADE_NAME"
+  fi
+  upgrade-helper vm-live-migrate-detector "$HARVESTER_UPGRADE_NODE_NAME" $upgrade_helper_args
   wait_vms_out
 
   echo "wait for fleet bundles before upgrading RKE2"

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -44,7 +44,6 @@ func Register(ctx context.Context, management *config.Management, options config
 	secrets := management.CoreFactory.Core().V1().Secret()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
 	lhSettings := management.LonghornFactory.Longhorn().V1beta2().Setting()
-	kubeVirt := management.VirtFactory.Kubevirt().V1().KubeVirt()
 
 	virtSubsrcConfig := rest.CopyConfig(management.RestConfig)
 	virtSubsrcConfig.GroupVersion = &schema.GroupVersion{Group: "subresources.kubevirt.io", Version: "v1"}
@@ -81,7 +80,6 @@ func Register(ctx context.Context, management *config.Management, options config
 		clusterCache:       clusters.Cache(),
 		lhSettingClient:    lhSettings,
 		lhSettingCache:     lhSettings.Cache(),
-		kubeVirtCache:      kubeVirt.Cache(),
 		vmRestClient:       virtSubresourceClient,
 	}
 	upgrades.OnChange(ctx, upgradeControllerName, controller.OnChanged)

--- a/pkg/upgradehelper/vmlivemigratedetector/detector.go
+++ b/pkg/upgradehelper/vmlivemigratedetector/detector.go
@@ -2,20 +2,33 @@ package vmlivemigratedetector
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/rancher/wrangler/v3/pkg/kv"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/util/retry"
+
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	harvNodeController "github.com/harvester/harvester/pkg/controller/master/node"
+	harvclient "github.com/harvester/harvester/pkg/generated/clientset/versioned"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
+)
+
+const (
+	vmPaused condition.Cond = "Paused"
 )
 
 type DetectorOptions struct {
@@ -23,16 +36,27 @@ type DetectorOptions struct {
 	KubeContext    string
 	Shutdown       bool
 	NodeName       string
+	RestoreVM      bool
+	Upgrade        string
 }
 
 type VMLiveMigrateDetector struct {
 	kubeConfig  string
 	kubeContext string
 
-	nodeName string
-	shutdown bool
+	nodeName  string
+	shutdown  bool
+	restoreVM bool
+	upgrade   string
 
 	virtClient kubecli.KubevirtClient
+	harvClient harvclient.Interface
+}
+
+type PatchStringValue struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
 }
 
 func NewVMLiveMigrateDetector(options DetectorOptions) *VMLiveMigrateDetector {
@@ -41,10 +65,16 @@ func NewVMLiveMigrateDetector(options DetectorOptions) *VMLiveMigrateDetector {
 		kubeContext: options.KubeContext,
 		nodeName:    options.NodeName,
 		shutdown:    options.Shutdown,
+		restoreVM:   options.RestoreVM,
+		upgrade:     options.Upgrade,
 	}
 }
 
 func (d *VMLiveMigrateDetector) Init() (err error) {
+	if d.restoreVM && d.upgrade == "" {
+		logrus.Fatal("restoreVM is true while upgrade is not set")
+	}
+
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{
 			ExplicitPath: d.kubeConfig,
@@ -60,6 +90,16 @@ func (d *VMLiveMigrateDetector) Init() (err error) {
 		logrus.Fatalf("cannot obtain KubeVirt client: %v\n", err)
 	}
 
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		logrus.Fatalf("cannot obtain rest config: %v\n", err)
+	}
+
+	d.harvClient, err = harvclient.NewForConfig(restConfig)
+	if err != nil {
+		logrus.Fatalf("cannot obtain harvester client: %v\n", err)
+	}
+
 	return
 }
 
@@ -68,44 +108,39 @@ func (d *VMLiveMigrateDetector) Run(ctx context.Context) error {
 		return fmt.Errorf("please specify a node name")
 	}
 
-	// Get all VMs running on the specified node, except for the upgrade-related ones
-	nodeReq, err := labels.NewRequirement("kubevirt.io/nodeName", selection.Equals, []string{d.nodeName})
+	nodes, err := d.getAllNodes(ctx)
 	if err != nil {
 		return err
-	}
-	notUpgradeReq, err := labels.NewRequirement("harvesterhci.io/upgrade", selection.DoesNotExist, nil)
-	if err != nil {
-		return err
-	}
-	selector := labels.NewSelector().Add(*nodeReq).Add(*notUpgradeReq)
-	listOptions := metav1.ListOptions{
-		LabelSelector: selector.String(),
-	}
-	vmiList, err := d.virtClient.VirtualMachineInstance("").List(ctx, listOptions)
-	if err != nil {
-		return err
-	}
-	vmis := make([]*kubevirtv1.VirtualMachineInstance, 0, len(vmiList.Items))
-	for i := range vmiList.Items {
-		vmis = append(vmis, &vmiList.Items[i])
 	}
 
-	// Get all nodes
-	nodeList, err := d.virtClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	listOptions, err := d.getVMIListOptions(nodes)
 	if err != nil {
 		return err
 	}
-	nodes := make([]*v1.Node, 0, nodeList.Size())
-	for i := range nodeList.Items {
-		nodes = append(nodes, &nodeList.Items[i])
+
+	vmis, err := d.getVMIs(ctx, listOptions)
+	if err != nil {
+		return err
 	}
 
-	nonLiveMigratableVMNames, err := virtualmachineinstance.GetAllNonLiveMigratableVMINames(vmis, nodes)
+	nonLiveMigratableVMNames, err := getNonLiveMigratableVMNames(vmis, nodes)
 	if err != nil {
 		return err
 	}
 
 	logrus.Infof("Non-migratable VM(s): %v", nonLiveMigratableVMNames)
+
+	if d.restoreVM {
+		nodeUID := getNodeUID(d.nodeName, nodes)
+		if nodeUID == "" {
+			return fmt.Errorf("cannot find node %s UID", d.nodeName)
+		}
+		getRestoreVMNames := getRestoreVMNames(vmis, nonLiveMigratableVMNames)
+		logrus.Infof("Patch upgrade CR with restoreVM annotation: %v", getRestoreVMNames)
+		if err := d.patchUpgradeCR(ctx, getRestoreVMNames, nodeUID); err != nil {
+			return err
+		}
+	}
 
 	if d.shutdown {
 		for _, namespacedName := range nonLiveMigratableVMNames {
@@ -118,4 +153,125 @@ func (d *VMLiveMigrateDetector) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (d *VMLiveMigrateDetector) getAllNodes(ctx context.Context) ([]*v1.Node, error) {
+	// filter out witness nodes as they are not available for vm migration
+	nodeReq, err := labels.NewRequirement(harvNodeController.HarvesterWitnessNodeLabelKey, selection.DoesNotExist, nil)
+	if err != nil {
+		return nil, err
+	}
+	nodeList, err := d.virtClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: nodeReq.String()})
+	if err != nil {
+		return nil, err
+	}
+	nodes := make([]*v1.Node, 0, nodeList.Size())
+	for i := range nodeList.Items {
+		nodes = append(nodes, &nodeList.Items[i])
+	}
+	return nodes, nil
+}
+
+func (d *VMLiveMigrateDetector) getVMIs(ctx context.Context, opts metav1.ListOptions) ([]*kubevirtv1.VirtualMachineInstance, error) {
+	vmiList, err := d.virtClient.VirtualMachineInstance("").List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	vmis := make([]*kubevirtv1.VirtualMachineInstance, 0, len(vmiList.Items))
+	for i := range vmiList.Items {
+		vmis = append(vmis, &vmiList.Items[i])
+	}
+	return vmis, nil
+}
+
+func (d *VMLiveMigrateDetector) getVMIListOptions(nodes []*v1.Node) (metav1.ListOptions, error) {
+	// All VMs are non-migratable if there is only one node
+	if len(nodes) == 1 {
+		return metav1.ListOptions{}, nil
+	}
+	nodeReq, err := labels.NewRequirement("kubevirt.io/nodeName", selection.Equals, []string{d.nodeName})
+	if err != nil {
+		return metav1.ListOptions{}, err
+	}
+	notUpgradeReq, err := labels.NewRequirement("harvesterhci.io/upgrade", selection.DoesNotExist, nil)
+	if err != nil {
+		return metav1.ListOptions{}, err
+	}
+	return metav1.ListOptions{
+		LabelSelector: labels.NewSelector().Add(*nodeReq).Add(*notUpgradeReq).String(),
+	}, nil
+}
+
+func getNonLiveMigratableVMNames(vmis []*kubevirtv1.VirtualMachineInstance, nodes []*v1.Node) ([]string, error) {
+	// All VMs are non-migratable if there is only one node
+	if len(nodes) == 1 {
+		names := make([]string, 0, len(vmis))
+		for _, vmi := range vmis {
+			names = append(names, vmi.Namespace+"/"+vmi.Name)
+		}
+		return names, nil
+	}
+	return virtualmachineinstance.GetAllNonLiveMigratableVMINames(vmis, nodes)
+}
+
+func getRestoreVMNames(vmis []*kubevirtv1.VirtualMachineInstance, nonMigratableVMNames []string) []string {
+	restoreVMs := make([]string, 0, 0)
+
+	// filter out paused VMs and upgrade repo VM from the non-migratable VMs
+	excludeVMs := make(map[string]struct{})
+	for _, vmi := range vmis {
+		if vmPaused.IsTrue(vmi) || vmi.Labels["harvesterhci.io/upgrade"] != "" {
+			namespacedName := fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)
+			excludeVMs[namespacedName] = struct{}{}
+		}
+	}
+	for _, name := range nonMigratableVMNames {
+		if _, exist := excludeVMs[name]; !exist {
+			restoreVMs = append(restoreVMs, name)
+		}
+	}
+	return restoreVMs
+}
+
+func (d *VMLiveMigrateDetector) patchUpgradeCR(ctx context.Context, restoreVMNames []string, nodeUID string) error {
+	annoKey := util.AnnotationRestoreVMPrefix + nodeUID
+	annoValue := strings.Join(restoreVMNames, ",")
+	payload, err := json.Marshal([]PatchStringValue{
+		{
+			Op: "add",
+			// JSON Patch format requires '/' to be replaced with '~1'
+			Path:  "/metadata/annotations/" + strings.ReplaceAll(annoKey, "/", "~1"),
+			Value: annoValue,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		upgrade, err := d.harvClient.HarvesterhciV1beta1().Upgrades(util.HarvesterSystemNamespaceName).
+			Get(ctx, d.upgrade, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if value, ok := upgrade.Annotations[annoKey]; ok && value == annoValue {
+			// already up-to-date
+			return nil
+		}
+
+		_, err = d.harvClient.HarvesterhciV1beta1().Upgrades(util.HarvesterSystemNamespaceName).
+			Patch(ctx, d.upgrade, types.JSONPatchType, payload, metav1.PatchOptions{})
+		return err
+	})
+	return err
+}
+
+func getNodeUID(nodeName string, nodes []*v1.Node) string {
+	for _, node := range nodes {
+		if node.Name == nodeName {
+			return string(node.UID)
+		}
+	}
+	return ""
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -57,6 +57,9 @@ const (
 	// Add to rancher-monitoring addon to record grafana pv name
 	AnnotationGrafanaPVName = prefix + "/grafana-pv-name"
 
+	AnnotationRestoreVMPrefix         = prefix + "/restore-vm-"
+	AnnotationRestoreVMFinishedPrefix = prefix + "/restore-vm-finished-"
+
 	// Add to harvester-longhorn storageclass to protect it
 	// For any storageclass created & protected by controller, the controller can utilize this annotation
 	AnnotationIsReservedStorageClass = prefix + "/is-reserved-storageclass"

--- a/pkg/util/setting.go
+++ b/pkg/util/setting.go
@@ -61,3 +61,11 @@ func GetAdditionalGuestMemoryOverheadRatio(settingCache ctlharvesterv1.SettingCa
 	value = agmorc.Value()
 	return &value, nil
 }
+
+func IsRestoreVM() (bool, error) {
+	upgradeConfig, err := settings.DecodeConfig[settings.UpgradeConfig](settings.UpgradeConfigSet.Get())
+	if err != nil || upgradeConfig == nil {
+		return false, err
+	}
+	return upgradeConfig.RestoreVM, nil
+}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1584,7 +1584,7 @@ func validateUpgradeConfigHelper(setting *v1beta1.Setting) (*settings.UpgradeCon
 	return config, nil
 }
 
-func validateUpgradeConfigFields(setting *v1beta1.Setting, isSingleNode bool) error {
+func validateUpgradeConfigFields(setting *v1beta1.Setting) error {
 	upgradeConfig, err := validateUpgradeConfigHelper(setting)
 	if err != nil {
 		return err
@@ -1609,20 +1609,11 @@ func validateUpgradeConfigFields(setting *v1beta1.Setting, isSingleNode bool) er
 		return fmt.Errorf("invalid image preload concurrency: %d", concurrency)
 	}
 
-	// Validate the restore VM field
-	if upgradeConfig.RestoreVM && !isSingleNode {
-		return fmt.Errorf("restoreVM is only supported in single node cluster")
-	}
-
 	return nil
 }
 
 func (v *settingValidator) validateUpgradeConfig(setting *v1beta1.Setting) error {
-	isSingleNode, err := v.isSingleNode()
-	if err != nil {
-		return err
-	}
-	return validateUpgradeConfigFields(setting, isSingleNode)
+	return validateUpgradeConfigFields(setting)
 }
 
 func (v *settingValidator) validateUpdateUpgradeConfig(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
@@ -1642,12 +1633,4 @@ func validateAdditionalGuestMemoryOverheadRatio(newSetting *v1beta1.Setting) err
 
 func validateUpdateAdditionalGuestMemoryOverheadRatio(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateAdditionalGuestMemoryOverheadRatio(newSetting)
-}
-
-func (v *settingValidator) isSingleNode() (bool, error) {
-	nodes, err := v.nodeCache.List(labels.Everything())
-	if err != nil {
-		return false, err
-	}
-	return len(nodes) == 1, nil
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -843,10 +843,9 @@ func Test_validateNTPServers(t *testing.T) {
 
 func Test_validateUpgradeConfig(t *testing.T) {
 	tests := []struct {
-		name         string
-		args         *v1beta1.Setting
-		isSingleNode bool
-		expectedErr  bool
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
 	}{
 		{
 			name: "empty config - default",
@@ -993,46 +992,26 @@ func Test_validateUpgradeConfig(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			name: "enable restoreVM under single node cluster",
+			name: "enable restoreVM",
 			args: &v1beta1.Setting{
 				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
 				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": true}`,
 			},
-			isSingleNode: true,
-			expectedErr:  false,
+			expectedErr: false,
 		},
 		{
-			name: "disable restoreVM under single node cluster",
+			name: "disable restoreVM",
 			args: &v1beta1.Setting{
 				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
 				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": false}`,
 			},
-			isSingleNode: true,
-			expectedErr:  false,
-		},
-		{
-			name: "enable restoreVM under multi node cluster",
-			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
-				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": true}`,
-			},
-			isSingleNode: false,
-			expectedErr:  true,
-		},
-		{
-			name: "disable restoreVM under multi node cluster",
-			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
-				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": false}`,
-			},
-			isSingleNode: false,
-			expectedErr:  false,
+			expectedErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateUpgradeConfigFields(tt.args, tt.isSingleNode)
+			err := validateUpgradeConfigFields(tt.args)
 			assert.Equal(t, tt.expectedErr, err != nil)
 		})
 	}

--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -200,8 +200,14 @@ func (v *upgradeValidator) checkResources(version *v1beta1.Version, upgrade *v1b
 		return err
 	}
 
-	if err := v.checkNonLiveMigratableVMs(); err != nil {
+	restoreVM, err := util.IsRestoreVM()
+	if err != nil {
 		return err
+	}
+	if !restoreVM {
+		if err := v.checkNonLiveMigratableVMs(); err != nil {
+			return err
+		}
 	}
 
 	return v.checkCerts(version)


### PR DESCRIPTION
#### Problem:

In the current upgrade flow, if there is any non-migratable & running VMs exist, Harvester will ask the user to shut them down. After the upgrade completes, users need to manually start those VMs again. If users want to minimize the downtime of non-migratable VMs, they have to monitor the upgrade process for each node and manually restart the VMs as soon as their node finishes upgrading, which is quite inconvenient.

#### Solution:

This PR aims to provide a way to automatically bring non-migratable VMs back online once their node has been upgraded. We already have an option for this (`restoreVM`), as documented here: https://docs.harvesterhci.io/v1.6/advanced/index/#upgrade-config. However, currently this feature only works in a single-node environment. This PR extends the feature to support multi-node environments.

The idea is quite simple:
If restoreVM set to `true`
1. Add annotation `harvesterhci.io/restore-vm-{node_name}={vmnames_separated_by_comma}` to upgrade CR in pre-drain job (multi-node env) or single-node-upgrade job (single node env).
2. Non-migratable VMs will be shut down automatically when their node is about to be upgraded (see https://github.com/harvester/harvester/blob/master/package/upgrade/upgrade_node.sh#L292). And for migratable VMs, they should remain in running state during the whole upgrade process (if there is no trouble).
3. Once the node upgrade is "succeeded", `upgrade_controller` start the VMs in the annotation `harvesterhci.io/restore-vm-{node_name}`. Repeat the same process after each subsequent node upgrade. And also add another annotation `harvesterhci.io/restore-vm-finished-{node_name}` to make which node restore VM process is finished.

[Note]: paused non-migratable VM **_won't be started again_** after node upgrade finished.

#### Related Issue(s):

#8049 

#### Test plan:

**Test single node upgrade**
There are 2 scenarios here:
1. v1.5.0 upgrade to the version that includes this patch.
    - Prepare 3 VMs vm-stopped (in stopped state), vm-paused (in paused state), vm-running (in running state).
    - Enable `restoreVM` option
    - After the upgrade finished, only vm-running should be in running state, others should be in stopped state.
2. master -> master
    - Prepare 2 VMs, vm-stopped, vm-paused, vm-running.
    - Enable `restoreVM` option
    - After the upgrade finished, only vm-running should be in running state, others should be in stopped state.

**Test multi-node upgrade**
- Prepare a multi-node harvester cluster, create 5VMs
  vm-running, vm-stopped, vm0 (node-selector: node0), vm1 (node-selector: node1), vm2 (node-selector: node2)
- Enable the `restoreVM` option in upgradeConfig setting
- After upgrade finished, the VM state should be like picture in below.
![image](https://github.com/user-attachments/assets/66521d64-a01b-4f12-b7df-80eaadeeaea4)

#### Additional documentation or context
What are non-migratable VMs?
- VM contains node selector
- VM contains PCIe devices
- VM contains node affinities while we can't migrate to those nodes in node-affinities settings 
- VM contains CD-ROM or container disks
https://github.com/harvester/harvester/blob/master/pkg/util/virtualmachineinstance/virtualmachineinstance.go#L17