### PR TITLE
ci: fix duplicately linking backport issue and pr

### DIFF
--- a/.github/workflows/issue-management-link-backport-pr.yaml
+++ b/.github/workflows/issue-management-link-backport-pr.yaml
@@ -69,6 +69,9 @@ jobs:
         for issue_number in ${{ env.ORIGINAL_ISSUE_NUMBER }}; do
           echo "Found source issue ${REPO_NAME}#${issue_number}"
           issue_title=$(gh issue view "$issue_number" --json title --jq ".title")
+          
+          # Reset backport_issue_number for each iteration
+          backport_issue_number=""
 
           if [[ -n "$issue_number" && -n "$issue_title" ]]; then
             search_title=$(cat <<EOF


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/8383

Basically, it works. But, there is a duplicate because the variable wasn't reset.

<img width="5083" height="1689" alt="image" src="https://github.com/user-attachments/assets/2c7b63f9-8120-4d3d-bd95-269c4bf48426" />

