### PR TITLE
builder: method for setting labels on template

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -131,6 +131,24 @@ func (v *VMBuilder) Labels(labels map[string]string) *VMBuilder {
 	return v
 }
 
+// VirtualMachineInstanceTemplateLabels is similar to the Labels method, but it
+// sets the labels in the template spec. Unlike lables on the VirtualMachine
+// object, labels in the template spec will propagate to the VMI and the
+// launcher pod.
+func (v *VMBuilder) VirtualMachineInstanceTemplateLabels(labels map[string]string) *VMBuilder {
+	vmiTemplate := v.VirtualMachine.Spec.Template
+
+	if vmiTemplate.ObjectMeta.Labels == nil {
+		vmiTemplate.ObjectMeta.Labels = labels
+		return v
+	}
+
+	for key, value := range labels {
+		vmiTemplate.OjectMeta.Labels[key] = value
+	}
+	return v
+}
+
 func (v *VMBuilder) Annotations(annotations map[string]string) *VMBuilder {
 	if v.VirtualMachine.ObjectMeta.Annotations == nil {
 		v.VirtualMachine.ObjectMeta.Annotations = annotations

--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -144,7 +144,7 @@ func (v *VMBuilder) VirtualMachineInstanceTemplateLabels(labels map[string]strin
 	}
 
 	for key, value := range labels {
-		vmiTemplate.OjectMeta.Labels[key] = value
+		vmiTemplate.ObjectMeta.Labels[key] = value
 	}
 	return v
 }


### PR DESCRIPTION
Add a method for setting the labels on the VMI template of a VM. Unlike labels on the VM object itself, the labels in the VMI template will propagate to the VMI and launcher pod.

related-to: harvester/harvester#7193


#### Problem:

To propagate labels from Rancher (i.e. the Harvester node driver) all the way to the launcher Pod, it's necessary to be able to set the labels on the VMI template spec.

#### Solution:

Add a method to the VMBuilder which allows setting labels for the VMI template spec

#### Related Issue(s):

related-to: harvester/harvester#7193