### PR TITLE
Revert "Adding a webhook for the validation of CPU pinning"

### DIFF
--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -12,8 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	ctlharvestercorev1 "github.com/harvester/harvester/pkg/generated/controllers/core/v1"
@@ -24,7 +23,6 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 	"github.com/harvester/harvester/pkg/util/resourcequota"
-	vmutil "github.com/harvester/harvester/pkg/util/virtualmachine"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	indexerwebhook "github.com/harvester/harvester/pkg/webhook/indexeres"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -42,7 +40,6 @@ func NewValidator(
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
 	nadCache ctlcniv1.NetworkAttachmentDefinitionCache,
 	settingCache ctlharvesterv1.SettingCache,
-	nodeCache v1.NodeCache,
 ) types.Validator {
 	return &vmValidator{
 		pvcCache:      pvcCache,
@@ -50,7 +47,6 @@ func NewValidator(
 		vmCache:       vmCache,
 		vmiCache:      vmiCache,
 		nadCache:      nadCache,
-		nodeCache:     nodeCache,
 
 		rqCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache, settingCache),
 	}
@@ -63,7 +59,6 @@ type vmValidator struct {
 	vmCache       ctlkubevirtv1.VirtualMachineCache
 	vmiCache      ctlkubevirtv1.VirtualMachineInstanceCache
 	nadCache      ctlcniv1.NetworkAttachmentDefinitionCache
-	nodeCache     v1.NodeCache
 	rqCalculator  *resourcequota.Calculator
 }
 
@@ -224,10 +219,6 @@ func (v *vmValidator) Create(_ *types.Request, newObj runtime.Object) error {
 		return err
 	}
 
-	if err := v.checkDedicatedCPUPlacement(vm); err != nil {
-		return err
-	}
-
 	if err := v.checkStorageResourceQuota(vm, nil); err != nil {
 		return err
 	}
@@ -246,10 +237,6 @@ func (v *vmValidator) Update(_ *types.Request, oldObj runtime.Object, newObj run
 	}
 
 	if err := v.checkVMSpec(newVM); err != nil {
-		return err
-	}
-
-	if err := v.checkDedicatedCPUPlacement(newVM); err != nil {
 		return err
 	}
 
@@ -542,34 +529,4 @@ func (v *vmValidator) checkReservedMemoryAnnotation(vm *kubevirtv1.VirtualMachin
 
 func (v *vmValidator) checkStorageResourceQuota(vm *kubevirtv1.VirtualMachine, oldVM *kubevirtv1.VirtualMachine) error {
 	return v.rqCalculator.CheckStorageResourceQuota(vm, oldVM)
-}
-
-func (v *vmValidator) checkDedicatedCPUPlacement(vm *kubevirtv1.VirtualMachine) error {
-	if !isDedicatedCPU(vm) {
-		return nil
-	}
-
-	// Skip check on VMs that are stopped. This allows the user to create
-	// VMs with CPU pinning enabled in advance even if the CPU Manager is
-	// currently disabled.
-	stopped, err := vmutil.IsVMStopped(vm, v.vmiCache)
-	if err != nil {
-		return werror.NewInternalError(fmt.Sprintf("failed to determine whether the VM is stopped or not: %s", err.Error()))
-	}
-	if stopped {
-		return nil
-	}
-
-	selector := labels.Set{kubevirtv1.CPUManager: "true"}.AsSelector()
-	nodeList, err := v.nodeCache.List(selector)
-	if err != nil {
-		return werror.NewInternalError(fmt.Sprintf("failed to list nodes with labels %s: %s", selector.String(), err.Error()))
-	}
-
-	if len(nodeList) == 0 {
-		return werror.NewInvalidError("VM requests CPU pinning, but no node with activated CPU Manager was found",
-			"spec.template.spec.domain.cpu.dedicatedCpuPlacement")
-	}
-
-	return nil
 }

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -13,8 +12,6 @@ import (
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
-
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
@@ -653,178 +650,11 @@ func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
 	fakeVMCache := fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines)
 	fakeNadCache := fakeclients.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
 
-	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache, nil, nil).(*vmValidator)
+	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache, nil).(*vmValidator)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validator.checkForDuplicateMacAddrs(tc.vm)
-			if tc.expectError {
-				assert.NotNil(t, err, tc.name)
-			} else {
-				assert.Nil(t, err, tc.name)
-			}
-		})
-	}
-}
-
-func Test_virtualMachineValidator_dedicatedCPUPlacement(t *testing.T) {
-	vm0 := &kubevirtv1.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vm-0",
-			Namespace: "default",
-		},
-		Spec: kubevirtv1.VirtualMachineSpec{
-			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: kubevirtv1.VirtualMachineInstanceSpec{
-					Domain: kubevirtv1.DomainSpec{
-						CPU: &kubevirtv1.CPU{
-							DedicatedCPUPlacement: true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	vm1 := &kubevirtv1.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vm-1",
-			Namespace: "default",
-		},
-		Spec: kubevirtv1.VirtualMachineSpec{
-			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: kubevirtv1.VirtualMachineInstanceSpec{
-					Domain: kubevirtv1.DomainSpec{},
-				},
-			},
-		},
-	}
-
-	vm2 := &kubevirtv1.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vm-2",
-			Namespace: "default",
-		},
-		Spec: kubevirtv1.VirtualMachineSpec{
-			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: kubevirtv1.VirtualMachineInstanceSpec{
-					Domain: kubevirtv1.DomainSpec{
-						CPU: &kubevirtv1.CPU{
-							DedicatedCPUPlacement: false,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	vm3 := &kubevirtv1.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vm-3",
-			Namespace: "default",
-		},
-		Spec: kubevirtv1.VirtualMachineSpec{
-			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: kubevirtv1.VirtualMachineInstanceSpec{
-					Domain: kubevirtv1.DomainSpec{
-						CPU: &kubevirtv1.CPU{
-							DedicatedCPUPlacement: true,
-						},
-					},
-				},
-			},
-		},
-		Status: kubevirtv1.VirtualMachineStatus{
-			PrintableStatus: kubevirtv1.VirtualMachineStatusStopped,
-		},
-	}
-
-	node0 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node-0",
-			Labels: map[string]string{
-				kubevirtv1.CPUManager: "true",
-			},
-		},
-	}
-
-	node1 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node-1",
-			Labels: map[string]string{
-				kubevirtv1.CPUManager: "false",
-			},
-		},
-	}
-
-	node2 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node-2",
-		},
-	}
-
-	tests := []struct {
-		name        string
-		vm          *kubevirtv1.VirtualMachine
-		nodes       []*corev1.Node
-		expectError bool
-	}{
-		{
-			name:        "CPU pinning enabled, w/o CPU Manager enabled, VM stopped, returns success",
-			vm:          vm3,
-			nodes:       []*corev1.Node{node1, node2},
-			expectError: false,
-		},
-		{
-			name:        "CPU pinning enabled, one CPU Manager enabled, returns success",
-			vm:          vm0,
-			nodes:       []*corev1.Node{node0, node1},
-			expectError: false,
-		},
-		{
-			name:        "CPU pinning enabled, w/o CPU Manager enabled, returns error [1]",
-			vm:          vm0,
-			nodes:       []*corev1.Node{node1, node2},
-			expectError: true,
-		},
-		{
-			name:        "CPU pinning enabled, w/o CPU Manager enabled, returns error [2]",
-			vm:          vm0,
-			nodes:       []*corev1.Node{node2},
-			expectError: true,
-		},
-		{
-			name:        "CPU pinning disabled, one CPU Manager enabled, returns success",
-			vm:          vm1,
-			nodes:       []*corev1.Node{node0},
-			expectError: false,
-		},
-		{
-			name:        "CPU pinning disabled, w/o CPU Manager enabled, returns success",
-			vm:          vm2,
-			nodes:       []*corev1.Node{node1, node2},
-			expectError: false,
-		},
-	}
-
-	for _, tc := range tests {
-		k8sclientset := k8sfake.NewSimpleClientset()
-
-		fakeNodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
-
-		for _, node := range tc.nodes {
-			err := k8sclientset.Tracker().Add(node)
-			assert.Nil(t, err, "mock resource should add into k8s fake controller tracker")
-		}
-
-		validator := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fakeNodeCache).(*vmValidator)
-
-		t.Run(tc.name, func(t *testing.T) {
-			err := validator.checkDedicatedCPUPlacement(tc.vm)
 			if tc.expectError {
 				assert.NotNil(t, err, tc.name)
 			} else {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -71,8 +71,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 			clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache(),
-			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
-			clients.CoreFactory.Core().V1().Node().Cache()),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		virtualmachineimage.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
 			clients.Core.Pod().Cache(),


### PR DESCRIPTION
#### Problem:
Can't add volume, delete and backup vm when vm enabled cpu pinning while cpu manager is disabled.

#### Solution:

revert https://github.com/harvester/harvester/commit/079cee711f0d3e91966cd4e97039920e346a6c4c

see https://github.com/harvester/harvester/pull/8800#issuecomment-3164167868 and https://github.com/harvester/harvester/pull/8800#issuecomment-3166406230

#### Related Issue(s):

#8778

#### Test plan:
- Enable CPU Manager in one node (e.g. harvester-node-0)
- Create a VM `test`
- Click Edit Config, enable CPU Pinning **WITHOUT** restart the VM.
- Disable CPU Manager in `harvester-node-0`
- Test add volume, delete and backup vm `test`, all operation should be successful.

#### Additional documentation or context
N/A