### PR TITLE
Resume managedcharts when upgrade is finished or stopped

### DIFF
--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -31,6 +31,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	versions := management.HarvesterFactory.Harvesterhci().V1beta1().Version()
 	settings := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
 	plans := management.UpgradeFactory.Upgrade().V1().Plan()
+	managedcharts := management.RancherManagementFactory.Management().V3().ManagedChart()
 	nodes := management.CoreFactory.Core().V1().Node()
 	jobs := management.BatchFactory.Batch().V1().Job()
 	pods := management.CoreFactory.Core().V1().Pod()
@@ -55,31 +56,33 @@ func Register(ctx context.Context, management *config.Management, options config
 	}
 
 	controller := &upgradeHandler{
-		ctx:               ctx,
-		jobClient:         jobs,
-		jobCache:          jobs.Cache(),
-		nodeCache:         nodes.Cache(),
-		namespace:         options.Namespace,
-		upgradeClient:     upgrades,
-		upgradeCache:      upgrades.Cache(),
-		upgradeController: upgrades,
-		upgradeLogClient:  upgradeLogs,
-		upgradeLogCache:   upgradeLogs.Cache(),
-		versionCache:      versions.Cache(),
-		planClient:        plans,
-		planCache:         plans.Cache(),
-		vmImageClient:     vmImages,
-		vmImageCache:      vmImages.Cache(),
-		vmClient:          vms,
-		vmCache:           vms.Cache(),
-		serviceClient:     services,
-		pvcClient:         pvcs,
-		clusterClient:     clusters,
-		clusterCache:      clusters.Cache(),
-		lhSettingClient:   lhSettings,
-		lhSettingCache:    lhSettings.Cache(),
-		kubeVirtCache:     kubeVirt.Cache(),
-		vmRestClient:      virtSubresourceClient,
+		ctx:                ctx,
+		jobClient:          jobs,
+		jobCache:           jobs.Cache(),
+		nodeCache:          nodes.Cache(),
+		namespace:          options.Namespace,
+		upgradeClient:      upgrades,
+		upgradeCache:       upgrades.Cache(),
+		upgradeController:  upgrades,
+		upgradeLogClient:   upgradeLogs,
+		upgradeLogCache:    upgradeLogs.Cache(),
+		versionCache:       versions.Cache(),
+		planClient:         plans,
+		planCache:          plans.Cache(),
+		managedChartClient: managedcharts,
+		managedChartCache:  managedcharts.Cache(),
+		vmImageClient:      vmImages,
+		vmImageCache:       vmImages.Cache(),
+		vmClient:           vms,
+		vmCache:            vms.Cache(),
+		serviceClient:      services,
+		pvcClient:          pvcs,
+		clusterClient:      clusters,
+		clusterCache:       clusters.Cache(),
+		lhSettingClient:    lhSettings,
+		lhSettingCache:     lhSettings.Cache(),
+		kubeVirtCache:      kubeVirt.Cache(),
+		vmRestClient:       virtSubresourceClient,
 	}
 	upgrades.OnChange(ctx, upgradeControllerName, controller.OnChanged)
 	upgrades.OnRemove(ctx, upgradeControllerName, controller.OnRemove)

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -12,6 +12,7 @@ import (
 	semverv3 "github.com/Masterminds/semver/v3"
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	provisioningctrl "github.com/rancher/rancher/pkg/generated/controllers/provisioning.cattle.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
@@ -101,6 +102,9 @@ type upgradeHandler struct {
 	versionCache      ctlharvesterv1.VersionCache
 	planClient        upgradectlv1.PlanClient
 	planCache         upgradectlv1.PlanCache
+
+	managedChartCache  mgmtv3.ManagedChartCache
+	managedChartClient mgmtv3.ManagedChartClient
 
 	vmImageClient ctlharvesterv1.VirtualMachineImageClient
 	vmImageCache  ctlharvesterv1.VirtualMachineImageCache
@@ -525,6 +529,33 @@ func (h *upgradeHandler) cleanup(upgrade *harvesterv1.Upgrade, cleanJobs bool) e
 				return err
 			}
 		}
+	}
+
+	return h.resumeManagedCharts()
+}
+
+func (h *upgradeHandler) resumeManagedCharts() error {
+	managedCharts, err := h.managedChartCache.List(util.FleetLocalNamespaceName, labels.Everything())
+	if err != nil {
+		return nil
+	}
+
+	// those managedcharts might be paused by the upgrade script, resume them if they are not un-paused
+	targetManagedcharts := map[string]struct{}{util.HarvesterCRDManagedChart: {}, util.HarvesterManagedChart: {}, util.RancherLoggingCRDManagedChart: {}, util.RancherMonitoringCRDManagedChart: {}}
+
+	for _, managedChart := range managedCharts {
+		if !managedChart.Spec.Paused {
+			continue
+		}
+		if _, ok := targetManagedcharts[managedChart.Name]; !ok {
+			continue
+		}
+		mc := managedChart.DeepCopy()
+		mc.Spec.Paused = false
+		if _, err := h.managedChartClient.Update(mc); err != nil {
+			return fmt.Errorf("failed to resume managedchart %v %w", mc.Name, err)
+		}
+		logrus.Infof("managedchart %v is resumed", mc.Name)
 	}
 
 	return nil

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -202,4 +202,9 @@ const (
 
 	StorageNetworkNetAttachDefPrefix    = "storagenetwork-"
 	StorageNetworkNetAttachDefNamespace = HarvesterSystemNamespaceName
+
+	HarvesterCRDManagedChart         = "harvester-crd"
+	HarvesterManagedChart            = "harvester"
+	RancherLoggingCRDManagedChart    = "rancher-logging-crd"
+	RancherMonitoringCRDManagedChart = "rancher-monitoring-crd"
 )

--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -43,7 +43,7 @@ const (
 	skipWebhookAnnotation                     = "harvesterhci.io/skipWebhook"
 	skipSingleReplicaDetachedVol              = "harvesterhci.io/skipSingleReplicaDetachedVol"
 	rkeInternalIPAnnotation                   = "rke2.io/internal-ip"
-	managedChartNamespace                     = "fleet-local"
+	managedChartNamespace                     = util.FleetLocalNamespaceName
 	defaultNewImageSize                uint64 = 13 * 1024 * 1024 * 1024 // 13GB, this value aggregates all tarball image sizes. It may change in the future.
 	defaultImageGCHighThresholdPercent        = 85.0                    // default value in kubelet config
 	freeSystemPartitionMsg                    = "df -h '/usr/local/'"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Upgrade script puased managedchart, and if the upgrade is stopped in some stages, the managedchart is not resumed.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Resume them when ugprade is stopped or finished.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8195

#### Test plan:
<!-- Describe the test plan by steps. -->

Only when the current Harvester POD image includes the fix, it can resume all managedcharts. The v1.4.3 cluster does not have the fix.

```
                                                         abort the upgrade
                               before Harvester POD is upgraded          after Harvester POD is upgraded
                               
v1.4.2 -> v1.4.3          managedcharts might not be fully resumed          might not be fully resumed                   
v1.4.3 -> v1.5.1                        might not be fully resumed              fully resumed
v1.5.1 -> v1.6.0                            fully resumed                       fully resumed
```


Normal upgrade:
1. Upgrade from a cluster with this patch to a new ISO with this patch
1. Wait unit it is finished, check below managedcharts, if their `paused` are not existing or `false` (expected value)

Abnormal upgrade:
1. Start the upgrade, check below managedcharts, if they are paused, then delete the upgrade CR to stop the upgrade ( note: stop on this stage may cause other issue;  this PR targets to recover managedchart if the upgrade is aborted in the middle, other issues are not in the scope of this PR);   if deletion of the upgrade CR is blocked by validator, then wait and retry to find another chance.
1. wait some time,  check below managedcharts, if their `paused` are not existing or `false` (expected value)


The target managedchart:

"harvester harvester-crd rancher-monitoring-crd rancher-logging-crd"


Local test log:
1. Trigger an master-head to master-head upgrade
2. Delete the upgrade.harvesterhci in between
3. Observed following log, the still paused charts are resumed
```
time="2025-05-12T19:24:43Z" level=info msg="Stop collecting logs"
time="2025-05-12T19:24:43Z" level=info msg="Tearing down the logging infrastructure for upgrade procedure"
time="2025-05-12T19:24:43Z" level=info msg="managedchart rancher-monitoring-crd is resumed"
time="2025-05-12T19:24:43Z" level=info msg="managedchart rancher-logging-crd is resumed"
```


#### Additional documentation or context
