### PR TITLE
webhook/image: ensure the StroageClass is set

### DIFF
--- a/pkg/image/backend/backend.go
+++ b/pkg/image/backend/backend.go
@@ -23,6 +23,7 @@ type Validator interface {
 
 type Mutator interface {
 	Create(vmi *harvesterv1.VirtualMachineImage) (types.PatchOps, error)
+	Update(oldVMI, newVMI *harvesterv1.VirtualMachineImage) (types.PatchOps, error)
 }
 
 type Downloader interface {

--- a/pkg/image/backingimage/mutate.go
+++ b/pkg/image/backingimage/mutate.go
@@ -16,5 +16,20 @@ func GetMutator(vmim common.VMIMutator) backend.Mutator {
 }
 
 func (bim *Mutator) Create(vmi *harvesterv1.VirtualMachineImage) (types.PatchOps, error) {
-	return bim.vmim.PatchImageSCParams(vmi)
+	patchOPs, err := bim.vmim.PatchImageSCParams(vmi)
+	if err != nil {
+		return patchOPs, err
+	}
+	tmpPatchOps, err := bim.vmim.EnsureTargetSC(vmi)
+	if err != nil {
+		return patchOPs, err
+	}
+	if tmpPatchOps != nil {
+		patchOPs = append(patchOPs, tmpPatchOps...)
+	}
+	return patchOPs, nil
+}
+
+func (bim *Mutator) Update(_, newVMI *harvesterv1.VirtualMachineImage) (types.PatchOps, error) {
+	return bim.vmim.EnsureTargetSC(newVMI)
 }

--- a/pkg/image/backingimage/validate.go
+++ b/pkg/image/backingimage/validate.go
@@ -20,6 +20,10 @@ func (biv *Validator) Create(request *types.Request, vmi *harvesterv1.VirtualMac
 		return err
 	}
 
+	if err := biv.vmiv.SCConsistency(nil, vmi); err != nil {
+		return err
+	}
+
 	if err := biv.vmiv.CheckURL(vmi); err != nil {
 		return err
 	}
@@ -37,6 +41,10 @@ func (biv *Validator) Create(request *types.Request, vmi *harvesterv1.VirtualMac
 
 func (biv *Validator) Update(oldVMI, newVMI *harvesterv1.VirtualMachineImage) error {
 	if err := biv.vmiv.SCParametersConsistency(oldVMI, newVMI); err != nil {
+		return err
+	}
+
+	if err := biv.vmiv.SCConsistency(oldVMI, newVMI); err != nil {
 		return err
 	}
 

--- a/pkg/image/cdi/mutate.go
+++ b/pkg/image/cdi/mutate.go
@@ -3,16 +3,22 @@ package cdi
 import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/image/backend"
+	"github.com/harvester/harvester/pkg/image/common"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
 type Mutator struct {
+	vmim common.VMIMutator
 }
 
-func GetMutator() backend.Mutator {
-	return &Mutator{}
+func GetMutator(vmim common.VMIMutator) backend.Mutator {
+	return &Mutator{vmim}
 }
 
-func (cm *Mutator) Create(_ *harvesterv1.VirtualMachineImage) (types.PatchOps, error) {
-	return nil, nil
+func (cm *Mutator) Create(vmImg *harvesterv1.VirtualMachineImage) (types.PatchOps, error) {
+	return cm.vmim.EnsureTargetSC(vmImg)
+}
+
+func (cm *Mutator) Update(_, newVMImg *harvesterv1.VirtualMachineImage) (types.PatchOps, error) {
+	return cm.vmim.EnsureTargetSC(newVMImg)
 }

--- a/pkg/image/cdi/validate.go
+++ b/pkg/image/cdi/validate.go
@@ -20,6 +20,10 @@ func (cv *Validator) Create(req *types.Request, vmImg *harvesterv1.VirtualMachin
 		return err
 	}
 
+	if err := cv.vmiv.SCConsistency(nil, vmImg); err != nil {
+		return err
+	}
+
 	if err := cv.vmiv.CheckURL(vmImg); err != nil {
 		return err
 	}
@@ -36,6 +40,10 @@ func (cv *Validator) Create(req *types.Request, vmImg *harvesterv1.VirtualMachin
 
 func (cv *Validator) Update(oldVMImg, newVMImg *harvesterv1.VirtualMachineImage) error {
 	if err := cv.vmiv.SourceTypeConsistency(oldVMImg, newVMImg); err != nil {
+		return err
+	}
+
+	if err := cv.vmiv.SCConsistency(oldVMImg, newVMImg); err != nil {
 		return err
 	}
 

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -8,7 +8,11 @@ import (
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	lhutil "github.com/longhorn/longhorn-manager/util"
+	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
+	"github.com/sirupsen/logrus"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
@@ -106,4 +110,34 @@ func GetImageDefaultStorageClassParameters() map[string]string {
 
 func GetVMIBackend(vmi *harvesterv1.VirtualMachineImage) harvesterv1.VMIBackend {
 	return vmi.Spec.Backend
+}
+
+func GetDefaultSC(scCache ctlstoragev1.StorageClassCache) *storagev1.StorageClass {
+	scList, err := GetSCWithSelector(scCache, labels.Everything())
+	if err != nil {
+		logrus.Warnf("failed to list all storage classes: %v", err)
+		return nil
+	}
+
+	// find the default storage class
+	for _, storageClass := range scList {
+		if storageClass.Annotations[AnnotationIsDefaultStorageClassName] == "true" {
+			return storageClass
+		}
+	}
+
+	return nil
+}
+
+func GetSCWithSelector(scCache ctlstoragev1.StorageClassCache, selector labels.Selector) ([]*storagev1.StorageClass, error) {
+	scList, err := scCache.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(scList) == 0 {
+		return nil, fmt.Errorf("no storage class found with selector %v", selector)
+	}
+
+	return scList, nil
 }

--- a/tests/framework/env/env.go
+++ b/tests/framework/env/env.go
@@ -51,6 +51,11 @@ const (
 	// export USE_EXISTING_CLUSTER=true
 	// export SKIP_HARVESTER_INSTALLATION=true
 	// export DONT_USE_EMULATION=true
+
+	// DefaultStorageClass in integration test is "standard", comes from `rancher.io/local-path`
+	DefaultStorageClassName = "standard"
+
+	AnnoVMImageStorageClass = "harvesterhci.io/storageClassName"
 )
 
 // IsTrue validates that the specified environment variable is true.

--- a/tests/integration/api/image_apis_test.go
+++ b/tests/integration/api/image_apis_test.go
@@ -9,6 +9,7 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/tests/framework/env"
 	"github.com/harvester/harvester/tests/framework/fuzz"
 	"github.com/harvester/harvester/tests/framework/helper"
 )
@@ -110,6 +111,16 @@ var _ = Describe("verify image APIs", func() {
 				image.Spec.StorageClassParameters = util.GetImageDefaultStorageClassParameters()
 				respCode, respBody, err := helper.GetObject(getImageURL, &retImage)
 				MustRespCodeIs(http.StatusOK, "get image", err, respCode, respBody)
+				// default SC is set by mutator, check it then remove it for annotation checking
+				v, find := retImage.Annotations[env.AnnoVMImageStorageClass]
+				Expect(find).To(BeTrue())
+				Expect(v).To(Equal(env.DefaultStorageClassName))
+				delete(retImage.Annotations, env.AnnoVMImageStorageClass)
+				// spec.targetStorageClassName is also set by mutator, check the result and
+				// fill into image for checking
+				if retImage.Spec.TargetStorageClassName == env.DefaultStorageClassName {
+					image.Spec.TargetStorageClassName = env.DefaultStorageClassName
+				}
 				Expect(retImage.Labels).To(BeEquivalentTo(image.Labels))
 				Expect(retImage.Annotations).To(BeEquivalentTo(image.Annotations))
 				Expect(retImage.Spec).To(BeEquivalentTo(image.Spec))
@@ -154,6 +165,16 @@ var _ = Describe("verify image APIs", func() {
 				image.Spec.StorageClassParameters = util.GetImageDefaultStorageClassParameters()
 				respCode, respBody, err := helper.GetObject(getImageURL, &retImage)
 				MustRespCodeIs(http.StatusOK, "get image", err, respCode, respBody)
+				// default SC is set by mutator, check it then remove it for annotation checking
+				v, find := retImage.Annotations[env.AnnoVMImageStorageClass]
+				Expect(find).To(BeTrue())
+				Expect(v).To(Equal(env.DefaultStorageClassName))
+				delete(retImage.Annotations, env.AnnoVMImageStorageClass)
+				// spec.targetStorageClassName is also set by mutator, check the result and
+				// fill into image for checking
+				if retImage.Spec.TargetStorageClassName == env.DefaultStorageClassName {
+					image.Spec.TargetStorageClassName = env.DefaultStorageClassName
+				}
 				Expect(retImage.Labels).To(BeEquivalentTo(image.Labels))
 				Expect(retImage.Annotations).To(BeEquivalentTo(image.Annotations))
 				Expect(retImage.Spec).To(BeEquivalentTo(image.Spec))
@@ -235,6 +256,16 @@ var _ = Describe("verify image APIs", func() {
 			By("then the image is updated")
 			respCode, respBody, err = helper.GetObject(imageURL, &retImage)
 			MustRespCodeIs(http.StatusOK, "get image", err, respCode, respBody)
+			// default SC is set by mutator, check it then remove it for annotation checking
+			v, find := retImage.Annotations[env.AnnoVMImageStorageClass]
+			Expect(find).To(BeTrue())
+			Expect(v).To(Equal(env.DefaultStorageClassName))
+			delete(retImage.Annotations, env.AnnoVMImageStorageClass)
+			// spec.targetStorageClassName is also set by mutator, check the result and
+			// fill into image for checking
+			if retImage.Spec.TargetStorageClassName == env.DefaultStorageClassName {
+				toUpdateImage.Spec.TargetStorageClassName = env.DefaultStorageClassName
+			}
 			Expect(retImage.Labels).To(BeEquivalentTo(toUpdateImage.Labels))
 			Expect(retImage.Annotations).To(BeEquivalentTo(toUpdateImage.Annotations))
 			Expect(retImage.Spec).To(BeEquivalentTo(toUpdateImage.Spec))


### PR DESCRIPTION
#### Problem:
If we create the VM image through terraform provider, we will lack the two fields `metadata/annotations/harvesterhci.io/storageClassName` and `spec.targetStorageClass`. The VM template generator depends on the `metadata/annotations/harvesterhci.io/storageClassName`. If we lack this field, the VM template will fail to generate.

#### Solution:
Ensure these two fields would be set even if we use the default storage class

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8166

#### Test plan:
1. create VM image through terraform provider with following tf content
```
resource "harvester_image" "ubuntu2204" {
  name      = "ubuntu22"
  namespace = "default"

  display_name = "ubuntu2204-server-cloudimg-amd64.img"
  source_type  = "download"
  url          = "https://free.nchc.org.tw/ubuntu-cloud-images/jammy/current/jammy-server-cloudimg-amd64-disk-kvm.img"
}
```
2. create VM with the above image
3. generate the VM template with the above vm

#### Additional documentation or context
