### PR TITLE
allow vm-import-controller managed vm's to directly used golden pvc

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -33,6 +33,7 @@ const (
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
 	AnnotationLastRefreshTime           = prefix + "/lastRefreshTime"
 	AnnotationMacAddressName            = prefix + "/mac-address"
+	AnnotationVMImportController        = "migration.harvesterhci.io/virtualmachineimport"
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
 

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -315,6 +315,10 @@ func (v *vmValidator) checkVolumeReq(newVM *kubevirtv1.VirtualMachine) error {
 		return nil
 	}
 
+	// if vm is being created by vm import controller then we need to skip pvc golden image validation
+	// this case needs to be treated differently from a standaard image scenario as user will boot directly from disk
+	imported := checkIsVirtualMachineImported(newVM)
+
 	for _, volReq := range newVM.Status.VolumeRequests {
 		if volReq.AddVolumeOptions == nil {
 			continue
@@ -331,6 +335,11 @@ func (v *vmValidator) checkVolumeReq(newVM *kubevirtv1.VirtualMachine) error {
 			}
 			return werror.NewInternalError(fmt.Sprintf("failed to get PVC %s/%s, err: %s", pvcNS, pvcName, err))
 		}
+
+		if imported {
+			continue
+		}
+
 		if _, ok := pvc.Annotations[util.AnnotationGoldenImage]; ok {
 			if pvc.Annotations[util.AnnotationGoldenImage] == "true" {
 				return werror.NewInvalidError(fmt.Sprintf("PVC %s/%s is a golden image, it can't be used as a hotplug volume in VM", pvcNS, pvcName), "status.volumeRequests")
@@ -434,6 +443,10 @@ func (v *vmValidator) checkGoldenImage(vm *kubevirtv1.VirtualMachine) error {
 		return nil
 	}
 
+	// if vm is being created by vm import controller then we need to skip pvc golden image validation
+	// this case needs to be treated differently from a standaard image scenario as user will boot directly from disk
+	imported := checkIsVirtualMachineImported(vm)
+
 	for _, volume := range vm.Spec.Template.Spec.Volumes {
 		if volume.PersistentVolumeClaim == nil {
 			continue
@@ -449,6 +462,11 @@ func (v *vmValidator) checkGoldenImage(vm *kubevirtv1.VirtualMachine) error {
 		if targetPVC.Annotations == nil {
 			continue
 		}
+
+		if imported {
+			continue
+		}
+
 		if _, ok := targetPVC.Annotations[util.AnnotationGoldenImage]; ok {
 			if targetPVC.Annotations[util.AnnotationGoldenImage] == "true" {
 				return werror.NewInvalidError(fmt.Sprintf("PVC %s/%s is a golden image, it can't be used as a volume in VM", targetPVC.Namespace, targetPVC.Name), "spec.templates.spec.volumes")
@@ -561,4 +579,14 @@ func (v *vmValidator) checkDedicatedCPUPlacement(vm *kubevirtv1.VirtualMachine) 
 	}
 
 	return nil
+}
+
+// checkIsVirtualMachineImported checks if a virtualmachine has been created by the vm import controller
+func checkIsVirtualMachineImported(vm *kubevirtv1.VirtualMachine) bool {
+	if vm.Annotations == nil {
+		return false
+	}
+
+	_, imported := vm.Annotations[util.AnnotationVMImportController]
+	return imported
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Harvester validating webhooks block VM's from currently using the golden pvc (source datavolume) directly in the VMs

This works fine in most scenarios except when used with vm-import-controller, which is being enhanced to support 3rd party csi. In this scenario we intend to import the source disk via virtual machine images and cdi combination. These disks are different from traditional vm images as we do not intend to make these the imported image available for subsequently cloning/snapshotting across multiple vm's. In addition these disks can be large, from a few hundred GB's to TB's, as a result it could become inefficient to keep multiple copies of data via the current golden pvc design.

To work around this we need to allow VM's to boot directly off golden pvc in certain scenarios.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

PR introduces a minor change to harvester webhook to skip pvc validation when the VM is being created by the vm-import-controller.

The change depends on an annotation https://github.com/harvester/vm-import-controller/blob/main/pkg/controllers/migration/virtualmachine.go#L43 added by the controller to all imported VM's

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/pull/7487
#### Test plan:
<!-- Describe the test plan by steps. -->
No specific changes are needed to validate harvester.

The test plan will be part of the vm-import-controller 3rd party csi support enhancement.

#### Additional documentation or context
