### PR TITLE
feat: patch macaddress to vmi

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -50,8 +50,6 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		snapshotCache    = snapshotClient.Cache()
 		scClient         = management.StorageFactory.Storage().V1().StorageClass()
 		scCache          = scClient.Cache()
-		crClient         = management.ControllerRevisionFactory.Apps().V1().ControllerRevision()
-		crClientCache    = crClient.Cache()
 		settingCache     = management.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()
 		recorder         = management.NewRecorder(vmControllerSetHaltIfInsufficientResourceQuotaControllerName, "", "")
 	)
@@ -107,8 +105,6 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		vmClient:  vmClient,
 		vmCache:   vmCache,
 		vmiClient: virtualMachineInstanceClient,
-		crClient:  crClient,
-		crCache:   crClientCache,
 	}
 	virtualMachineInstanceClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
 

--- a/pkg/controller/master/virtualmachine/vmi_network_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller.go
@@ -2,24 +2,19 @@ package virtualmachine
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/validation"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	vmwatch "kubevirt.io/kubevirt/pkg/virt-controller/watch/vm"
 
-	ctlappsv1 "github.com/harvester/harvester/pkg/generated/controllers/apps/v1"
 	vmv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 type VMNetworkController struct {
 	vmCache   vmv1.VirtualMachineCache
 	vmClient  vmv1.VirtualMachineClient
 	vmiClient vmv1.VirtualMachineInstanceClient
-	crCache   ctlappsv1.ControllerRevisionCache
-	crClient  ctlappsv1.ControllerRevisionClient
 }
 
 // SetDefaultNetworkMacAddress set the default mac address of networks using the initial allocated mac address from the VMI status,
@@ -61,71 +56,32 @@ func (h *VMNetworkController) updateVMDefaultNetworkMacAddress(vmi *kubevirtv1.V
 		}
 	}
 
-	for i, vmIface := range vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces {
-		macAddress, ok := vmiInterfaces[vmIface.Name]
-		// only set the network mac address when it has no existing value
-		if ok && vmIface.MacAddress == "" {
-			logrus.Debugf("set VM %s management network %s macAddress to %s", vm.Name, vmIface.Name, macAddress)
-			vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = macAddress
+	vmiInterfaceBytes, err := json.Marshal(vmiInterfaces)
+	if err != nil {
+		return err
+	}
+
+	if vmCopy.Annotations == nil {
+		vmCopy.Annotations = make(map[string]string)
+	}
+
+	previousMacAddress := vmCopy.Annotations[util.AnnotationMacAddressName]
+
+	if previousMacAddress != string(vmiInterfaceBytes) {
+		vmCopy.Annotations[util.AnnotationMacAddressName] = string(vmiInterfaceBytes)
+		if err = validation.ValidateAnnotationsSize(vmCopy.Annotations); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"name":      vmCopy.Name,
+				"namespace": vmCopy.Namespace,
+			}).Error("cannot set vmi interfaces to vm annotations")
+			// skip error to avoid the controller keeps reconciling the VM
+			return nil
 		}
-	}
 
-	// note: this function is related to vm/vmi, should always run on vmi change
-	if err := h.regenerateControllerRevision(vmi, vm); err != nil {
-		return err
-	}
-
-	if equality.Semantic.DeepEqual(vmCopy.Spec.Template.Spec.Domain.Devices, vm.Spec.Template.Spec.Domain.Devices) {
-		return nil
-	}
-	if _, err := h.vmClient.Update(vmCopy); err != nil {
-		return err
+		if _, err := h.vmClient.Update(vmCopy); err != nil {
+			return err
+		}
 	}
 
 	return nil
-}
-
-func (h *VMNetworkController) regenerateControllerRevision(vmi *kubevirtv1.VirtualMachineInstance, vm *kubevirtv1.VirtualMachine) error {
-	crObj, err := h.crCache.Get(vmi.Namespace, vmi.Status.VirtualMachineRevisionName)
-	if err != nil {
-		return fmt.Errorf("error fetch controller revision object for vmi %s-%s: %v", vmi.Name, vmi.Namespace, err)
-	}
-
-	revisionSpec := &vmwatch.VirtualMachineRevisionData{}
-	if err = json.Unmarshal(crObj.Data.Raw, revisionSpec); err != nil {
-		return err
-	}
-	if !equality.Semantic.DeepEqual(revisionSpec.Spec.Template, vm.Spec.Template) && vm.Generation != vm.Status.ObservedGeneration {
-		patch, patchGenError := patchVMRevision(vm)
-		if patchGenError != nil {
-			return fmt.Errorf("error during patch generation for vmi %s-%s: %v", vmi.Name, vmi.Name, patchGenError)
-		}
-		if deletionErr := h.crClient.Delete(vmi.Namespace, crObj.Name, &metav1.DeleteOptions{}); deletionErr != nil {
-			return fmt.Errorf("error during deletion of controllerRevision for vmi %s-%s: %v", vmi.Name, vmi.Name, deletionErr)
-		}
-		logrus.Debugf("VM %s/%s delete and create new cr object to patch generation: %s", vm.Namespace, vm.Name, patch)
-		crObj.Data.Raw = patch
-		crObj.ResourceVersion = ""
-		_, err = h.crClient.Create(crObj)
-	}
-
-	return err
-}
-
-// copied from kubevirt.io/kubevirt/pkg/virt-controller/watch as this is a private method
-func patchVMRevision(vm *kubevirtv1.VirtualMachine) ([]byte, error) {
-	vmBytes, err := json.Marshal(vm)
-	if err != nil {
-		return nil, err
-	}
-	var raw map[string]interface{}
-	err = json.Unmarshal(vmBytes, &raw)
-	if err != nil {
-		return nil, err
-	}
-	objCopy := make(map[string]interface{})
-	spec := raw["spec"].(map[string]interface{})
-	objCopy["spec"] = spec
-	patch, err := json.Marshal(objCopy)
-	return patch, err
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -32,6 +32,7 @@ const (
 	AnnotationStorageProvisioner        = prefix + "/storageProvisioner"
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
 	AnnotationLastRefreshTime           = prefix + "/lastRefreshTime"
+	AnnotationMacAddressName            = prefix + "/mac-address"
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
 

--- a/pkg/webhook/resources/virtualmachineinstance/mutator.go
+++ b/pkg/webhook/resources/virtualmachineinstance/mutator.go
@@ -1,0 +1,79 @@
+package virtualmachineinstance
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewMutator(
+	vm ctlkubevirtv1.VirtualMachineCache,
+) types.Mutator {
+	return &vmiMutator{
+		vm: vm,
+	}
+}
+
+type vmiMutator struct {
+	types.DefaultMutator
+	vm ctlkubevirtv1.VirtualMachineCache
+}
+
+func (m *vmiMutator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{"virtualmachineinstances"},
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   kubevirtv1.SchemeGroupVersion.Group,
+		APIVersion: kubevirtv1.SchemeGroupVersion.Version,
+		ObjectType: &kubevirtv1.VirtualMachineInstance{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (m *vmiMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+	vmi := newObj.(*kubevirtv1.VirtualMachineInstance)
+
+	logrus.Debugf("create VMI %s/%s", vmi.Namespace, vmi.Name)
+
+	vm, err := m.vm.Get(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if vm.Annotations == nil || vm.Annotations[util.AnnotationMacAddressName] == "" {
+		return nil, nil
+	}
+
+	vmiInterfaces := map[string]string{}
+	if err = json.Unmarshal([]byte(vm.Annotations[util.AnnotationMacAddressName]), &vmiInterfaces); err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"name":      vm.Name,
+			"namespace": vm.Namespace,
+			"macs":      vm.Annotations[util.AnnotationMacAddressName],
+		}).Error("failed to unmarshal mac-address from vm annotation")
+		return nil, err
+	}
+
+	patchOps := types.PatchOps{}
+	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
+		if vm.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress != "" {
+			continue
+		}
+		ifaceMac, ok := vmiInterfaces[iface.Name]
+		if !ok || ifaceMac == "" {
+			continue
+		}
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "add", "path": "/spec/domain/devices/interfaces/%d/macAddress", "value": "%s"}`, i, ifaceMac))
+	}
+	return patchOps, nil
+}

--- a/pkg/webhook/resources/virtualmachineinstance/mutator.go
+++ b/pkg/webhook/resources/virtualmachineinstance/mutator.go
@@ -50,18 +50,22 @@ func (m *vmiMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patc
 		return nil, err
 	}
 
+	return m.patchMacAddress(vm, vmi)
+}
+
+func (m *vmiMutator) patchMacAddress(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance) (types.PatchOps, error) {
 	if vm.Annotations == nil || vm.Annotations[util.AnnotationMacAddressName] == "" {
 		return nil, nil
 	}
 
 	vmiInterfaces := map[string]string{}
-	if err = json.Unmarshal([]byte(vm.Annotations[util.AnnotationMacAddressName]), &vmiInterfaces); err != nil {
+	if err := json.Unmarshal([]byte(vm.Annotations[util.AnnotationMacAddressName]), &vmiInterfaces); err != nil {
 		logrus.WithError(err).WithFields(logrus.Fields{
 			"name":      vm.Name,
 			"namespace": vm.Namespace,
 			"macs":      vm.Annotations[util.AnnotationMacAddressName],
 		}).Error("failed to unmarshal mac-address from vm annotation")
-		return nil, err
+		return nil, nil
 	}
 
 	patchOps := types.PatchOps{}

--- a/pkg/webhook/resources/virtualmachineinstance/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachineinstance/mutator_test.go
@@ -1,0 +1,242 @@
+package virtualmachineinstance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+const (
+	replaceOP        = "replace"
+	nodeAffinityPath = "/spec/template/spec/affinity"
+)
+
+func TestPatchMacAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		vm      *kubevirtv1.VirtualMachine
+		vmi     *kubevirtv1.VirtualMachineInstance
+		patches types.PatchOps
+	}{
+		{
+			name: "vm without annotation",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			vmi:     &kubevirtv1.VirtualMachineInstance{},
+			patches: nil,
+		},
+		{
+			name: "vm without harvesterhci.io/mac-address annotation",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			vmi:     &kubevirtv1.VirtualMachineInstance{},
+			patches: nil,
+		},
+		{
+			name: "vm with empty harvesterhci.io/mac-address annotation",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"harvesterhci.io/mac-address": "",
+					},
+				},
+			},
+			vmi:     &kubevirtv1.VirtualMachineInstance{},
+			patches: nil,
+		},
+		{
+			name: "vm with invalid harvesterhci.io/mac-address annotation",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"harvesterhci.io/mac-address": "invalid-json",
+					},
+				},
+			},
+			vmi:     &kubevirtv1.VirtualMachineInstance{},
+			patches: nil,
+		},
+		{
+			name: "vm with valid harvesterhci.io/mac-address annotation and vm interfaces don't have macaddress",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"harvesterhci.io/mac-address": `{"default":"00:11:22:33:44:55"}`,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Devices: kubevirtv1.Devices{
+									Interfaces: []kubevirtv1.Interface{
+										{
+											Name: "default",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			patches: types.PatchOps{`{"op": "add", "path": "/spec/domain/devices/interfaces/0/macAddress", "value": "00:11:22:33:44:55"}`},
+		},
+		{
+			name: "vm with valid harvesterhci.io/mac-address annotation and vm interfaces have macaddress",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"harvesterhci.io/mac-address": `{"default":"00:11:22:33:44:55"}`,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Devices: kubevirtv1.Devices{
+									Interfaces: []kubevirtv1.Interface{
+										{
+											Name:       "default",
+											MacAddress: "11:22:33:44:55:66",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			patches: types.PatchOps{},
+		},
+		{
+			name: "vm with valid harvesterhci.io/mac-address annotation, but it doesn't have matched name with vm interfaces",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"harvesterhci.io/mac-address": `{}`,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Devices: kubevirtv1.Devices{
+									Interfaces: []kubevirtv1.Interface{
+										{
+											Name: "default",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			patches: types.PatchOps{},
+		},
+		{
+			name: "vm with valid harvesterhci.io/mac-address annotation, but matched name entry with empty value",
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"harvesterhci.io/mac-address": `{"default":""}`,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Devices: kubevirtv1.Devices{
+									Interfaces: []kubevirtv1.Interface{
+										{
+											Name: "default",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			patches: types.PatchOps{},
+		},
+	}
+
+	type patch struct {
+		Op    string       `json:"op"`
+		Path  string       `json:"path"`
+		Value *v1.Affinity `json:"value"`
+	}
+
+	for _, tc := range tests {
+		clientSet := fake.NewSimpleClientset()
+		mutator := NewMutator(fakeclients.VirtualMachineCache(clientSet.KubevirtV1().VirtualMachines))
+		patchOps, err := mutator.(*vmiMutator).patchMacAddress(tc.vm, tc.vmi)
+		assert.Nil(t, err, tc.name)
+		assert.Equal(t, tc.patches, patchOps, tc.name)
+	}
+}

--- a/pkg/webhook/server/mutation.go
+++ b/pkg/webhook/server/mutation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachine"
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachinebackup"
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachineimage"
+	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachineinstance"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
@@ -26,11 +27,13 @@ func Mutation(clients *clients.Clients, options *config.Options) (http.Handler, 
 	vmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()
 	pvcCache := clients.Core.PersistentVolumeClaim().Cache()
 	vmImgCache := clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache()
+	vmCache := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	mutators := []types.Mutator{
 		persistentvolumeclaim.NewMutator(pvcCache, vmImgCache),
 		pod.NewMutator(settingCache),
 		templateversion.NewMutator(),
 		virtualmachine.NewMutator(settingCache, nadCache),
+		virtualmachineinstance.NewMutator(vmCache),
 		virtualmachineimage.NewMutator(storageClassCache),
 		virtualmachinebackup.NewMutator(vmBackupCache),
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
In before, we backport VMI macaddress to VM, so VM can have same macaddress after restart. However, this makes VM bumps revision and has `VirtualMachineRestartRequired` condition.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Backport VMI macaddress to VM annotation and use mutator to add macaddress data to new VMI.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8331

#### Test plan:
<!-- Describe the test plan by steps. -->
1. Create a VM and check there is `harvesterhci.io/mac-address` annotation.
2. Migrate / Restart / Stop and Start VM. Check VMI has same mac address.
