### PR TITLE
tweak machine types returned to match supported emulated machine types

### DIFF
--- a/pkg/api/cluster/formatter.go
+++ b/pkg/api/cluster/formatter.go
@@ -116,7 +116,7 @@ func generateMachineTypes() ([]byte, error) {
 	var machineTypes []string
 	switch runtime.GOARCH {
 	case "amd64":
-		machineTypes = append(machineTypes, "pc", "q53")
+		machineTypes = append(machineTypes, "pc-q35", "q35")
 	case "arm64":
 		machineTypes = append(machineTypes, "virt")
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR https://github.com/harvester/harvester/pull/7355 introduced to add machine type lookup based on underlying host architecture returns incorrect machine type `q53`

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR fixes the same and returns machine types which satisfy the support emulated machine types in upstream kubevirt
https://github.com/kubevirt/kubevirt/blob/v1.4.0/pkg/virt-config/virt-config.go#L51-L53

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5364
#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
