### PR TITLE
feat: add new machine validator under webhook

### DIFF
--- a/pkg/webhook/resources/machine/validator.go
+++ b/pkg/webhook/resources/machine/validator.go
@@ -1,0 +1,40 @@
+package machine
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(client client.Client) types.Validator {
+	return &machineValidator{
+		client: client,
+	}
+}
+
+type machineValidator struct {
+	types.DefaultValidator
+	client client.Client
+}
+
+func (v *machineValidator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{"machines"},
+		Scope:      admissionregv1.ClusterScope,
+		APIGroup:   corev1.SchemeGroupVersion.Group,
+		APIVersion: corev1.SchemeGroupVersion.Version,
+		ObjectType: &corev1.Node{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (v *machineValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+
+	return nil
+}


### PR DESCRIPTION
#### Issue #8370


#### Problem:
Adding a new node to a cluster can lead to unknown problems and even put the cluster into a limbo state

#### Solution:
1. Create a machine webhook to validate the intetions of the user to creating a new Node

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
