### PR TITLE
Update max_hotplug_ratio error processing and add upper limit

### DIFF
--- a/pkg/controller/master/setting/max_hotplug_ratio.go
+++ b/pkg/controller/master/setting/max_hotplug_ratio.go
@@ -44,7 +44,8 @@ func (h *Handler) syncMaxHotplugRatio(setting *harvesterv1.Setting) error {
 	if kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration == nil {
 		kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration = &kubevirtv1.LiveUpdateConfiguration{}
 	}
-	kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration.MaxHotplugRatio = uint32(num)
+	// skip gosec G115
+	kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration.MaxHotplugRatio = uint32(num) //nolint:gosec
 
 	if !reflect.DeepEqual(kubevirt.Spec.Configuration.LiveUpdateConfiguration, kubevirtCpy.Spec.Configuration.LiveUpdateConfiguration) {
 		if _, err := h.kubeVirtConfig.Update(kubevirtCpy); err != nil {

--- a/pkg/util/peakvalues.go
+++ b/pkg/util/peakvalues.go
@@ -1,0 +1,8 @@
+package util
+
+const (
+
+	// the allowed min and max HotplugRatio value
+	MaxHotplugRatioValue = 20
+	MinHotplugRatioValue = 1
+)

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1676,10 +1676,10 @@ func validateMaxHotplugRatioHelper(field, value string) error {
 	}
 	num, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
-		return fmt.Errorf("failed to parse %s: %v", field, err)
+		return fmt.Errorf("failed to parse %v: %v %w", field, value, err)
 	}
-	if num < 1 {
-		return fmt.Errorf("%s must be greater than or equal to 1", field)
+	if num < util.MinHotplugRatioValue || num > util.MaxHotplugRatioValue {
+		return fmt.Errorf("%v: %v must be in range [%v .. %v]", field, value, util.MinHotplugRatioValue, util.MaxHotplugRatioValue)
 	}
 	return nil
 }

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -1202,3 +1202,84 @@ func Test_validateStorageNetworkConfig(t *testing.T) {
 
 	}
 }
+
+func Test_validateMaxHotplugRatio(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   *v1beta1.Setting
+		errMsg string
+	}{
+		{
+			name: "ok to create max-hotplug-ratio with none values",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.MaxHotplugRatioSettingName},
+			},
+			errMsg: "",
+		},
+		{
+			name: "ok to create max-hotplug-ratio with empty default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.MaxHotplugRatioSettingName},
+				Default:    "",
+			},
+			errMsg: "",
+		},
+		{
+			name: "ok to create max-hotplug-ratio with empty default and value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.MaxHotplugRatioSettingName},
+				Default:    "",
+				Value:      "",
+			},
+			errMsg: "",
+		},
+		{
+			name: "fail to create max-hotplug-ratio with invalid value -1",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.MaxHotplugRatioSettingName},
+				Default:    "",
+				Value:      "-1",
+			},
+			errMsg: "failed to parse",
+		},
+		{
+			name: "fail to create max-hotplug-ratio with invalid value 3.5",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.MaxHotplugRatioSettingName},
+				Default:    "3.5",
+				Value:      "",
+			},
+			errMsg: "failed to parse",
+		},
+		{
+			name: "fail to create max-hotplug-ratio with invalid value 21",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.MaxHotplugRatioSettingName},
+				Default:    "21",
+				Value:      "",
+			},
+			errMsg: "must be in range",
+		},
+		{
+			name: "ok to create max-hotplug-ratio with valid value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.MaxHotplugRatioSettingName},
+				Default:    "5",
+				Value:      "2",
+			},
+			errMsg: "",
+		},
+	}
+
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Create(nil, tt.args)
+			if tt.errMsg != "" {
+				assert.True(t, strings.Contains(err.Error(), tt.errMsg))
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Additional update to PR https://github.com/harvester/harvester/pull/8452

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5835
https://github.com/harvester/harvester/pull/8452

#### Test plan:
<!-- Describe the test plan by steps. -->
per https://github.com/harvester/harvester/pull/8452

Even when a value "30" is set on the setting bypassed the validator, the final kubevirt value is still the default value 4

```

$kubectl get settings.harvesterhci max-hotplug-ratio -oyaml
apiVersion: harvesterhci.io/v1beta1
default: "4"
kind: Setting
metadata:
  annotations:
    harvesterhci.io/hash: 6332531eeafc6e0ede272192be898f549950fb32b209d04f0a98306a
  creationTimestamp: "2025-06-17T08:37:59Z"
  generation: 3
  name: max-hotplug-ratio
  resourceVersion: "924480"
  uid: 9e5d1a99-08f4-4198-b14f-aed14e4a32dc
status:
  conditions:
  - lastUpdateTime: "2025-06-20T12:25:08Z"
    status: "True"
    type: configured
value: "30"



$kubectl get kubevirt kubevirt -n harvester-system -oyaml | grep plug -i
      - HotplugVolumes
      maxHotplugRatio: 4


edit setting to value 8

$kubectl edit settings.harvesterhci max-hotplug-ratio

setting.harvesterhci.io/max-hotplug-ratio edited

$kubectl get kubevirt kubevirt -n harvester-system -oyaml | grep plug -i
      - HotplugVolumes
      maxHotplugRatio: 8

```

#### Additional documentation or context



