### PR TITLE
Remove unused legacy upgrade code

### DIFF
--- a/package/upgrade/lib.sh
+++ b/package/upgrade/lib.sh
@@ -295,19 +295,6 @@ lower_version_check()
   fi
 }
 
-shutdown_all_vms()
-{
-  kubectl get vmi -A -o json |
-    jq -r '.items[] | [.metadata.name, .metadata.namespace] | @tsv' |
-    while IFS=$'\t' read -r name namespace; do
-      if [ -z "$name" ]; then
-        break
-      fi
-      echo "Stop ${namespace}/${name}"
-      virtctl stop $name -n $namespace
-    done
-}
-
 wait_for_fleet_bundles()
 {
   # wait for the changes to be applied to bundle object first


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Some legacy codes are out-dated.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**This PR targets for v170**, in v1.6.x->v1.7.0 upgrade path, those unused legacy code (esp. they are called on specific previous version like v1.0.3, v1.5.x) will get removed.


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8938

#### Test plan:
<!-- Describe the test plan by steps. -->
1. Install v160 cluster
2. Upgrade to master-head, it should not block


#### Additional documentation or context


note: Harvester upgrade is controlled in defined paths, e.g. v1.3.x->v1.4.x->v1.5.x->v1.6.x->v1.7.x, you can't ugprade from v1.4.x to v1.7.x directly.