### PR TITLE
feat: add new machine validator under webhook

### DIFF
--- a/pkg/webhook/resources/machine/validator.go
+++ b/pkg/webhook/resources/machine/validator.go
@@ -1,0 +1,40 @@
+package machine
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(client client.Client) types.Validator {
+	return &machineValidator{
+		client: client,
+	}
+}
+
+type machineValidator struct {
+	types.DefaultValidator
+	client client.Client
+}
+
+func (v *machineValidator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{"machines"},
+		Scope:      admissionregv1.ClusterScope,
+		APIGroup:   corev1.SchemeGroupVersion.Group,
+		APIVersion: corev1.SchemeGroupVersion.Version,
+		ObjectType: &corev1.Node{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (v *machineValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+
+	return nil
+}

--- a/pkg/webhook/resources/machine/validator.go
+++ b/pkg/webhook/resources/machine/validator.go
@@ -34,7 +34,9 @@ func (v *machineValidator) Resource() types.Resource {
 	}
 }
 
-func (v *machineValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+func (v *machineValidator) Create(req *types.Request, newObj runtime.Object) error {
+
+	// if cluster is upgrading, intercept the request
 
 	return nil
 }

--- a/pkg/webhook/resources/machine/validator.go
+++ b/pkg/webhook/resources/machine/validator.go
@@ -1,32 +1,40 @@
 package machine
 
 import (
+	"fmt"
+
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
-func NewValidator(client client.Client) types.Validator {
+func NewValidator(client client.Client, upgradeCache ctlharvesterv1.UpgradeCache) types.Validator {
 	return &machineValidator{
-		client: client,
+		client:       client,
+		upgradeCache: upgradeCache,
 	}
 }
 
 type machineValidator struct {
 	types.DefaultValidator
-	client client.Client
+	client       client.Client
+	upgradeCache ctlharvesterv1.UpgradeCache
 }
 
 func (v *machineValidator) Resource() types.Resource {
 	return types.Resource{
 		Names:      []string{"machines"},
 		Scope:      admissionregv1.ClusterScope,
-		APIGroup:   corev1.SchemeGroupVersion.Group,
-		APIVersion: corev1.SchemeGroupVersion.Version,
+		APIGroup:   "cluster.x-k8s.io",
+		APIVersion: "v1beta1",
 		ObjectType: &corev1.Node{},
 		OperationTypes: []admissionregv1.OperationType{
 			admissionregv1.Create,
@@ -37,6 +45,28 @@ func (v *machineValidator) Resource() types.Resource {
 func (v *machineValidator) Create(req *types.Request, newObj runtime.Object) error {
 
 	// if cluster is upgrading, intercept the request
+	isUpgrading, err := v.isClusterUpgrading()
+	if err != nil {
+		return fmt.Errorf("failed to check if cluster is upgrading: %w", err)
+	}
+	if isUpgrading {
+		return fmt.Errorf("cluster is upgrading, cannot create machine")
+	}
 
 	return nil
+}
+
+func (v *machineValidator) isClusterUpgrading() (bool, error) {
+
+	upgrades, err := v.upgradeCache.List(util.HarvesterSystemNamespaceName, labels.NewSelector())
+
+	if err != nil {
+		return false, err
+	}
+	for _, upgrade := range upgrades {
+		if !harvesterv1.UpgradeCompleted.IsFalse(upgrade) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -45,10 +45,13 @@ func (v *nodeValidator) Resource() types.Resource {
 		APIVersion: corev1.SchemeGroupVersion.Version,
 		ObjectType: &corev1.Node{},
 		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
 			admissionregv1.Update,
 		},
 	}
 }
+
+// func (v *nodeValidator) Create() error {}
 
 func (v *nodeValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldNode := oldObj.(*corev1.Node)

--- a/scripts/default
+++ b/scripts/default
@@ -5,7 +5,7 @@ set -e
 cd $(dirname $0)
 
 ./build
-./test
-./package
-./package-webhook
-./package-upgrade
+#./test
+#./package
+#./package-webhook
+#./package-upgrade


### PR DESCRIPTION
Issue https://github.com/harvester/harvester/issues/7601
Problem:
Adding a new node to a cluster can lead to unknown problems and even put the cluster into a limbo state

Solution:
Create a machine webhook to validate the intetions of the user to creating a new Node
Related Issue(s):
Test plan:
Additional documentation or context