### PR TITLE
minor change to fix check for external storage in the upgrade path

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -650,7 +650,7 @@ EOF
   GRUBENV_FILE="/oem/grubcustom"
   chroot $HOST_DIR /bin/bash -c "if ! [ -f ${GRUBENV_FILE} ]; then touch ${GRUBENV_FILE}; fi"
 
-  multiPathEnabled=$(yq '.os.externalStorageConfig.enabled // false' ${HOST_DIR}/oem/harvester.config)
+  multiPathEnabled=$(yq '.os.externalstorage.enabled // false' ${HOST_DIR}/oem/harvester.config)
   if [ ${multiPathEnabled} == false ]
   then
     thirdPartyArgs=$(chroot $HOST_DIR grub2-editenv /oem/grubenv list |grep third_party_kernel_args | awk -F"third_party_kernel_args=" '{print $2}')


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
`upgrade_node.sh` script checks existing harvester.config to verify if `externalStorageConfig` is enabled and if not, it patches `multipath` kernel arguments. This has been done in the past to allow us to migrate from various multipath disabling options when external storage support is not needed.

We are using `gopkg.in/yaml.v3` to marshal the configuration to yaml, which results in the following field

https://github.com/harvester/harvester-installer/blob/master/pkg/config/config.go#L213

Being encoded as follows in the saved `harvester.config`

```
os:
    externalstorage:
        enabled: true
```

This results in the field being `os.externalstorage.enabled` and not `os.externalStorageConfig.enabled`

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR fixes the check in the upgrade script to ensure field is accessed correctly, there by avoiding setting `multipath=off` when external storage is in use.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8689

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
