### PR TITLE
chore: bump harvester-eventrouter to v1.5.1-rc4

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -517,8 +517,8 @@ upgrade_addon_rancher_logging_with_patch_eventrouter_image()
   if [ $EXIT_CODE != 0 ]; then
     echo "eventrouter is not found, need not patch"
   else
-    if [[ "rancher/harvester-eventrouter:v1.5.0-dev.0" > $tag ]]; then
-      echo "eventrouter image is $tag, will patch to v1.5.0-dev.0"
+    if [[ "rancher/harvester-eventrouter:v1.5.1-rc4" > $tag ]]; then
+      echo "eventrouter image is $tag, will patch to v1.5.1-rc4"
       fixeventrouter=true
     else
       echo "eventrouter image is updated, need not patch"
@@ -536,7 +536,7 @@ upgrade_addon_rancher_logging_with_patch_eventrouter_image()
   cat $valuesfile
 
   if [[ $fixeventrouter == true ]]; then
-    yq -e '.eventTailer.workloadOverrides.containers[0].image = "rancher/harvester-eventrouter:v1.5.0-dev.0"' -i $valuesfile
+    yq -e '.eventTailer.workloadOverrides.containers[0].image = "rancher/harvester-eventrouter:v1.5.1-rc4"' -i $valuesfile
   fi
 
   # add 4 spaces to each line


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The harvester-eventrouter image still remains at v1.5.0-dev.0.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Manually bump it to v1.5.1-rc4. This PR specifically addresses the upgrade path.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#8503

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

This PR supersedes the to-be-created backport PR of #8502 for v1.5.1 releases for schedule urgency. In the long run, we'll have a unified way to manage the harvester-eventrouter's version, like what we proposed in #8502.