### PR TITLE
Ensure one node has CPU Manager when there is vm has cpu pinning

### DIFF
--- a/pkg/util/indexeres/virtualmachine.go
+++ b/pkg/util/indexeres/virtualmachine.go
@@ -10,6 +10,9 @@ import (
 const (
 	VMByPVCIndex        = "harvesterhci.io/vm-by-pvc"
 	VMByHotplugPVCIndex = "harvesterhci.io/vm-by-hp-pvc"
+	VMByCPUPinningIndex = "harvesterhci.io/vm-by-cpu-pinning"
+
+	CPUPinningEnabled = "enabled"
 )
 
 func VMByPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
@@ -42,6 +45,18 @@ func VMByHotplugPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
 		if isVolumeHotplugged(volume) {
 			results = append(results, ref.Construct(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
 		}
+	}
+	return results, nil
+}
+
+func VMByCPUPinning(obj *kubevirtv1.VirtualMachine) ([]string, error) {
+	if obj == nil || obj.Spec.Template == nil {
+		return nil, nil
+	}
+
+	var results []string
+	if obj.Spec.Template.Spec.Domain.CPU != nil && obj.Spec.Template.Spec.Domain.CPU.DedicatedCPUPlacement {
+		return []string{CPUPinningEnabled}, nil
 	}
 	return results, nil
 }

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -56,6 +56,7 @@ func RegisterIndexers(clients *clients.Clients) {
 	vmInformer := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmInformer.AddIndexer(indexeresutil.VMByPVCIndex, indexeresutil.VMByPVC)
 	vmInformer.AddIndexer(indexeresutil.VMByHotplugPVCIndex, indexeresutil.VMByHotplugPVC)
+	vmInformer.AddIndexer(indexeresutil.VMByCPUPinningIndex, indexeresutil.VMByCPUPinning)
 
 	svmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache()
 	svmBackupCache.AddIndexer(ScheduleVMBackupBySourceVM, scheduleVMBackupBySourceVM)
@@ -70,7 +71,6 @@ func RegisterIndexers(clients *clients.Clients) {
 
 	vmCache := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmCache.AddIndexer(VMByMacAddress, vmByMacaddrs)
-	vmInformer.AddIndexer(indexeresutil.VMByCPUPinningIndex, indexeresutil.VMByCPUPinning)
 }
 
 func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -70,6 +70,7 @@ func RegisterIndexers(clients *clients.Clients) {
 
 	vmCache := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmCache.AddIndexer(VMByMacAddress, vmByMacaddrs)
+	vmInformer.AddIndexer(indexeresutil.VMByCPUPinningIndex, indexeresutil.VMByCPUPinning)
 }
 
 func vmBackupBySourceUID(obj *harvesterv1.VirtualMachineBackup) ([]string, error) {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -51,6 +51,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		node.NewValidator(
 			clients.Core.Node().Cache(),
 			clients.Batch.Job().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache()),
 		persistentvolumeclaim.NewValidator(
 			clients.Core.PersistentVolumeClaim().Cache(),


### PR DESCRIPTION
#### Problem:
Can't add volume, delete and backup vm when vm enabled cpu pinning while cpu manager is disabled.

The root cause is we currently check for running VMIs with CPU pinning, but we didn't check the corresponding VMs before disabling CPU the Manager. Once the CPU Manager is disabled, if no node has it enabled, the validator is triggered. https://github.com/harvester/harvester/blob/22470dab30aa3981079cb5689e7d63f1cbd668f3/pkg/webhook/resources/virtualmachine/validator.go#L252 This blocks any further operations (e.g. add volume, delete vm...), as at least one node with CPU Manager enabled is required.

#### Solution:

Prevent disabling CPU Manager on the last enabled node when pinned VMs exist

https://github.com/user-attachments/assets/a9a57209-fd7b-435a-b0ab-378a2dbc6952

#### Related Issue(s):

#8778

#### Test plan:
- Enable CPU Manager in one node (e.g. harvester-node-0)
- Create a VM `test`
- Click Edit Config, enable CPU Pinning **WITHOUT** restart the VM.
- Disable CPU Manager in `harvester-node-0`, error pops up: `At least one node must have CPU Manager enabled when a VM is using CPU pinning. Please remove CPU pinning from the following VM(s) to proceed: default/test`.

#### Additional documentation or context
N/A