### PR TITLE
chore: add link between backport issue and backport PR [skip ci]

### DIFF
--- a/.github/workflows/issue-management-link-backport-pr.yaml
+++ b/.github/workflows/issue-management-link-backport-pr.yaml
@@ -1,0 +1,92 @@
+name: "[Issue Management] Link Backport PR Issue"
+
+on:
+  pull_request_target:
+    types: [ opened ]
+    branches:
+    - master
+    - "v*"
+
+env:
+  REPO_NAME: harvester/harvester
+
+jobs:
+  check-backport:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Check if PR is a backport
+      run: |
+        title=$(cat <<EOF
+        "${{ github.event.pull_request.title }}"
+        EOF
+        )
+
+        echo "PR Title: $title"
+
+        if [[ "$(echo "$title" | sed 's/"/\\"/g')" =~ "backport #" ]]; then
+          echo "BACKPORT=true" >> $GITHUB_ENV
+        else
+          echo "BACKPORT=false" >> $GITHUB_ENV
+        fi
+
+    - name: Extract backport branch and issue number
+      if: env.BACKPORT == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      run: |
+        # Extract branch from the target branch of the PR
+        BRANCH=$(echo "${{ github.event.pull_request.base.ref }}")
+        echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+        # Extract issue numbers from PR body (support both formats)
+        BODY=$(cat <<EOF
+        "${{ github.event.pull_request.body }}"
+        EOF
+        )
+        ISSUE_NUMBERS=$(echo "$BODY" | grep -oE "${REPO_NAME}#([0-9]+)" | cut -d'#' -f2)
+        ISSUE_NUMBERS_URL=$(echo "$BODY" | grep -oE "https://github.com/${REPO_NAME}/issues/[0-9]+" | awk -F'/' '{print $NF}')
+        ALL_ISSUES=$(echo -e "$ISSUE_NUMBERS\n$ISSUE_NUMBERS_URL" | grep -E '^[0-9]+$' | sort -u)
+        
+        ORIGINAL_ISSUE_NUMBER=$(echo $ALL_ISSUES | xargs) # trim
+        echo "ORIGINAL_ISSUE_NUMBER=$ORIGINAL_ISSUE_NUMBER" >> $GITHUB_ENV
+
+    - name: Link the PR with the backport issue
+      if: ${{ env.BACKPORT == 'true' && env.ORIGINAL_ISSUE_NUMBER != '' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      run: |
+        for issue_number in "${{ env.ORIGINAL_ISSUE_NUMBER }}"; do
+          echo "Found source issue ${REPO_NAME}#${issue_number}"
+          issue_title=$(gh issue view "$issue_number" --json title --jq ".title")
+
+          if [[ -n "$issue_number" && -n "$issue_title" ]]; then
+            search_title=$(cat <<EOF
+        [backport ${BRANCH}] ${issue_title}
+        EOF
+        )
+        
+            echo "Searching for backport issue with title: '${search_title}'"
+
+            backport_issue_number=$(gh issue list --state open --search "${search_title}" --json number --jq ".[].number")
+
+            if [[ -n "$backport_issue_number" ]]; then
+              echo "Found backport issue ${REPO_NAME}#${backport_issue_number}"
+              echo "Linking backport issue ${REPO_NAME}#${backport_issue_number}"
+
+              # comment on the backport issue
+              gh issue comment "${backport_issue_number}" --body "Backport PR: ${{ github.event.pull_request.html_url }}"
+
+              # comment on the PR
+              backport_issue_url=$(gh issue view "${backport_issue_number}" --json url --jq ".url")
+              gh pr comment "${{ github.event.pull_request.number }}" --body "Backport issue: ${backport_issue_url}"
+              continue
+            fi
+          fi
+
+          echo "No issue title found"
+        done


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/8383

The original GA also has escape string issue. So, I use EOF to replace it as well.

Test Action: https://github.com/JackTestHook/test/actions/runs/15409902431/job/43359604325

