### PR TITLE
Upgrade the eventrouter image to defined version on repo

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -36,6 +36,7 @@ detect_repo()
   REPO_RANCHER_VERSION=$(yq -e e '.rancher' $release_file)
   REPO_MONITORING_CHART_VERSION=$(yq -e e '.monitoringChart' $release_file)
   REPO_LOGGING_CHART_VERSION=$(yq -e e '.loggingChart' $release_file)
+  REPO_LOGGING_CHART_HARVESTER_EVENTROUTER_VERSION=$(yq -e e '.loggingChartHarvesterEventRouter' $release_file)
   REPO_FLEET_CHART_VERSION=$(yq -e e '.rancherDependencies.fleet.chart' $release_file)
   REPO_FLEET_APP_VERSION=$(yq -e e '.rancherDependencies.fleet.app' $release_file)
   REPO_FLEET_CRD_CHART_VERSION=$(yq -e e '.rancherDependencies.fleet-crd.chart' $release_file)
@@ -78,6 +79,11 @@ detect_repo()
 
   if [ -z "$REPO_LOGGING_CHART_VERSION" ]; then
     echo "[ERROR] Fail to get logging chart version from upgrade repo."
+    exit 1
+  fi
+
+  if [ -z "$REPO_LOGGING_CHART_HARVESTER_EVENTROUTER_VERSION" ]; then
+    echo "[ERROR] Fail to get logging chart harvester eventrouter version from upgrade repo."
     exit 1
   fi
 
@@ -494,7 +500,8 @@ upgrade_addon_rancher_logging_with_patch_eventrouter_image()
   local name=rancher-logging
   local namespace=cattle-logging-system
   local newversion=$1
-  echo "try to patch addon $name in $namespace to $newversion, with patch of eventrouter image"
+  local ernewversion=$2
+  echo "try to patch addon $name in $namespace to $newversion, with patch of eventrouter image to $ernewversion"
 
   # check if addon is there
   local version=$(kubectl get addons.harvesterhci.io $name -n $namespace -o=jsonpath='{.spec.version}' || true)
@@ -517,16 +524,12 @@ upgrade_addon_rancher_logging_with_patch_eventrouter_image()
   if [ $EXIT_CODE != 0 ]; then
     echo "eventrouter is not found, need not patch"
   else
-    if [[ "rancher/harvester-eventrouter:v1.5.0-dev.0" > $tag ]]; then
-      echo "eventrouter image is $tag, will patch to v1.5.0-dev.0"
-      fixeventrouter=true
-    else
-      echo "eventrouter image is updated, need not patch"
-    fi
+    echo "eventrouter image is $tag, will patch to $ernewversion"
+    fixeventrouter=true
   fi
 
   if [[ $fixeventrouter == false ]]; then
-    echo "eventrouter image is updated/not found, fallback to the normal addon $name upgrade"
+    echo "eventrouter image is not found, fallback to the normal addon $name upgrade"
     rm -f $valuesfile
     upgrade_addon_try_patch_version_only $name $namespace $newversion
     return 0
@@ -536,7 +539,7 @@ upgrade_addon_rancher_logging_with_patch_eventrouter_image()
   cat $valuesfile
 
   if [[ $fixeventrouter == true ]]; then
-    yq -e '.eventTailer.workloadOverrides.containers[0].image = "rancher/harvester-eventrouter:v1.5.0-dev.0"' -i $valuesfile
+    NEW_VERSION=$ernewversion yq -e '.eventTailer.workloadOverrides.containers[0].image = strenv(NEW_VERSION)' -i $valuesfile
   fi
 
   # add 4 spaces to each line

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1137,12 +1137,8 @@ upgrade_addon_rancher_logging()
 {
   echo "upgrade addon rancher-logging"
   # .spec.valuesContent has dynamic fields, cannot merge simply, review in each release
-  # in v1.5.0, the eventrouter needs to be patched
-  if [ "$REPO_LOGGING_CHART_VERSION" = "105.2.0+up4.10.0" ]; then
-    upgrade_addon_rancher_logging_with_patch_eventrouter_image $REPO_LOGGING_CHART_VERSION
-  else
-    upgrade_addon_try_patch_version_only "rancher-logging" "cattle-logging-system" $REPO_LOGGING_CHART_VERSION
-  fi
+  # the eventrouter image tag is aligned with Harvester tag, e.g. v1.5.1-rc3, v1.6.0
+  upgrade_addon_rancher_logging_with_patch_eventrouter_image $REPO_LOGGING_CHART_VERSION $REPO_LOGGING_CHART_HARVESTER_EVENTROUTER_VERSION
 }
 
 # NOTE: review in each release, add corresponding process, runs before rancher-logging is bumped


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

harvester-eventrouter image tag is staled on v1.5.1, needs to be bumped on both new installation and upgrade path

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. the installer via https://github.com/harvester/harvester-installer/pull/1052, saves eventrouter image tag to repo

2. upgrade path read the info from upgrade repo, and add processing

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8503

https://github.com/harvester/harvester/issues/6289

#### Test plan:
<!-- Describe the test plan by steps. -->

upgrade to new version, the eventrouter image tag is as expected.

#### Additional documentation or context

installation PR: 
master-head: https://github.com/harvester/harvester-installer/pull/1052
v1.5: https://github.com/harvester/harvester-installer/pull/1053