### PR TITLE
Add webhook which reject storage class name change

### DIFF
--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -799,6 +799,26 @@ func TestVmValidator_Update(t *testing.T) {
 			newSpec:       nil,
 			expectedError: false,
 		},
+		{
+			name:  "nil storage class name is handled properly",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0"` +
+						`,"annotations":{"harvesterhci.io/imageId":"default/image"}},"spec":{"accessModes"` +
+						`:["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":` +
+						`"Block"}},{"metadata":{"name":"test-disk-1",` +
+						`"annotations":{"harvesterhci.io/imageId":"default/image"}},"spec":{"accessModes":` +
+						`["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":` +
+						`"Block"}}]`,
+				},
+			},
+			newSpec:       nil,
+			expectedError: false,
+		},
 	}
 
 	corefakeclientset := corefake.NewClientset()
@@ -811,6 +831,9 @@ func TestVmValidator_Update(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.oldObjMeta != nil {
+				test.oldVM.ObjectMeta = *test.oldObjMeta
+			}
 			if test.newObjMeta != nil {
 				test.newVM.ObjectMeta = *test.newObjMeta
 			}

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	corefake "k8s.io/client-go/kubernetes/fake"
 
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -659,6 +662,167 @@ func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
 				assert.NotNil(t, err, tc.name)
 			} else {
 				assert.Nil(t, err, tc.name)
+			}
+		})
+	}
+}
+
+func TestVmValidator_Update(t *testing.T) {
+	templateVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0",` +
+					`"annotations":{"harvesterhci.io/imageId":"default/image"}},` +
+					`"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}}` +
+					`,"volumeMode":"Block","storageClassName":"longhorn-image"}}]`,
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "nic-1",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/vlan-1",
+								},
+							},
+						},
+					},
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name:       "nic-1",
+									MacAddress: "00:00:00:00:00:01",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		oldVM         *kubevirtv1.VirtualMachine
+		newVM         *kubevirtv1.VirtualMachine
+		oldObjMeta    *metav1.ObjectMeta
+		newObjMeta    *metav1.ObjectMeta
+		newSpec       *kubevirtv1.VirtualMachineSpec
+		expectedError bool
+	}{
+		{
+			name:  "storage class name is changed which results in rejection",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0",` +
+						`"annotations":{"harvesterhci.io/imageId":"default/image"}},` +
+						`"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}}` +
+						`,"volumeMode":"Block","storageClassName":"longhorn"}}]`,
+				},
+			},
+			newSpec:       nil,
+			expectedError: true,
+		},
+		{
+			name:  "annotation removed resulting in success",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+			},
+			newSpec:       nil,
+			expectedError: false,
+		},
+		{
+			name:  "annotation added resulting in success",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0"` +
+						`,"annotations":{"harvesterhci.io/imageId":"default/image"}},"spec":{"accessModes"` +
+						`:["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":` +
+						`"Block","storageClassName":"longhorn-image"}},{"metadata":{"name":"test-disk-1",` +
+						`"annotations":{"harvesterhci.io/imageId":"default/image"}},"spec":{"accessModes":` +
+						`["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":` +
+						`"Block","storageClassName":"longhorn"}}]`,
+				},
+			},
+			newSpec:       nil,
+			expectedError: false,
+		},
+		{
+			name:  "annotations with bad json are rejected",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"]`,
+				},
+			},
+			newSpec:       nil,
+			expectedError: true,
+		},
+		{
+			name:  "empty annotation is allowed on both objects",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			oldObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": "",
+				},
+			},
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": "",
+				},
+			},
+			newSpec:       nil,
+			expectedError: false,
+		},
+	}
+
+	corefakeclientset := corefake.NewClientset()
+	err := corefakeclientset.Tracker().Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: templateVM.Namespace,
+	}})
+	assert.NoError(t, err)
+	fakeNSCache := fakeclients.NamespaceCache(corefakeclientset.CoreV1().Namespaces)
+	validator := NewValidator(fakeNSCache, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*vmValidator)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.newObjMeta != nil {
+				test.newVM.ObjectMeta = *test.newObjMeta
+			}
+			if test.newSpec != nil {
+				test.newVM.Spec = *test.newSpec
+			}
+			err := validator.Update(nil, test.oldVM, test.newVM)
+
+			if test.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
Adding webhook which rejects storage class name changes as part of the `harvesterhci.io/volumeClaimTemplates` annotation.

Creating, deleting and adding to the annotaion is allowed, but changing the storage class name itself is rejected. Also setting empty storage class name is allowed as well - following the omitempty flag of the field in the object.

#### Problem:
Changes to the volume's storage class is rejected through UI, but allowed through API - direct edits of the raw yaml.

#### Solution:
Introduce webhook which will detect such changes to already existing attached volumes and reject changes to the storage class name.

#### Related Issue(s):
Issue #8772

#### Test plan:
1. Build iso with the change
2. Create local harvester with the iso (single node)
3. Create storage class - `default-sc` with replication 1 and set it as default storage class
4. Create VM
5. Create volume and attach it as additional volume to the VM
6. Try to edit the original attached volume through kubectl and UI the value of key `storageClassName` - expect rejection (need to scroll a little):
```
    harvesterhci.io/volumeClaimTemplates: >-
      [{"metadata":{"name":"test-disk-0-kgsuo","creationTimestamp":null,"annotations":{"harvesterhci.io/imageId":"default/image-wd7kd"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"storageClassName":"default-sc","volumeMode":"Block"},"status":{}},{"metadata":{"name":"testtest","creationTimestamp":null},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"storageClassName":"default-sc","volumeMode":"Block"},"status":{}}]
                                                                                                                                                                                                                                                                                                                                                                                                                                              ### from this here ###########
```
             
to (need to scroll a little):
```
    harvesterhci.io/volumeClaimTemplates: >-
      [{"metadata":{"name":"test-disk-0-kgsuo","creationTimestamp":null,"annotations":{"harvesterhci.io/imageId":"default/image-wd7kd"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"storageClassName":"default-sc","volumeMode":"Block"},"status":{}},{"metadata":{"name":"testtest","creationTimestamp":null},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"storageClassName":"longhorn","volumeMode":"Block"},"status":{}}]
                                                                                                                                                                                                                                                                                                                                                                                                                                              ### to this here ###########
```
7. Try to edit the additional attached volume as above

#### Additional documentation or context
Initially logic was not triggered because of [this check](https://github.com/harvester/harvester/blob/abce991f78d6c4020cf2dff6f72c660d7124e098/pkg/webhook/resources/virtualmachine/validator.go#L268) always returning nil:
```
	if oldVM.Spec.Template != nil && newVM.Spec.Template != nil && reflect.DeepEqual(oldVM.Spec.Template.Spec.Domain.Devices.Interfaces, newVM.Spec.Template.Spec.Domain.Devices.Interfaces) {
		return nil
	}
```
Added a comment above it so all new validation should come before the comment and the check.