### PR TITLE
Move annotations from Version to Upgrade

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	semverv3 "github.com/Masterminds/semver/v3"
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -673,37 +672,6 @@ func getCachedRepoInfo(upgrade *harvesterv1.Upgrade) (*repoinfo.RepoInfo, error)
 		return nil, err
 	}
 	return repoInfo, nil
-}
-
-func isVersionUpgradable(currentVersion, minUpgradableVersion string) error {
-	if minUpgradableVersion == "" {
-		logrus.Debug("No minimum upgradable version specified, continue the upgrading")
-		return nil
-	}
-
-	// short-circuit the equal cases as the library doesn't support the hack applied below
-	if currentVersion == minUpgradableVersion {
-		logrus.Debug("Upgrade from the exact same version as the minimum requirement")
-		return nil
-	}
-	// to enable comparisons against prerelease versions
-	constraint := fmt.Sprintf(">= %s-z", minUpgradableVersion)
-
-	c, err := semverv3.NewConstraint(constraint)
-	if err != nil {
-		return err
-	}
-	v, err := semverv3.NewVersion(currentVersion)
-	if err != nil {
-		return err
-	}
-
-	if a := c.Check(v); !a {
-		message := fmt.Sprintf("The current version %s is less than the minimum upgradable version %s.", currentVersion, minUpgradableVersion)
-		return fmt.Errorf("%s", message)
-	}
-
-	return nil
 }
 
 func upgradeEligibilityCheck(upgrade *harvesterv1.Upgrade) (bool, string) {

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -254,66 +254,6 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 	}
 }
 
-func Test_isVersionUpgradable(t *testing.T) {
-	var testCases = []struct {
-		name                 string
-		currentVersion       string
-		minUpgradableVersion string
-		isUpgradable         bool
-	}{
-		{
-			name:                 "upgrade from versions above the minimal requirement",
-			currentVersion:       "v1.1.1",
-			minUpgradableVersion: "v1.1.0",
-			isUpgradable:         true,
-		},
-		{
-			name:                 "upgrade from the exact version of the minimal requirement",
-			currentVersion:       "v1.1.0",
-			minUpgradableVersion: "v1.1.0",
-			isUpgradable:         true,
-		},
-		{
-			name:                 "upgrade from rc versions lower than the minimal requirement",
-			currentVersion:       "v1.1.0-rc1",
-			minUpgradableVersion: "v1.1.0",
-			isUpgradable:         false,
-		},
-		{
-			name:                 "upgrade from rc versions above the minimal requirement (rc minUpgradableVersion)",
-			currentVersion:       "v1.1.0-rc2",
-			minUpgradableVersion: "v1.1.0-rc1",
-			isUpgradable:         true,
-		},
-		{
-			name:                 "upgrade from rc versions lower than the minimal requirement (rc minUpgradableVersion)",
-			currentVersion:       "v1.1.0-rc1",
-			minUpgradableVersion: "v1.1.0-rc2",
-			isUpgradable:         false,
-		},
-		{
-			name:                 "upgrade from the exact rc version of the minimal requirement (rc minUpgradableVersion)",
-			currentVersion:       "v1.1.0-rc1",
-			minUpgradableVersion: "v1.1.0-rc1",
-			isUpgradable:         true,
-		},
-		{
-			name:                 "upgrade from versions lower than the minimal requirement",
-			currentVersion:       "v1.0.3",
-			minUpgradableVersion: "v1.1.0",
-			isUpgradable:         false,
-		},
-	}
-	for _, tc := range testCases {
-		err := isVersionUpgradable(tc.currentVersion, tc.minUpgradableVersion)
-		if tc.isUpgradable {
-			assert.Nil(t, err, "case %q", tc.name)
-		} else {
-			assert.NotNil(t, err, "case %q", tc.name)
-		}
-	}
-}
-
 func TestUpgradeHandler_prepareNodesForUpgrade(t *testing.T) {
 	type input struct {
 		upgrade *harvesterv1.Upgrade

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -61,6 +61,9 @@ const (
 	// For any storageclass created & protected by controller, the controller can utilize this annotation
 	AnnotationIsReservedStorageClass = prefix + "/is-reserved-storageclass"
 
+	AnnotationSkipGarbageCollectionThresholdCheck = prefix + "/skipGarbageCollectionThresholdCheck"
+	AnnotationMinCertsExpirationInDay             = prefix + "/minCertsExpirationInDay"
+
 	HarvesterManagedNodeLabelKey = prefix + "/managed"
 
 	HarvesterPromoteNodeLabelKey        = prefix + "/promote-node"

--- a/pkg/webhook/resources/version/validator.go
+++ b/pkg/webhook/resources/version/validator.go
@@ -3,7 +3,6 @@ package version
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,11 +14,6 @@ import (
 
 var (
 	SHA512Pattern = regexp.MustCompile(`^[a-f0-9]{128}$`)
-)
-
-const (
-	SkipGarbageCollectionThreadholdCheckAnnotation = "harvesterhci.io/skipGarbageCollectionThresholdCheck"
-	MinCertsExpirationInDayAnnotation              = "harvesterhci.io/minCertsExpirationInDay"
 )
 
 func NewValidator() types.Validator {
@@ -49,34 +43,12 @@ func (v *versionValidator) Create(_ *types.Request, newObj runtime.Object) error
 	return checkVersion(newVersion)
 }
 
-func checkAnnotations(version *v1beta1.Version) error {
-	if value, ok := version.Annotations[SkipGarbageCollectionThreadholdCheckAnnotation]; ok {
-		_, err := strconv.ParseBool(value)
-		if err != nil {
-			return werror.NewBadRequest(fmt.Sprintf("invalid value %s for annotation %s", value, SkipGarbageCollectionThreadholdCheckAnnotation))
-		}
-	}
-
-	if value, ok := version.Annotations[MinCertsExpirationInDayAnnotation]; ok {
-		minCertsExpirationInDay, err := strconv.Atoi(value)
-		if err != nil {
-			return werror.NewBadRequest(fmt.Sprintf("invalid value %s for annotation %s", value, MinCertsExpirationInDayAnnotation))
-		} else if minCertsExpirationInDay <= 0 {
-			return werror.NewBadRequest(fmt.Sprintf("invalid value %s for annotation %s, it should be greater than 0", value, MinCertsExpirationInDayAnnotation))
-		}
-	}
-	return nil
-}
-
 func (v *versionValidator) Update(_ *types.Request, _ runtime.Object, newObj runtime.Object) error {
 	newVersion := newObj.(*v1beta1.Version)
 	return checkVersion(newVersion)
 }
 
 func checkVersion(version *v1beta1.Version) error {
-	if err := checkAnnotations(version); err != nil {
-		return err
-	}
 	return checkISOChecksum(version)
 }
 


### PR DESCRIPTION
#### Problem:

Directly perform Upgrade via uploading ISO image without creating Version first case below error.
![image](https://github.com/user-attachments/assets/de497798-2a0d-40ed-bef7-df148f6f2895)
The root cause is we didn't check if the version object exists in ugprade/validator.go#checkCerts https://github.com/harvester/harvester/blob/master/pkg/webhook/resources/upgrade/validator.go#L647, if we directly create upgrade object without first creating a version object, a NPE occurred, causing the upgrade creation process to fail.

#### Solution:

Now there are two validations in upgrade/validator.go rely on the version object:

- skipGarbageCollectionThresholdCheck https://docs.harvesterhci.io/v1.5/upgrade/index/#skipgarbagecollectionthresholdcheck-annotation
- minCertsExpirationInDay https://docs.harvesterhci.io/v1.5/upgrade/index/#mincertsexpirationinday-annotation

Move annotations harvesterhci.io/skipGarbageCollectionThresholdCheck and harvesterhci.io/minCertsExpirationInDay from Version CRD to Upgrade CRD could mitigate this issue

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8078
https://github.com/harvester/harvester/issues/8213
https://github.com/harvester/harvester/issues/7690

#### Test plan:
Since we move 2 annotations from Upgrade to Version object, we have to check if both 2 annotations works as expected.
Please Prepare 2+ nodes harvester cluster to perform below tests.

## Test minCertsExpirationInDay annotation
### minCertsExpirationInDay with value 0
1. Create a version.
```
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master
  namespace: harvester-system
spec:
  isoURL: http://192.168.100.1:8000/harvester-master-amd64.iso
```
2. Create an upgrade
```
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  annotations: 
    harvesterhci.io/minCertsExpirationInDay: "0"
  generateName: hvst-upgrade-
  namespace: harvester-system
spec:
  version: "master"
```
3. Expect harvester-webhook raise validation error `Error from server (BadRequest): error when creating "upgrade.yaml": admission webhook "validator.harvesterhci.io" denied the request: invalid value 0 for annotation harvesterhci.io/minCertsExpirationInDay, it should be greater than 0`

### minCertsExpirationInDay with negative value
Basically do the same thing as last test but this time add `harvesterhci.io/minCertsExpirationInDay: "-1"`, and we should get same error `Error from server (BadRequest): error when creating "upgrade.yaml": admission webhook "validator.harvesterhci.io" denied the request: invalid value -1 for annotation harvesterhci.io/minCertsExpirationInDay, it should be greater than 0`

## Test skipGarbageCollectionThresholdCheck annotation
1. Make one node disk full. Like `dd if=/dev/random of=/usr/local/test.img bs=1G count=100`
2. Create a test version.
```
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master
  namespace: harvester-system
spec:
  isoURL: http://192.168.100.1:8000/harvester-master-amd64.iso
```
3. Create a Upgrade object
```
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  generateName: hvst-upgrade-
  namespace: harvester-system
spec:
  version: "master"
```
4. Expect harvester-webhook raised validation error.
5. Add annotation `harvesterhci.io/skipGarbageCollectionThresholdCheck: true` to the Upgrade object.
```
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  annotation:
    harvesterhci.io/skipGarbageCollectionThresholdCheck: true
  generateName: hvst-upgrade-
  namespace: harvester-system
spec:
  version: "master"
```
6. The upgrade should proceed.

## Test Upgrade via uploading ISO image
1. Click top-right corner > Click Preferences > Check "Enable View in API"
2. Go to settings page > Click server-version 3-vertical-dots button > Click Upgrade
3. Upload harvester ISO, and upgrade continue, no error pops up.

#### Additional documentation or context
N/A