### PR TITLE
fix: migrate VM should have multiple nodes

### DIFF
--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -103,6 +103,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	vmformatter := vmformatter{
 		pvcCache:      pvcs.Cache(),
 		vmiCache:      vmis.Cache(),
+		nodeCache:     nodes.Cache(),
 		scCache:       storageClasses.Cache(),
 		vmBackupCache: backups.Cache(),
 		clientSet:     *scaled.Management.ClientSet,


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
A cluster with single node can migrate VM, but it cannot find another node to do it.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Check node count before migrate VM.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5835, https://github.com/harvester/harvester/issues/8774

#### Test plan:
<!-- Describe the test plan by steps. -->
Create a single node cluster. There should not have migrate VM or cpu / memory hotplug button.

#### Additional documentation or context
