### PR TITLE
add networking binding configuration for managedtap

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -91,6 +91,10 @@ kubevirt:
         ## and then the user can focus on the above "defaultNetworkInterface".
         ##
         permitBridgeInterfaceOnPodNetwork: true
+        ## enable managedTap binding so allow vxlan based VM's to get DHCP correctly
+        binding:
+          managedtap:
+            domainAttachmentType: managedTap
 
     customizeComponents:
       patches:


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
DHCP configuration is incomplete / fails when using overlay networks
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
This can be addressed by editing the VM interface to use `managedtap` binding

To use this the kubevirt configuration needs to contain network binding settings for type `managedTap`.

The PR addresses by adding it to the kubevirt configuration. 

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8847

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
