### PR TITLE
Extend restoreVM to support multi-node environments

### DIFF
--- a/cmd/upgradehelper/cmd/restorevm/restorevm.go
+++ b/cmd/upgradehelper/cmd/restorevm/restorevm.go
@@ -1,0 +1,60 @@
+package restorevm
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/harvester/harvester/cmd/upgradehelper/cmd"
+	"github.com/harvester/harvester/pkg/upgradehelper/restorevm"
+)
+
+var (
+	upgrade  string
+	nodeName string
+)
+
+var restoreVMCmd = &cobra.Command{
+	Use:   "restore-vm --node NODENAME --upgrade UPGRADENAME",
+	Short: "Restore VMs after upgrade",
+	Long: `Restore VMs for a node after upgrade.
+
+This command will:
+1. Get VM names from the upgrade ConfigMap.
+2. Wait until KubeVirt is ready.
+3. Start all VMs listed in the ConfigMap for the node.
+`,
+	Run: func(_ *cobra.Command, _ []string) {
+		ctx := context.Background()
+		handler, err := restorevm.NewRestoreVMHandler(cmd.KubeConfigPath, cmd.KubeContext, nodeName, upgrade)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create restore handler: %v\n", err)
+			os.Exit(1)
+		}
+		if err := handler.Run(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "restore failed: %v\n", err)
+			os.Exit(1)
+		}
+		logrus.Info("Restore VM completed successfully")
+	},
+}
+
+func init() {
+	restoreVMCmd.Flags().StringVar(&nodeName, "node", "", "Node name (required)")
+	restoreVMCmd.Flags().StringVar(&upgrade, "upgrade", "", "Upgrade CR name (required)")
+	err := restoreVMCmd.MarkFlagRequired("node")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to mark node flag as required: %v\n", err)
+		os.Exit(1)
+	}
+	err = restoreVMCmd.MarkFlagRequired("upgrade")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to mark upgrade flag as required: %v\n", err)
+		os.Exit(1)
+	}
+
+	cmd.RootCmd.AddCommand(restoreVMCmd)
+}

--- a/cmd/upgradehelper/cmd/vmlivemigratedetector/vmlivemigratedetector.go
+++ b/cmd/upgradehelper/cmd/vmlivemigratedetector/vmlivemigratedetector.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	shutdown bool
+	upgrade  string
 )
 
 var vmLiveMigrateDetectorCmd = &cobra.Command{
@@ -31,6 +32,7 @@ If there is no place to go, it can optionally shut down the VMs.
 			KubeConfigPath: cmd.KubeConfigPath,
 			KubeContext:    cmd.KubeContext,
 			Shutdown:       shutdown,
+			Upgrade:        upgrade,
 			NodeName:       args[0],
 		}
 		if err := run(ctx, options); err != nil {
@@ -42,6 +44,9 @@ If there is no place to go, it can optionally shut down the VMs.
 
 func init() {
 	vmLiveMigrateDetectorCmd.Flags().BoolVar(&shutdown, "shutdown", false, "Shutdown non-migratable VMs")
+	vmLiveMigrateDetectorCmd.Flags().StringVar(&upgrade, "upgrade", "",
+		"Upgrade CR name. If non-empty, it's used to generate the name of the configmap that stores all "+
+			"non-migratable VMs stopped by Harvester during the upgrade")
 
 	cmd.RootCmd.AddCommand(vmLiveMigrateDetectorCmd)
 }

--- a/cmd/upgradehelper/main.go
+++ b/cmd/upgradehelper/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/harvester/harvester/cmd/upgradehelper/cmd"
+	_ "github.com/harvester/harvester/cmd/upgradehelper/cmd/restorevm"
 	_ "github.com/harvester/harvester/cmd/upgradehelper/cmd/versionguard"
 	_ "github.com/harvester/harvester/cmd/upgradehelper/cmd/vmlivemigratedetector"
 )

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -289,7 +289,7 @@ command_pre_drain() {
   wait_longhorn_engines
 
   # Shut down non-live migratable VMs
-  upgrade-helper vm-live-migrate-detector "$HARVESTER_UPGRADE_NODE_NAME" --shutdown
+  upgrade-helper vm-live-migrate-detector "$HARVESTER_UPGRADE_NODE_NAME" --shutdown --upgrade "$HARVESTER_UPGRADE_NAME"
 
   # Live migrate VMs
   kubectl taint node $HARVESTER_UPGRADE_NODE_NAME --overwrite kubevirt.io/drain=draining:NoSchedule
@@ -723,8 +723,8 @@ command_single_node_upgrade() {
   NEW_OS_SQUASHFS_IMAGE_FILE=$(mktemp -p $UPGRADE_TMP_DIR)
   download_file "$UPGRADE_REPO_SQUASHFS_IMAGE" "$NEW_OS_SQUASHFS_IMAGE_FILE"
 
-  # Stop all VMs
-  shutdown_all_vms
+  # Shut down non-live migratable VMs
+  upgrade-helper vm-live-migrate-detector "$HARVESTER_UPGRADE_NODE_NAME" --shutdown --upgrade "$HARVESTER_UPGRADE_NAME"
   wait_vms_out
 
   echo "wait for fleet bundles before upgrading RKE2"

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -40,10 +40,9 @@ const (
 	//   1. promote the witness node to etcd node. (maxmimum: 1)
 	//   2. promote the mgmt node to mgmt node.
 	//   3. do not promote the worker node.
-	HarvesterNodeRoleLabelPrefix = "node-role.harvesterhci.io/"
-	HarvesterWitnessNodeLabelKey = HarvesterNodeRoleLabelPrefix + "witness"
-	HarvesterMgmtNodeLabelKey    = HarvesterNodeRoleLabelPrefix + "management"
-	HarvesterWorkerNodeLabelKey  = HarvesterNodeRoleLabelPrefix + "worker"
+	HarvesterWitnessNodeLabelKey = util.HarvesterWitnessNodeLabelKey
+	HarvesterMgmtNodeLabelKey    = util.HarvesterMgmtNodeLabelKey
+	HarvesterWorkerNodeLabelKey  = util.HarvesterWorkerNodeLabelKey
 
 	HarvesterManagedNodeLabelKey        = util.HarvesterManagedNodeLabelKey
 	HarvesterPromoteNodeLabelKey        = util.HarvesterPromoteNodeLabelKey

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -44,7 +44,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	secrets := management.CoreFactory.Core().V1().Secret()
 	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
 	lhSettings := management.LonghornFactory.Longhorn().V1beta2().Setting()
-	kubeVirt := management.VirtFactory.Kubevirt().V1().KubeVirt()
+	configMaps := management.CoreFactory.Core().V1().ConfigMap()
 
 	virtSubsrcConfig := rest.CopyConfig(management.RestConfig)
 	virtSubsrcConfig.GroupVersion = &schema.GroupVersion{Group: "subresources.kubevirt.io", Version: "v1"}
@@ -81,7 +81,6 @@ func Register(ctx context.Context, management *config.Management, options config
 		clusterCache:       clusters.Cache(),
 		lhSettingClient:    lhSettings,
 		lhSettingCache:     lhSettings.Cache(),
-		kubeVirtCache:      kubeVirt.Cache(),
 		vmRestClient:       virtSubresourceClient,
 	}
 	upgrades.OnChange(ctx, upgradeControllerName, controller.OnChanged)
@@ -97,14 +96,17 @@ func Register(ctx context.Context, management *config.Management, options config
 	plans.OnChange(ctx, planControllerName, planHandler.OnChanged)
 
 	jobHandler := &jobHandler{
-		namespace:     options.Namespace,
-		planCache:     plans.Cache(),
-		upgradeClient: upgrades,
-		upgradeCache:  upgrades.Cache(),
-		machineCache:  machines.Cache(),
-		secretClient:  secrets,
-		nodeClient:    nodes,
-		nodeCache:     nodes.Cache(),
+		namespace:      options.Namespace,
+		planCache:      plans.Cache(),
+		upgradeClient:  upgrades,
+		upgradeCache:   upgrades.Cache(),
+		machineCache:   machines.Cache(),
+		secretClient:   secrets,
+		nodeClient:     nodes,
+		nodeCache:      nodes.Cache(),
+		jobClient:      jobs,
+		jobCache:       jobs.Cache(),
+		configMapCache: configMaps.Cache(),
 	}
 	jobs.OnChange(ctx, jobControllerName, jobHandler.OnChanged)
 

--- a/pkg/upgradehelper/restorevm/restorevm.go
+++ b/pkg/upgradehelper/restorevm/restorevm.go
@@ -1,0 +1,197 @@
+package restorevm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
+	ctlharvester "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	RestoreVMCompleted = "RestoreVMCompleted"
+	RestoreVMFailed    = "RestoreVMFailed"
+)
+
+var healthzPath = "/apis/" + kubevirtv1.SubresourceGroupName + "/" + kubevirtv1.ApiLatestVersion + "/healthz"
+
+type RestoreVMHandler struct {
+	kubeConfig  string
+	kubeContext string
+
+	nodeName    string
+	upgradeName string
+
+	virtClient   kubecli.KubevirtClient
+	factory      *ctlharvester.Factory
+	upgradeCache ctlharvesterv1.UpgradeCache
+
+	vmRestClient *rest.RESTClient
+	k8sClient    *kubernetes.Clientset
+	recorder     record.EventRecorder
+}
+
+func NewRestoreVMHandler(kubeConfig, kubeContext, nodeName, upgrade string) (*RestoreVMHandler, error) {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	if err != nil {
+		logrus.Fatalf("failed to build REST config: %v", err)
+	}
+
+	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(restConfig)
+	if err != nil {
+		logrus.Fatalf("failed to get kubevirt client: %v", err)
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		logrus.Fatalf("failed to create Kubernetes client: %v", err)
+	}
+
+	factory, err := ctlharvester.NewFactoryFromConfig(restConfig)
+	if err != nil {
+		logrus.Fatalf("cannot obtain harvester factory: %v", err)
+	}
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: virtClient.CoreV1().Events(util.HarvesterSystemNamespaceName)})
+	recorder := broadcaster.NewRecorder(
+		scheme.Scheme,
+		corev1.EventSource{Component: "restore-vm", Host: nodeName},
+	)
+
+	return &RestoreVMHandler{
+		kubeConfig:   kubeConfig,
+		kubeContext:  kubeContext,
+		nodeName:     nodeName,
+		upgradeName:  upgrade,
+		virtClient:   virtClient,
+		factory:      factory,
+		upgradeCache: factory.Harvesterhci().V1beta1().Upgrade().Cache(),
+		vmRestClient: virtClient.RestClient(),
+		k8sClient:    k8sClient,
+		recorder:     recorder,
+	}, nil
+}
+
+func (h *RestoreVMHandler) Run(ctx context.Context) error {
+	defer func() {
+		// wait for events to be flushed
+		time.Sleep(10 * time.Second)
+	}()
+
+	if err := h.factory.Sync(ctx); err != nil {
+		return fmt.Errorf("failed to sync factory: %w", err)
+	}
+
+	vmNames, err := h.getVMNamesFromConfigMap(ctx)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logrus.Warn("ConfigMap not found")
+			h.recordUpgradeEvent(corev1.EventTypeWarning, RestoreVMFailed, "ConfigMap not found")
+			return nil // ConfigMap not found, nothing to restore
+		}
+		return err
+	}
+	if len(vmNames) == 0 {
+		logrus.Info("No VMs to restore")
+		h.recordUpgradeEvent(corev1.EventTypeNormal, RestoreVMCompleted,
+			"Restored 0 VM for node %s during upgrade %s", h.nodeName, h.upgradeName)
+		return nil
+	}
+
+	if err := h.checkKubeVirtHealth(ctx); err != nil {
+		return fmt.Errorf("KubeVirt not ready: %w", err)
+	}
+
+	vmSuccessCnt := 0
+	vmFailedCnt := 0
+	for _, vmFullName := range vmNames {
+		parts := strings.SplitN(vmFullName, "/", 2)
+		if len(parts) != 2 {
+			logrus.Errorf("Invalid VM name: %s, should be namespace/name", vmFullName)
+			continue
+		}
+		ns, name := parts[0], parts[1]
+		logrus.Infof("Starting VM %s/%s...", ns, name)
+		if err := h.startVM(ctx, ns, name); err != nil {
+			logrus.Errorf("Failed to start VM %s/%s: %v", ns, name, err)
+			h.recordUpgradeEvent(corev1.EventTypeWarning, RestoreVMFailed,
+				"Failed to restore VM %s/%s for node %s during upgrade %s: %v", ns, name, h.nodeName, h.upgradeName, err)
+			vmFailedCnt++
+		} else {
+			vmSuccessCnt++
+		}
+	}
+
+	h.recordUpgradeEvent(corev1.EventTypeNormal, RestoreVMCompleted,
+		"Restored %d VMs for node %s during upgrade %s, success: %d, failed: %d", len(vmNames), h.nodeName, h.upgradeName, vmSuccessCnt, vmFailedCnt)
+	return nil
+}
+
+func (h *RestoreVMHandler) checkKubeVirtHealth(ctx context.Context) error {
+	logrus.Infof("Waiting for KubeVirt to be ready...")
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+		res := h.vmRestClient.Get().AbsPath(healthzPath).Do(ctx)
+		if res.Error() != nil {
+			logrus.Errorf("KubeVirt health check failed: %v, retry...", res.Error())
+			return false, nil // keep retrying
+		}
+		return true, nil
+	})
+}
+
+func (h *RestoreVMHandler) getVMNamesFromConfigMap(ctx context.Context) ([]string, error) {
+	cmName := util.GetRestoreVMConfigMapName(h.upgradeName)
+	cm, err := h.k8sClient.CoreV1().ConfigMaps(util.HarvesterSystemNamespaceName).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get configmap: %w", err)
+	}
+	vmNamesStr, ok := cm.Data[h.nodeName]
+	// handle empty string case
+	if !ok || strings.TrimSpace(vmNamesStr) == "" {
+		return []string{}, nil
+	}
+	// split and filter out empty names
+	rawNames := strings.Split(vmNamesStr, ",")
+	vmNames := make([]string, 0, len(rawNames))
+	for _, name := range rawNames {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			vmNames = append(vmNames, name)
+		}
+	}
+	return vmNames, nil
+}
+
+func (h *RestoreVMHandler) startVM(ctx context.Context, namespace, name string) error {
+	return h.virtClient.VirtualMachine(namespace).Start(ctx, name, &kubevirtv1.StartOptions{})
+}
+
+func (h *RestoreVMHandler) recordUpgradeEvent(eventType, reason, messageFmt string, args ...interface{}) {
+	upgrade, err := h.upgradeCache.Get(util.HarvesterSystemNamespaceName, h.upgradeName)
+	if err != nil {
+		logrus.Warnf("Record upgrade events failed: %v", err)
+		return
+	}
+	logrus.Info("Recording event for upgrade", h.upgradeName, ":", eventType, reason, fmt.Sprintf(messageFmt, args...))
+	h.recorder.Eventf(upgrade, eventType, reason, messageFmt, args...)
+}

--- a/pkg/upgradehelper/vmlivemigratedetector/detector.go
+++ b/pkg/upgradehelper/vmlivemigratedetector/detector.go
@@ -3,19 +3,43 @@ package vmlivemigratedetector
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/rancher/wrangler/v3/pkg/condition"
+	ctlcore "github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
+	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/kv"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	harvv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
+	ctlharvester "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
+)
+
+const (
+	vmPaused condition.Cond = "Paused"
+
+	RestoreVMConfigMapFailed  = "RestoreVMConfigMapFailed"
+	RestoreVMConfigMapCreated = "RestoreVMConfigMapCreated"
+	VMShutdownFailed          = "VMShutdownFailed"
+	VMShutdownCompleted       = "VMShutdownCompleted"
 )
 
 type DetectorOptions struct {
@@ -23,16 +47,23 @@ type DetectorOptions struct {
 	KubeContext    string
 	Shutdown       bool
 	NodeName       string
+	Upgrade        string
 }
 
 type VMLiveMigrateDetector struct {
 	kubeConfig  string
 	kubeContext string
 
-	nodeName string
-	shutdown bool
+	nodeName    string
+	shutdown    bool
+	upgradeName string
 
-	virtClient kubecli.KubevirtClient
+	virtClient   kubecli.KubevirtClient
+	harvFactory  *ctlharvester.Factory
+	upgradeCache ctlharvesterv1.UpgradeCache
+	coreFactory  *ctlcore.Factory
+	nodeCache    ctlcorev1.NodeCache
+	recorder     record.EventRecorder
 }
 
 func NewVMLiveMigrateDetector(options DetectorOptions) *VMLiveMigrateDetector {
@@ -41,10 +72,15 @@ func NewVMLiveMigrateDetector(options DetectorOptions) *VMLiveMigrateDetector {
 		kubeContext: options.KubeContext,
 		nodeName:    options.NodeName,
 		shutdown:    options.Shutdown,
+		upgradeName: options.Upgrade,
 	}
 }
 
 func (d *VMLiveMigrateDetector) Init() (err error) {
+	if d.nodeName == "" {
+		logrus.Fatal("please specify a node name")
+	}
+
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{
 			ExplicitPath: d.kubeConfig,
@@ -57,47 +93,59 @@ func (d *VMLiveMigrateDetector) Init() (err error) {
 
 	d.virtClient, err = kubecli.GetKubevirtClientFromClientConfig(clientConfig)
 	if err != nil {
-		logrus.Fatalf("cannot obtain KubeVirt client: %v\n", err)
+		logrus.Fatalf("cannot obtain KubeVirt client: %v", err)
 	}
+
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		logrus.Fatalf("cannot obtain rest config: %v", err)
+	}
+
+	harvFactory, err := ctlharvester.NewFactoryFromConfig(restConfig)
+	if err != nil {
+		logrus.Fatalf("cannot obtain harvester factory: %v", err)
+	}
+	d.harvFactory = harvFactory
+	d.upgradeCache = harvFactory.Harvesterhci().V1beta1().Upgrade().Cache()
+
+	coreFactory, err := ctlcore.NewFactoryFromConfig(restConfig)
+	if err != nil {
+		logrus.Fatalf("cannot obtain harvester factory: %v", err)
+	}
+	d.coreFactory = coreFactory
+	d.nodeCache = coreFactory.Core().V1().Node().Cache()
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: d.virtClient.CoreV1().Events(util.HarvesterSystemNamespaceName)})
+	d.recorder = broadcaster.NewRecorder(
+		scheme.Scheme,
+		corev1.EventSource{Component: "vm-live-migrate-detector", Host: d.nodeName},
+	)
 
 	return
 }
 
 func (d *VMLiveMigrateDetector) Run(ctx context.Context) error {
-	if d.nodeName == "" {
-		return fmt.Errorf("please specify a node name")
+	defer func() {
+		// wait for events to be flushed
+		time.Sleep(10 * time.Second)
+	}()
+
+	if err := d.harvFactory.Sync(ctx); err != nil {
+		return fmt.Errorf("failed to sync havester factory: %w", err)
+	}
+	if err := d.coreFactory.Sync(ctx); err != nil {
+		return fmt.Errorf("failed to sync havester factory: %w", err)
 	}
 
-	// Get all VMs running on the specified node, except for the upgrade-related ones
-	nodeReq, err := labels.NewRequirement("kubevirt.io/nodeName", selection.Equals, []string{d.nodeName})
+	vmis, err := d.getVMIs(ctx)
 	if err != nil {
 		return err
-	}
-	notUpgradeReq, err := labels.NewRequirement("harvesterhci.io/upgrade", selection.DoesNotExist, nil)
-	if err != nil {
-		return err
-	}
-	selector := labels.NewSelector().Add(*nodeReq).Add(*notUpgradeReq)
-	listOptions := metav1.ListOptions{
-		LabelSelector: selector.String(),
-	}
-	vmiList, err := d.virtClient.VirtualMachineInstance("").List(ctx, listOptions)
-	if err != nil {
-		return err
-	}
-	vmis := make([]*kubevirtv1.VirtualMachineInstance, 0, len(vmiList.Items))
-	for i := range vmiList.Items {
-		vmis = append(vmis, &vmiList.Items[i])
 	}
 
-	// Get all nodes
-	nodeList, err := d.virtClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := d.nodeCache.List(labels.Everything())
 	if err != nil {
-		return err
-	}
-	nodes := make([]*v1.Node, 0, nodeList.Size())
-	for i := range nodeList.Items {
-		nodes = append(nodes, &nodeList.Items[i])
+		return fmt.Errorf("failed to get nodes: %w", err)
 	}
 
 	nonLiveMigratableVMNames, err := virtualmachineinstance.GetAllNonLiveMigratableVMINames(vmis, nodes)
@@ -107,15 +155,148 @@ func (d *VMLiveMigrateDetector) Run(ctx context.Context) error {
 
 	logrus.Infof("Non-migratable VM(s): %v", nonLiveMigratableVMNames)
 
+	if d.upgradeName != "" {
+		vmNames := getRestoreVMNames(vmis, nonLiveMigratableVMNames)
+		logrus.Infof("Store vm info to configmap: %v", vmNames)
+		err = d.createOrUpdateConfigMap(ctx, vmNames)
+		if err != nil {
+			d.recordUpgradeEvent(corev1.EventTypeWarning, RestoreVMConfigMapFailed, err.Error())
+			return err
+		}
+	}
+
+	vmSuccessCnt := 0
+	vmFailedCnt := 0
 	if d.shutdown {
 		for _, namespacedName := range nonLiveMigratableVMNames {
 			namespace, name := kv.RSplit(namespacedName, "/")
 			if err := d.virtClient.VirtualMachine(namespace).Stop(ctx, name, &kubevirtv1.StopOptions{}); err != nil {
-				return err
+				d.recordUpgradeEvent(corev1.EventTypeNormal, VMShutdownFailed,
+					fmt.Sprintf("Shutdown failed for VM %s on node %s, error: %v", namespacedName, d.nodeName, err))
+				logrus.Errorf("failed to stop VM %s: %v", namespacedName, err)
+				vmFailedCnt++
+			} else {
+				vmSuccessCnt++
 			}
 			logrus.Infof("vm %s was administratively stopped", namespacedName)
 		}
 	}
 
+	d.recordUpgradeEvent(corev1.EventTypeNormal, VMShutdownCompleted,
+		fmt.Sprintf("Shutdown completed for %d VM(s) on node %s, success: %d, failed: %d ", len(nonLiveMigratableVMNames), d.nodeName, vmSuccessCnt, vmFailedCnt))
+
 	return nil
+}
+
+func (d *VMLiveMigrateDetector) getVMIs(ctx context.Context) ([]*kubevirtv1.VirtualMachineInstance, error) {
+	// filter out VMs that are not on the current node
+	nodeReq, err := labels.NewRequirement("kubevirt.io/nodeName", selection.Equals, []string{d.nodeName})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node label requirement: %w", err)
+	}
+	options := metav1.ListOptions{LabelSelector: labels.NewSelector().Add(*nodeReq).String()}
+
+	vmiList, err := d.virtClient.VirtualMachineInstance("").List(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	vmis := make([]*kubevirtv1.VirtualMachineInstance, 0, len(vmiList.Items))
+	for i := range vmiList.Items {
+		vmis = append(vmis, &vmiList.Items[i])
+	}
+	return vmis, nil
+}
+
+func getRestoreVMNames(vmis []*kubevirtv1.VirtualMachineInstance, candidateVMNames []string) []string {
+	restoreVMs := make([]string, 0)
+
+	// exclude paused VMs and upgrade repo VM from the candidate VMs
+	// as they are not supposed to be restored
+	excludeVMs := make(map[string]struct{})
+	for _, vmi := range vmis {
+		if vmPaused.IsTrue(vmi) || vmi.Labels["harvesterhci.io/upgrade"] != "" {
+			namespacedName := fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)
+			excludeVMs[namespacedName] = struct{}{}
+		}
+	}
+	for _, name := range candidateVMNames {
+		if _, exist := excludeVMs[name]; !exist {
+			restoreVMs = append(restoreVMs, name)
+		}
+	}
+	return restoreVMs
+}
+
+func (d *VMLiveMigrateDetector) createOrUpdateConfigMap(ctx context.Context, restoreVMNames []string) error {
+	vmNames := strings.Join(restoreVMNames, ",")
+	name := util.GetRestoreVMConfigMapName(d.upgradeName)
+	namespace := util.HarvesterSystemNamespaceName
+	upgrade, err := d.upgradeCache.Get(util.HarvesterSystemNamespaceName, d.upgradeName)
+	if err != nil {
+		return fmt.Errorf("failed to get Upgrade CR %s: %w", d.upgradeName, err)
+	}
+
+	return retry.OnError(
+		retry.DefaultBackoff,
+		func(err error) bool {
+			return errors.IsConflict(err) || errors.IsServerTimeout(err)
+		},
+		func() error {
+			configMap, err := d.virtClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					// create a new ConfigMap if it does not exist
+					newConfigMap := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									Name:       upgrade.Name,
+									Kind:       "Upgrade",
+									UID:        upgrade.UID,
+									APIVersion: harvv1.SchemeGroupVersion.String(),
+								},
+							},
+						},
+						Data: map[string]string{
+							d.nodeName: vmNames,
+						},
+					}
+					_, createErr := d.virtClient.CoreV1().ConfigMaps(namespace).Create(ctx, newConfigMap, metav1.CreateOptions{})
+					if createErr != nil && !errors.IsAlreadyExists(createErr) {
+						return fmt.Errorf("failed to create ConfigMap: %w", createErr)
+					}
+					d.recordUpgradeEvent(corev1.EventTypeNormal, RestoreVMConfigMapCreated,
+						fmt.Sprintf("ConfigMap %s/%s created", util.HarvesterSystemNamespaceName, util.GetRestoreVMConfigMapName(d.upgradeName)))
+					return nil
+				}
+				return fmt.Errorf("failed to get ConfigMap: %w", err)
+			}
+
+			// update the existing ConfigMap
+			if configMap.Data == nil {
+				configMap.Data = map[string]string{}
+			}
+			configMap.Data[d.nodeName] = vmNames
+
+			_, updateErr := d.virtClient.CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+			if updateErr != nil {
+				return fmt.Errorf("failed to update ConfigMap: %w", updateErr)
+			}
+			return nil
+		})
+}
+
+func (d *VMLiveMigrateDetector) recordUpgradeEvent(eventType, reason, message string) {
+	if d.upgradeName == "" {
+		return
+	}
+	upgrade, err := d.upgradeCache.Get(util.HarvesterSystemNamespaceName, d.upgradeName)
+	if err != nil {
+		logrus.Warnf("record event failed to get Upgrade CR %s: %v", d.upgradeName, err)
+		return
+	}
+	logrus.Info("Recording event for upgrade", d.upgradeName, ":", eventType, reason, message)
+	d.recorder.Event(upgrade, eventType, reason, message)
 }

--- a/pkg/util/configmap.go
+++ b/pkg/util/configmap.go
@@ -1,0 +1,7 @@
+package util
+
+import "github.com/rancher/wrangler/v3/pkg/name"
+
+func GetRestoreVMConfigMapName(upgradeName string) string {
+	return name.SafeConcatName(upgradeName, RestoreVMConfigMap)
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -217,4 +217,11 @@ const (
 	HarvesterManagedChart            = "harvester"
 	RancherLoggingCRDManagedChart    = "rancher-logging-crd"
 	RancherMonitoringCRDManagedChart = "rancher-monitoring-crd"
+
+	RestoreVMConfigMap = "restore-vm"
+
+	HarvesterNodeRoleLabelPrefix = "node-role.harvesterhci.io/"
+	HarvesterWitnessNodeLabelKey = HarvesterNodeRoleLabelPrefix + "witness"
+	HarvesterMgmtNodeLabelKey    = HarvesterNodeRoleLabelPrefix + "management"
+	HarvesterWorkerNodeLabelKey  = HarvesterNodeRoleLabelPrefix + "worker"
 )

--- a/pkg/util/fakeclients/job.go
+++ b/pkg/util/fakeclients/job.go
@@ -10,12 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	batchv1type "k8s.io/client-go/kubernetes/typed/batch/v1"
+	"k8s.io/client-go/rest"
 )
 
 type JobCache func(string) batchv1type.JobInterface
 
-func (c JobCache) Get(_, _ string) (*batchv1.Job, error) {
-	panic("implement me")
+func (c JobCache) Get(namespace, name string) (*batchv1.Job, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
 func (c JobCache) List(namespace string, selector labels.Selector) ([]*batchv1.Job, error) {
@@ -49,8 +50,8 @@ func (c JobClient) Update(job *batchv1.Job) (*batchv1.Job, error) {
 func (c JobClient) Get(_, _ string, _ metav1.GetOptions) (*batchv1.Job, error) {
 	panic("implement me")
 }
-func (c JobClient) Create(*batchv1.Job) (*batchv1.Job, error) {
-	panic("implement me")
+func (c JobClient) Create(job *batchv1.Job) (*batchv1.Job, error) {
+	return c(job.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
 }
 func (c JobClient) UpdateStatus(*batchv1.Job) (*batchv1.Job, error) {
 	panic("implement me")
@@ -58,12 +59,15 @@ func (c JobClient) UpdateStatus(*batchv1.Job) (*batchv1.Job, error) {
 func (c JobClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
 	panic("implement me")
 }
-func (c JobClient) List(_ string, _ metav1.ListOptions) (*batchv1.Job, error) {
+func (c JobClient) List(_ string, _ metav1.ListOptions) (*batchv1.JobList, error) {
 	panic("implement me")
 }
 func (c JobClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 func (c JobClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *batchv1.Job, err error) {
+	panic("implement me")
+}
+func (c JobClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*batchv1.Job, *batchv1.JobList], error) {
 	panic("implement me")
 }

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ExcludeWitnessNodes(nodes []*corev1.Node) []*corev1.Node {
+	nonWitnessNodes := make([]*corev1.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if _, ok := node.Labels[HarvesterWitnessNodeLabelKey]; !ok {
+			nonWitnessNodes = append(nonWitnessNodes, node)
+		}
+	}
+	return nonWitnessNodes
+}

--- a/pkg/util/setting.go
+++ b/pkg/util/setting.go
@@ -60,3 +60,11 @@ func GetAdditionalGuestMemoryOverheadRatio(settingCache ctlharvesterv1.SettingCa
 	value = agmorc.Value()
 	return &value, nil
 }
+
+func IsRestoreVM() (bool, error) {
+	upgradeConfig, err := settings.DecodeConfig[settings.UpgradeConfig](settings.UpgradeConfigSet.Get())
+	if err != nil || upgradeConfig == nil {
+		return false, err
+	}
+	return upgradeConfig.RestoreVM, nil
+}

--- a/pkg/util/virtualmachineinstance/virtualmachineinstance_test.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance_test.go
@@ -12,6 +12,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
 
@@ -49,6 +50,91 @@ func Test_GetNonLiveMigratableVMIs(t *testing.T) {
 					},
 					Status: kubevirtv1.VirtualMachineInstanceStatus{
 						NodeName: "node1",
+					},
+				},
+			},
+			output: []string{"default/vm1", "default/vm2"},
+			err:    nil,
+		},
+		{
+			name: "witness node",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							util.HarvesterWitnessNodeLabelKey: "true",
+						},
+					},
+				},
+			},
+			vmis: []*kubevirtv1.VirtualMachineInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "vm1",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						NodeName: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "vm2",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						NodeName: "node1",
+					},
+				},
+			},
+			output: []string{"default/vm1", "default/vm2"},
+			err:    nil,
+		},
+		{
+			name: "witness node and all live migratable",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							util.HarvesterWitnessNodeLabelKey: "true",
+						},
+					},
+				},
+			},
+			vmis: []*kubevirtv1.VirtualMachineInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "vm1",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						NodeName: "node1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "vm2",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						NodeName: "node2",
 					},
 				},
 			},

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1712,7 +1712,7 @@ func validateUpgradeConfigHelper(setting *v1beta1.Setting) (*settings.UpgradeCon
 	return config, nil
 }
 
-func validateUpgradeConfigFields(setting *v1beta1.Setting, isSingleNode bool) error {
+func validateUpgradeConfigFields(setting *v1beta1.Setting) error {
 	upgradeConfig, err := validateUpgradeConfigHelper(setting)
 	if err != nil {
 		return err
@@ -1737,20 +1737,11 @@ func validateUpgradeConfigFields(setting *v1beta1.Setting, isSingleNode bool) er
 		return fmt.Errorf("invalid image preload concurrency: %d", concurrency)
 	}
 
-	// Validate the restore VM field
-	if upgradeConfig.RestoreVM && !isSingleNode {
-		return fmt.Errorf("restoreVM is only supported in single node cluster")
-	}
-
 	return nil
 }
 
 func (v *settingValidator) validateUpgradeConfig(setting *v1beta1.Setting) error {
-	isSingleNode, err := v.isSingleNode()
-	if err != nil {
-		return err
-	}
-	return validateUpgradeConfigFields(setting, isSingleNode)
+	return validateUpgradeConfigFields(setting)
 }
 
 func (v *settingValidator) validateUpdateUpgradeConfig(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
@@ -1770,14 +1761,6 @@ func validateAdditionalGuestMemoryOverheadRatio(newSetting *v1beta1.Setting) err
 
 func validateUpdateAdditionalGuestMemoryOverheadRatio(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateAdditionalGuestMemoryOverheadRatio(newSetting)
-}
-
-func (v *settingValidator) isSingleNode() (bool, error) {
-	nodes, err := v.nodeCache.List(labels.Everything())
-	if err != nil {
-		return false, err
-	}
-	return len(nodes) == 1, nil
 }
 
 func validateMaxHotplugRatio(setting *v1beta1.Setting) error {

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -844,10 +844,9 @@ func Test_validateNTPServers(t *testing.T) {
 
 func Test_validateUpgradeConfig(t *testing.T) {
 	tests := []struct {
-		name         string
-		args         *v1beta1.Setting
-		isSingleNode bool
-		expectedErr  bool
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
 	}{
 		{
 			name: "empty config - default",
@@ -994,46 +993,26 @@ func Test_validateUpgradeConfig(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			name: "enable restoreVM under single node cluster",
+			name: "enable restoreVM",
 			args: &v1beta1.Setting{
 				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
 				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": true}`,
 			},
-			isSingleNode: true,
-			expectedErr:  false,
+			expectedErr: false,
 		},
 		{
-			name: "disable restoreVM under single node cluster",
+			name: "disable restoreVM",
 			args: &v1beta1.Setting{
 				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
 				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": false}`,
 			},
-			isSingleNode: true,
-			expectedErr:  false,
-		},
-		{
-			name: "enable restoreVM under multi node cluster",
-			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
-				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": true}`,
-			},
-			isSingleNode: false,
-			expectedErr:  true,
-		},
-		{
-			name: "disable restoreVM under multi node cluster",
-			args: &v1beta1.Setting{
-				ObjectMeta: metav1.ObjectMeta{Name: settings.UpgradeConfigSettingName},
-				Value:      `{"imagePreloadOption":{"strategy":{"type":"parallel","concurrency":2}}, "restoreVM": false}`,
-			},
-			isSingleNode: false,
-			expectedErr:  false,
+			expectedErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateUpgradeConfigFields(tt.args, tt.isSingleNode)
+			err := validateUpgradeConfigFields(tt.args)
 			assert.Equal(t, tt.expectedErr, err != nil)
 		})
 	}


### PR DESCRIPTION
#### Problem:

In the current upgrade flow, if there is any non-migratable & running VMs exist, Harvester will ask the user to shut them down. After the upgrade completes, users need to manually start those VMs again. If users want to minimize the downtime of non-migratable VMs, they have to monitor the upgrade process for each node and manually restart the VMs as soon as their node finishes upgrading, which is quite inconvenient.

#### Solution:

This PR aims to provide a way to automatically bring non-migratable VMs back online once their node has been upgraded. We already have an option for this (`restoreVM`), as documented here: https://docs.harvesterhci.io/v1.6/advanced/index/#upgrade-config. However, currently this feature only works in a single-node environment. This PR extends the feature to support multi-node environments.

The idea is quite simple:
If restoreVM set to `true`
1. Record all non-migratable VMs to configmap in pre-drain job (multi-node env) or single-node-upgrade job (single node env).
2. Non-migratable VMs will be shut down automatically when their node is about to be upgraded. And for migratable VMs, they should remain in running state during the whole upgrade process (if there is no trouble).
3. Once the node upgrade finished (i.e. os image upgraded), `upgrade/job_controller` submit the restore-vm job to restart VMs recorded in the configmap created in step1. Repeat the same process after each subsequent node upgrade.

[Note]: 
- paused non-migratable VM **_won't be started again_** after node upgrade finished.
- if upgrade failed, non-migratable VMs won't be restarted. 

#### Related Issue(s):

#8049 

#### Test plan:

**Test single node upgrade**
There are 2 scenarios here:
1. v1.5.0 upgrade to the version that includes this patch.
    - Prepare 3 VMs vm-stopped (in stopped state), vm-paused (in paused state), vm-running (in running state).
    - Enable `restoreVM` option
    - After the upgrade finished, only vm-running should be in running state, others should be in stopped state.
3. master -> master
    - Prepare 2 VMs, vm-stopped, vm-paused, vm-running.
    - Enable `restoreVM` option
    - After the upgrade finished, only vm-running should be in running state, others should be in stopped state.

**Test multi-node upgrade**
- **WARNING: this can only be done by upgrading from master to master** as restore-vm option is only supported in single node before this PR merged. 
- Prepare a multi-node harvester cluster, create 5VMs
  vm-running, vm-stopped, vm0 (node-selector: node0), vm1 (node-selector: node1), vm2 (node-selector: node2)
- Enable the `restoreVM` option in upgradeConfig setting
- After upgrade finished, the VM state should be like picture in below.
![image](https://github.com/user-attachments/assets/66521d64-a01b-4f12-b7df-80eaadeeaea4)

#### Additional documentation or context
What are non-migratable VMs?
- VM contains node selector
- VM contains PCIe devices
- VM contains node affinities while we can't migrate to those nodes in node-affinities settings 
- VM contains CD-ROM or container disks
https://github.com/harvester/harvester/blob/master/pkg/util/virtualmachineinstance/virtualmachineinstance.go#L17