### PR TITLE
fix(webhook): pod mutator should also consider namespace

### DIFF
--- a/pkg/webhook/resources/pod/mutator.go
+++ b/pkg/webhook/resources/pod/mutator.go
@@ -18,18 +18,18 @@ import (
 )
 
 var matchingLabelsForNamespace = map[string][]labels.Set {
-	"longhorn-system": {
+	util.LonghornSystemNamespaceName: {
 		{
 			"longhorn.io/component": "backing-image-data-source",
 		},
 	},
-	"harvester-system": {
+	util.HarvesterSystemNamespaceName: {
 		{
 			"app.kubernetes.io/name":      "harvester",
 			"app.kubernetes.io/component": "apiserver",
 		},
 	},
-	"cattle-system": {
+	util.CattleSystemNamespaceName: {
 		{
 			"app": "rancher",
 		},

--- a/pkg/webhook/resources/pod/mutator.go
+++ b/pkg/webhook/resources/pod/mutator.go
@@ -235,15 +235,15 @@ func volumeMountPatch(target []corev1.VolumeMount, path string, volumeMount core
 }
 
 func shouldPatch(pod *corev1.Pod) bool {
+	matchingLabels, exists := matchingLabelsForNamespace[pod.Namespace]
+	if !exists {
+		return false
+	}
+
 	podLabels := labels.Set(pod.Labels)
-	for namespace, ls := range matchingLabelsForNamespace {
-		if pod.Namespace != namespace {
-			continue
-		}
-		for _, v := range ls {
-			if v.AsSelector().Matches(podLabels) {
-				return true
-			}
+	for _, ls := range matchingLabels {
+		if ls.AsSelector().Matches(podLabels) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
When a VM is created with the `app=rancher` instance label, it gets stuck indefinitely in the "Starting" phase. The root cause is that the corresponding pod fails to start due to a missing Kubernetes secret.

The pod's event logs show the following error:
```
failed for volume "additional-ca-volume" : secret "harvester-additional-ca" not found
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Limit the mutator to handle only system pods by making the pod filter check the namespace. It now only affects pods that are in the right namespace and have the right labels.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
#8962 

#### Test plan:
<!-- Describe the test plan by steps. -->
1. Go to Advanced > Settings set additional-ca ([reference](https://docs.harvesterhci.io/v1.5/advanced/index/#additional-ca))
2. Create a VM with one of the Instance Labels to be app = rancher
3. It should be created successfully and eventually at "Running" phase

#### Additional documentation or context
N/A
