### PR TITLE
chore: add suse org reporter flow

### DIFF
--- a/.github/workflows/issue-management-add-to-projects.yml
+++ b/.github/workflows/issue-management-add-to-projects.yml
@@ -8,6 +8,39 @@ env:
   COMMUNITY_PROJECT_URL: https://github.com/orgs/harvester/projects/10
 
 jobs:
+  suse-org:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Is SUSE Member
+      id: is-suse-member
+      uses: rancher/gh-issue-mgr/get-user-teams-membership@main
+      with:
+        username: ${{ github.event.issue.user.login }}
+        organization: SUSE
+        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+    
+    - name: Is Harvester Member
+      id: is-harvester-member
+      uses: rancher/gh-issue-mgr/get-user-teams-membership@main
+      with:
+        username: ${{ github.event.issue.user.login }}
+        organization: harvester
+        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+    
+    - name: Set Require PM Review Label
+      if: ${{
+        fromJSON(steps.is-suse-member.outputs.teams)[0] != null &&
+        fromJSON(steps.is-harvester-member.outputs.teams)[0] == null
+        }}
+      run: |
+        gh issue edit ${{ github.event.issue.number }} --add-label "require/pm-review"
+      env:
+        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        
+
   harvester:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/issue-management-stale.yml
+++ b/.github/workflows/issue-management-stale.yml
@@ -35,6 +35,6 @@ jobs:
         stale-issue-label: 'status/stale'
         stale-pr-label: 'status/stale'
         exempt-all-assignees: true
-        exempt-issue-labels: 'kind/enhancement,kind/feature,require/investigate'
+        exempt-issue-labels: 'kind/enhancement,kind/feature,require/investigate,require/pm-review'
         exempt-draft-pr: true
         exempt-all-milestones: true


### PR DESCRIPTION
#7983 

- Don't make issue with `require/pm-review` become stale
- Add  the `require/pm-review` label to open issue from SUS org, but not from harvester.