### PR TITLE
chore: make stale bot ignore require/investigate label [skip ci]

### DIFF
--- a/.github/workflows/issue-management-stale.yml
+++ b/.github/workflows/issue-management-stale.yml
@@ -35,6 +35,6 @@ jobs:
         stale-issue-label: 'status/stale'
         stale-pr-label: 'status/stale'
         exempt-all-assignees: false
-        exempt-issue-labels: 'require/pm-review'
+        exempt-issue-labels: 'require/pm-review,require/investigate'
         exempt-draft-pr: true
         exempt-all-milestones: true


### PR DESCRIPTION
#7983

since some issues require more time for investigation, so we decided to make the stale bot ignore `require/investigate` label.
