### PR TITLE
Use `migration.harvesterhci.io/imported` label to check if VM is imported by vm-import-controller

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -27,13 +27,13 @@ const (
 	LabelSVMBackupUID                   = prefix + "/svmbackupUID"
 	LabelSVMBackupTimestamp             = prefix + "/svmbackupTimestamp"
 	LabelVMCreator                      = prefix + "/creator"
+	LabelVMimported                     = "migration.harvesterhci.io/imported"
 	LabelNodeNameKey                    = "kubevirt.io/nodeName"
 	AnnotationStorageClassName          = prefix + "/storageClassName"
 	AnnotationStorageProvisioner        = prefix + "/storageProvisioner"
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
 	AnnotationLastRefreshTime           = prefix + "/lastRefreshTime"
 	AnnotationMacAddressName            = prefix + "/mac-address"
-	AnnotationVMImportController        = "migration.harvesterhci.io/virtualmachineimport"
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
 

--- a/pkg/util/virtualmachineimporter.go
+++ b/pkg/util/virtualmachineimporter.go
@@ -1,0 +1,16 @@
+package util
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// IsImportedByVMIC checks if the given object has been created by the vm-import-controller.
+func IsImportedByVMIC(obj metav1.Object) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	value, exists := labels[LabelVMimported]
+	if !exists {
+		return false
+	}
+	return value == "true"
+}

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -258,11 +258,15 @@ func (v *pvcValidator) checkGoldenImageAnno(pvc *corev1.PersistentVolumeClaim) e
 					}
 				}
 			}
-			if _, err := v.imageCache.Get(imageNS, imageName); err != nil {
+			vmImage, err := v.imageCache.Get(imageNS, imageName)
+			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return nil
 				}
 				return fmt.Errorf("get image %s/%s failed: %v", imageNS, imageName, err)
+			}
+			if util.IsImportedByVMIC(vmImage) {
+				return nil
 			}
 			// ignore the golden image PVC if it is in Lost/Terminating status
 			if pvc.Status.Phase == corev1.ClaimLost || pvc.Status.Phase == "Terminating" {

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -258,15 +258,11 @@ func (v *pvcValidator) checkGoldenImageAnno(pvc *corev1.PersistentVolumeClaim) e
 					}
 				}
 			}
-			vmImage, err := v.imageCache.Get(imageNS, imageName)
-			if err != nil {
+			if _, err := v.imageCache.Get(imageNS, imageName); err != nil {
 				if apierrors.IsNotFound(err) {
 					return nil
 				}
 				return fmt.Errorf("get image %s/%s failed: %v", imageNS, imageName, err)
-			}
-			if util.IsImportedByVMIC(vmImage) {
-				return nil
 			}
 			// ignore the golden image PVC if it is in Lost/Terminating status
 			if pvc.Status.Phase == corev1.ClaimLost || pvc.Status.Phase == "Terminating" {


### PR DESCRIPTION
Make use of the label `migration.harvesterhci.io/imported` instead of the annotation `migration.harvesterhci.io/virtualmachineimport`.

There is no need to migrate existing annotations `migration.harvesterhci.io/virtualmachineimport` to `migration.harvesterhci.io/imported` label because the annotation was not used previously in Harvester code. It was only used by vm-import-controller itself.

Related to: https://github.com/harvester/harvester/pull/8481
