### PR TITLE
address multipath upgrade failures

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,3 +1,4 @@
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:v1.6 as baseos
 FROM registry.suse.com/bci/bci-base:15.6
 
 ARG ARCH=amd64
@@ -13,7 +14,8 @@ RUN curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kub
 RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.4.0/virtctl-v1.4.0-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.8/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
-
+# Copy elemental binary to be used for upgrades
+COPY --from=baseos /usr/bin/elemental /usr/local/bin/elemental
 COPY do_upgrade_node.sh /usr/local/bin/
 COPY upgrade_node.sh /usr/local/bin/
 COPY upgrade_manifests.sh /usr/local/bin/


### PR DESCRIPTION


<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
currently upgrades on hosts booting off external disks and leveraging multipath fail because elemental generates an upgrade spec which leverages the underlying multipath device and attempts to mount the same to perform the upgrade.

This fails and results in upgrade failing during the OS upgrade

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
elemental-cli v1.1.7 has a fix to allow it to identify a mapper device during an upgrade and use the same to generate the upgrade spec.

minor change to upgrade path to package latest elemental binary from current builds, to ensure new binary is used during upgrade. In addition if mpath is being used mount COS_STATE into /run/cos/state to ensure upgrade can work smoothly

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->
https://github.com/harvester/harvester/issues/8689
#### Additional documentation or context
