### PR TITLE
fix: securityParameters error message

### DIFF
--- a/pkg/image/common/validator.go
+++ b/pkg/image/common/validator.go
@@ -310,7 +310,7 @@ func (v *vmiValidator) URLConsistency(oldVMI, newVMI *v1beta1.VirtualMachineImag
 
 func (v *vmiValidator) SecurityParameterConsistency(oldVMI, newVMI *v1beta1.VirtualMachineImage) error {
 	if !reflect.DeepEqual(oldVMI.Spec.SecurityParameters, newVMI.Spec.SecurityParameters) {
-		return werror.NewInvalidError("url cannot be modified", "spec.url")
+		return werror.NewInvalidError("securityParameters cannot be modified", "spec.securityParameters")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:

The error message is wrong while testing terraform. It shouldn't be `url`.

```
╷
│ Error: admission webhook "validator.harvesterhci.io" denied the request: url cannot be modified
│
│   with harvester_image.encrypted_image,
│   on main.tf line 46, in resource "harvester_image" "encrypted_image":
│   46: resource "harvester_image" "encrypted_image" {
│
```

#### Solution:


#### Related Issue(s):
https://github.com/harvester/harvester/issues/8148

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
