### PR TITLE
Log app info when it starts

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -5,7 +5,6 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/rancher/wrangler/v3/pkg/signals"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
 	"github.com/harvester/harvester/pkg/cmd"
@@ -13,6 +12,10 @@ import (
 	apiserver "github.com/harvester/harvester/pkg/server"
 	"github.com/harvester/harvester/pkg/webhook/config"
 	"github.com/harvester/harvester/pkg/webhook/server"
+)
+
+const (
+	name = "Harvester Admission Webhook Server"
 )
 
 func main() {
@@ -55,15 +58,14 @@ func main() {
 		},
 	}
 
-	app := cmd.NewApp("Harvester Admission Webhook Server", "", flags, func(commonOptions *harvesterconfig.CommonOptions) error {
+	app := cmd.NewApp(name, "", flags, func(commonOptions *harvesterconfig.CommonOptions) error {
 		return run(commonOptions, &options)
 	})
+
 	app.Run()
 }
 
 func run(commonOptions *harvesterconfig.CommonOptions, options *config.Options) error {
-	logrus.Info("Starting webhook server")
-
 	ctx := signals.SetupSignalContext()
 
 	kubeConfig, err := apiserver.GetConfig(commonOptions.KubeConfig)
@@ -75,8 +77,6 @@ func run(commonOptions *harvesterconfig.CommonOptions, options *config.Options) 
 	if err != nil {
 		return err
 	}
-
-	logrus.Debugf("Harvester controller username: %s", options.HarvesterControllerUsername)
 
 	s := server.New(ctx, restCfg, options)
 	if err := s.ListenAndServe(); err != nil {

--- a/main.go
+++ b/main.go
@@ -11,12 +11,15 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/rancher/wrangler/v3/pkg/signals"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
 	"github.com/harvester/harvester/pkg/cmd"
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/server"
+)
+
+const (
+	name = "Harvester API Server"
 )
 
 func main() {
@@ -72,14 +75,14 @@ func main() {
 		},
 	}
 
-	app := cmd.NewApp("Harvester API Server", "", flags, func(commonOptions *config.CommonOptions) error {
+	app := cmd.NewApp(name, "", flags, func(commonOptions *config.CommonOptions) error {
 		return run(commonOptions, options)
 	})
+
 	app.Run()
 }
 
 func run(commonOptions *config.CommonOptions, options config.Options) error {
-	logrus.Info("Starting controller")
 	ctx := signals.SetupSignalContext()
 
 	kubeConfig, err := server.GetConfig(commonOptions.KubeConfig)

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -71,10 +71,13 @@ func NewApp(name string, usage string, flags []cli.Flag, action Action) *App {
 		return action(&options)
 	}
 
-	return &App{
+	app := &App{
 		app:     cliApp,
 		Options: &options,
 	}
+	// log app basic info
+	app.info()
+	return app
 }
 
 func initProfiling(options *config.CommonOptions) {
@@ -116,4 +119,9 @@ func (a *App) Run() {
 	if err := a.app.Run(os.Args); err != nil {
 		logrus.Fatal(err)
 	}
+}
+
+func (a *App) info() {
+	logrus.Infof("Starting %v version %v", a.app.Name, a.app.Version)
+	logrus.Debugf("Options: %+v", a.Options)
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Harvester POD log does not include the version and commit info, you need to cross check the pod/container info to confirm.

It has been linked to binary
https://github.com/harvester/harvester/blob/0ab8afd0a19946a681fa7228cd8458129220d803/scripts/build#L23

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Log the info when app starts.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8486

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Check harvester pod log when it starts
2. There are info like
```
time="2025-06-17T09:10:52Z" level=info msg="Starting Harvester API Server version f9ccd696 (f9ccd696)"
time="2025-06-17T09:10:53Z" level=info msg="Do not update the existing CRD KeyPair"
```

#### Additional documentation or context
