### PR TITLE
Fix upgrade stuck caused by upgrade repo VM

### DIFF
--- a/cmd/upgradehelper/cmd/vmlivemigratedetector/vmlivemigratedetector.go
+++ b/cmd/upgradehelper/cmd/vmlivemigratedetector/vmlivemigratedetector.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	shutdown bool
+	shutdown      bool
+	excludeRepoVM bool
 )
 
 var vmLiveMigrateDetectorCmd = &cobra.Command{
@@ -31,6 +32,7 @@ If there is no place to go, it can optionally shut down the VMs.
 			KubeConfigPath: cmd.KubeConfigPath,
 			KubeContext:    cmd.KubeContext,
 			Shutdown:       shutdown,
+			ExcludeRepoVM:  excludeRepoVM,
 			NodeName:       args[0],
 		}
 		if err := run(ctx, options); err != nil {
@@ -42,6 +44,7 @@ If there is no place to go, it can optionally shut down the VMs.
 
 func init() {
 	vmLiveMigrateDetectorCmd.Flags().BoolVar(&shutdown, "shutdown", false, "Shutdown non-migratable VMs")
+	vmLiveMigrateDetectorCmd.Flags().BoolVar(&excludeRepoVM, "exclude-repo-vm", false, "Exclude upgrade repo VM from detection")
 
 	cmd.RootCmd.AddCommand(vmLiveMigrateDetectorCmd)
 }

--- a/pkg/upgradehelper/vmlivemigratedetector/detector_test.go
+++ b/pkg/upgradehelper/vmlivemigratedetector/detector_test.go
@@ -1,0 +1,56 @@
+package vmlivemigratedetector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestVMSelector(t *testing.T) {
+	tests := []struct {
+		name           string
+		nodeName       string
+		excludeRepoVM  bool
+		expectedLabels map[string]string
+		excludeLabel   string
+	}{
+		{
+			name:          "No exclusion, match node label",
+			nodeName:      "node-1",
+			excludeRepoVM: false,
+			expectedLabels: map[string]string{
+				"kubevirt.io/nodeName": "node-1",
+			},
+		},
+		{
+			name:          "Exclude upgrade VMs",
+			nodeName:      "node-2",
+			excludeRepoVM: true,
+			expectedLabels: map[string]string{
+				"kubevirt.io/nodeName": "node-2",
+			},
+			excludeLabel: "harvesterhci.io/upgrade",
+		},
+	}
+
+	assert := require.New(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			selector, err := vmSelector(tc.nodeName, tc.excludeRepoVM)
+			assert.NoError(err)
+
+			// Must match expected nodeName
+			assert.True(selector.Matches(labels.Set(tc.expectedLabels)))
+
+			// Must not match excluded label if applicable
+			if tc.excludeLabel != "" {
+				excludeSet := labels.Set{
+					"kubevirt.io/nodeName": tc.nodeName,
+					tc.excludeLabel:        "true",
+				}
+				assert.False(selector.Matches(excludeSet))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Problem:
The upgrade repo VM uses the CPUModeHostPassthrough setting, which may cause live migration to fail if the source and target nodes have different CPU settings. In such cases, QEMU might raise an error during migration, leading to the upgrade process getting stuck. See https://bugzilla.redhat.com/show_bug.cgi?id=1439078 for more details.

#### Solution:

This patch introduces a new flag `--exclude-repo-vm` to the VM live migration detector (default: false). During the upgrade process, the detector will no longer skip upgrade repo VMs. Instead, it will shut it down before the node is upgraded to avoid migration failure.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8298

#### Test plan:
1. Prepare a Harvester cluster with at least two nodes using the built ISO image from this PR (for QAs, please use the master-head ISO image)
1. Trigger the upgrade with the same ISO image
1. Monitor the upgrade progress and the upgrade repo VM
1. The upgrade should succeed with the upgrade repo VM being shut down during the time.

#### Additional documentation or context
