### PR TITLE
feat: add vm-migration-network setting

### DIFF
--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	corefake "k8s.io/client-go/kubernetes/fake"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	kubevirtutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 
 	"github.com/harvester/harvester/pkg/controller/master/migration"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -25,6 +26,7 @@ func TestMigrateAction(t *testing.T) {
 		name       string
 		nodeName   string
 		vmInstance *kubevirtv1.VirtualMachineInstance
+		kubeVirt   *kubevirtv1.KubeVirt
 	}
 	type output struct {
 		vmInstanceMigrations []*kubevirtv1.VirtualMachineInstanceMigration
@@ -41,6 +43,7 @@ func TestMigrateAction(t *testing.T) {
 				namespace:  "default",
 				name:       "test",
 				vmInstance: nil,
+				kubeVirt:   nil,
 			},
 			expected: output{
 				vmInstanceMigrations: []*kubevirtv1.VirtualMachineInstanceMigration{},
@@ -87,6 +90,7 @@ func TestMigrateAction(t *testing.T) {
 						},
 					},
 				},
+				kubeVirt: nil,
 			},
 			expected: output{
 				vmInstanceMigrations: []*kubevirtv1.VirtualMachineInstanceMigration{},
@@ -113,10 +117,71 @@ func TestMigrateAction(t *testing.T) {
 						},
 					},
 				},
+				kubeVirt: nil,
 			},
 			expected: output{
 				vmInstanceMigrations: []*kubevirtv1.VirtualMachineInstanceMigration{},
 				err:                  errors.New("Can't migrate the VM, the VM is not in ready status"),
+			},
+		},
+		{
+			name: "kubevirt not found",
+			given: input{
+				namespace: "default",
+				name:      "test",
+				vmInstance: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Phase: kubevirtv1.Running,
+						Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
+							{
+								Type:   kubevirtv1.VirtualMachineInstanceReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				kubeVirt: nil,
+			},
+			expected: output{
+				vmInstanceMigrations: []*kubevirtv1.VirtualMachineInstanceMigration{},
+				err:                  apierrors.NewNotFound(kubevirtv1.Resource("kubevirts"), "kubevirt"),
+			},
+		},
+		{
+			name: "kubevirt condition not found",
+			given: input{
+				namespace: "default",
+				name:      "test",
+				vmInstance: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Phase: kubevirtv1.Running,
+						Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
+							{
+								Type:   kubevirtv1.VirtualMachineInstanceReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				kubeVirt: &kubevirtv1.KubeVirt{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "harvester-system",
+						Name:      "kubevirt",
+					},
+					Status: kubevirtv1.KubeVirtStatus{},
+				},
+			},
+			expected: output{
+				vmInstanceMigrations: []*kubevirtv1.VirtualMachineInstanceMigration{},
+				err:                  errors.New("KubeVirt is not ready"),
 			},
 		},
 		{
@@ -135,6 +200,21 @@ func TestMigrateAction(t *testing.T) {
 							{
 								Type:   kubevirtv1.VirtualMachineInstanceReady,
 								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				kubeVirt: &kubevirtv1.KubeVirt{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "harvester-system",
+						Name:      "kubevirt",
+					},
+					Status: kubevirtv1.KubeVirtStatus{
+						Conditions: []kubevirtv1.KubeVirtCondition{
+							{
+								Type:   kubevirtv1.KubeVirtConditionAvailable,
+								Status: corev1.ConditionTrue,
+								Reason: kubevirtutil.ConditionReasonDeploymentReady,
 							},
 						},
 					},
@@ -177,6 +257,10 @@ func TestMigrateAction(t *testing.T) {
 			err := clientset.Tracker().Add(tc.given.vmInstance)
 			assert.Nil(t, err, "Mock resource should add into fake controller tracker")
 		}
+		if tc.given.kubeVirt != nil {
+			err := clientset.Tracker().Add(tc.given.kubeVirt)
+			assert.Nil(t, err, "Mock resource should add into fake controller tracker")
+		}
 
 		for _, node := range fakeNodeList {
 			err := coreclientset.Tracker().Add(node)
@@ -184,11 +268,12 @@ func TestMigrateAction(t *testing.T) {
 		}
 
 		var handler = &vmActionHandler{
-			nodeCache: fakeclients.NodeCache(coreclientset.CoreV1().Nodes),
-			vmis:      fakeclients.VirtualMachineInstanceClient(clientset.KubevirtV1().VirtualMachineInstances),
-			vmiCache:  fakeclients.VirtualMachineInstanceCache(clientset.KubevirtV1().VirtualMachineInstances),
-			vmims:     fakeclients.VirtualMachineInstanceMigrationClient(clientset.KubevirtV1().VirtualMachineInstanceMigrations),
-			vmimCache: fakeclients.VirtualMachineInstanceMigrationCache(clientset.KubevirtV1().VirtualMachineInstanceMigrations),
+			nodeCache:     fakeclients.NodeCache(coreclientset.CoreV1().Nodes),
+			kubevirtCache: fakeclients.KubeVirtCache(clientset.KubevirtV1().KubeVirts),
+			vmis:          fakeclients.VirtualMachineInstanceClient(clientset.KubevirtV1().VirtualMachineInstances),
+			vmiCache:      fakeclients.VirtualMachineInstanceCache(clientset.KubevirtV1().VirtualMachineInstances),
+			vmims:         fakeclients.VirtualMachineInstanceMigrationClient(clientset.KubevirtV1().VirtualMachineInstanceMigrations),
+			vmimCache:     fakeclients.VirtualMachineInstanceMigrationCache(clientset.KubevirtV1().VirtualMachineInstanceMigrations),
 		}
 
 		var actual output

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -39,6 +39,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	server.BaseSchemas.MustImportAndCustomize(CPUAndMemoryHotplugInput{}, nil)
 
 	dataVolumeClient := scaled.CdiFactory.Cdi().V1beta1().DataVolume()
+	kubevirtCache := scaled.VirtFactory.Kubevirt().V1().KubeVirt().Cache()
 	vms := scaled.VirtFactory.Kubevirt().V1().VirtualMachine()
 	vmis := scaled.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	vmims := scaled.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration()
@@ -71,6 +72,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	actionHandler := vmActionHandler{
 		namespace:                 options.Namespace,
 		datavolumeClient:          dataVolumeClient,
+		kubevirtCache:             kubevirtCache,
 		vms:                       vms,
 		vmCache:                   vms.Cache(),
 		vmis:                      vmis,

--- a/pkg/controller/master/kubevirt/vm_migration_network.go
+++ b/pkg/controller/master/kubevirt/vm_migration_network.go
@@ -1,0 +1,254 @@
+package kubevirt
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/config"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
+	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/network"
+)
+
+const (
+	ControllerName = "harvester-vm-migration-network-controller"
+
+	VMMigrationNetworkPrefix         = "vm-migration-network.settings.harvesterhci.io"
+	VMMigrationNetworkHashLabel      = VMMigrationNetworkPrefix + "/hash"
+	VMMigrationNetworkHashAnnotation = VMMigrationNetworkHashLabel
+	VMMigrationNetworkNadAnnotation  = VMMigrationNetworkPrefix + "/net-attach-def"
+
+	KubeVirtName                         = "kubevirt"
+	VMMigrationNetworkNetAttachDefPrefix = "vm-migration-network-"
+)
+
+type Handler struct {
+	ctx                               context.Context
+	settings                          ctlharvesterv1.SettingClient
+	networkAttachmentDefinitions      ctlcniv1.NetworkAttachmentDefinitionClient
+	networkAttachmentDefinitionsCache ctlcniv1.NetworkAttachmentDefinitionCache
+	kubevirts                         ctlkubevirtv1.KubeVirtClient
+	kubevirtCache                     ctlkubevirtv1.KubeVirtCache
+}
+
+// register the setting controller and reconsile longhorn setting when storage network changed
+func Register(ctx context.Context, management *config.Management, _ config.Options) error {
+	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
+	networkAttachmentDefinitions := management.CniFactory.K8s().V1().NetworkAttachmentDefinition()
+	kubevirts := management.VirtFactory.Kubevirt().V1().KubeVirt()
+
+	controller := &Handler{
+		ctx:                               ctx,
+		settings:                          settings,
+		networkAttachmentDefinitions:      networkAttachmentDefinitions,
+		networkAttachmentDefinitionsCache: networkAttachmentDefinitions.Cache(),
+		kubevirts:                         kubevirts,
+		kubevirtCache:                     kubevirts.Cache(),
+	}
+
+	settings.OnChange(ctx, ControllerName, controller.OnVMMigrationNetworkChange)
+	return nil
+}
+
+func (h *Handler) setConfiguredCondition(setting *harvesterv1.Setting, finish bool, reason, msg, nadAnnotation string) (*harvesterv1.Setting, error) {
+	settingCopy := setting.DeepCopy()
+	if settingCopy.Annotations == nil {
+		settingCopy.Annotations = make(map[string]string)
+	}
+	settingCopy.Annotations[VMMigrationNetworkNadAnnotation] = nadAnnotation
+	settingCopy.Annotations[VMMigrationNetworkHashAnnotation] = h.sha1(setting.Value)
+
+	harvesterv1.SettingConfigured.Reason(settingCopy, reason)
+	harvesterv1.SettingConfigured.Message(settingCopy, msg)
+	if finish {
+		harvesterv1.SettingConfigured.True(settingCopy)
+	} else {
+		harvesterv1.SettingConfigured.False(settingCopy)
+	}
+
+	if !reflect.DeepEqual(settingCopy, setting) {
+		s, err := h.settings.Update(settingCopy)
+		if err != nil {
+			return s, err
+		}
+		return s, nil
+	}
+
+	return setting, nil
+}
+
+func (h *Handler) OnVMMigrationNetworkChange(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != settings.VMMigrationNetworkSettingName {
+		return setting, nil
+	}
+
+	if setting.Annotations == nil {
+		if setting.Value == "" {
+			// initialization case, don't update status, just skip it.
+			return setting, nil
+		}
+		setting.Annotations = make(map[string]string)
+	}
+
+	if h.checkIsSameHashValue(setting) {
+		return setting, nil
+	}
+
+	logrus.Infof("vm migration network change: %s", setting.Value)
+
+	kubevirt, err := h.kubevirtCache.Get(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)
+	if err != nil {
+		return h.setConfiguredCondition(setting, false, "GetKubeVirtError", fmt.Sprintf("get kubevirt error %v", err), setting.Annotations[VMMigrationNetworkNadAnnotation])
+	}
+	kubevirtCopy := kubevirt.DeepCopy()
+	if kubevirtCopy.Spec.Configuration.MigrationConfiguration == nil {
+		kubevirtCopy.Spec.Configuration.MigrationConfiguration = &kubevirtv1.MigrationConfiguration{}
+	}
+
+	oldNadAnnotation := setting.Annotations[VMMigrationNetworkNadAnnotation]
+	removeOldNad := true
+
+	var nadAnnotation string
+	if setting.Value != "" {
+		nad, err := h.findOrCreateNad(setting)
+		if err != nil {
+			return h.setConfiguredCondition(setting, false, "CreateNadError", fmt.Sprintf("create nad error %v", err), oldNadAnnotation)
+		}
+		nadAnnotation = fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
+		if oldNadAnnotation == nadAnnotation {
+			removeOldNad = false
+		}
+
+		kubevirtCopy.Spec.Configuration.MigrationConfiguration.Network = &nad.Name
+	} else {
+		kubevirtCopy.Spec.Configuration.MigrationConfiguration.Network = nil
+	}
+
+	if !reflect.DeepEqual(kubevirt.Spec.Configuration, kubevirtCopy.Spec.Configuration) {
+		if _, err = h.kubevirts.Update(kubevirtCopy); err != nil {
+			return h.setConfiguredCondition(setting, false, "UpdateKubeVirtError", fmt.Sprintf("update kubevirt error %v", err), oldNadAnnotation)
+		}
+	}
+
+	if removeOldNad {
+		oldNadNamespaceAndName := strings.Split(oldNadAnnotation, "/")
+		if len(oldNadNamespaceAndName) == 2 {
+			if err = h.removeOldNad(oldNadNamespaceAndName[0], oldNadNamespaceAndName[1]); err != nil {
+				return h.setConfiguredCondition(setting, false, "RemoveOldNadError", fmt.Sprintf("remove old nad error %v", err), oldNadAnnotation)
+			}
+		}
+	}
+
+	return h.setConfiguredCondition(setting, true, "", "", nadAnnotation)
+}
+
+// calc sha1 hash
+func (h *Handler) sha1(s string) string {
+	hash := sha1.New()
+	hash.Write([]byte(s))
+	sha1sum := hash.Sum(nil)
+	return fmt.Sprintf("%x", sha1sum)
+}
+
+func (h *Handler) checkIsSameHashValue(setting *harvesterv1.Setting) bool {
+	currentHash := h.sha1(setting.Value)
+	savedHash := setting.Annotations[VMMigrationNetworkHashLabel]
+	return currentHash == savedHash
+}
+
+func (h *Handler) createNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachmentDefinition, error) {
+	var config network.Config
+	if err := json.Unmarshal([]byte(setting.Value), &config); err != nil {
+		return nil, fmt.Errorf("parsing value error %v", err)
+	}
+	bridgeConfig := network.CreateBridgeConfig(config)
+
+	nadConfig, err := json.Marshal(bridgeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("output json error %v", err)
+	}
+
+	nad := nadv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: VMMigrationNetworkNetAttachDefPrefix,
+			Namespace:    util.HarvesterSystemNamespaceName,
+		},
+	}
+	nad.Annotations = map[string]string{
+		VMMigrationNetworkPrefix: "true",
+	}
+	nad.Labels = map[string]string{
+		VMMigrationNetworkHashLabel: h.sha1(setting.Value),
+	}
+	nad.Spec.Config = string(nadConfig)
+
+	// create nad
+	var nadResult *nadv1.NetworkAttachmentDefinition
+	if nadResult, err = h.networkAttachmentDefinitions.Create(&nad); err != nil {
+		return nil, fmt.Errorf("create net-attach-def failed %v", err)
+	}
+
+	return nadResult, nil
+}
+
+func (h *Handler) findOrCreateNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachmentDefinition, error) {
+	nads, err := h.networkAttachmentDefinitions.List(util.HarvesterSystemNamespaceName, metav1.ListOptions{
+		LabelSelector: labels.Set{
+			VMMigrationNetworkHashLabel: h.sha1(setting.Value),
+		}.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nads.Items) == 0 {
+		return h.createNad(setting)
+	}
+
+	if len(nads.Items) > 1 {
+		logrus.WithFields(logrus.Fields{
+			"sha1":     h.sha1(setting.Value),
+			"count":    len(nads.Items),
+			"nad.name": nads.Items[0].Name,
+		}).Info("found more than one match nad")
+	}
+
+	return &nads.Items[0], nil
+}
+
+func (h *Handler) removeOldNad(namespace, name string) error {
+	if _, err := h.networkAttachmentDefinitionsCache.Get(namespace, name); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"nad.namespace": namespace,
+			"nad.name":      name,
+		}).Warn("NAD not found")
+		return err
+	}
+
+	if err := h.networkAttachmentDefinitions.Delete(namespace, name, &metav1.DeleteOptions{}); err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"nad.namespace": namespace,
+			"nad.name":      name,
+		}).Warn("cannot delete nad")
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -93,6 +93,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		harvSettings.MaxHotplugRatioSettingName:                  controller.syncMaxHotplugRatio,
 		// for "backup-target" syncer, please check harvester-backup-target-controller
 		// for "storage-network" syncer, please check harvester-storage-network-controller
+		// for "vm-migration-network" syncer, please check harvester-vm-migration-network-controller
 	}
 
 	settings.OnChange(ctx, controllerName, controller.settingOnChanged)

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/backup"
 	"github.com/harvester/harvester/pkg/controller/master/image"
 	"github.com/harvester/harvester/pkg/controller/master/keypair"
+	"github.com/harvester/harvester/pkg/controller/master/kubevirt"
 	"github.com/harvester/harvester/pkg/controller/master/machine"
 	"github.com/harvester/harvester/pkg/controller/master/mcmsettings"
 	"github.com/harvester/harvester/pkg/controller/master/migration"
@@ -65,6 +66,7 @@ var registerFuncs = []registerFunc{
 	schedulevmbackup.Register,
 	resourcequota.Register,
 	vmimagedownloader.Register,
+	kubevirt.Register,
 }
 
 func register(ctx context.Context, management *config.Management, options config.Options) error {

--- a/pkg/controller/master/storagenetwork/storage_network.go
+++ b/pkg/controller/master/storagenetwork/storage_network.go
@@ -27,6 +27,7 @@ import (
 	whereaboutscniv1 "github.com/harvester/harvester/pkg/generated/controllers/whereabouts.cni.cncf.io/v1alpha1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/network"
 )
 
 const (
@@ -46,10 +47,6 @@ const (
 	StorageNetworkNetAttachDefNamespace = util.StorageNetworkNetAttachDefNamespace
 
 	BridgeSuffix = "-br"
-	CNIVersion   = "0.3.1"
-	DefaultPVID  = 1
-	DefaultCNI   = "bridge"
-	DefaultIPAM  = "whereabouts"
 
 	// status
 	ReasonInProgress         = "In Progress"
@@ -64,43 +61,6 @@ const (
 
 	longhornStorageNetworkName = "storage-network"
 )
-
-type Config struct {
-	ClusterNetwork string   `json:"clusterNetwork,omitempty"`
-	Vlan           uint16   `json:"vlan,omitempty"`
-	Range          string   `json:"range,omitempty"`
-	Exclude        []string `json:"exclude,omitempty"`
-}
-
-// Note: this data type should align with https://github.com/containernetworking/cni/blob/main/pkg/types/types.go#L64-L78
-// and https://github.com/containernetworking/plugins/blob/main/plugins/main/bridge/bridge.go#L47-L75
-type BridgeConfig struct {
-	CNIVersion  string     `json:"cniVersion"`
-	Type        string     `json:"type"`
-	Bridge      string     `json:"bridge"`
-	PromiscMode bool       `json:"promiscMode"`
-	Vlan        int        `json:"vlan"`
-	IPAM        IPAMConfig `json:"ipam"`
-}
-
-// Note: this data type should align with https://github.com/k8snetworkplumbingwg/whereabouts/blob/master/pkg/types/types.go#L48-L75
-type IPAMConfig struct {
-	Type    string   `json:"type"`
-	Range   string   `json:"range"`
-	Exclude []string `json:"exclude,omitempty"`
-}
-
-func NewBridgeConfig() *BridgeConfig {
-	return &BridgeConfig{
-		CNIVersion:  CNIVersion,
-		Type:        DefaultCNI,
-		PromiscMode: true,
-		Vlan:        DefaultPVID,
-		IPAM: IPAMConfig{
-			Type: DefaultIPAM,
-		},
-	}
-}
 
 type Handler struct {
 	ctx                               context.Context
@@ -283,24 +243,11 @@ func (h *Handler) setNadAnnotations(setting *harvesterv1.Setting, newNad string)
 }
 
 func (h *Handler) createNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachmentDefinition, error) {
-	var config Config
-	bridgeConfig := NewBridgeConfig()
-
+	var config network.Config
 	if err := json.Unmarshal([]byte(setting.Value), &config); err != nil {
 		return nil, fmt.Errorf("parsing value error %v", err)
 	}
-
-	bridgeConfig.Bridge = config.ClusterNetwork + BridgeSuffix
-	bridgeConfig.IPAM.Range = config.Range
-
-	if config.Vlan == 0 {
-		config.Vlan = DefaultPVID
-	}
-	bridgeConfig.Vlan = int(config.Vlan)
-
-	if len(config.Exclude) > 0 {
-		bridgeConfig.IPAM.Exclude = config.Exclude
-	}
+	bridgeConfig := network.CreateBridgeConfig(config)
 
 	nadConfig, err := json.Marshal(bridgeConfig)
 	if err != nil {
@@ -428,7 +375,7 @@ func (h *Handler) validateIPAddressesAllocations(setting *harvesterv1.Setting) e
 	//and only the number of nodes each running an instance-manager pod is used
 	MinAllocatableIPAddrs := len(nodes)
 
-	var config Config
+	var config network.Config
 
 	if err := json.Unmarshal([]byte(setting.Value), &config); err != nil {
 		return fmt.Errorf("parsing value error %v", err)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -60,6 +60,7 @@ var (
 	WhiteListedSettings    = []string{ServerVersionSettingName, DefaultStorageClassSettingName, HarvesterCSICCMSettingName, DefaultVMTerminationGracePeriodSecondsSettingName}
 	UpgradeConfigSet       = NewSetting(UpgradeConfigSettingName, `{"imagePreloadOption":{"strategy":{"type":"sequential"}}, "restoreVM": false}`)
 	MaxHotplugRatio        = NewSetting(MaxHotplugRatioSettingName, "4")
+	VMMigrationNetwork     = NewSetting(VMMigrationNetworkSettingName, "")
 )
 
 const (
@@ -107,6 +108,7 @@ const (
 	SupportBundleNamespacesSettingName                = "support-bundle-namespaces"
 	DefaultStorageClassSettingName                    = "default-storage-class"
 	MaxHotplugRatioSettingName                        = "max-hotplug-ratio"
+	VMMigrationNetworkSettingName                     = "vm-migration-network"
 
 	// settings have `default` and `value` string used in many places, replace them with const
 	KeywordDefault = "default"

--- a/pkg/util/fakeclients/kubevirt.go
+++ b/pkg/util/fakeclients/kubevirt.go
@@ -1,0 +1,40 @@
+package fakeclients
+
+import (
+	"context"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kubevirtv1api "kubevirt.io/api/core/v1"
+
+	kubevirtv1 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/kubevirt.io/v1"
+)
+
+type KubeVirtCache func(string) kubevirtv1.KubeVirtInterface
+
+func (c KubeVirtCache) Get(namespace, name string) (*kubevirtv1api.KubeVirt, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c KubeVirtCache) List(namespace string, selector labels.Selector) ([]*kubevirtv1api.KubeVirt, error) {
+	list, err := c(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*kubevirtv1api.KubeVirt, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, err
+}
+
+func (c KubeVirtCache) AddIndexer(_ string, _ generic.Indexer[*kubevirtv1api.KubeVirt]) {
+	panic("implement me")
+}
+
+func (c KubeVirtCache) GetByIndex(_, _ string) ([]*kubevirtv1api.KubeVirt, error) {
+	panic("implement me")
+}

--- a/pkg/util/network/common.go
+++ b/pkg/util/network/common.go
@@ -1,0 +1,59 @@
+package network
+
+const (
+	BridgeSuffix = "-br"
+	CNIVersion   = "0.3.1"
+	DefaultPVID  = 1
+	DefaultCNI   = "bridge"
+	DefaultIPAM  = "whereabouts"
+)
+
+type Config struct {
+	ClusterNetwork string   `json:"clusterNetwork,omitempty"`
+	Vlan           uint16   `json:"vlan,omitempty"`
+	Range          string   `json:"range,omitempty"`
+	Exclude        []string `json:"exclude,omitempty"`
+}
+
+// Note: this data type should align with https://github.com/containernetworking/cni/blob/main/pkg/types/types.go#L64-L78
+// and https://github.com/containernetworking/plugins/blob/main/plugins/main/bridge/bridge.go#L47-L75
+type BridgeConfig struct {
+	CNIVersion  string     `json:"cniVersion"`
+	Type        string     `json:"type"`
+	Bridge      string     `json:"bridge"`
+	PromiscMode bool       `json:"promiscMode"`
+	Vlan        int        `json:"vlan"`
+	IPAM        IPAMConfig `json:"ipam"`
+}
+
+// Note: this data type should align with https://github.com/k8snetworkplumbingwg/whereabouts/blob/master/pkg/types/types.go#L48-L75
+type IPAMConfig struct {
+	Type    string   `json:"type"`
+	Range   string   `json:"range"`
+	Exclude []string `json:"exclude,omitempty"`
+}
+
+func CreateBridgeConfig(config Config) BridgeConfig {
+	bridgeConfig := BridgeConfig{
+		CNIVersion:  CNIVersion,
+		Type:        DefaultCNI,
+		PromiscMode: true,
+		Vlan:        DefaultPVID,
+		IPAM: IPAMConfig{
+			Type: DefaultIPAM,
+		},
+	}
+	bridgeConfig.Bridge = config.ClusterNetwork + BridgeSuffix
+	bridgeConfig.IPAM.Range = config.Range
+
+	if config.Vlan == 0 {
+		config.Vlan = DefaultPVID
+	}
+	bridgeConfig.Vlan = int(config.Vlan)
+
+	if len(config.Exclude) > 0 {
+		bridgeConfig.IPAM.Exclude = config.Exclude
+	}
+
+	return bridgeConfig
+}

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -1190,7 +1190,7 @@ func Test_validateStorageNetworkConfig(t *testing.T) {
 		// more tests are depending on a bunch of fake objects
 	}
 
-	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1271,7 +1271,7 @@ func Test_validateMaxHotplugRatio(t *testing.T) {
 		},
 	}
 
-	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -129,6 +129,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache(),
 			clients.RancherManagementFactory.Management().V3().Feature().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta2().Volume().Cache(),
 			clients.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),

--- a/pkg/webhook/util/ip_test.go
+++ b/pkg/webhook/util/ip_test.go
@@ -5,19 +5,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	storagenetworkctl "github.com/harvester/harvester/pkg/controller/master/storagenetwork"
+	networkutil "github.com/harvester/harvester/pkg/util/network"
 )
 
 func Test_ipAddressRange(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		config      *storagenetworkctl.Config
+		config      *networkutil.Config
 		expectedErr bool
 	}{
 		{
 			name: "exclude a subset of include range,returns > MinallocatableIPAddrs addresses",
-			config: &storagenetworkctl.Config{
+			config: &networkutil.Config{
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.1/30"},
 			},
@@ -25,7 +25,7 @@ func Test_ipAddressRange(t *testing.T) {
 		},
 		{
 			name: "exclude a subset of include range,returns > MinallocatableIPAddrs addresses",
-			config: &storagenetworkctl.Config{
+			config: &networkutil.Config{
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.1/28"},
 			},
@@ -33,7 +33,7 @@ func Test_ipAddressRange(t *testing.T) {
 		},
 		{
 			name: "valid include range,returns > MinallocatableIPAddrs addresses",
-			config: &storagenetworkctl.Config{
+			config: &networkutil.Config{
 				Range:   "192.168.2.0/27",
 				Exclude: []string{},
 			},
@@ -41,7 +41,7 @@ func Test_ipAddressRange(t *testing.T) {
 		},
 		{
 			name: "exclude all from include subnet,returns no allocatable addresses",
-			config: &storagenetworkctl.Config{
+			config: &networkutil.Config{
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.0/24"},
 			},
@@ -49,7 +49,7 @@ func Test_ipAddressRange(t *testing.T) {
 		},
 		{
 			name: "exclude all from include subnet,returns no allocatable addresses",
-			config: &storagenetworkctl.Config{
+			config: &networkutil.Config{
 				Range:   "192.168.2.0/30",
 				Exclude: []string{"192.168.2.1/30"},
 			},
@@ -57,7 +57,7 @@ func Test_ipAddressRange(t *testing.T) {
 		},
 		{
 			name: "no allocatable ip addresses in include range",
-			config: &storagenetworkctl.Config{
+			config: &networkutil.Config{
 				Range:   "192.168.2.0/32",
 				Exclude: []string{},
 			},
@@ -65,7 +65,7 @@ func Test_ipAddressRange(t *testing.T) {
 		},
 		{
 			name: "no allocatable ip addresses in include range",
-			config: &storagenetworkctl.Config{
+			config: &networkutil.Config{
 				Range:   "192.168.2.0/31",
 				Exclude: []string{},
 			},


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

### Problem:
Currently, the harvester only supports VM migration on mgmt network.

### Solution:
Support to use other [migration network](https://kubevirt.io/user-guide/compute/live_migration/#using-a-different-network-for-migrations).

### Related Issue(s):
https://github.com/harvester/harvester/issues/5848

### Test plan:
#### Setup
1. Use [ipxe vagrant](https://github.com/harvester/ipxe-examples/tree/main/vagrant-pxe-harvester) to create a 3-node harvester.
2. Add new network "Virtual network 'harvester'" on each node.
    <img width="760" alt="Image" src="https://github.com/user-attachments/assets/dd8de2f6-b209-47a7-b8cf-d3a18e6796c9" />
3. Run `ip a` on each node and there is `ens7` on each node.
4. Run `ip link set ens7 up` on each node.
5. Add new network "Virtual network 'default'" on each node.
6. Run `ip a` on each node and there is `ens8` on each node.
7. Run `ip link set ens8 up` on each node.
8. Create `test-1` and `test-2` Cluster Network.
9. Create Network under `test-1` with "Select all nodes" and and NIC "ens7".
10. Create Network under `test-2` with "Select all nodes" and and NIC "ens8".

#### Case 1: Change `vm-migration-network` from default value to `test-1` network
1. Modify `vm-migration-network` setting with value `{"clusterNetwork":"test-1","vlan":1,"range":"10.1.2.0/24"}`.
2. Check `harvester-system/kubevirt` KubeVirt resource, the `Available` type condition has reason `UpdateInProgress`.
3. Before the `Available` type condition has reason `AllComponentsReady`, users cannot migrate VM.
4. After the `Available` type condition has reason `AllComponentsReady`, migrate VM can work.

#### Case 2: Change `vm-migration-network` from `test-1` to `test-2` network
1. Modify `vm-migration-network` setting with value `{"clusterNetwork":"test-2","vlan":1,"range":"10.1.2.0/24"}`.
2. Check `harvester-system/kubevirt` KubeVirt resource, the `Available` type condition has reason `UpdateInProgress`.
3. Before the `Available` type condition has reason `AllComponentsReady`, users cannot migrate VM.
4. After the `Available` type condition has reason `AllComponentsReady`, migrate VM can work.

#### Case 3: Change `vm-migration-network` from `test-2` to default value
1. Modify `vm-migration-network` setting with value `""`.
2. Check `harvester-system/kubevirt` KubeVirt resource, the `Available` type condition has reason `UpdateInProgress`.
3. Before the `Available` type condition has reason `AllComponentsReady`, users cannot migrate VM.
4. After the `Available` type condition has reason `AllComponentsReady`, migrate VM can work.

#### Case 4: Webhook deny wrong setting
* Non-existent cluster network: `{"clusterNetwork":"non-existent","vlan":1,"range":"10.1.2.0/24"}`
* Range doesn't provide enough ip all nodes: `{"clusterNetwork":"test-2","vlan":1,"range":"10.1.2.0/32"}`
* (Range - Exclude) doesn't provide enough ip all nodes: `{"clusterNetwork":"test-2","vlan":1,"range":"10.1.2.0/30","exclude":["10.1.2.0/32","10.1.2.1/32"]}`