### PR TITLE
adding make help and description for scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-TARGETS := $(shell ls scripts)
+TARGETS := $(shell ls --ignore=help --ignore='*.txt' scripts)
+
+help:
+	@./scripts/help "$(MAKEFILE_LIST)" $(TARGETS)
 
 .dapper:
 	@echo Downloading dapper

--- a/scripts/arm
+++ b/scripts/arm
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Build the binaries for arm architecture
 set -e
 
 cd $(dirname $0)

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Build the binaries for Harvester, harvester-webhook and upgrade-helper
 set -e
 
 source $(dirname $0)/version

--- a/scripts/build-iso
+++ b/scripts/build-iso
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Build the Harvester ISO
 set -e
 
 source $(dirname $0)/version

--- a/scripts/check-dep-image-tags
+++ b/scripts/check-dep-image-tags
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-
+# DESC: Check dependencies for image tags
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 VALUES_FILE=$TOP_DIR/deploy/charts/harvester/values.yaml
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Build the binaries for x64 architecture
 set -e
 
 cd $(dirname $0)

--- a/scripts/default
+++ b/scripts/default
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Default target when running `make`. Builds the binaries, runs the tests and generates the Webhook and Upgrade images
 set -e
 
 cd $(dirname $0)

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Entrypoint of the build scripts
 set -e
 
 mkdir -p bin dist

--- a/scripts/generate
+++ b/scripts/generate
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Runs `go generate`
 set -e
 
 cd $(dirname $0)/..

--- a/scripts/generate-addons
+++ b/scripts/generate-addons
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: package addons yamls
 set -e
 
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"

--- a/scripts/generate-manifest
+++ b/scripts/generate-manifest
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Generate manifest
 set -e
 
 # The root of the harvester directory

--- a/scripts/generate-openapi
+++ b/scripts/generate-openapi
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Generate Swagger JSON file
 set -e
 
 # Add +k8s:openapi-gen=true to pkg/apis/harvesterhci.io/v1beta1/doc.go

--- a/scripts/help
+++ b/scripts/help
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Description: Makefile to build, test and package Harvester
+Documentation: https://github.com/harvester/harvester/wiki#build--development
+Source: https://github.com/harvester/harvester/tree/master/scripts
+Maintainer: @harvester/maintainer
+
+Targets:"
+
+shift
+for target in "${@}"; do 
+  desc=$(grep -m1 '^# DESC:' "scripts/${target}" | sed 's/^# DESC:[[:space:]]*//')
+  if [ -z "${desc}" ]; then 
+    desc="(no description)"
+  fi;
+  printf "  \033[36m%-20s\033[0m %s\n" "${target}" "${desc}"
+done

--- a/scripts/package
+++ b/scripts/package
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Build the Harvester container image
 set -e
 
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"

--- a/scripts/package-upgrade
+++ b/scripts/package-upgrade
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Build, tag and push the harvester-upgrade image
 set -e
 
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"

--- a/scripts/package-webhook
+++ b/scripts/package-webhook
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Build, tag and push the webhook image
 set -e
 
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"

--- a/scripts/release
+++ b/scripts/release
@@ -1,3 +1,4 @@
 #!/bin/bash
+# DESC: Executes `ci`
 
 exec $(dirname $0)/ci

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Runs the unit tests
 set -e
 
 # The root of the harvester directory

--- a/scripts/test-integration
+++ b/scripts/test-integration
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Runs the integration tests
 set -e
 
 source $(dirname $0)/version

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Runs following validations: go fmt, go vet, and golangci-lint
 set -e
 
 cd $(dirname $0)/..

--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Validates the CI environment by running a dirty check on the Git repository.
 set -e
 
 cd $(dirname $0)/..

--- a/scripts/version
+++ b/scripts/version
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DESC: Generates versioning metadata for a build system. It calculates VERSION, TAG and CHART_VERSION based on a Git state.
 
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 PACKAGE_DIR="${TOP_DIR}/package"


### PR DESCRIPTION

#### Problem:
Add a make help

#### Solution:
Added a make help to harvester Makefile

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8370

#### Test plan:
run `make help`

#### Additional documentation or context
Maybe the descriptions needs to be enhanced. Would appreciate some guidance

![image](https://github.com/user-attachments/assets/6b2a2e96-12f9-44ad-a75a-a82f445ad4b2)
