### PR TITLE
feat: add max-hotplug-ratio setting

### DIFF
--- a/pkg/controller/master/setting/max_hotplug_ratio.go
+++ b/pkg/controller/master/setting/max_hotplug_ratio.go
@@ -1,0 +1,50 @@
+package setting
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harvSettings "github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func (h *Handler) syncMaxHotplugRatio(setting *harvesterv1.Setting) error {
+	var value string
+	if setting.Value != "" {
+		value = setting.Value
+	} else {
+		value = setting.Default
+	}
+
+	hotplugRatio := virtconfig.DefaultMaxHotplugRatio
+	if value != "" {
+		num, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("Invalid value `%s`: %s", setting.Value, err.Error())
+		}
+		hotplugRatio = num
+	}
+
+	kubevirt, err := h.kubeVirtConfigCache.Get(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)
+	if err != nil {
+		return fmt.Errorf("failed to get kubevirt object %v/%v", util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)
+	}
+
+	kubevirtCpy := kubevirt.DeepCopy()
+	if kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration == nil {
+		kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration = &kubevirtv1.LiveUpdateConfiguration{}
+	}
+	kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration.MaxHotplugRatio = uint32(hotplugRatio)
+
+	if !reflect.DeepEqual(kubevirt.Spec.Configuration.LiveUpdateConfiguration, kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration) {
+		if _, err := h.kubeVirtConfig.Update(kubevirtCpy); err != nil {
+			return fmt.Errorf("failed to update %v as %v to kubevirt %w", harvSettings.MaxHotplugRatioSettingName, value, err)
+		}
+	}
+	return nil
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -90,6 +90,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		harvSettings.AutoRotateRKE2CertsSettingName:              controller.syncAutoRotateRKE2Certs,
 		harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName: controller.syncKubeconfigTTL,
 		harvSettings.AdditionalGuestMemoryOverheadRatioName:      controller.syncAdditionalGuestMemoryOverheadRatio,
+		harvSettings.MaxHotplugRatioSettingName:                  controller.syncMaxHotplugRatio,
 		// for "backup-target" syncer, please check harvester-backup-target-controller
 		// for "storage-network" syncer, please check harvester-storage-network-controller
 	}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -58,6 +58,7 @@ var (
 	NTPServers             = NewSetting(NTPServersSettingName, "")
 	WhiteListedSettings    = []string{ServerVersionSettingName, DefaultStorageClassSettingName, HarvesterCSICCMSettingName, DefaultVMTerminationGracePeriodSecondsSettingName}
 	UpgradeConfigSet       = NewSetting(UpgradeConfigSettingName, `{"imagePreloadOption":{"strategy":{"type":"sequential"}}, "restoreVM": false}`)
+	MaxHotplugRatio        = NewSetting(MaxHotplugRatioSettingName, "4")
 )
 
 const (
@@ -103,6 +104,7 @@ const (
 	ReleaseDownloadURLSettingName                     = "release-download-url"
 	SupportBundleNamespacesSettingName                = "support-bundle-namespaces"
 	DefaultStorageClassSettingName                    = "default-storage-class"
+	MaxHotplugRatioSettingName                        = "max-hotplug-ratio"
 
 	// settings have `default` and `value` string used in many places, replace them with const
 	KeywordDefault = "default"

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1676,7 +1676,7 @@ func validateMaxHotplugRatioHelper(field, value string) error {
 	if value == "" {
 		return nil
 	}
-	num, err := strconv.Atoi(value)
+	num, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
 		return fmt.Errorf("failed to parse %s: %v", field, err)
 	}


### PR DESCRIPTION
#### Solution:
There is a `maxHotplugRatio` configuration to control all VM's `maxSockets` and `maxGuest` based on `sockets` and `guest`. The default value is 4. It's better to let user to control this.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5835

#### Test plan:
1. Update the `max-hotplug-ratio` to `-1` and it cannot be applied.
2. Update the `max-hotplug-ratio` to `0` and it cannot be applied.
3. Update the `max-hotplug-ratio` to `non-int` and it cannot be applied.
4. Update the `max-hotplug-ratio` to `1` and it can be applied.
5. Update the `max-hotplug-ratio` to `4` and it can be applied.
6. Remove value in `max-hotpug-ratio` and it uses default value `4` in KubeVirt.
