### PR TITLE
Use setting cache instead of provider in IsRestoreVM

### DIFF
--- a/pkg/controller/master/upgrade/job_controller.go
+++ b/pkg/controller/master/upgrade/job_controller.go
@@ -66,6 +66,7 @@ type jobHandler struct {
 	jobClient      jobv1.JobClient
 	jobCache       jobv1.JobCache
 	configMapCache ctlcorev1.ConfigMapCache
+	settingCache   ctlharvesterv1.SettingCache
 }
 
 func (h *jobHandler) OnChanged(_ string, job *batchv1.Job) (*batchv1.Job, error) {
@@ -298,7 +299,7 @@ func (h *jobHandler) setNodeWaitRebootLabel(node *v1.Node, repoInfo *repoinfo.Re
 }
 
 func (h *jobHandler) sendRestoreVMJob(upgrade *harvesterv1.Upgrade, node *v1.Node, repoInfo *repoinfo.RepoInfo) error {
-	restoreVM, err := util.IsRestoreVM()
+	restoreVM, err := util.IsRestoreVM(h.settingCache)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{"name": upgrade.Name, "node": node.Name}).WithError(err).
 			Errorf("Failed to get setting UpgradeConfig, skip restore VM job")

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -107,6 +107,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		jobClient:      jobs,
 		jobCache:       jobs.Cache(),
 		configMapCache: configMaps.Cache(),
+		settingCache:   settings.Cache(),
 	}
 	jobs.OnChange(ctx, jobControllerName, jobHandler.OnChanged)
 

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -171,7 +171,7 @@ type ImagePreloadOption struct {
 type UpgradeConfig struct {
 	// Options for the Image Preload phase of Harvester Upgrade
 	PreloadOption ImagePreloadOption `json:"imagePreloadOption,omitempty"`
-	// set true to restore vm to the pre-upgrade state, this option only works under single node.
+	// set true to restore vm to the pre-upgrade state
 	RestoreVM bool `json:"restoreVM,omitempty"`
 }
 

--- a/pkg/util/setting.go
+++ b/pkg/util/setting.go
@@ -61,8 +61,21 @@ func GetAdditionalGuestMemoryOverheadRatio(settingCache ctlharvesterv1.SettingCa
 	return &value, nil
 }
 
-func IsRestoreVM() (bool, error) {
-	upgradeConfig, err := settings.DecodeConfig[settings.UpgradeConfig](settings.UpgradeConfigSet.Get())
+func IsRestoreVM(settingCache ctlharvesterv1.SettingCache) (bool, error) {
+	value := ""
+	if settingCache == nil {
+		return false, fmt.Errorf("the settingCache is empty, can't get the setting")
+	}
+	s, err := settingCache.Get(settings.UpgradeConfigSettingName)
+	if err != nil {
+		return false, err
+	}
+	value = s.Value
+	if value == "" {
+		value = s.Default
+	}
+
+	upgradeConfig, err := settings.DecodeConfig[settings.UpgradeConfig](value)
 	if err != nil || upgradeConfig == nil {
 		return false, err
 	}

--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -58,6 +58,7 @@ func NewValidator(
 	versionCache ctlharvesterv1.VersionCache,
 	vmBackupCache ctlharvesterv1.VirtualMachineBackupCache,
 	svmbackupCache ctlharvesterv1.ScheduleVMBackupCache,
+	settingCache ctlharvesterv1.SettingCache,
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
 	endpointCache v1.EndpointsCache,
 	httpClient *http.Client,
@@ -75,6 +76,7 @@ func NewValidator(
 		svmbackupCache:    svmbackupCache,
 		vmiCache:          vmiCache,
 		endpointCache:     endpointCache,
+		settingCache:      settingCache,
 		httpClient:        httpClient,
 		bearToken:         bearToken,
 	}
@@ -94,6 +96,7 @@ type upgradeValidator struct {
 	svmbackupCache    ctlharvesterv1.ScheduleVMBackupCache
 	vmiCache          ctlkubevirtv1.VirtualMachineInstanceCache
 	endpointCache     v1.EndpointsCache
+	settingCache      ctlharvesterv1.SettingCache
 	httpClient        *http.Client
 	bearToken         string
 }
@@ -196,7 +199,7 @@ func (v *upgradeValidator) checkResources(upgrade *v1beta1.Upgrade) error {
 		return err
 	}
 
-	restoreVM, err := util.IsRestoreVM()
+	restoreVM, err := util.IsRestoreVM(v.settingCache)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -91,6 +91,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Version().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 			clients.Core.Endpoints().Cache(),
 			&http.Client{


### PR DESCRIPTION
#### Problem:

Set restoreVM to true, but the non-migratable VM validator still working, which isn't expected.
The root cause is there is no settings provider registered in harvester-webhook, and we cannot register one since the webhook is only responsible for handling validation and mutation logic — not managing settings updates.

#### Solution:

In a typical settings provider, SetAll would be called to initialize all settings and trigger settings#update. However, this mechanism is not available in the webhook context.

Therefore, this change uses the settings cache directly instead of relying on a provider to retrieve setting values.

#### Related Issue(s):

#8049 

#### Test plan:

#### Additional documentation or context
