### PR TITLE
chore: fix link backport loop issue

### DIFF
--- a/.github/workflows/issue-management-link-backport-pr.yaml
+++ b/.github/workflows/issue-management-link-backport-pr.yaml
@@ -66,7 +66,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
         GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
       run: |
-        for issue_number in "${{ env.ORIGINAL_ISSUE_NUMBER }}"; do
+        for issue_number in ${{ env.ORIGINAL_ISSUE_NUMBER }}; do
           echo "Found source issue ${REPO_NAME}#${issue_number}"
           issue_title=$(gh issue view "$issue_number" --json title --jq ".title")
 


### PR DESCRIPTION
#8383 

Separating issue.

![image](https://github.com/user-attachments/assets/ea251d9f-bbaa-4a63-b804-761bfd05705c)

After removing `""`:

![image](https://github.com/user-attachments/assets/42411b97-17d1-4b67-ab18-7f3330a31d88)
