### PR TITLE
feat: use sockets stands for cpu

### DIFF
--- a/tests/integration/api/vm_apis_test.go
+++ b/tests/integration/api/vm_apis_test.go
@@ -134,7 +134,7 @@ var _ = Describe("verify vm APIs", func() {
 			AfterVMRunning(vmController, vmNamespace, vmName, func(vm *kubevirtv1.VirtualMachine) bool {
 				spec := vm.Spec.Template.Spec
 				MustEqual(len(spec.Domain.Devices.Disks), 3)
-				MustEqual(spec.Domain.CPU.Cores, uint32(testVMUpdatedCPUCore))
+				MustEqual(spec.Domain.CPU.Sockets, uint32(testVMUpdatedCPUCore))
 				MustEqual(spec.Domain.Resources.Limits[corev1.ResourceMemory], resource.MustParse(testVMUpdatedMemory))
 				return true
 			})
@@ -156,7 +156,7 @@ var _ = Describe("verify vm APIs", func() {
 				func(vmi *kubevirtv1.VirtualMachineInstance) bool {
 					spec := vmi.Spec
 					MustEqual(len(spec.Domain.Devices.Disks), 3)
-					MustEqual(spec.Domain.CPU.Cores, uint32(testVMUpdatedCPUCore))
+					MustEqual(spec.Domain.CPU.Sockets, uint32(testVMUpdatedCPUCore))
 					MustEqual(spec.Domain.Resources.Limits[corev1.ResourceMemory], resource.MustParse(testVMUpdatedMemory))
 					return true
 				})


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Our client implementation sets cpu value to `cores`. However, the cpu hot-plug feature needs to patch value on `sockets`, not `cores`. It's better to mutate cpu value to `sockets` in backend, so we don't need to change each client side.

#### Solution:
Use mutator to patch cpu value to sockets.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5835

#### Test plan:

* On UI, create a new VM with 2 CPU, the mutator change the value to sockets.
```
          cores: 1
          sockets: 2
          threads: 1
```
* On UI, update the VM to 3 CPU, the mutator change the value to sockets.
```
          cores: 1
          sockets: 3
          threads: 1
```

The UI shows the CPU based on `cores`, so you have to use YAML to validate it.
