### PR TITLE
fix: clone harvesterhci.io/enableCPUAndMemoryHotplug annotation

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -61,6 +61,7 @@ const (
 var (
 	cloneVMAnnotationKeys = []string{
 		util.AnnotationReservedMemory,
+		util.AnnotationEnableCPUAndMemoryHotplug,
 	}
 )
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
We didn't clone `harvesterhci.io/enableCPUAndMemoryHotplug` to the new VM, so mutator uses `resources.limits.memory` as VM memory.

#### Solution:
Clone `harvesterhci.io/enableCPUAndMemoryHotplug` annotation.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8890

#### Test plan:
1. Create a new vm
2. Enable the CPU and memory hotplug option
3. Set the maximum cpu and memory value 
4. Clone the vm to a new one
5. Check the CPU, memory value of the cloned vm

#### Additional documentation or context
