### PR TITLE
feat: patch guest value if there is no enableCPUAndMemoryHotplug annotation

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -18,6 +18,7 @@ import (
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/indexeres"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/virtualmachine"
 	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
 )
 
@@ -411,6 +412,9 @@ func canCPUAndMemoryHotplug(vm *kubevirtv1.VirtualMachine) bool {
 		return false
 	}
 	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
+		return false
+	}
+	if !virtualmachine.SupportCPUAndMemoryHotplug(vm) {
 		return false
 	}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -34,6 +34,7 @@ const (
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
 	AnnotationLastRefreshTime           = prefix + "/lastRefreshTime"
 	AnnotationMacAddressName            = prefix + "/mac-address"
+	AnnotationEnableCPUAndMemoryHotplug = prefix + "/enableCPUAndMemoryHotplug"
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
 

--- a/pkg/util/virtualmachine/virtualmachine.go
+++ b/pkg/util/virtualmachine/virtualmachine.go
@@ -2,12 +2,14 @@ package virtualmachine
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 // IsVMStopped checks VM is stopped or not. It will check two cases
@@ -49,4 +51,12 @@ func IsVMStopped(
 	}
 
 	return false, nil
+}
+
+func SupportCPUAndMemoryHotplug(vm *kubevirtv1.VirtualMachine) bool {
+	if vm == nil || vm.Annotations == nil {
+		return false
+	}
+
+	return strings.ToLower(vm.Annotations[util.AnnotationEnableCPUAndMemoryHotplug]) == "true"
 }

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -540,6 +540,14 @@ func (v *vmValidator) checkReservedMemoryAnnotation(vm *kubevirtv1.VirtualMachin
 	if reservedMemory.Cmp(*mem) >= 0 {
 		return werror.NewInvalidError("reservedMemory cannot be equal or greater than limits.memory", field)
 	}
+	if vm.Spec.Template.Spec.Domain.Memory != nil && vm.Spec.Template.Spec.Domain.Memory.Guest != nil {
+		guestMemory := vm.Spec.Template.Spec.Domain.Memory.Guest
+		totalMemory := *guestMemory
+		totalMemory.Add(reservedMemory)
+		if totalMemory.Cmp(*mem) > 0 {
+			return werror.NewInvalidError(fmt.Sprintf("guest memory %v plus reservedMemory %v cannot be greater than limits.memory %v", guestMemory.Value(), reservedMemory.Value(), mem.Value()), field)
+		}
+	}
 	if reservedMemory.CmpInt64(0) == -1 {
 		return werror.NewInvalidError("reservedMemory cannot be less than 0", field)
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

* Patch guest value if there is no enableCPUAndMemoryHotplug annotation.
* Validate guest + reserved memory <= limits memory

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5835

#### Test plan:

* Case 1: VM without `harvesterhci.io/enableCPUAndMemoryHotplug` can work as usual. Using `resources.limits` as memory input.
* Case 2: VM with `harvesterhci.io/enableCPUAndMemoryHotplug` use domain guest memory as memory input.
  * Create a VM without reserved memory, the guest input should not be updated.
  * Create a VM with reserved memory + guest memory > limits memory, the request should be denied.
  * Create a VM with 1 socket, 1Gi guest and 4Gi limits memory. Use `cpuAndMemoryHotplug` action to patch sockets to 2 and guest to 2Gi. The action should be successful.
