### PR TITLE
feat: add kubevirt-migration setting

### DIFF
--- a/pkg/controller/master/setting/kubevirt_migration.go
+++ b/pkg/controller/master/setting/kubevirt_migration.go
@@ -1,0 +1,54 @@
+package setting
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func (h *Handler) syncKubeVirtMigration(setting *harvesterv1.Setting) error {
+	var value string
+	if setting.Value != "" {
+		value = setting.Value
+	} else {
+		value = setting.Default
+	}
+
+	var err error
+	migrationConfiguration := &kubevirtv1.MigrationConfiguration{}
+
+	if value != "" {
+		err = json.Unmarshal([]byte(value), migrationConfiguration)
+		if err != nil {
+			return fmt.Errorf("invalid value: `%s`: %w", value, err)
+		}
+	}
+
+	kubevirt, err := h.kubeVirtConfigCache.Get(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)
+	if err != nil {
+		return fmt.Errorf("failed to get kubevirt object %v/%v %w", util.HarvesterSystemNamespaceName, util.KubeVirtObjectName, err)
+	}
+
+	kubevirtCpy := kubevirt.DeepCopy()
+	if kubevirtCpy.Spec.Configuration.MigrationConfiguration == nil {
+		kubevirtCpy.Spec.Configuration.MigrationConfiguration = &kubevirtv1.MigrationConfiguration{}
+	}
+	// ignore nodeDrainTaintKey and network field
+	// The default nodeDrainTaintKey is "kubevirt.io/drain" and it's used in upgrade script.
+	// The network field is handled by "vm-migration-network" setting.
+	migrationConfiguration.NodeDrainTaintKey = nil
+	migrationConfiguration.Network = kubevirtCpy.Spec.Configuration.MigrationConfiguration.Network
+
+	if !reflect.DeepEqual(kubevirtCpy.Spec.Configuration.MigrationConfiguration, migrationConfiguration) {
+		kubevirtCpy.Spec.Configuration.MigrationConfiguration = migrationConfiguration
+		if _, err := h.kubeVirtConfig.Update(kubevirtCpy); err != nil {
+			return fmt.Errorf("failed to update KubeVirt migration configuration, err: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -91,6 +91,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName: controller.syncKubeconfigTTL,
 		harvSettings.AdditionalGuestMemoryOverheadRatioName:      controller.syncAdditionalGuestMemoryOverheadRatio,
 		harvSettings.MaxHotplugRatioSettingName:                  controller.syncMaxHotplugRatio,
+		harvSettings.KubeVirtMigrationSettingName:                controller.syncKubeVirtMigration,
 		// for "backup-target" syncer, please check harvester-backup-target-controller
 		// for "storage-network" syncer, please check harvester-storage-network-controller
 		// for "vm-migration-network" syncer, please check harvester-vm-migration-network-controller

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -62,6 +62,7 @@ var (
 	UpgradeConfigSet       = NewSetting(UpgradeConfigSettingName, `{"imagePreloadOption":{"strategy":{"type":"sequential"}}, "restoreVM": false, "logReadyTimeout": "5"}`)
 	MaxHotplugRatio        = NewSetting(MaxHotplugRatioSettingName, "4")
 	VMMigrationNetwork     = NewSetting(VMMigrationNetworkSettingName, "")
+	KubeVirtMigration      = NewSetting(KubeVirtMigrationSettingName, `{"parallelOutboundMigrationsPerNode":2,"parallelMigrationsPerCluster":5,"allowAutoConverge":false,"bandwidthPerMigration":0,"completionTimeoutPerGiB":150,"progressTimeout":150,"unsafeMigrationOverride":false,"allowPostCopy":false,"allowWorkloadDisruption":false,"disableTLS":false,"matchSELinuxLevelOnMigration":false}`)
 )
 
 const (
@@ -111,6 +112,7 @@ const (
 	MaxHotplugRatioSettingName                        = "max-hotplug-ratio"
 	VMMigrationNetworkSettingName                     = "vm-migration-network"
 	RancherClusterSettingName                         = "rancher-cluster"
+	KubeVirtMigrationSettingName                      = "kubevirt-migration"
 
 	// settings have `default` and `value` string used in many places, replace them with const
 	KeywordDefault = "default"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

Use "kubevirt-migration" configuration to config `migrationConfiguration` in KubeVirt.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8581

#### Test plan:

Case 1: Use kubevirt-migration setting to update following fields
* parallelOutboundMigrationsPerNode
* parallelMigrationsPerCluster
* allowAutoConverge
* bandwidthPerMigration
* completionTimeoutPerGiB
* progressTimeout
* unsafeMigrationOverride
* allowPostCopy
* allowWorkloadDisruption
* disableTLS
* matchSELinuxLevelOnMigration

Case 2: Use kubevirt-migration setting to update following fields and will get webhook error
* nodeDrainTaintKey
* network

#### Additional documentation or context
