### PR TITLE
enhancement: enable LH orphan-resource-auto-deletion

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -493,6 +493,7 @@ longhorn:
     concurrentAutomaticEngineUpgradePerNodeLimit: 3
     priorityClass: &longhornPriorityClass system-cluster-critical
     autoCleanupSnapshotWhenDeleteBackup: true
+    orphanResourceAutoDeletion: instance
 
   # after upgrade to longhorn 1.6.0, we need to set the priorityClass for longhorn-manager, longhorn-driver and longhorn-ui
   # or it will be default one longhorn-critical


### PR DESCRIPTION
#### Problem:
Enable the Longhorn setting `orphan-resource-auto-deletion` to allow automatic cleanup of orphaned instance resources. Refer to the enhancement documentation: [Orphaned Runtime Cleanup](https://github.com/longhorn/longhorn/blob/master/enhancements/20250331-orphaned-runtime-cleanup.md).

#### Solution:
Enable the Longhorn setting `orphan-resource-auto-deletion` to allow automatic cleanup of orphaned instance resources. Refer to the enhancement documentation: [Orphaned Runtime Cleanup](https://github.com/longhorn/longhorn/blob/master/enhancements/20250331-orphaned-runtime-cleanup.md).


#### Related Issue(s):
#8474 

#### Test plan:
- Build Harvester from this PR
- Verify that the Longhorn setting `orphan-resource-auto-deletion` is set to `instance`
  ```
  apiVersion: longhorn.io/v1beta2
  kind: Setting
  metadata:
    name: orphan-resource-auto-deletion
    namespace: longhorn-system
  status:
    applied: true
  value: instance
  ```

#### Additional documentation or context
Longhorn team has already conducted sufficient verification on this, along with well-documented reproduction steps https://github.com/longhorn/longhorn/issues/6764#issuecomment-2666839915
