### PR TITLE
settings/longhorn: set autoDeletePodWhenVolumeDetachedUnexpectedly false

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -494,6 +494,7 @@ longhorn:
     priorityClass: &longhornPriorityClass system-cluster-critical
     autoCleanupSnapshotWhenDeleteBackup: true
     orphanResourceAutoDeletion: instance
+    autoDeletePodWhenVolumeDetachedUnexpectedly: false
 
   # after upgrade to longhorn 1.6.0, we need to set the priorityClass for longhorn-manager, longhorn-driver and longhorn-ui
   # or it will be default one longhorn-critical


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
autoDeletePodWhenVolumeDetachedUnexpectedly = true would cause the virt-launcher/hp-volume pod to be deleted unexpectedly.

#### Solution:
set autoDeletePodWhenVolumeDetachedUnexpectedly = false

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5580

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
