### PR TITLE
chore: add milestone condition guard

### DIFF
--- a/.github/workflows/issue-management-update-community-projects.yaml
+++ b/.github/workflows/issue-management-update-community-projects.yaml
@@ -162,4 +162,9 @@ jobs:
         GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
       run: |
         ISSUE_NUMBER="${{ github.event.issue.number }}"
-        gh issue edit "$ISSUE_NUMBER" --milestone "Planning"
+
+        # Reduce the chance that milestone is modified by users and actions at the same time.
+        MILESTONE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json milestone --jq '.milestone.title')
+        if [ -z "$MILESTONE_TITLE" ]; then
+          gh issue edit "$ISSUE_NUMBER" --milestone "Planning"
+        fi

--- a/.github/workflows/issue-management-update-harvester-projects.yaml
+++ b/.github/workflows/issue-management-update-harvester-projects.yaml
@@ -64,7 +64,12 @@ jobs:
         GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
       run: |
         ISSUE_NUMBER="${{ github.event.issue.number }}"
-        gh issue edit "$ISSUE_NUMBER" --milestone "Planning"
+
+        # Reduce the chance that milestone is modified by users and actions at the same time.
+        MILESTONE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json milestone --jq '.milestone.title')
+        if [ -z "$MILESTONE_TITLE" ]; then
+          gh issue edit "$ISSUE_NUMBER" --milestone "Planning"
+        fi
         
     -  name: Update Project Item
        if: ${{


### PR DESCRIPTION
#7983 

Prevent the bot from adding a planning milestone to an issue that has already been assigned a milestone.