### PR TITLE
fix: allow volume online resizing when configured from the VM page

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -235,4 +235,5 @@ const (
 	AnnotationStorageProfileSnapshotClass         = AnnotationCDIPrefix + "/storageProfileVolumeSnapshotClass"
 	AnnotationStorageProfileVolumeModeAccessModes = AnnotationCDIPrefix + "/storageProfileVolumeModeAccessModes"
 	FSOverheadRegex                               = `^(0(?:\.\d{1,3})?|1)$`
+	PVCExpandErrorPrefix                          = "PVC_EXPAND"
 )

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -181,7 +181,7 @@ func (v *pvcValidator) checkExpand(pvc *corev1.PersistentVolumeClaim) error {
 		return err
 	}
 	if !isKubevirtExpandEnabled(kubevirt) {
-		return werror.NewInvalidError("kubevirt ExpandDisks not included in featureGate", "")
+		return werror.NewInvalidError(util.PVCExpandErrorPrefix+": kubevirt ExpandDisks not included in featureGate", "")
 	}
 
 	hotpluggedFSPVC, err := v.isHotpluggedFilesystemPVC(pvc)
@@ -191,7 +191,7 @@ func (v *pvcValidator) checkExpand(pvc *corev1.PersistentVolumeClaim) error {
 	if hotpluggedFSPVC {
 		return werror.NewInvalidError(
 			fmt.Sprintf(
-				"Expansion of hotplugged PVC '%s/%s' in filesystem mode is not supported",
+				util.PVCExpandErrorPrefix+": Expansion of hotplugged PVC '%s/%s' in filesystem mode is not supported",
 				pvc.Namespace,
 				pvc.Name,
 			),
@@ -206,7 +206,7 @@ func (v *pvcValidator) checkExpand(pvc *corev1.PersistentVolumeClaim) error {
 	if !expandable {
 		return werror.NewInvalidError(
 			fmt.Sprintf(
-				"pvc %s/%s is not online expandable with its provider",
+				util.PVCExpandErrorPrefix+": pvc %s/%s is not online expandable with its provider",
 				pvc.Namespace,
 				pvc.Name,
 			),

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -406,7 +406,6 @@ func (v *vmValidator) checkResizeVolumes(oldVM, newVM *kubevirtv1.VirtualMachine
 		newPvcMap[pvc.Name] = pvc
 	}
 
-	isResizeVolume := false
 	for name, oldPvc := range oldPvcMap {
 		newPvc, ok := newPvcMap[name]
 		if !ok || newPvc == nil {
@@ -418,19 +417,6 @@ func (v *vmValidator) checkResizeVolumes(oldVM, newVM *kubevirtv1.VirtualMachine
 		// 1 means newPVC > oldPVC
 		if newPvc.Spec.Resources.Requests.Storage().Cmp(*oldPvc.Spec.Resources.Requests.Storage()) == -1 {
 			return werror.NewInvalidError(fmt.Sprintf("%s PVC requests storage can't be less than previous value", newPvc.Name), fmt.Sprintf("metadata.annotations.%s", util.AnnotationVolumeClaimTemplates))
-		} else if newPvc.Spec.Resources.Requests.Storage().Cmp(*oldPvc.Spec.Resources.Requests.Storage()) == 1 {
-			isResizeVolume = true
-		}
-	}
-
-	if isResizeVolume {
-		stopped, err := vmutil.IsVMStopped(newVM, v.vmiCache)
-		if err != nil {
-			return werror.NewInternalError(fmt.Sprintf("failed to get vm is stopped or not, err: %s", err.Error()))
-		}
-
-		if !stopped {
-			return werror.NewInvalidError("please stop the VM before resizing volumes", fmt.Sprintf("metadata.annotations.%s", util.AnnotationVolumeClaimTemplates))
 		}
 	}
 


### PR DESCRIPTION
#### Problem:
Volume online resizing is blocked when configured from the VM page

#### Solution:
allow volume online resizing when configured from the VM page

#### Related Issue(s):
#8625 

#### Test plan:
- Update the Harvester webhook deployment with this PR.
- Create a VM and start it.
- Change the volume size from the VM details page.
- Verify that the volume resizing is successfully applied.

#### Additional documentation or context
