### PR TITLE
fix: ensure VM image and corresponding remote metadata are deleted when the image type is `restore`

### DIFF
--- a/pkg/image/common/operator.go
+++ b/pkg/image/common/operator.go
@@ -74,6 +74,7 @@ type VMIOperator interface {
 	UpdateSize(old *harvesterv1.VirtualMachineImage, size int64) (*harvesterv1.VirtualMachineImage, error)
 	UpdateVirtualSizeAndSize(old *harvesterv1.VirtualMachineImage, virtualSize, size int64) (*harvesterv1.VirtualMachineImage, error)
 	UpdateLastFailedTime(old *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error)
+	UpdateBackupTarget(old *harvesterv1.VirtualMachineImage, bt *harvesterv1.BackupTarget) (*harvesterv1.VirtualMachineImage, error)
 
 	FailUpload(old *harvesterv1.VirtualMachineImage, msg string) error
 
@@ -233,6 +234,12 @@ func (vmio *vmiOperator) UpdateVirtualSizeAndSize(old *harvesterv1.VirtualMachin
 func (vmio *vmiOperator) UpdateLastFailedTime(old *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
 	newVMI := old.DeepCopy()
 	newVMI.Status.LastFailedTime = time.Now().Format(time.RFC3339)
+	return vmio.UpdateVMI(old, newVMI)
+}
+
+func (vmio *vmiOperator) UpdateBackupTarget(old *harvesterv1.VirtualMachineImage, bt *harvesterv1.BackupTarget) (*harvesterv1.VirtualMachineImage, error) {
+	newVMI := old.DeepCopy()
+	newVMI.Status.BackupTarget = bt
 	return vmio.UpdateVMI(old, newVMI)
 }
 


### PR DESCRIPTION
Ensure VM image and corresponding remote metadata are deleted when the image type is `restore`

#### Problem:
VM Image Is Unexpectedly Recovered After Deletion

#### Solution:
Ensure VM image and corresponding remote metadata are deleted when the image type is `restore`

#### Related Issue(s):
#8292 

#### Test plan:
1. Build Harvester with this PR
2. Create a VM image.
3. Create a VM using that VM image.
4. Back up the VM to a remote target.
5. After the VM backup completes, disconnect the remote backup target.
6. Delete the related VM, VM backup, and VM image.
7. Reconnect the same remote backup target and set the `refresh interval` to 10 seconds. The VM image will be recovered with the `restore` type (along with the VM backup)
8. Delete the recovered VM image and VM backup again.
9. The VM image will not be recovered again.

#### Additional documentation or context
