### PR TITLE
change machine type order 

### DIFF
--- a/pkg/api/cluster/formatter.go
+++ b/pkg/api/cluster/formatter.go
@@ -116,7 +116,7 @@ func generateMachineTypes() ([]byte, error) {
 	var machineTypes []string
 	switch runtime.GOARCH {
 	case "amd64":
-		machineTypes = append(machineTypes, "pc-q35", "q35")
+		machineTypes = append(machineTypes, "q35", "pc-q35")
 	case "arm64":
 		machineTypes = append(machineTypes, "virt")
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR https://github.com/harvester/harvester/pull/8336 returns different machine types based on underlying host architecture.

The harvester UI picks up the first machine type being returned as the default, which causes issues as pc-q35 seems to be less common as the q35 machine type.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces a minor fix to change the order in which machine types are returned.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5364
#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
