### PR TITLE
charts: add volumeattachments capability to harvesterhci.io:csi-driver

### DIFF
--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -173,6 +173,7 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  - volumeattachments
   verbs:
   - get
   - list


### PR DESCRIPTION
    - We need check volumeattachments on latest Harvester-CSI-Driver

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The new Harvester CSI driver needs permission for volumeattachment 

#### Solution:
Add volumeattachment to corresponding RBAC

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
1. install harvester v1.5.0 or v1.5.1 cluster
2. upgrade to v1.6.0 with this PR
3. ensure the the harvester-csi-driver have permission of volumeattachments 

#### Additional documentation or context
