### PR TITLE
chore: only update issue [skip ci]

### DIFF
--- a/.github/workflows/issue-management-update-projects.yaml
+++ b/.github/workflows/issue-management-update-projects.yaml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   harvester:
+    # Skip PR
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -45,6 +47,8 @@ jobs:
         gh issue edit "$ISSUE_NUMBER" --milestone "Planning"
 
   community:
+    # Skip PR
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
#7983 

Don't need to handle PR. Example is #8110  

![image](https://github.com/user-attachments/assets/a96f2fe6-0461-404e-b281-cce528fc3e93)

[References](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only)