### PR TITLE
feat: move backup util to pkg/util/backup

### DIFF
--- a/pkg/api/backuptarget/healthy_handler.go
+++ b/pkg/api/backuptarget/healthy_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
 type HealthyHandler struct {
@@ -53,7 +54,7 @@ func (h *HealthyHandler) ServeHTTP(rw http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	_, err = util.GetBackupStoreDriver(h.secretCache, target)
+	_, err = backuputil.GetBackupStoreDriver(h.secretCache, target)
 	if err != nil {
 		util.ResponseError(rw, http.StatusServiceUnavailable, fmt.Errorf("can't connect to backup target %+v, error: %w", target, err))
 		return

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -42,6 +42,7 @@ import (
 	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
 const (
@@ -208,7 +209,7 @@ func (h *Handler) OnBackupRemove(_ string, vmBackup *harvesterv1.VirtualMachineB
 	// when we delete VM Backup and its backup target is not same as current backup target,
 	// VolumeSnapshot and VolumeSnapshotContent may not be deleted immediately.
 	// We should force delete them to avoid that users re-config backup target back and associated LH Backup may be deleted.
-	if !util.IsBackupTargetSame(vmBackup.Status.BackupTarget, target) {
+	if !backuputil.IsBackupTargetSame(vmBackup.Status.BackupTarget, target) {
 		if err := h.forceDeleteVolumeSnapshotAndContent(vmBackup.Namespace, vmBackup.Status.VolumeBackups); err != nil {
 			return nil, err
 		}
@@ -819,11 +820,11 @@ func (h *Handler) deleteVMBackupMetadata(vmBackup *harvesterv1.VirtualMachineBac
 		return nil
 	}
 
-	if !util.IsBackupTargetSame(vmBackup.Status.BackupTarget, target) {
+	if !backuputil.IsBackupTargetSame(vmBackup.Status.BackupTarget, target) {
 		return nil
 	}
 
-	bsDriver, err := util.GetBackupStoreDriver(h.secretCache, target)
+	bsDriver, err := backuputil.GetBackupStoreDriver(h.secretCache, target)
 	if err != nil {
 		return err
 	}
@@ -854,11 +855,11 @@ func (h *Handler) uploadVMBackupMetadata(vmBackup *harvesterv1.VirtualMachineBac
 		return nil
 	}
 
-	if !util.IsBackupTargetSame(vmBackup.Status.BackupTarget, target) {
+	if !backuputil.IsBackupTargetSame(vmBackup.Status.BackupTarget, target) {
 		return nil
 	}
 
-	bsDriver, err := util.GetBackupStoreDriver(h.secretCache, target)
+	bsDriver, err := backuputil.GetBackupStoreDriver(h.secretCache, target)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/master/backup/backup_backing_image.go
+++ b/pkg/controller/master/backup/backup_backing_image.go
@@ -24,6 +24,7 @@ import (
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
 const (
@@ -106,7 +107,7 @@ func (h *backupBackingImageHandler) OnBackupBackingImageChange(_ string, backupB
 		return nil, nil
 	}
 
-	bsDriver, err := util.GetBackupStoreDriver(h.secretCache, target)
+	bsDriver, err := backuputil.GetBackupStoreDriver(h.secretCache, target)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +131,7 @@ func (h *backupBackingImageHandler) OnBackupBackingImageChange(_ string, backupB
 	}
 
 	shouldUpload := true
-	destPath := util.GetVMImageMetadataFilePath(vmImage.Namespace, vmImage.Name)
+	destPath := backuputil.GetVMImageMetadataFilePath(vmImage.Namespace, vmImage.Name)
 	if bsDriver.FileExists(destPath) {
 		if remoteVMImageMetadata, err := loadVMImageMetadataInBackupTarget(destPath, bsDriver); err != nil {
 			return nil, err

--- a/pkg/controller/master/backup/backup_metadata.go
+++ b/pkg/controller/master/backup/backup_metadata.go
@@ -33,6 +33,7 @@ import (
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
 const (
@@ -232,23 +233,23 @@ func (h *MetadataHandler) renewBackupTarget(setting *harvesterv1.Setting) (*harv
 }
 
 func (h *MetadataHandler) syncVMImage(target *settings.BackupTarget) error {
-	bsDriver, err := util.GetBackupStoreDriver(h.secretCache, target)
+	bsDriver, err := backuputil.GetBackupStoreDriver(h.secretCache, target)
 	if err != nil {
 		return err
 	}
 
-	namespaceFolders, err := bsDriver.List(filepath.Join(util.VMImageMetadataFolderPath))
+	namespaceFolders, err := bsDriver.List(filepath.Join(backuputil.VMImageMetadataFolderPath))
 	if err != nil {
 		return err
 	}
 
 	for _, namespaceFolder := range namespaceFolders {
-		fileNames, err := bsDriver.List(filepath.Join(util.VMImageMetadataFolderPath, namespaceFolder))
+		fileNames, err := bsDriver.List(filepath.Join(backuputil.VMImageMetadataFolderPath, namespaceFolder))
 		if err != nil {
 			return err
 		}
 		for _, fileName := range fileNames {
-			imageMetadata, err := loadVMImageMetadataInBackupTarget(filepath.Join(util.VMImageMetadataFolderPath, namespaceFolder, fileName), bsDriver)
+			imageMetadata, err := loadVMImageMetadataInBackupTarget(filepath.Join(backuputil.VMImageMetadataFolderPath, namespaceFolder, fileName), bsDriver)
 			if err != nil {
 				return err
 			}
@@ -364,7 +365,7 @@ func (h *MetadataHandler) createVMImageIfNotExist(imageMetadata VirtualMachineIm
 }
 
 func (h *MetadataHandler) syncVMBackup(target *settings.BackupTarget) error {
-	bsDriver, err := util.GetBackupStoreDriver(h.secretCache, target)
+	bsDriver, err := backuputil.GetBackupStoreDriver(h.secretCache, target)
 	if err != nil {
 		return err
 	}
@@ -532,7 +533,7 @@ func (h *MetadataHandler) checkDependentLonghornBackupExist(target *settings.Bac
 
 		volumeName := vb.PersistentVolumeClaim.Spec.VolumeName
 		// check whether data is in the backup target
-		volumes, err := backupstore.List(volumeName, util.ConstructEndpoint(target), false)
+		volumes, err := backupstore.List(volumeName, backuputil.ConstructEndpoint(target), false)
 		if err != nil || volumes[volumeName] == nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"namespace": backupMetadata.Namespace,

--- a/pkg/controller/master/backup/backup_target.go
+++ b/pkg/controller/master/backup/backup_target.go
@@ -23,6 +23,7 @@ import (
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
 const (
@@ -171,7 +172,7 @@ func (h *TargetHandler) updateLonghornTarget(backupTarget *settings.BackupTarget
 	}
 
 	lhBackupTargetCpy := lhBackupTarget.DeepCopy()
-	lhBackupTargetCpy.Spec.BackupTargetURL = util.ConstructEndpoint(backupTarget)
+	lhBackupTargetCpy.Spec.BackupTargetURL = backuputil.ConstructEndpoint(backupTarget)
 
 	if reflect.DeepEqual(lhBackupTarget, lhBackupTargetCpy) {
 		return nil

--- a/pkg/controller/master/backup/util.go
+++ b/pkg/controller/master/backup/util.go
@@ -25,6 +25,7 @@ import (
 	ctllonghornv2 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
 const (
@@ -314,7 +315,7 @@ func checkStorageClass(storageClassCache ctlstoragev1.StorageClassCache, name st
 
 func checkVolumeInBackupTarget(vmBackup *harvesterv1.VirtualMachineBackup, volumeBackup *harvesterv1.VolumeBackup, target *settings.BackupTarget) (string, error) {
 	volumeName := volumeBackup.PersistentVolumeClaim.Spec.VolumeName
-	volumes, err := backupstore.List(volumeName, util.ConstructEndpoint(target), false)
+	volumes, err := backupstore.List(volumeName, backuputil.ConstructEndpoint(target), false)
 	if err != nil {
 		// The backup target may be offline. In this case, we don't want to trigger reconciliation.
 		return err.Error(), nil

--- a/pkg/image/backingimage/backingimage.go
+++ b/pkg/image/backingimage/backingimage.go
@@ -26,6 +26,7 @@ import (
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 )
 
 const (
@@ -288,7 +289,7 @@ func (bib *Backend) deleteVMImageMetadata(vmi *harvesterv1.VirtualMachineImage) 
 		return nil
 	}
 
-	if !util.IsBackupTargetSame(vmi.Status.BackupTarget, target) {
+	if !backuputil.IsBackupTargetSame(vmi.Status.BackupTarget, target) {
 		logrus.WithFields(logrus.Fields{
 			"namespace":            vmio.GetNamespace(vmi),
 			"name":                 vmio.GetName(vmi),
@@ -298,12 +299,12 @@ func (bib *Backend) deleteVMImageMetadata(vmi *harvesterv1.VirtualMachineImage) 
 		return nil
 	}
 
-	bsDriver, err := util.GetBackupStoreDriver(bib.secretCache, target)
+	bsDriver, err := backuputil.GetBackupStoreDriver(bib.secretCache, target)
 	if err != nil {
 		return err
 	}
 
-	destURL := util.GetVMImageMetadataFilePath(vmio.GetNamespace(vmi), vmio.GetName(vmi))
+	destURL := backuputil.GetVMImageMetadataFilePath(vmio.GetNamespace(vmi), vmio.GetName(vmi))
 	if exist := bsDriver.FileExists(destURL); exist {
 		logrus.WithFields(logrus.Fields{
 			"namespace":    vmio.GetNamespace(vmi),

--- a/pkg/util/backup/backup.go
+++ b/pkg/util/backup/backup.go
@@ -1,4 +1,4 @@
-package util
+package backup
 
 import (
 	"fmt"
@@ -11,6 +11,7 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 const (
@@ -31,14 +32,14 @@ func ConstructEndpoint(target *settings.BackupTarget) string {
 
 func GetBackupStoreDriver(secretCache ctlcorev1.SecretCache, target *settings.BackupTarget) (backupstore.BackupStoreDriver, error) {
 	if target.Type == settings.S3BackupType {
-		secret, err := secretCache.Get(LonghornSystemNamespaceName, BackupTargetSecretName)
+		secret, err := secretCache.Get(util.LonghornSystemNamespaceName, util.BackupTargetSecretName)
 		if err != nil {
 			return nil, err
 		}
-		os.Setenv(AWSAccessKey, string(secret.Data[AWSAccessKey]))
-		os.Setenv(AWSSecretKey, string(secret.Data[AWSSecretKey]))
-		os.Setenv(AWSEndpoints, string(secret.Data[AWSEndpoints]))
-		os.Setenv(AWSCERT, string(secret.Data[AWSCERT]))
+		os.Setenv(util.AWSAccessKey, string(secret.Data[util.AWSAccessKey]))
+		os.Setenv(util.AWSSecretKey, string(secret.Data[util.AWSSecretKey]))
+		os.Setenv(util.AWSEndpoints, string(secret.Data[util.AWSEndpoints]))
+		os.Setenv(util.AWSCERT, string(secret.Data[util.AWSCERT]))
 	}
 
 	endpoint := ConstructEndpoint(target)

--- a/pkg/webhook/resources/schedulevmbackup/validator.go
+++ b/pkg/webhook/resources/schedulevmbackup/validator.go
@@ -14,6 +14,7 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/indexeres"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -82,7 +83,7 @@ func (v *scheuldeVMBackupValidator) checkTargetHealth() error {
 		return fmt.Errorf("setting %s is not set", settings.BackupTargetSettingName)
 	}
 
-	if _, err := util.GetBackupStoreDriver(v.secretCache, target); err != nil {
+	if _, err := backuputil.GetBackupStoreDriver(v.secretCache, target); err != nil {
 		return err
 	}
 

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -52,6 +52,7 @@ import (
 	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 	networkutil "github.com/harvester/harvester/pkg/util/network"
 	tlsutil "github.com/harvester/harvester/pkg/util/tls"
 	vmUtil "github.com/harvester/harvester/pkg/util/virtualmachine"
@@ -569,7 +570,7 @@ func (v *settingValidator) validateBackupTarget(setting *v1beta1.Setting) error 
 	// GetBackupStoreDriver tests whether the driver can List objects, so we don't need to do it again here.
 	// S3: https://github.com/longhorn/backupstore/blob/56ddc538b85950b02c37432e4854e74f2647ca61/s3/s3.go#L38-L87
 	// NFS: https://github.com/longhorn/backupstore/blob/56ddc538b85950b02c37432e4854e74f2647ca61/nfs/nfs.go#L46-L81
-	endpoint := util.ConstructEndpoint(target)
+	endpoint := backuputil.ConstructEndpoint(target)
 	if _, err := backupstore.GetBackupStoreDriver(endpoint); err != nil {
 		return werror.NewInvalidError(err.Error(), settings.KeywordValue)
 	}

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	backuputil "github.com/harvester/harvester/pkg/util/backup"
 	"github.com/harvester/harvester/pkg/util/resourcequota"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/indexeres"
@@ -327,7 +328,7 @@ func (v *restoreValidator) checkBackupTarget(vmBackup *v1beta1.VirtualMachineBac
 		return fmt.Errorf("backup target is not set")
 	}
 
-	if !util.IsBackupTargetSame(vmBackup.Status.BackupTarget, backupTarget) {
+	if !backuputil.IsBackupTargetSame(vmBackup.Status.BackupTarget, backupTarget) {
 		return fmt.Errorf("backup target %+v is not matched in vmBackup %s/%s", backupTarget, vmBackup.Namespace, vmBackup.Name)
 	}
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
When releasing terraform-harvester-provider v1.6.0, it failed to build darwin binary.
https://github.com/harvester/terraform-provider-harvester/actions/runs/16897490805/job/47870256530

The reason is longhorn/backupstore doesn't support darwin. We didn't have this issue. The related dependence is because we moved some functions to pkg/util.
https://github.com/harvester/harvester/commit/79e4a6ad5c73c5e015c8e646a85856cf1fd93c12

The dependence path is like:
```
> go mod why -m github.com/longhorn/backupstore
# github.com/longhorn/backupstore
github.com/harvester/terraform-provider-harvester/internal/provider/image
github.com/harvester/harvester/pkg/util
github.com/longhorn/backupstore
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Move bakup utility functions to `pkg/util/backup`.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
