### PR TITLE
chore: minor fixes in issue management flow [skip ci]

### DIFF
--- a/.github/workflows/issue-management-close-issue.yaml
+++ b/.github/workflows/issue-management-close-issue.yaml
@@ -35,7 +35,7 @@ jobs:
         [backport v${{ env.MAJOR_MINOR_VERSION }}] ${{ github.event.issue.title }}
         EOF
         )
-        BACKPORT_ISSUE=$(gh issue list --search "$SEARCH_TITLE" --json number --jq '.[0].number')
+        BACKPORT_ISSUE=$(gh search issues "${SEARCH_TITLE}" --state open --match title --json number --jq '.[0].number')
 
         if [ -n "$BACKPORT_ISSUE" ]; then
           echo "Closing backport issue #$BACKPORT_ISSUE for version ${{ env.MAJOR_MINOR_VERSION }}"
@@ -62,7 +62,7 @@ jobs:
         [e2e] ${{ github.event.issue.title }}
         EOF
         )
-        E2E_ISSUE=$(gh issue list --search "$E2E_TITLE" --json number --jq '.[0].number')
+        E2E_ISSUE=$(gh search issues "${E2E_TITLE}" --state open --match title --json number --jq '.[0].number')
 
         if [ -n "$E2E_ISSUE" ]; then
           echo "Closing e2e issue #$E2E_ISSUE"

--- a/.github/workflows/issue-management-link-backport-pr.yaml
+++ b/.github/workflows/issue-management-link-backport-pr.yaml
@@ -79,7 +79,7 @@ jobs:
             echo "Searching for backport issue with title: '${search_title}'"
 
             # Get both number and title from the search results
-            backport_issues_json=$(gh issue list --state open --search "${search_title}" --json number,title)
+            backport_issues_json=$(gh search issues "${search_title}" --state open --match title  --json number,title)
 
             if [[ "$backport_issues_json" != "[]" && -n "$backport_issues_json" ]]; then
               # Get the length of the JSON array

--- a/.github/workflows/issue-management-update-harvester-projects.yaml
+++ b/.github/workflows/issue-management-update-harvester-projects.yaml
@@ -80,6 +80,12 @@ jobs:
        run: |
          ASSIGNEES='${{ toJSON(github.event.issue.assignees) }}'
 
+         # Skip if status is already Closed
+         if [[ "${{ steps.get-status-field.outputs.values }}" == "Closed" ]]; then
+           echo "Status is Closed, skipping update"
+           exit 0
+         fi
+
          if [[ ( "${{ steps.get-status-field.outputs.values }}" == "New Issues" || "${{ steps.get-status-field.outputs.values }}" == "" ) &&
                $ASSIGNEES != "[]" ]]; then
            echo "Updating to Backlog since it's assigned and status is New Issues or empty"


### PR DESCRIPTION
#7983 

- Not expected result running `gh issue list --search "[backport v1.5] [BUG] Backing images' on-disk data might be removed during upgrade"`. Instead, use another command https://cli.github.com/manual/gh_search_issues.
- Check if the issue status is `Closed` before updating project item.