### PR TITLE
Add upgrade processing of grafana nginx configmap

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -838,3 +838,49 @@ upgrade_nvidia_driver_toolkit_addon()
   fi
   upgrade_addon nvidia-driver-toolkit harvester-system
 }
+
+patch_grafana_nginx_proxy_config_configmap() {
+  local EXIT_CODE=0
+  local cm=grafana-nginx-proxy-config
+  local originValuesfile="/tmp/configmapvalue.yaml"
+  rm -f ${originValuesfile}
+
+  echo "try to patch configmap $cm when it exists"
+
+  kubectl get configmap -n cattle-monitoring-system ${cm} -ojsonpath="{.data['nginx\.conf']}" > ${originValuesfile} || EXIT_CODE=$?
+  if [[ $EXIT_CODE -gt 0 ]]; then
+    # e.g. the rancher-monitoring addon is not enabled
+    echo "did not find configmap $cm, skip"
+    return 0
+  fi
+
+  grep "c-m-" ${originValuesfile} || EXIT_CODE=$?
+  if [[ $EXIT_CODE -gt 0 ]]; then
+    echo "configmap $cm c-m- has been patched to c-"
+     rm -f ${originValuesfile}
+    return 0
+  fi
+
+  # replace the keyword "c-m-*" with "c-*"
+  sed -i -e 's/c-m-/c-/' ${originValuesfile}
+  # add 4 spaces to each line
+  sed -i -e 's/^/    /' ${originValuesfile}
+  local newvalues=$(<${originValuesfile})
+  rm -f ${originValuesfile}
+  local patchfile="/tmp/configmappatch.yaml"
+
+cat > ${patchfile} <<EOF
+data:
+  nginx.conf: |
+${newvalues}
+EOF
+
+  echo "the prepared patch file content"
+  cat ${patchfile}
+
+  kubectl patch configmap ${cm} -n cattle-monitoring-system --patch-file ${patchfile} --type merge || echo "patch configmap $cm failed"
+  rm -f ${patchfile}
+
+  echo "replace the grafana pod to use the new configmap"
+  kubectl delete pods -n cattle-monitoring-system -l app.kubernetes.io/name=grafana || echo "failed to delete the grafana pod, wait until the related host node is rebooted and then it gets the new configmap"
+}

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1127,9 +1127,15 @@ EOF
 upgrade_addon_rancher_monitoring()
 {
   echo "upgrade addon rancher-monitoring"
+
   # .spec.valuesContent has dynamic fields, cannot merge simply, review in each release
   # in v1.5.0, patch version is OK
   upgrade_addon_try_patch_version_only "rancher-monitoring" "cattle-monitoring-system" $REPO_MONITORING_CHART_VERSION
+
+  # patch configmap and replace grafana pod if necessary
+  if [ "$REPO_MONITORING_CHART_VERSION" = "105.1.2+up61.3.2" ]; then
+    patch_grafana_nginx_proxy_config_configmap
+  fi
 }
 
 # NOTE: review in each release, add corresponding process


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
After bumping Rancher to v2.11.2, the Rancher->Harvester can't load grafana


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. Update the grafana nginx proxy setting to filter the imported cluster name.
2. Update the configmap it on the upgrade path

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

upgrade to version with this PR, the issue https://github.com/harvester/harvester/issues/8498 is gone, grafana can be loaded on Rancher->Harvester->dashboard

#### Additional documentation or context
Installer PR: https://github.com/harvester/harvester-installer/pull/1056