### PR TITLE
add/update kubeovn components in the upgrade path

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1183,6 +1183,8 @@ upgrade_addons()
   upgrade_harvester_upgradelog_logging_fluentd_fluentbit
 
   upgrade_nvidia_driver_toolkit_addon
+
+  manage_kubeovn
 }
 
 reuse_vlan_cn() {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR introduces changes to upgrade path to ensure kubeovn-operator-crd managed chart is installed upgraded
and kubeovn-operator addon is upgraded

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/7413
#### Test plan:
<!-- Describe the test plan by steps. -->
To test:
* Install Harvester v1.5.x cluster
* Upgrade to master-head/v1.6 head by manually creating a version object
* Wait for upgrade to complete
* Post upgrade the kubeovn-operator-crd managedchart should be available in the upgraded cluster
* Post upgrade an addon for kubeovn-operator is available in the upgrade cluster
* Enable kubeovn-operator addon and check kubeovn components deployed in the kube-system namespace
 
#### Additional documentation or context
