### PR TITLE
Update storagenetwork check

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1343,7 +1343,7 @@ func (v *settingValidator) checkVCSpansAllNodes(config *storagenetworkctl.Config
 }
 
 func (v *settingValidator) checkStorageNetworkVlanValid(config *storagenetworkctl.Config) error {
-	if config.Vlan < 0 || config.Vlan > 4094 {
+	if config.Vlan > 4094 {
 		return fmt.Errorf("The valid value range for VLAN IDs is 0 to 4094")
 	}
 

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1108,5 +1109,96 @@ func Test_validateAdditionalGuestMemoryOverheadRatio(t *testing.T) {
 			err := validateAdditionalGuestMemoryOverheadRatio(tt.args)
 			assert.Equal(t, tt.expectedErr, err != nil)
 		})
+	}
+}
+
+func Test_validateStorageNetworkConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   *v1beta1.Setting
+		errMsg string
+	}{
+		{
+			name: "ok to create storge-network with none values",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			},
+			errMsg: "",
+		},
+		{
+			name: "ok to create storge-network with empty default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+			},
+			errMsg: "",
+		},
+		{
+			name: "ok to create storge-network with empty default and value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      "",
+			},
+			errMsg: "",
+		},
+		{
+			name: "fail to create storge-network with invalid json",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"invalid"}`,
+			},
+			errMsg: "failed to unmarshal the setting value",
+		},
+		{
+			name: "fail to create storge-network with invalid vlan id 4095",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"vlan":4095}`,
+			},
+			errMsg: "The valid value range for VLAN IDs",
+		},
+		{
+			name: "fail to create storge-network with invalid vlan id 65536",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"vlan":65536}`, // invalid uint16
+			},
+			errMsg: "failed to unmarshal the setting value",
+		},
+		{
+			name: "fail to create storge-network with invalid vlan id -1",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"vlan":-1}`, // invalid uint16
+			},
+			errMsg: "failed to unmarshal the setting value",
+		},
+		{
+			name: "fail to create storge-network with mgmt clusternetwork",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"vlan":1, "clusterNetwork":"mgmt"}`,
+			},
+			errMsg: "not allowed on",
+		},
+		// more tests are depending on a bunch of fake objects
+	}
+
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Create(nil, tt.args)
+			if tt.errMsg != "" {
+				assert.True(t, strings.Contains(err.Error(), tt.errMsg))
+			}
+		})
+
 	}
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When a cluster is newly installed and has no storagenetwork, if VM starts before Harvester POD creates the empty storagenetwork default setting, then Harvester POD stucks.


before this pr:

```
0. run any vm on a newly installed running cluster which has no storage-network setting

1. remove current webhook

kubectl delete ValidatingWebhookConfiguration harvester-validator

2. remove current sn setting
kubectl delete settings.harvesterhci.io storage-network

3. replace harvester-webhook pod to let it re-add the webhook
kubectl delete pod -n harvester-system harvester-webhook-8f77d684d-hn9b6

4. replace harvester pod, it will stuck on CrashLoopBackOff 
kubectl delete pod -n harvester-system harvester-5c4f7f555c-xt2kg

with error:

time="2025-05-30T08:26:31Z" level=fatal msg="failed to create harvester server: admission webhook \"validator.harvesterhci.io\" denied the request: Please stop all VMs before configuring the storage-network setting"
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8407

#### Test plan:
<!-- Describe the test plan by steps. -->

```
0. run any vm on a newly installed running cluster which has no storage-network setting

1. remove current webhook

kubectl delete ValidatingWebhookConfiguration harvester-validator

2. remove current sn setting
kubectl delete settings.harvesterhci.io storage-network

3. replace harvester-webhook pod to let it re-add the webhook
kubectl delete pod -n harvester-system harvester-webhook-8f77d684d-hn9b6

4. replace harvester pod, it will run smoothly

5. check webhook and storage-network sn

 kubectl get ValidatingWebhookConfiguration harvester-validator 
NAME                  WEBHOOKS   AGE
harvester-validator   1          6s  // newly created by new harvester-webhook pod



kubectl get settings.harvesterhci.io storage-network -oyaml
apiVersion: harvesterhci.io/v1beta1
kind: Setting
metadata:
  creationTimestamp: "2025-05-30T10:30:09Z"  // newly created by harvester pod
  generation: 1
  name: storage-network
  resourceVersion: "415790"
  uid: 0e9f8bc6-40b3-4275-ae22-709c7e0ac629
status: {}

```


#### Additional documentation or context
