### PR TITLE
fix: update vm node select instead of vmi

### DIFF
--- a/pkg/controller/master/migration/vmi_controller.go
+++ b/pkg/controller/master/migration/vmi_controller.go
@@ -5,7 +5,6 @@ import (
 
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -68,11 +67,12 @@ func (h *Handler) OnVmiChanged(_ string, vmi *kubevirtv1.VirtualMachineInstance)
 
 func (h *Handler) resetHarvesterMigrationStateInVMI(vmi *kubevirtv1.VirtualMachineInstance) error {
 	toUpdate := vmi.DeepCopy()
+
 	delete(toUpdate.Annotations, util.AnnotationMigrationUID)
 	delete(toUpdate.Annotations, util.AnnotationMigrationState)
+
 	if vmi.Annotations[util.AnnotationMigrationTarget] != "" {
 		delete(toUpdate.Annotations, util.AnnotationMigrationTarget)
-		delete(toUpdate.Spec.NodeSelector, corev1.LabelHostname)
 	}
 
 	if err := util.VirtClientUpdateVmi(context.Background(), h.restClient, h.namespace, vmi.Namespace, vmi.Name, toUpdate); err != nil {

--- a/pkg/controller/master/migration/vmim_controller.go
+++ b/pkg/controller/master/migration/vmim_controller.go
@@ -93,6 +93,7 @@ func (h *Handler) syncVM(vmi *kubevirtv1.VirtualMachineInstance) error {
 		toUpdateVM.Annotations = make(map[string]string)
 	}
 	toUpdateVM.Annotations[util.AnnotationTimestamp] = time.Now().Format(time.RFC3339)
+	delete(toUpdateVM.Spec.Template.Spec.NodeSelector, corev1.LabelHostname)
 
 	_, err = h.vms.Update(toUpdateVM)
 	return err


### PR DESCRIPTION
#### Problem:
Check this https://github.com/harvester/harvester/issues/8670 for more details.

#### Solution:
Since the KubeVirt checks the nodeSelect between vm and vmi spec, we can just update the vm spec instead of vmi. 

However, this fix is temporary. We will use more formal way to migrate the VM in https://github.com/harvester/harvester/issues/8703.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8670

#### Test plan:

Prepare a three nodes cluster to migrate the VM.


Please check this one.

https://github.com/user-attachments/assets/50dc6a35-fbd5-444f-a913-b5f69454f4d9

---

This is the old one. Please just ignore this. I keep it because other people had some comments about the old one.

https://github.com/user-attachments/assets/2c45d022-596d-4d5c-bf3b-5963f9839a91


#### Additional documentation or context

Upgrades use eviction concept to migrate the VM, so this shouldn't affect the upgrade. Thanks @starbops.

