### PR TITLE
Fix the sync of migrate button on UI

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -255,7 +255,7 @@ func isReady(vmi *kubevirtv1.VirtualMachineInstance) bool {
 }
 
 func canMigrate(vmi *kubevirtv1.VirtualMachineInstance) bool {
-	if vmi == nil {
+	if vmi == nil || vmi.DeletionTimestamp != nil || vmi.Annotations[util.AnnotationMigrationState] != "" {
 		return false
 	}
 
@@ -267,11 +267,10 @@ func canMigrate(vmi *kubevirtv1.VirtualMachineInstance) bool {
 }
 
 func canAbortMigrate(vmi *kubevirtv1.VirtualMachineInstance) bool {
-	if vmi != nil &&
-		vmi.Annotations[util.AnnotationMigrationState] == migration.StateMigrating {
-		return true
+	if vmi == nil {
+		return false
 	}
-	return false
+	return vmi.Annotations[util.AnnotationMigrationState] == migration.StateMigrating || vmi.Annotations[util.AnnotationMigrationState] == migration.StatePending
 }
 
 func (vf *vmformatter) canDoBackup(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance) bool {

--- a/pkg/controller/global/settings/register.go
+++ b/pkg/controller/global/settings/register.go
@@ -43,7 +43,7 @@ func (s *settingsProvider) Get(name string) string {
 		return value
 	}
 
-	logrus.Infof("Attempting to fetch setting %s from cache", name)
+	logrus.Debugf("Attempting to fetch setting %s from cache", name)
 	obj, err := s.settingsLister.Get(name)
 	if err != nil {
 		logrus.Warnf("Failed to fetch setting %s from cache, attempting direct API call: %v", name, err)
@@ -60,7 +60,7 @@ func (s *settingsProvider) Get(name string) string {
 		return obj.Default
 	}
 
-	logrus.Infof("Setting %s found with value: %s", name, obj.Value)
+	logrus.Debugf("Setting %s found with value: %s", name, obj.Value)
 	return obj.Value
 }
 

--- a/pkg/controller/master/migration/vmim_controller.go
+++ b/pkg/controller/master/migration/vmim_controller.go
@@ -16,11 +16,12 @@ import (
 
 const (
 	// StateMigrating represents kubevirt MigrationScheduling, MigrationScheduled, MigrationPreparingTarget, MigrationTargetReady, MigrationRunning
-	StateMigrating         = "Migrating"
+	StateMigrating = "Migrating"
+
 	StateAbortingMigration = "Aborting migration"
 
 	// StatePending represents kubevirt MigrationPhaseUnset, MigrationPending
-	StatePending = "Pending"
+	StatePending = "Pending migration"
 )
 
 // The handler adds the AnnotationMigrationUID annotation to the VMI when vmim starts.

--- a/pkg/controller/master/migration/vmim_controller_test.go
+++ b/pkg/controller/master/migration/vmim_controller_test.go
@@ -24,6 +24,7 @@ const (
 	resourceQuotaNamespace = "rs"
 	resourceQuotaName      = "rq1"
 	uid                    = "6afcf4d9-b8a7-464a-a4e9-abe81fc7eacd"
+	vmimUID                = "8afcf4d9-b8a7-464a-a4e9-abe81fc7eacd"
 
 	longVMIName = "a-very-long-name-exceeds-the-63-length-and-it-reports-error-in-old-version"
 
@@ -91,6 +92,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
 						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -107,6 +112,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
@@ -153,6 +159,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 						Name:      longVMIName,
 						Namespace: resourceQuotaNamespace,
 						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -169,6 +179,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: longVMIName},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
@@ -217,6 +228,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -233,6 +248,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
@@ -280,6 +296,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
 						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -296,6 +316,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
@@ -338,6 +359,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -354,6 +379,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
@@ -394,6 +420,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -410,6 +440,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
@@ -450,6 +481,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -466,6 +501,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
@@ -504,6 +540,10 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vm1",
 						Namespace: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
@@ -520,6 +560,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "vmim1",
 						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
 					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Per issue desc on https://github.com/harvester/harvester/issues/7180

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add better sync between vm, vmi, vmim

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/7180


#### Test plan:
<!-- Describe the test plan by steps. -->


1. Create 4 or more VMs on a same node
1.1 Maintain the node
1.2  4 VM migrations are created
1.3 2 of them starts ( by default 2 in parallel)
1.4 check UI, the still migrating vms have UI menu `Abort Migration`

VM shows `Pending` when it is in the waiting list to be migrated.
<img width="3170" height="1040" alt="image" src="https://github.com/user-attachments/assets/ad5f803d-7b89-4cbd-b73c-00b9b048a16d" />

It looks `Pending migration` is better than `Pending`, the latter is hard to connect with `migration`.

<img width="3178" height="866" alt="image" src="https://github.com/user-attachments/assets/8499a535-b576-49fb-8a46-6339ccde35d6" />

<img width="3150" height="548" alt="image" src="https://github.com/user-attachments/assets/c7815fb9-c72a-489e-aed7-a62b71c21cd2" />



Note: kubevirt allows 2 VMs to be migrated in parallel when it evacuats vms, additional vm is in a new UI state `Pending Migration`

```
kubevirt-evacuation-2l2qn 
```

note the issue desc https://github.com/harvester/harvester/issues/7180



2. Create 4 or more VMs on a same node
2.1 Click `migrate` on each vm
2.2 When a vm is in `migrating`/`pending`, you can click `Abort Migration`
<img width="3254" height="1104" alt="image" src="https://github.com/user-attachments/assets/c761e0ab-637e-4896-b627-99a9e876145d" />

#### Additional documentation or context
When a vm is in migration, below log is alway seen
```
time="2025-07-21T12:16:24Z" level=debug msg="Fetching setting: csi-driver-config"

time="2025-07-21T12:16:24Z" level=info msg="Attempting to fetch setting csi-driver-config from cache"

time="2025-07-21T12:16:24Z" level=debug msg="Setting csi-driver-config has no value, using default: {\"driver.longhorn.io\":{\"volumeSnapshotClassName\":\"longhorn-snapshot\",\"backupVolumeSnapshotClassName\":\"longhorn\"}}"
```

Solution: Lower info `Attempting to fetch setting csi-driver-config from cache` to debug level.


The original planned PR https://github.com/harvester/harvester/pull/7195 is replaced by this one.