### PR TITLE
feat: add enableCPUAndMemoryHotplug label

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"strings"
+
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -407,6 +409,12 @@ func canDismissInsufficientResourceQuota(vm *kubevirtv1.VirtualMachine) bool {
 }
 
 func canCPUAndMemoryHotplug(vm *kubevirtv1.VirtualMachine) bool {
+	if vm.Labels == nil {
+		return false
+	}
+	if v, ok := vm.Labels[util.LabelCPUAndMemoryHotplugEnabled]; !ok || !strings.EqualFold(v, "true") {
+		return false
+	}
 	if vm.Spec.Template.Spec.Domain.CPU != nil && (vm.Spec.Template.Spec.Domain.CPU.Cores != 1 || vm.Spec.Template.Spec.Domain.CPU.Threads != 1) {
 		return false
 	}

--- a/pkg/controller/master/setting/max_hotplug_ratio.go
+++ b/pkg/controller/master/setting/max_hotplug_ratio.go
@@ -27,7 +27,7 @@ func (h *Handler) syncMaxHotplugRatio(setting *harvesterv1.Setting) error {
 
 	num, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
-		return fmt.Errorf("Invalid value `%s`: %s", setting.Value, err.Error())
+		return fmt.Errorf("invalid value `%s`: %s", setting.Value, err.Error())
 	}
 
 	kubevirt, err := h.kubeVirtConfigCache.Get(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -216,4 +216,6 @@ const (
 	HarvesterManagedChart            = "harvester"
 	RancherLoggingCRDManagedChart    = "rancher-logging-crd"
 	RancherMonitoringCRDManagedChart = "rancher-monitoring-crd"
+
+	LabelCPUAndMemoryHotplugEnabled = prefix + "/enableCPUAndMemoryHotplug"
 )


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5835

#### Test plan:
* Check only VM with `harvesterhci.io/enableCPUAndMemoryHotplug` label, `cores` and `threads` is 1 can run `cpuAndMemoryHotplug` action.

#### Additional documentation or context
