### PR TITLE
[Enhancement] Better handling of failed maintenance mode

### DIFF
--- a/pkg/util/drainhelper/helper_test.go
+++ b/pkg/util/drainhelper/helper_test.go
@@ -99,7 +99,9 @@ func Test_failsControlPlaneRequirementsHA(t *testing.T) {
 	assert.NoError(err, "expected no error while updating cpNode1")
 
 	err = DrainPossible(nodeCache, cpNode2)
+	assert.Error(err, "expected error while trying to place cpNode2 in maintenance mode")
 	assert.True(errors.Is(err, errHAControlPlaneNode), "expected error while checking cpNode2")
+	assert.True(errors.Is(err, ErrNodeDrainNotPossible), "expected error ErrNodeDrainNotPossible")
 }
 
 func Test_failsControlPlaneRequirementsSingleNode(t *testing.T) {
@@ -113,6 +115,7 @@ func Test_failsControlPlaneRequirementsSingleNode(t *testing.T) {
 	err := DrainPossible(nodeCache, cpNode1)
 	assert.Error(err, "expected error while trying to place cpNode1 in maintenance mode")
 	assert.True(errors.Is(err, errSingleControlPlaneNode), "expected error singleControlPlaneNodeError")
+	assert.True(errors.Is(err, ErrNodeDrainNotPossible), "expected error ErrNodeDrainNotPossible")
 }
 
 func Test_meetsWorkerRequirement(t *testing.T) {


### PR DESCRIPTION
#### Problem:
- Annotations are not cleaned up correctly in case of an error.
- There is a useless if query which can be removed because it is candled some lines above.

#### Solution:
- Remove annotations in case draining the node is not possible.
- Remove `if` query and correctly indent code.
- Additionally several improvements are applied with this PR as well.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8985

#### Test plan:
##### Case 1 ####
- Setup a 3-node cluster.
- Set node `harvester-node-2` into maintenance mode.
- Use `Edit YAML` action menu on node `harvester-node-1`.
- Apply `harvesterhci.io/drain-requested: 'true'` in `metadata.annotations` and press `Save`.
- The node should not go into maintenance mode.
- In the logs of the `harvester` pod the following line should appear:
```
time="2025-09-02T10:04:14Z" level=info msg="Attempting to place node in maintenance mode" forced=false node_name=harvester-node-1
time="2025-09-02T10:04:14Z" level=warning msg="Draining is not possible: another controlplane is already in maintenance mode, cannot place current node in maintenance mode" node_name=harvester-node-1
```
- Use `Edit YAML` action menu on node `harvester-node-1` again.
- Make sure there is no `harvesterhci.io/drain-requested` or `harvesterhci.io/maintain-status` annotation.

#### Additional documentation or context
n/a