### PR TITLE
make use of `namespaceOverride` consistent

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -19,6 +19,7 @@ metadata:
 {{ include "harvester.labels" . | indent 4 }}
 data:
   promote.sh: |-
+    LONGHORN_NAMESPACE={{ .Values.longhorn.namespaceOverride | quote }}
     {{`KUBECTL="/host/$(readlink /host/var/lib/rancher/rke2/bin)/kubectl"
     YQ="/host/usr/bin/yq"
     ROLE_LABELS="rke.cattle.io/control-plane-role=true rke.cattle.io/etcd-role=true"
@@ -115,10 +116,10 @@ data:
     kickout_longhorn_node()
     {
       target=$1
-      found=$($KUBECTL get nodes.longhorn.io -n {{ .Values.longhorn.namespaceOverride }} |grep -q $target && echo true || echo false)
+      found=$($KUBECTL get nodes.longhorn.io -n $LONGHORN_NAMESPACE |grep -q $target && echo true || echo false)
       if [[ $found == true ]]; then
         echo "Found longhorn node $target, kicking it out..."
-        $KUBECTL delete nodes.longhorn.io $target -n {{ .Values.longhorn.namespaceOverride }}
+        $KUBECTL delete nodes.longhorn.io $target -n $LONGHORN_NAMESPACE
       fi
     }
 

--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -115,10 +115,10 @@ data:
     kickout_longhorn_node()
     {
       target=$1
-      found=$($KUBECTL get nodes.longhorn.io -n longhorn-system |grep -q $target && echo true || echo false)
+      found=$($KUBECTL get nodes.longhorn.io -n {{ .Values.longhorn.namespaceOverride }} |grep -q $target && echo true || echo false)
       if [[ $found == true ]]; then
         echo "Found longhorn node $target, kicking it out..."
-        $KUBECTL delete nodes.longhorn.io $target -n longhorn-system
+        $KUBECTL delete nodes.longhorn.io $target -n {{ .Values.longhorn.namespaceOverride }}
       fi
     }
 

--- a/deploy/charts/harvester/templates/longhorn-network-policy.yaml
+++ b/deploy/charts/harvester/templates/longhorn-network-policy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: backing-image-data-source
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -31,7 +31,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: backing-image-manager
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -58,7 +58,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: instance-manager
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -85,7 +85,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-manager
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -120,7 +120,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-recovery-backend
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -137,7 +137,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-conversion-webhook
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -154,7 +154,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: longhorn-admission-webhook
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -170,7 +170,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: cattle-monitoring-prometheus
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:
@@ -190,7 +190,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: harvester
-  namespace: longhorn-system
+  namespace: {{ .Values.longhorn.namespaceOverride }}
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
Make consistent use of .Values.longhorn.namespaceOverride to specify install location of Longhorn.

related-to: harvester/harvester#7931

#### Problem:

Usage of `.Values.longhorn.namespaceOverride` needs to be consistent or replaced with hardcoded value. Since Longhorn requires this option or else it will be installed in the `harvester-system` namespace as well (which isn't good), the Harvester helm chart must make consistent use of the `.Values.longhorn.namespaceOverride` setting in every auxiliary resource that it installs into the Longhorn namespace.

The inconsistent use of this setting makes it impossible for users to customize the namespace in which Longhorn is installed in a Harvester cluster.

#### Solution:

Replace all hard-coded instances of `longhorn-system` in the templates installed by the Harvester Helm chart by `{{ .Values.longhorn.namespaceOverride }}`.

#### Related Issue(s):

#7931

#### Test plan:

Regression testing:
- Install Harvester
- Observe no errors, Longhorn should work normally, Prometheus rules should be correctly in place

#### Additional documentation or context

N/A