### PR TITLE
Check node and machine are strictly matching before upgrade

### DIFF
--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/util"
 	utilHelm "github.com/harvester/harvester/pkg/util/helm"
 )
 
@@ -44,10 +45,9 @@ const (
 	HarvesterMgmtNodeLabelKey    = HarvesterNodeRoleLabelPrefix + "management"
 	HarvesterWorkerNodeLabelKey  = HarvesterNodeRoleLabelPrefix + "worker"
 
-	HarvesterLabelAnnotationPrefix      = "harvesterhci.io/"
-	HarvesterManagedNodeLabelKey        = HarvesterLabelAnnotationPrefix + "managed"
-	HarvesterPromoteNodeLabelKey        = HarvesterLabelAnnotationPrefix + "promote-node"
-	HarvesterPromoteStatusAnnotationKey = HarvesterLabelAnnotationPrefix + "promote-status"
+	HarvesterManagedNodeLabelKey        = util.HarvesterManagedNodeLabelKey
+	HarvesterPromoteNodeLabelKey        = util.HarvesterPromoteNodeLabelKey
+	HarvesterPromoteStatusAnnotationKey = util.HarvesterPromoteStatusAnnotationKey
 
 	PromoteStatusComplete = "complete"
 	PromoteStatusRunning  = "running"

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -49,7 +49,7 @@ const (
 	upgradeServiceAccount          = "system-upgrade-controller"
 	harvesterSystemNamespace       = util.HarvesterSystemNamespaceName
 	harvesterUpgradeLabel          = "harvesterhci.io/upgrade"
-	harvesterManagedLabel          = "harvesterhci.io/managed"
+	harvesterManagedLabel          = util.HarvesterManagedNodeLabelKey
 	harvesterLatestUpgradeLabel    = "harvesterhci.io/latestUpgrade"
 	harvesterUpgradeComponentLabel = "harvesterhci.io/upgradeComponent"
 	harvesterNodeLabel             = "harvesterhci.io/node"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -61,6 +61,11 @@ const (
 	// For any storageclass created & protected by controller, the controller can utilize this annotation
 	AnnotationIsReservedStorageClass = prefix + "/is-reserved-storageclass"
 
+	HarvesterManagedNodeLabelKey = prefix + "/managed"
+
+	HarvesterPromoteNodeLabelKey        = prefix + "/promote-node"
+	HarvesterPromoteStatusAnnotationKey = prefix + "/promote-status"
+
 	ContainerdRegistrySecretName = "harvester-containerd-registry"
 	ContainerdRegistryFileName   = "registries.yaml"
 

--- a/pkg/webhook/error/error.go
+++ b/pkg/webhook/error/error.go
@@ -85,3 +85,13 @@ func NewInternalError(message string) AdmitError {
 		reason:  metav1.StatusReasonInternalError,
 	}
 }
+
+// 500
+// Let error package to unwrap the string
+func NewInternalErrorFromErr(err error) AdmitError {
+	return AdmitError{
+		code:    http.StatusInternalServerError,
+		message: err.Error(),
+		reason:  metav1.StatusReasonInternalError,
+	}
+}

--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -384,13 +384,17 @@ func (v *upgradeValidator) checkNodeMachineMatching() error {
 		return werror.NewInternalErrorFromErr(fmt.Errorf("can't list nodes, err: %w", err))
 	}
 
-	if len(nodes) == 0 {
-		return werror.NewInternalError(fmt.Sprintf("no node was listed, this shall not happen"))
-	}
-
 	machines, err := v.machines.List(util.FleetLocalNamespaceName, labels.Everything())
 	if err != nil {
 		return werror.NewInternalErrorFromErr(fmt.Errorf("can't list machines, err: %w", err))
+	}
+
+	return isNodeMachineMatching(nodes, machines)
+}
+
+func isNodeMachineMatching(nodes []*corev1.Node, machines []*clusterv1.Machine) error {
+	if len(nodes) == 0 {
+		return werror.NewInternalError(fmt.Sprintf("no node was listed, this shall not happen"))
 	}
 
 	if len(nodes) != len(machines) {
@@ -423,7 +427,7 @@ func (v *upgradeValidator) checkNodeMachineMatching() error {
 		// each node should have this when it is correctly provisioned
 		mc := node.Annotations[clusterv1.MachineAnnotation]
 		if mc == "" {
-			return werror.NewInternalError(fmt.Sprintf("node %v has no nnnotation %v, check the cluster provision", node.Name, clusterv1.MachineAnnotation))
+			return werror.NewInternalError(fmt.Sprintf("node %v has no expected annotation %v, check the cluster provision", node.Name, clusterv1.MachineAnnotation))
 		}
 
 		nRef, ok := machineMap[mc]

--- a/pkg/webhook/resources/upgrade/validator_test.go
+++ b/pkg/webhook/resources/upgrade/validator_test.go
@@ -1,0 +1,417 @@
+package upgrade
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	node1    = "node1"
+	node2    = "node2"
+	machine1 = "machine1"
+	machine2 = "machine2"
+)
+
+func Test_isNodeMachineMatching(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodes       []*corev1.Node
+		machines    []*clusterv1.Machine
+		expectError bool
+		errorKey    string
+	}{
+		{
+			name:        "no node was listed",
+			nodes:       []*corev1.Node{},
+			expectError: true,
+			errorKey:    "no node was listed",
+		},
+		{
+			name: "count mismatch 1 node 0 machine",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "do not match",
+		},
+		{
+			name: "count mismatch 1 node 2 machines",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine2,
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "do not match",
+		},
+		{
+			name: "machine has empty NodeRef",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "empty NodeRef",
+		},
+		{
+			name: "node has no labels",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "no labels",
+		},
+		{
+			name: "node has empty label",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   node1,
+						Labels: map[string]string{},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "no expected label",
+		},
+		{
+			name: "node has no expected label (false value)",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "false",
+						},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "no expected label",
+		},
+		{
+			name: "node has no nnnotations",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "no nnnotations",
+		},
+		{
+			name: "node has empty nnnotations",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "no expected annotation",
+		},
+		{
+			name: "node refers to none-existing machine",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							clusterv1.MachineAnnotation: machine2,
+						},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "machine does not exist",
+		},
+		{
+			name: "node refers to machine, but machine refers to other node",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							clusterv1.MachineAnnotation: machine1,
+						},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node2,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "machine refers to another node",
+		},
+		{
+			name: "two machines refer to same node",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							clusterv1.MachineAnnotation: machine1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							clusterv1.MachineAnnotation: machine2,
+						},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine2,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorKey:    "machine refers to another node",
+		},
+		{
+			name: "good match",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							clusterv1.MachineAnnotation: machine1,
+						},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+			},
+			expectError: false,
+			errorKey:    "",
+		},
+		{
+			name: "dangling machine",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1,
+						Labels: map[string]string{
+							util.HarvesterManagedNodeLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							clusterv1.MachineAnnotation: machine1,
+						},
+					},
+				},
+			},
+			machines: []*clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine1,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: machine2,
+					},
+					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Name: node2,
+						},
+					},
+				},
+			},
+
+			expectError: true,
+			errorKey:    "do not match",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isNodeMachineMatching(tc.nodes, tc.machines)
+			if tc.expectError {
+				assert.NotNil(t, err, tc.name)
+				assert.True(t, strings.Contains(err.Error(), tc.errorKey), tc.name)
+			} else {
+				assert.Nil(t, err, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When a cluster has incorrectly provisioned nodes/machines, the upgrade will encounter issues.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Check all nodes and machines are well matched and referring to each other.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8179

#### Test plan:
<!-- Describe the test plan by steps. -->

1. It is not easy to produce the expected mismatching of node and machine on real clusters, the test code is added to ensure the check covers all cases.

2. Create a fake machine, trigger the upgrade, the webhook error:

![image](https://github.com/user-attachments/assets/c71b9d71-bd73-456b-b3e1-44de92ba0fbd)


#### Additional documentation or context
https://github.com/harvester/harvester/issues/8195