### PR TITLE
fix: update pvc mutator to not overwrite existing pvc data source

### DIFF
--- a/pkg/webhook/resources/persistentvolumeclaim/mutator_test.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/mutator_test.go
@@ -1,0 +1,123 @@
+package persistentvolumeclaim
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func TestPatchDataSource(t *testing.T) {
+	var (
+		blockMode = corev1.PersistentVolumeBlock
+		fsMode    = corev1.PersistentVolumeFilesystem
+	)
+	var testCases = []struct {
+		desc        string
+		pvc         *corev1.PersistentVolumeClaim
+		expected    string
+		expectedErr error
+	}{
+		{
+			desc: "skip if block volume mode",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pvc",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeMode: &blockMode,
+				},
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "skip if no annotations",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pvc",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeMode: &fsMode,
+				},
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "skip if data source ref exists",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pvc",
+					Annotations: map[string]string{
+						util.AnnotationVolForVM: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeMode: &fsMode,
+					DataSourceRef: &corev1.TypedObjectReference{
+						Name: "new-snapshot-test",
+						Kind: "VolumeSnapshot",
+					},
+				},
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "skip if data source exists",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pvc",
+					Annotations: map[string]string{
+						util.AnnotationVolForVM: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeMode: &fsMode,
+					DataSource: &corev1.TypedLocalObjectReference{
+						Name: "new-snapshot-test",
+						Kind: "VolumeSnapshot",
+					},
+				},
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "generate patch if no data source",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pvc",
+					Annotations: map[string]string{
+						util.AnnotationVolForVM: "true",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeMode: &fsMode,
+				},
+			},
+			expected:    `{"op": "replace", "path": "/spec/dataSourceRef", "value": {"apiGroup":"cdi.kubevirt.io","kind":"VolumeImportSource","name":"filesystem-blank-source"}}`,
+			expectedErr: nil,
+		},
+	}
+
+	m := pvcMutator{}
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			actual, err := m.patchDataSource(testCase.pvc)
+			if err != nil {
+				if err != testCase.expectedErr {
+					t.Fatal("unexpected error: ", err)
+				}
+			}
+
+			if actual != testCase.expected {
+				t.Fatalf("expected %s, got %s", testCase.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
The PVC mutator overrides any existing data source of a 3rd party storage file system data volumes, with the `filesystem-blank-source` `VolumeImportSource` configuration. This wipes any data restored by CSI because the CSI `VolumeSnapshot` data source would be overwritten. This prevents 3rd party CSI-based backup/restore software like Velero from restoring the volumes correctly.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Change the PVC mutator to skip patching (replacing) any existing data source of a file system PVC.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
#8334

#### Test plan:

##### Test Setup

1. Set up the NFS CSI, NFS server and NFS storage class by following the instructions in the [NFS CSI doc](https://github.com/kubernetes-csi/csi-driver-nfs/blob/master/deploy/example/README.md)
2. Enable volume snapshotting on the NFS CSI following the instructions in the [NFS CSI snapshot doc](https://github.com/kubernetes-csi/csi-driver-nfs/tree/master/deploy/example/snapshot)
3. Create a VM image based on the NFS CSI storage class 

##### Test Case 1 - Regression Test

1. Create a VM with NFS root volume and data volume
2. Expect the VM to be successfully created and the additional disk of the data volume is mounted

    * SSH into the VM
    * Confirm the additional disk is attached: `sudo fdisk -l`
        * This example assumes it's `/dev/vdb`
    * Partition disk: `sudo fdisk /dev/vdb`
         * Create partition: `n`
         * Use default settings for the new partition
         * Save changes: `w`
    * Format disk: `sudo mkfs.ext4 /dev/vdb1`
    * Mount disk: `sudo mount /dev/vdb1 /mnt/data`
    * Write data to `/mnt/data`:

```sh
sudo touch /mnt/data/00.dat
sudo touch /mnt/data/01.dat
sudo touch /mnt/data/02.dat
sudo /bin/bash -c 'echo "hello world0" > /mnt/data/00.dat'
sudo /bin/bash -c 'echo "hello world1" > /mnt/data/01.dat'
sudo /bin/bash -c 'echo "hello world2" > /mnt/data/02.dat'
```

##### Test Case 2 - Restore Data Volume Snapshot

1. Re-use the VM from Test Case 1
2. Take a CSI snapshot of the NFS data volume:

```sh
cat <<EOF | k -n <vm-ns> apply -f -
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: vm-00-snap
spec:
  volumeSnapshotClassName: csi-nfs-snapclass  # default name from nfs csi doc
  source:
    persistentVolumeClaimName: <data-volume-pvc-name>
EOF
```

3. Confirm that the snapshot is successfully created:

```sh
k -n demo-src get volumesnapshot
NAME         READYTOUSE   SOURCEPVC            SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS       SNAPSHOTCONTENT                                    CREATIONTIME   AGE
vm-00-snap   true         vm-00-disk-1-zfck3                           9902618       csi-nfs-snapclass   snapcontent-3e74d348-c122-4a55-a12f-fbce8d58775f   17s            46s
```

4. Restore the snapshot to a new PVC:

```sh
cat <<EOF | k -n <vm-ns> apply -f -
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: restore-pvc
  annotations:
    harvesterhci.io/volumeForVirtualMachine: "true" # label this pvc as a data volume
spec:
  accessModes:
  - ReadWriteMany
  dataSource:
    name: vm-00-snap
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  resources:
    requests:
      storage: 10Gi
  storageClassName: nfs-csi
  volumeMode: Filesystem
EOF
```

5. Confirm that the PVC is successfully restored:

```sh
k -n demo-src get pvc restore-pvc
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
restore-pvc   Bound    pvc-bb58ab7d-3ffa-4163-9eee-dffa188b696a   10Gi       RWX            nfs-csi        <unset>                 42s
```

6. Create a new VM to mount the `restore-pvc` as an extra disk:

![image](https://github.com/user-attachments/assets/9fd6d38a-a2cc-40e5-87c3-a17dec19c799)

7. Once the VM is ready, access it via SSH and confirm that the disk and its data is correctly restored:

```sh
ubuntu@vm-00-restored:~$ sudo fdisk -l /dev/vdb
Disk /dev/vdb: 9.45 GiB, 10146021376 bytes, 19816448 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x1fe9f7a3

Device     Boot Start      End  Sectors  Size Id Type
/dev/vdb1        2048 19816447 19814400  9.4G 83 Linux

ubuntu@vm-00-restored:~$ sudo mkdir /mnt/data
ubuntu@vm-00-restored:~$ sudo mount /dev/vdb1 /mnt/data
ubuntu@vm-00-restored:~$ ls -al /mnt/data
total 36
drwxr-xr-x 3 root root  4096 May 20 21:17 .
drwxr-xr-x 3 root root  4096 May 21 18:33 ..
-rw-r--r-- 1 root root    13 May 20 21:17 00.dat
-rw-r--r-- 1 root root    13 May 20 21:17 01.dat
-rw-r--r-- 1 root root    13 May 20 21:17 02.dat
drwx------ 2 root root 16384 May 20 21:17 lost+found

```

#### Additional documentation or context
