### PR TITLE
[ENHANCEMENT] Make use of status conditions when activating maintenance mode

### DIFF
--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -71,7 +71,7 @@ func Formatter(request *types.APIRequest, resource *types.RawResource) {
 		return
 	}
 
-	if resource.APIObject.Data().String("metadata", "annotations", ctlnode.MaintainStatusAnnotationKey) != "" {
+	if resource.APIObject.Data().String("metadata", "annotations", util.MaintainStatusAnnotation) != "" {
 		resource.AddAction(request, disableMaintenanceModeAction)
 		resource.AddAction(request, powerAction)
 	} else {
@@ -206,9 +206,9 @@ func (h ActionHandler) enableMaintenanceMode(req *http.Request, node *corev1.Nod
 		if nodeObj.Annotations == nil {
 			nodeObj.Annotations = make(map[string]string)
 		}
-		nodeObj.Annotations[drainhelper.DrainAnnotation] = "true"
+		nodeObj.Annotations[util.DrainAnnotation] = "true"
 		if maintenanceInput.Force == "true" {
-			nodeObj.Annotations[drainhelper.ForcedDrain] = "true"
+			nodeObj.Annotations[util.ForcedDrainAnnotation] = "true"
 		}
 		_, err = h.nodeClient.Update(nodeObj)
 		return err
@@ -218,7 +218,7 @@ func (h ActionHandler) enableMaintenanceMode(req *http.Request, node *corev1.Nod
 type maintenanceModeUpdateFunc func(node *corev1.Node)
 
 func (h ActionHandler) disableMaintenanceMode(nodeName string) error {
-	disableMaintaenanceModeFunc := func(node *corev1.Node) {
+	disableMaintenanceModeFunc := func(node *corev1.Node) {
 		node.Spec.Unschedulable = false
 		for i, taint := range node.Spec.Taints {
 			if taint.Key == drainKey {
@@ -226,12 +226,10 @@ func (h ActionHandler) disableMaintenanceMode(nodeName string) error {
 				break
 			}
 		}
-		delete(node.Annotations, drainhelper.DrainAnnotation)
-		delete(node.Annotations, drainhelper.ForcedDrain)
-		delete(node.Annotations, ctlnode.MaintainStatusAnnotationKey)
+		util.RemoveMaintenanceModeAnnotations(node)
 	}
 
-	err := h.retryMaintenanceModeUpdate(nodeName, disableMaintaenanceModeFunc, "disable")
+	err := h.retryMaintenanceModeUpdate(nodeName, disableMaintenanceModeFunc, "disable")
 	if err != nil {
 		return err
 	}

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -43,7 +43,6 @@ import (
 	volumeapi "github.com/harvester/harvester/pkg/api/volume"
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/builder"
-	nodecontroller "github.com/harvester/harvester/pkg/controller/master/node"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
@@ -51,7 +50,6 @@ import (
 	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
-	"github.com/harvester/harvester/pkg/util/drainhelper"
 	"github.com/harvester/harvester/pkg/util/virtualmachine"
 	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
 )
@@ -716,10 +714,10 @@ func (h *vmActionHandler) findMigratableNodesByVMI(vmi *kubevirtv1.VirtualMachin
 }
 
 func isDrained(node *corev1.Node) bool {
-	if _, ok := node.Annotations[nodecontroller.MaintainStatusAnnotationKey]; ok {
+	if _, ok := node.Annotations[util.MaintainStatusAnnotation]; ok {
 		return ok
 	}
-	if _, ok := node.Annotations[drainhelper.DrainAnnotation]; ok {
+	if _, ok := node.Annotations[util.DrainAnnotation]; ok {
 		return ok
 	}
 	if node.Spec.Unschedulable {

--- a/pkg/controller/master/node/maintain_controller.go
+++ b/pkg/controller/master/node/maintain_controller.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -17,16 +18,17 @@ import (
 )
 
 const (
-	maintainNodeControllerName  = "maintain-node-controller"
-	MaintainStatusAnnotationKey = "harvesterhci.io/maintain-status"
-	MaintainStatusComplete      = "completed"
-	MaintainStatusRunning       = "running"
+	maintainNodeControllerName        = "maintain-node-controller"
+	maintainErrorRetentionTimeSeconds = 120
+	MaintainStatusAnnotationKey       = "harvesterhci.io/maintain-status"
+	MaintainStatusComplete            = "completed"
+	MaintainStatusRunning             = "running"
 )
 
-// maintainNodeHandler updates maintenance status of a node in its annotations, so that we can tell whether the node is
-// entering maintenance mode(migrating VMs on it) or in maintenance mode(VMs migrated).
+// maintainNodeHandler updates the maintenance status of a node in its annotations, so that we can tell whether the node is
+// entering maintenance mode (migrating VMs on it) or in maintenance mode(VMs migrated).
 type maintainNodeHandler struct {
-	nodes                       ctlcorev1.NodeClient
+	nodes                       ctlcorev1.NodeController
 	nodeCache                   ctlcorev1.NodeCache
 	virtualMachineClient        v1.VirtualMachineClient
 	virtualMachineCache         v1.VirtualMachineCache
@@ -57,7 +59,39 @@ func (h *maintainNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev
 	if node == nil || node.DeletionTimestamp != nil {
 		return node, nil
 	}
+
 	if maintenanceStatus, ok := node.Annotations[MaintainStatusAnnotationKey]; !ok || maintenanceStatus != MaintainStatusRunning {
+		// Make sure the maintenance mode status condition is cleaned up when
+		// there is no "harvesterhci.io/maintain-status" annotation (e.g., the
+		// maintenance mode has been disabled).
+
+		// If it is an error status condition, then reconcile again for a short
+		// period (~ 2 minute) so that there is some time to display the error
+		// on the `Hosts` page (Wrangler collects such status conditions and
+		// the UI displays them). If the status is older than the configured
+		// retention time, proceed with the cleanup.
+		condition := util.FindNodeStatusCondition(node.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+		if condition != nil && condition.Reason == util.NodeConditionReasonError {
+			retentionTime := time.Duration(maintainErrorRetentionTimeSeconds) * time.Second
+			if time.Since(condition.LastHeartbeatTime.Time) <= retentionTime {
+				h.nodes.EnqueueAfter(node.Name, 5*time.Second)
+				return node, nil
+			}
+		}
+
+		// Clean up the maintenance mode status condition if the annotation is
+		// not present; otherwise leave it as is.
+		if !ok {
+			nodeCopy := node.DeepCopy()
+			removed := util.RemoveNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode)
+			if removed {
+				if _, err := h.nodes.UpdateStatus(nodeCopy); err != nil {
+					return node, fmt.Errorf("failed to clean up %q condition: %w", util.NodeConditionTypeMaintenanceMode, err)
+				}
+				return nodeCopy, nil
+			}
+		}
+
 		return node, nil
 	}
 
@@ -70,48 +104,21 @@ func (h *maintainNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev
 		return node, nil
 	}
 
-	// Restart those VMs that have been labeled to be shut down before
-	// maintenance mode and that should be restarted when the node has
-	// successfully switched into maintenance mode.
-	selector := labels.Set{util.LabelMaintainModeStrategy: util.MaintainModeStrategyShutdownAndRestartAfterEnable}.AsSelector()
-	vmList, err := h.virtualMachineCache.List(node.Namespace, selector)
+	// Restart VMs that were shut down for maintenance and should be restarted.
+	if err = h.restartShutdownVMs(node); err != nil {
+		return node, err
+	}
+
+	nodeCopy := node.DeepCopy()
+	nodeCopy.Annotations[MaintainStatusAnnotationKey] = MaintainStatusComplete
+	nodeCopy, err = h.nodes.Update(nodeCopy)
 	if err != nil {
-		return node, fmt.Errorf("failed to list VMs with labels %s: %w", selector.String(), err)
-	}
-	for _, vm := range vmList {
-		// Make sure that this VM was shut down as part of the maintenance
-		// mode of the given node.
-		if vm.Annotations[util.AnnotationMaintainModeStrategyNodeName] != node.Name {
-			continue
-		}
-
-		logrus.WithFields(logrus.Fields{
-			"namespace":           vm.Namespace,
-			"virtualmachine_name": vm.Name,
-		}).Info("restarting the VM that was temporary shut down for maintenance mode")
-
-		// Update the run strategy of the VM to start it and remove the
-		// annotation that was previously set when the node went into
-		// maintenance mode.
-		// Get the running strategy that is stored in the annotation of the
-		// VM when it is shut down. Note, in general this is automatically
-		// patched by the VM mutator in general.
-		runStrategy := kubevirtv1.VirtualMachineRunStrategy(vm.Annotations[util.AnnotationRunStrategy])
-		if runStrategy == "" {
-			runStrategy = kubevirtv1.RunStrategyRerunOnFailure
-		}
-		vmCopy := vm.DeepCopy()
-		vmCopy.Spec.RunStrategy = &[]kubevirtv1.VirtualMachineRunStrategy{runStrategy}[0]
-		delete(vmCopy.Annotations, util.AnnotationMaintainModeStrategyNodeName)
-		_, err = h.virtualMachineClient.Update(vmCopy)
-		if err != nil {
-			return node, fmt.Errorf("failed to start VM %s/%s: %w", vm.Namespace, vm.Name, err)
-		}
+		return node, err
 	}
 
-	toUpdate := node.DeepCopy()
-	toUpdate.Annotations[MaintainStatusAnnotationKey] = MaintainStatusComplete
-	return h.nodes.Update(toUpdate)
+	util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonCompleted, "Maintenance mode enabled")
+
+	return h.nodes.UpdateStatus(nodeCopy)
 }
 
 // OnNodeRemoved Ensure that all "harvesterhci.io/maintain-mode-strategy-node-name"
@@ -143,4 +150,50 @@ func (h *maintainNodeHandler) OnNodeRemoved(_ string, node *corev1.Node) (*corev
 	}
 
 	return node, nil
+}
+
+// restartShutdownVMs restarts those VMs that have been labeled to be shut down
+// before maintenance mode, and that should be restarted when the node has
+// successfully switched into maintenance mode.
+func (h *maintainNodeHandler) restartShutdownVMs(node *corev1.Node) error {
+	selector := labels.Set{util.LabelMaintainModeStrategy: util.MaintainModeStrategyShutdownAndRestartAfterEnable}.AsSelector()
+	vmList, err := h.virtualMachineCache.List(node.Namespace, selector)
+	if err != nil {
+		return fmt.Errorf("failed to list VMs with labels %s: %w", selector.String(), err)
+	}
+
+	for _, vm := range vmList {
+		// Make sure that this VM was shut down as part of the maintenance
+		// mode of the given node.
+		if vm.Annotations == nil || vm.Annotations[util.AnnotationMaintainModeStrategyNodeName] != node.Name {
+			continue
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"namespace":           vm.Namespace,
+			"virtualmachine_name": vm.Name,
+		}).Info("Restarting the VM that was temporarily shut down for maintenance mode")
+
+		// Update the run strategy of the VM to start it and remove the
+		// annotation that was previously set when the node went into
+		// maintenance mode.
+		// Get the running strategy that is stored in the annotation of the
+		// VM when it is shut down. Note, in general this is automatically
+		// patched by the VM mutator in general.
+		runStrategy := kubevirtv1.VirtualMachineRunStrategy(vm.Annotations[util.AnnotationRunStrategy])
+		if runStrategy == "" {
+			runStrategy = kubevirtv1.RunStrategyRerunOnFailure
+		}
+
+		vmCopy := vm.DeepCopy()
+		vmCopy.Spec.RunStrategy = &[]kubevirtv1.VirtualMachineRunStrategy{runStrategy}[0]
+		delete(vmCopy.Annotations, util.AnnotationMaintainModeStrategyNodeName)
+
+		_, err = h.virtualMachineClient.Update(vmCopy)
+		if err != nil {
+			return fmt.Errorf("failed to start VM %s/%s: %w", vm.Namespace, vm.Name, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/controller/master/node/maintain_controller.go
+++ b/pkg/controller/master/node/maintain_controller.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"time"
 
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -18,17 +17,13 @@ import (
 )
 
 const (
-	maintainNodeControllerName        = "maintain-node-controller"
-	maintainErrorRetentionTimeSeconds = 120
-	MaintainStatusAnnotationKey       = "harvesterhci.io/maintain-status"
-	MaintainStatusComplete            = "completed"
-	MaintainStatusRunning             = "running"
+	maintainNodeControllerName = "maintain-node-controller"
 )
 
 // maintainNodeHandler updates the maintenance status of a node in its annotations, so that we can tell whether the node is
 // entering maintenance mode (migrating VMs on it) or in maintenance mode(VMs migrated).
 type maintainNodeHandler struct {
-	nodes                       ctlcorev1.NodeController
+	nodes                       ctlcorev1.NodeClient
 	nodeCache                   ctlcorev1.NodeCache
 	virtualMachineClient        v1.VirtualMachineClient
 	virtualMachineCache         v1.VirtualMachineCache
@@ -60,38 +55,39 @@ func (h *maintainNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev
 		return node, nil
 	}
 
-	if maintenanceStatus, ok := node.Annotations[MaintainStatusAnnotationKey]; !ok || maintenanceStatus != MaintainStatusRunning {
-		// Make sure the maintenance mode status condition is cleaned up when
-		// there is no "harvesterhci.io/maintain-status" annotation (e.g., the
-		// maintenance mode has been disabled).
+	nodeCopy := node.DeepCopy()
 
-		// If it is an error status condition, then reconcile again for a short
-		// period (~ 2 minute) so that there is some time to display the error
-		// on the `Hosts` page (Wrangler collects such status conditions and
-		// the UI displays them). If the status is older than the configured
-		// retention time, proceed with the cleanup.
-		condition := util.FindNodeStatusCondition(node.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
-		if condition != nil && condition.Reason == util.NodeConditionReasonError {
-			retentionTime := time.Duration(maintainErrorRetentionTimeSeconds) * time.Second
-			if time.Since(condition.LastHeartbeatTime.Time) <= retentionTime {
-				h.nodes.EnqueueAfter(node.Name, 5*time.Second)
-				return node, nil
+	maintenanceStatus, ok := node.Annotations[util.MaintainStatusAnnotation]
+	if !ok {
+		// We ended up here because maintenance mode was probably disabled
+		// in the UI.
+		cond := util.FindNodeStatusCondition(node.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+		// Cleanup the status condition only if we are not in an error condition.
+		if cond != nil && cond.Reason != util.NodeConditionReasonError {
+			if util.RemoveNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode) {
+				return h.nodes.UpdateStatus(nodeCopy)
 			}
 		}
+		// Finally we are done in this handler. Exit.
+		return node, nil
+	}
 
-		// Clean up the maintenance mode status condition if the annotation is
-		// not present; otherwise leave it as is.
-		if !ok {
-			nodeCopy := node.DeepCopy()
-			removed := util.RemoveNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode)
-			if removed {
-				if _, err := h.nodes.UpdateStatus(nodeCopy); err != nil {
-					return node, fmt.Errorf("failed to clean up %q condition: %w", util.NodeConditionTypeMaintenanceMode, err)
-				}
-				return nodeCopy, nil
-			}
+	// Make sure the status is in sync with the annotation.
+	switch maintenanceStatus {
+	case util.MaintainStatusRunning:
+		cond := util.FindNodeStatusCondition(node.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+		if cond == nil || cond.Reason != util.NodeConditionReasonRunning {
+			util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonRunning, "Draining the node")
+			return h.nodes.UpdateStatus(nodeCopy)
 		}
-
+		// Continue with this handler.
+	case util.MaintainStatusComplete:
+		cond := util.FindNodeStatusCondition(node.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+		if cond == nil || cond.Reason != util.NodeConditionReasonCompleted {
+			util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonCompleted, "Maintenance mode enabled")
+			return h.nodes.UpdateStatus(nodeCopy)
+		}
+		// The handler has already been successfully executed. Exit.
 		return node, nil
 	}
 
@@ -109,16 +105,8 @@ func (h *maintainNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev
 		return node, err
 	}
 
-	nodeCopy := node.DeepCopy()
-	nodeCopy.Annotations[MaintainStatusAnnotationKey] = MaintainStatusComplete
-	nodeCopy, err = h.nodes.Update(nodeCopy)
-	if err != nil {
-		return node, err
-	}
-
-	util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonCompleted, "Maintenance mode enabled")
-
-	return h.nodes.UpdateStatus(nodeCopy)
+	nodeCopy.Annotations[util.MaintainStatusAnnotation] = util.MaintainStatusComplete
+	return h.nodes.Update(nodeCopy)
 }
 
 // OnNodeRemoved Ensure that all "harvesterhci.io/maintain-mode-strategy-node-name"
@@ -128,7 +116,7 @@ func (h *maintainNodeHandler) OnNodeRemoved(_ string, node *corev1.Node) (*corev
 		return node, nil
 	}
 
-	if _, ok := node.Annotations[MaintainStatusAnnotationKey]; !ok {
+	if _, ok := node.Annotations[util.MaintainStatusAnnotation]; !ok {
 		return node, nil
 	}
 
@@ -172,7 +160,7 @@ func (h *maintainNodeHandler) restartShutdownVMs(node *corev1.Node) error {
 		logrus.WithFields(logrus.Fields{
 			"namespace":           vm.Namespace,
 			"virtualmachine_name": vm.Name,
-		}).Info("Restarting the VM that was temporarily shut down for maintenance mode")
+		}).Info("restarting the VM that was temporarily shut down for maintenance mode")
 
 		// Update the run strategy of the VM to start it and remove the
 		// annotation that was previously set when the node went into

--- a/pkg/controller/master/node/maintain_controller_test.go
+++ b/pkg/controller/master/node/maintain_controller_test.go
@@ -1,0 +1,206 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterfake "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+// buildNode builds a minimal Node with the given maintenance annotation value
+// (pass "" to omit the annotation) and optional existing status conditions.
+func buildNode(maintainAnnotation string, conditions []corev1.NodeCondition) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node",
+			Annotations: map[string]string{},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: conditions,
+		},
+	}
+	if maintainAnnotation != "" {
+		node.Annotations[util.MaintainStatusAnnotation] = maintainAnnotation
+	}
+	return node
+}
+
+// maintenanceModeCondition returns a NodeCondition for MaintenanceMode with the
+// given reason.
+func maintenanceModeCondition(reason string) corev1.NodeCondition {
+	return corev1.NodeCondition{
+		Type:   util.NodeConditionTypeMaintenanceMode,
+		Status: corev1.ConditionTrue,
+		Reason: reason,
+	}
+}
+
+// newHandler creates a minimal maintainNodeHandler wired up to a fake
+// clientset that contains the given node.
+func newHandler(node *corev1.Node) *maintainNodeHandler {
+	cs := harvesterfake.NewSimpleClientset(node)
+	return &maintainNodeHandler{
+		nodes:                       fakeclients.NodeClient(cs.CoreV1().Nodes),
+		virtualMachineInstanceCache: fakeclients.VirtualMachineInstanceCache(cs.KubevirtV1().VirtualMachineInstances),
+		virtualMachineCache:         fakeclients.VirtualMachineCache(cs.KubevirtV1().VirtualMachines),
+		virtualMachineClient:        fakeclients.VirtualMachineClient(cs.KubevirtV1().VirtualMachines),
+	}
+}
+
+// Test_OnNodeChanged_NoAnnotation_NoCondition: annotation absent, no
+// MaintenanceMode condition present → handler returns without calling
+// UpdateStatus (no-op).
+func Test_OnNodeChanged_NoAnnotation_NoCondition(t *testing.T) {
+	node := buildNode("", nil)
+	h := newHandler(node)
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	// No condition to remove → original node returned unchanged.
+	assert.Equal(t, node.Name, result.Name)
+	cond := util.FindNodeStatusCondition(result.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+	assert.Nil(t, cond, "expected no MaintenanceMode condition")
+}
+
+// Test_OnNodeChanged_NoAnnotation_WithNonErrorCondition: annotation absent but
+// a MaintenanceMode/Completed condition is present → condition should be
+// removed (UpdateStatus called).
+func Test_OnNodeChanged_NoAnnotation_WithNonErrorCondition(t *testing.T) {
+	node := buildNode("", []corev1.NodeCondition{
+		maintenanceModeCondition(util.NodeConditionReasonCompleted),
+	})
+	h := newHandler(node)
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	cond := util.FindNodeStatusCondition(result.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+	assert.Nil(t, cond, "expected MaintenanceMode condition to be removed")
+}
+
+// Test_OnNodeChanged_NoAnnotation_WithErrorCondition: annotation absent but a
+// MaintenanceMode/Error condition present → error condition must NOT be
+// removed.
+func Test_OnNodeChanged_NoAnnotation_WithErrorCondition(t *testing.T) {
+	node := buildNode("", []corev1.NodeCondition{
+		maintenanceModeCondition(util.NodeConditionReasonError),
+	})
+	h := newHandler(node)
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	cond := util.FindNodeStatusCondition(result.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+	require.NotNil(t, cond, "expected error condition to be preserved")
+	assert.Equal(t, util.NodeConditionReasonError, cond.Reason)
+}
+
+// Test_OnNodeChanged_Running_NoCondition: annotation=running, no condition set
+// yet → handler must set the Running condition via UpdateStatus.
+func Test_OnNodeChanged_Running_NoCondition(t *testing.T) {
+	node := buildNode(util.MaintainStatusRunning, nil)
+	h := newHandler(node)
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	cond := util.FindNodeStatusCondition(result.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+	require.NotNil(t, cond, "expected MaintenanceMode condition to be set")
+	assert.Equal(t, util.NodeConditionReasonRunning, cond.Reason)
+	assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	assert.Equal(t, util.MaintainStatusRunning, result.Annotations[util.MaintainStatusAnnotation])
+}
+
+// Test_OnNodeChanged_Running_ConditionAlreadyRunning: annotation=running,
+// Running condition already in sync → UpdateStatus should NOT be called again;
+// handler continues to the VMI-wait logic (which returns early because there
+// are no VMIs in the fake store).
+func Test_OnNodeChanged_Running_ConditionAlreadyRunning(t *testing.T) {
+	node := buildNode(util.MaintainStatusRunning, []corev1.NodeCondition{
+		maintenanceModeCondition(util.NodeConditionReasonRunning),
+	})
+	h := newHandler(node)
+
+	// With no VMIs available the handler will mark the node as Complete.
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	assert.Equal(t, util.MaintainStatusComplete, result.Annotations[util.MaintainStatusAnnotation],
+		"expected annotation to be updated to Complete after no VMIs remaining")
+}
+
+// Test_OnNodeChanged_Complete_NoCondition: annotation=completed, no condition
+// set yet → handler sets Completed condition via UpdateStatus.
+func Test_OnNodeChanged_Complete_NoCondition(t *testing.T) {
+	node := buildNode(util.MaintainStatusComplete, nil)
+	h := newHandler(node)
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	cond := util.FindNodeStatusCondition(result.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+	require.NotNil(t, cond, "expected MaintenanceMode condition to be set")
+	assert.Equal(t, util.NodeConditionReasonCompleted, cond.Reason)
+	assert.Equal(t, corev1.ConditionTrue, cond.Status)
+	assert.Equal(t, util.MaintainStatusComplete, result.Annotations[util.MaintainStatusAnnotation])
+}
+
+// Test_OnNodeChanged_Complete_WrongCondition: annotation=completed but
+// condition has wrong reason → handler must update condition to Completed.
+func Test_OnNodeChanged_Complete_WrongCondition(t *testing.T) {
+	node := buildNode(util.MaintainStatusComplete, []corev1.NodeCondition{
+		maintenanceModeCondition(util.NodeConditionReasonRunning),
+	})
+	h := newHandler(node)
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	cond := util.FindNodeStatusCondition(result.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+	require.NotNil(t, cond, "expected MaintenanceMode condition to be present")
+	assert.Equal(t, util.NodeConditionReasonCompleted, cond.Reason,
+		"expected condition reason to be updated to Completed")
+	assert.Equal(t, util.MaintainStatusComplete, result.Annotations[util.MaintainStatusAnnotation])
+}
+
+// Test_OnNodeChanged_Complete_ConditionAlreadyCompleted: annotation=completed,
+// Completed condition already in sync → handler returns node unchanged (no
+// further UpdateStatus call).
+func Test_OnNodeChanged_Complete_ConditionAlreadyCompleted(t *testing.T) {
+	node := buildNode(util.MaintainStatusComplete, []corev1.NodeCondition{
+		maintenanceModeCondition(util.NodeConditionReasonCompleted),
+	})
+	h := newHandler(node)
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	// The same node object should be returned (pointer equality), since no
+	// update was needed.
+	assert.Equal(t, node.Name, result.Name)
+	cond := util.FindNodeStatusCondition(result.Status.Conditions, util.NodeConditionTypeMaintenanceMode)
+	require.NotNil(t, cond)
+	assert.Equal(t, util.NodeConditionReasonCompleted, cond.Reason)
+	assert.Equal(t, util.MaintainStatusComplete, result.Annotations[util.MaintainStatusAnnotation])
+}
+
+// Test_OnNodeChanged_NilNode: nil node → handler returns immediately without
+// error.
+func Test_OnNodeChanged_NilNode(t *testing.T) {
+	h := &maintainNodeHandler{}
+	result, err := h.OnNodeChanged("", nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// Test_OnNodeChanged_DeletedNode: node with DeletionTimestamp → handler
+// returns immediately without error.
+func Test_OnNodeChanged_DeletedNode(t *testing.T) {
+	node := buildNode("", nil)
+	now := metav1.Now()
+	node.DeletionTimestamp = &now
+	h := &maintainNodeHandler{}
+
+	result, err := h.OnNodeChanged("", node)
+	require.NoError(t, err)
+	assert.Equal(t, node, result)
+}

--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -95,11 +95,23 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 	err := drainhelper.DrainPossible(ndc.nodeCache, node)
 	if err != nil {
 		if errors.Is(err, drainhelper.ErrNodeDrainNotPossible) {
-			nodeUpdate, errUpdate := ndc.cleanupMaintenanceModeAnnotations(node)
-			if errUpdate != nil {
-				return node, errors.Join(err, errUpdate)
+			logrus.WithFields(logrus.Fields{
+				"node_name": node.Name,
+			}).Errorf("Draining is not possible: %v", err)
+
+			nodeUpdate, errNodeUpdate := ndc.cleanupMaintenanceModeAnnotations(node)
+			if errNodeUpdate != nil {
+				return node, errors.Join(err, errNodeUpdate)
 			}
-			return nodeUpdate, fmt.Errorf("enabling maintenance mode is impossible: %w", err)
+
+			util.SetNodeStatusCondition(nodeUpdate, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonError, err.Error())
+
+			nodeUpdate, errNodeUpdate = ndc.nodes.UpdateStatus(nodeUpdate)
+			if errNodeUpdate != nil {
+				return node, errors.Join(err, fmt.Errorf("failed to set condition %s: %w", util.NodeConditionTypeMaintenanceMode, errNodeUpdate))
+			}
+
+			return nodeUpdate, err
 		}
 
 		return node, err
@@ -131,8 +143,16 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 				reasons = append(reasons, fmt.Sprintf("%s cannot be migrated due to %s", strings.Join(vms, ","), condition))
 			}
 
-			return nodeUpdate, fmt.Errorf("enabling maintenance mode is impossible. Non-migratable VMs found: %s. Use 'force drain' to perform a collective shutdown",
-				strings.Join(reasons, "; "))
+			err = fmt.Errorf("enabling maintenance mode is impossible. Non-migratable VMs found: %s. Use 'force drain' to perform a collective shutdown", strings.Join(reasons, "; "))
+
+			util.SetNodeStatusCondition(nodeUpdate, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonError, err.Error())
+
+			nodeUpdate, errNodeUpdate := ndc.nodes.UpdateStatus(nodeUpdate)
+			if errNodeUpdate != nil {
+				return node, errors.Join(err, fmt.Errorf("failed to set condition %s: %w", util.NodeConditionTypeMaintenanceMode, errNodeUpdate))
+			}
+
+			return nodeUpdate, err
 		}
 
 		// Get the list of VMs that are labeled to forcibly shut down
@@ -217,19 +237,41 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 		}).Info("force stopping VM")
 	}
 
+	logrus.WithFields(logrus.Fields{
+		"node_name": node.Name,
+	}).Info("Starting to drain the node...")
+
 	nodeCopy := node.DeepCopy()
 
 	// run node drain
 	err = drainhelper.DrainNode(ndc.context, ndc.restConfig, nodeCopy)
 	if err != nil {
-		return node, err
+		logrus.WithFields(logrus.Fields{
+			"node_name": node.Name,
+		}).Errorf("Failed to drain the node: %v", err)
+
+		util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonError, err.Error())
+
+		nodeCopy, errUpdate := ndc.nodes.UpdateStatus(nodeCopy)
+		if errUpdate != nil {
+			return node, errors.Join(err, fmt.Errorf("failed to set condition %s: %w", util.NodeConditionTypeMaintenanceMode, errUpdate))
+		}
+
+		return nodeCopy, err
 	}
 
 	nodeCopy.Annotations[ctlnode.MaintainStatusAnnotationKey] = ctlnode.MaintainStatusRunning
 	delete(nodeCopy.Annotations, drainhelper.DrainAnnotation)
 	delete(nodeCopy.Annotations, drainhelper.ForcedDrain)
 
-	return ndc.nodes.Update(nodeCopy)
+	nodeCopy, err = ndc.nodes.Update(nodeCopy)
+	if err != nil {
+		return node, err
+	}
+
+	util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonRunning, "Draining the node")
+
+	return ndc.nodes.UpdateStatus(nodeCopy)
 }
 
 // findAndStopVM is a wrapper function to identify the owner VM for a VMI, and patch the run strategy

--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -19,7 +19,6 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/config"
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/util"
@@ -78,12 +77,20 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 		return node, nil
 	}
 
-	_, ok := node.Annotations[drainhelper.DrainAnnotation]
+	nodeCopy := node.DeepCopy()
+
+	_, ok := node.Annotations[util.DrainAnnotation]
 	if !ok {
+		// We are done in this handler. Exit.
 		return node, nil
 	}
 
-	_, forced := node.Annotations[drainhelper.ForcedDrain]
+	// Remove an existing status condition.
+	if util.RemoveNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode) {
+		return ndc.nodes.UpdateStatus(nodeCopy)
+	}
+
+	_, forced := node.Annotations[util.ForcedDrainAnnotation]
 
 	logrus.WithFields(logrus.Fields{
 		"node_name": node.Name,
@@ -97,7 +104,7 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 		if errors.Is(err, drainhelper.ErrNodeDrainNotPossible) {
 			logrus.WithFields(logrus.Fields{
 				"node_name": node.Name,
-			}).Errorf("Draining is not possible: %v", err)
+			}).Errorf("draining is not possible: %v", err)
 
 			nodeUpdate, errNodeUpdate := ndc.cleanupMaintenanceModeAnnotations(node)
 			if errNodeUpdate != nil {
@@ -241,14 +248,12 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 		"node_name": node.Name,
 	}).Info("Starting to drain the node...")
 
-	nodeCopy := node.DeepCopy()
-
 	// run node drain
 	err = drainhelper.DrainNode(ndc.context, ndc.restConfig, nodeCopy)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"node_name": node.Name,
-		}).Errorf("Failed to drain the node: %v", err)
+		}).Errorf("failed to drain the node: %v", err)
 
 		util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonError, err.Error())
 
@@ -260,18 +265,10 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 		return nodeCopy, err
 	}
 
-	nodeCopy.Annotations[ctlnode.MaintainStatusAnnotationKey] = ctlnode.MaintainStatusRunning
-	delete(nodeCopy.Annotations, drainhelper.DrainAnnotation)
-	delete(nodeCopy.Annotations, drainhelper.ForcedDrain)
+	util.RemoveMaintenanceModeAnnotations(nodeCopy)
+	nodeCopy.Annotations[util.MaintainStatusAnnotation] = util.MaintainStatusRunning
 
-	nodeCopy, err = ndc.nodes.Update(nodeCopy)
-	if err != nil {
-		return node, err
-	}
-
-	util.SetNodeStatusCondition(nodeCopy, util.NodeConditionTypeMaintenanceMode, corev1.ConditionTrue, util.NodeConditionReasonRunning, "Draining the node")
-
-	return ndc.nodes.UpdateStatus(nodeCopy)
+	return ndc.nodes.Update(nodeCopy)
 }
 
 // findAndStopVM is a wrapper function to identify the owner VM for a VMI, and patch the run strategy
@@ -576,9 +573,7 @@ func (ndc *ControllerHandler) listVMILabelMaintainModeStrategy(node *corev1.Node
 
 func (ndc *ControllerHandler) cleanupMaintenanceModeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 	nodeCopy := node.DeepCopy()
-	delete(nodeCopy.Annotations, ctlnode.MaintainStatusAnnotationKey)
-	delete(nodeCopy.Annotations, drainhelper.DrainAnnotation)
-	delete(nodeCopy.Annotations, drainhelper.ForcedDrain)
+	util.RemoveMaintenanceModeAnnotations(nodeCopy)
 	nodeUpdate, err := ndc.nodes.Update(nodeCopy)
 	if err != nil {
 		return node, fmt.Errorf("failed to clean up maintenance mode annotations: %w", err)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,5 +1,7 @@
 package util
 
+import corev1 "k8s.io/api/core/v1"
+
 const (
 	prefix                              = "harvesterhci.io"
 	RemovedPVCsAnnotationKey            = prefix + "/removedPersistentVolumeClaims"
@@ -33,6 +35,7 @@ const (
 	LabelHarvesterUpgrade               = prefix + "/upgrade"
 	LabelHarvesterUpgradeState          = prefix + "/upgradeState"
 	LabelHarvesterUpgradeComponent      = prefix + "/upgradeComponent"
+	LabelInjectError                    = prefix + "/injectError"
 	AnnotationStorageClassName          = prefix + "/storageClassName"
 	AnnotationStorageProvisioner        = prefix + "/storageProvisioner"
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
@@ -308,4 +311,11 @@ const (
 	HarvesterManagedPSSValue = "true"
 
 	GoArchArm64 = "arm64"
+)
+
+const (
+	NodeConditionTypeMaintenanceMode corev1.NodeConditionType = "MaintenanceMode"
+	NodeConditionReasonRunning       string                   = "Running"
+	NodeConditionReasonCompleted     string                   = "Completed"
+	NodeConditionReasonError         string                   = "Error"
 )

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -35,7 +35,6 @@ const (
 	LabelHarvesterUpgrade               = prefix + "/upgrade"
 	LabelHarvesterUpgradeState          = prefix + "/upgradeState"
 	LabelHarvesterUpgradeComponent      = prefix + "/upgradeComponent"
-	LabelInjectError                    = prefix + "/injectError"
 	AnnotationStorageClassName          = prefix + "/storageClassName"
 	AnnotationStorageProvisioner        = prefix + "/storageProvisioner"
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
@@ -191,6 +190,13 @@ const (
 	APIServerCAKey                           = "apiServerCA"
 
 	RKEControlPlaneRoleLabel = "rke.cattle.io/control-plane-role"
+
+	DrainAnnotation       = prefix + "/drain-requested"
+	ForcedDrainAnnotation = prefix + "/drain-forced"
+
+	MaintainStatusAnnotation = prefix + "/maintain-status"
+	MaintainStatusComplete   = "completed"
+	MaintainStatusRunning    = "running"
 
 	LabelMaintainModeStrategy              = prefix + "/maintain-mode-strategy"
 	AnnotationMaintainModeStrategyNodeName = prefix + "/maintain-mode-strategy-node-name"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,5 +1,7 @@
 package util
 
+import corev1 "k8s.io/api/core/v1"
+
 const (
 	prefix                              = "harvesterhci.io"
 	RemovedPVCsAnnotationKey            = prefix + "/removedPersistentVolumeClaims"
@@ -33,6 +35,7 @@ const (
 	LabelHarvesterUpgrade               = prefix + "/upgrade"
 	LabelHarvesterUpgradeState          = prefix + "/upgradeState"
 	LabelHarvesterUpgradeComponent      = prefix + "/upgradeComponent"
+	LabelInjectError                    = prefix + "/injectError"
 	AnnotationStorageClassName          = prefix + "/storageClassName"
 	AnnotationStorageProvisioner        = prefix + "/storageProvisioner"
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"
@@ -216,6 +219,13 @@ var (
 	}
 
 	DefaultHarvesterNamespaceWhiteList = []string{"calico-apiserver", "calico-system", "cattle-alerting", "cattle-csp-adapter-system", "cattle-elemental-system", "cattle-epinio-system", "cattle-externalip-system", "cattle-fleet-local-system", "cattle-fleet-system", "cattle-gatekeeper-system", "cattle-global-data", "cattle-global-nt", "cattle-impersonation-system", "cattle-istio", "cattle-istio-system", "cattle-logging", "cattle-logging-system", "cattle-monitoring-system", "cattle-neuvector-system", "cattle-prometheus", "cattle-provisioning-capi-system", "cattle-resources-system", "cattle-sriov-system", "cattle-system", "cattle-ui-plugin-system", "cattle-windows-gmsa-system", "cert-manager", "cis-operator-system", "fleet-default", "ingress-nginx", "istio-system", "kube-node-lease", "kube-public", "kube-system", "longhorn-system", "rancher-alerting-drivers", "security-scan", "tigera-operator", "harvester-system", "harvester-public", "rancher-vcluster", "cattle-dashboards", "fleet-local", "local", "forklift"}
+)
+
+const (
+	NodeConditionTypeMaintenanceMode corev1.NodeConditionType = "MaintenanceMode"
+	NodeConditionReasonRunning       string                   = "Running"
+	NodeConditionReasonCompleted     string                   = "Completed"
+	NodeConditionReasonError         string                   = "Error"
 )
 
 const (

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -60,7 +60,7 @@ func defaultDrainHelper(ctx context.Context, cfg *rest.Config) (*drain.Helper, e
 		Out:                 logger.Writer(),
 		ErrOut:              logger.Writer(),
 		Timeout:             defaultTimeOut,
-		AdditionalFilters:   []drain.PodFilter{maintainModeStrategyFilter},
+		AdditionalFilters:   []drain.PodFilter{maintainModeStrategyFilter, injectErrorFilter},
 	}, nil
 }
 
@@ -81,11 +81,6 @@ func DrainNode(ctx context.Context, cfg *rest.Config, node *corev1.Node) error {
 // DrainPossible is a helper method to check a node object and query remaining
 // nodes in the cluster to identify if it is possible to place the current mode
 // in maintenance mode.
-// Returns true if it is possible to drain the node, false if not possible. If
-// true and an error are returned, then the drain operation can be reconciled
-// again since the error does not rule out the possibility of a drain. If false
-// and an error are returned, then the conditions for a drain are not met and
-// reconciling does not make sense.
 func DrainPossible(nodeCache ctlcorev1.NodeCache, node *corev1.Node) error {
 	_, cpLabelOK := node.Labels["node-role.kubernetes.io/control-plane"]
 	_, etcdLabelOK := node.Labels["node-role.kubernetes.io/etcd"]
@@ -170,6 +165,13 @@ func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
 				vmName, util.LabelMaintainModeStrategy, value)
 			return drain.MakePodDeleteStatusSkip()
 		}
+	}
+	return drain.MakePodDeleteStatusOkay()
+}
+
+func injectErrorFilter(pod corev1.Pod) drain.PodDeleteStatus {
+	if _, ok := pod.Labels[util.LabelInjectError]; ok {
+		return drain.MakePodDeleteStatusWithError(fmt.Sprintf("Pods with label %q (Note, this is for testing purposes only)", util.LabelInjectError))
 	}
 	return drain.MakePodDeleteStatusOkay()
 }

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/drain"
 
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -31,8 +30,6 @@ const (
 	defaultSkipPodLabels      = "app!=csi-attacher,app!=csi-provisioner,kubevirt.io!=hotplug-disk"
 	defaultGracePeriodSeconds = 180
 	defaultTimeOut            = 240 * time.Second
-	DrainAnnotation           = "harvesterhci.io/drain-requested"
-	ForcedDrain               = "harvesterhci.io/drain-forced"
 	defaultSingleCPCount      = 1
 	defaultHACPCount          = 3
 )
@@ -60,7 +57,7 @@ func defaultDrainHelper(ctx context.Context, cfg *rest.Config) (*drain.Helper, e
 		Out:                 logger.Writer(),
 		ErrOut:              logger.Writer(),
 		Timeout:             defaultTimeOut,
-		AdditionalFilters:   []drain.PodFilter{maintainModeStrategyFilter, injectErrorFilter},
+		AdditionalFilters:   []drain.PodFilter{maintainModeStrategyFilter},
 	}, nil
 }
 
@@ -132,7 +129,7 @@ func DrainPossible(nodeCache ctlcorev1.NodeCache, node *corev1.Node) error {
 
 	var availableNodes int
 	for _, v := range nodeMap {
-		_, ok := v.Annotations[ctlnode.MaintainStatusAnnotationKey]
+		_, ok := v.Annotations[util.MaintainStatusAnnotation]
 		logrus.Debugf("nodeName: %s,  annotation present: %v", v.Name, ok)
 		if !ok {
 			availableNodes++
@@ -165,13 +162,6 @@ func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
 				vmName, util.LabelMaintainModeStrategy, value)
 			return drain.MakePodDeleteStatusSkip()
 		}
-	}
-	return drain.MakePodDeleteStatusOkay()
-}
-
-func injectErrorFilter(pod corev1.Pod) drain.PodDeleteStatus {
-	if _, ok := pod.Labels[util.LabelInjectError]; ok {
-		return drain.MakePodDeleteStatusWithError(fmt.Sprintf("Pods with label %q (Note, this is for testing purposes only)", util.LabelInjectError))
 	}
 	return drain.MakePodDeleteStatusOkay()
 }

--- a/pkg/util/drainhelper/helper_test.go
+++ b/pkg/util/drainhelper/helper_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/drain"
 
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
@@ -89,7 +88,7 @@ func Test_failsControlPlaneRequirementsHA(t *testing.T) {
 	clientset := fake.NewSimpleClientset(testNode, cpNode1, cpNode2, cpNode3)
 
 	cpNode1.Annotations = map[string]string{
-		ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+		util.MaintainStatusAnnotation: util.MaintainStatusRunning,
 	}
 
 	nodeCache := fakeclients.NodeCache(clientset.CoreV1().Nodes)

--- a/pkg/util/fakeclients/node.go
+++ b/pkg/util/fakeclients/node.go
@@ -3,7 +3,6 @@ package fakeclients
 import (
 	"context"
 
-	corev1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
+
+	corev1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/v1"
 )
 
 type NodeCache func() corev1type.NodeInterface
@@ -64,8 +65,8 @@ func (c NodeClient) List(metav1.ListOptions) (*v1.NodeList, error) {
 	panic("implement me")
 }
 
-func (c NodeClient) UpdateStatus(*v1.Node) (*v1.Node, error) {
-	panic("implement me")
+func (c NodeClient) UpdateStatus(node *v1.Node) (*v1.Node, error) {
+	return c().UpdateStatus(context.TODO(), node, metav1.UpdateOptions{})
 }
 
 func (c NodeClient) Watch(metav1.ListOptions) (watch.Interface, error) {

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -85,7 +85,7 @@ func IsManagementRole(node *corev1.Node) bool {
 	return false
 }
 
-// count the number of nodes running instance manager pod
+// CountNonWitnessNodes count the number of nodes running instance manager pod
 func CountNonWitnessNodes(nodes []*corev1.Node) int {
 	count := 0
 
@@ -146,4 +146,25 @@ func FindNodeStatusCondition(conditions []corev1.NodeCondition, conditionType co
 		}
 	}
 	return nil
+}
+
+// RemoveNodeStatusCondition removes the condition of the node based on the condition type.
+// It returns true if the condition is removed, otherwise false.
+func RemoveNodeStatusCondition(node *corev1.Node, condType corev1.NodeConditionType) bool {
+	numConditions := len(node.Status.Conditions)
+	if numConditions == 0 {
+		return false
+	}
+
+	newConditions := make([]corev1.NodeCondition, 0, numConditions)
+
+	for _, c := range node.Status.Conditions {
+		if c.Type != condType {
+			newConditions = append(newConditions, c)
+		}
+	}
+
+	node.Status.Conditions = newConditions
+
+	return numConditions != len(newConditions)
 }

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -120,6 +120,8 @@ func SetNodeStatusCondition(node *corev1.Node, condType corev1.NodeConditionType
 	}
 
 	if cond.Status != status {
+		// Per Kubernetes convention, `LastTransitionTime` only changes
+		// when `Status` flips.
 		cond.Status = status
 		cond.LastTransitionTime = now
 	}
@@ -167,4 +169,10 @@ func RemoveNodeStatusCondition(node *corev1.Node, condType corev1.NodeConditionT
 	node.Status.Conditions = newConditions
 
 	return numConditions != len(newConditions)
+}
+
+func RemoveMaintenanceModeAnnotations(node *corev1.Node) {
+	delete(node.Annotations, MaintainStatusAnnotation)
+	delete(node.Annotations, DrainAnnotation)
+	delete(node.Annotations, ForcedDrainAnnotation)
 }

--- a/pkg/util/node_test.go
+++ b/pkg/util/node_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -28,7 +29,7 @@ func TestGetNodeCondition_FoundFirstMatch(t *testing.T) {
 	}
 
 	cond := FindNodeStatusCondition(conditions, corev1.NodeReady)
-	assert.NotNil(t, cond, "expected to find NodeReady condition")
+	require.NotNil(t, cond, "expected to find NodeReady condition")
 	assert.Equal(t, corev1.NodeReady, cond.Type)
 	assert.Equal(t, "ready", cond.Reason)
 }
@@ -40,7 +41,7 @@ func TestGetNodeCondition_MultipleSameType_ReturnsFirstAndIsCopy(t *testing.T) {
 	}
 
 	cond := FindNodeStatusCondition(conditions, corev1.NodeReady)
-	assert.NotNil(t, cond, "expected to find NodeReady condition")
+	require.NotNil(t, cond, "expected to find NodeReady condition")
 	assert.Equal(t, "first", cond.Reason)
 
 	// Mutate the returned condition and ensure the original slice element
@@ -54,7 +55,7 @@ func TestSetNodeCondition_AppendsWhenMissing(t *testing.T) {
 
 	SetNodeStatusCondition(node, corev1.NodeReady, corev1.ConditionTrue, "reason", "message")
 
-	assert.Len(t, node.Status.Conditions, 1, "expected one condition appended")
+	require.Len(t, node.Status.Conditions, 1, "expected one condition appended")
 	c := node.Status.Conditions[0]
 	assert.Equal(t, corev1.NodeReady, c.Type)
 	assert.Equal(t, corev1.ConditionTrue, c.Status)
@@ -83,7 +84,7 @@ func TestSetNodeCondition_UpdatesExisting_SameStatus(t *testing.T) {
 
 	SetNodeStatusCondition(node, corev1.NodeReady, corev1.ConditionTrue, "new-reason", "new-msg")
 
-	assert.Len(t, node.Status.Conditions, 1)
+	require.Len(t, node.Status.Conditions, 1)
 	c := node.Status.Conditions[0]
 	assert.Equal(t, corev1.ConditionTrue, c.Status)
 	assert.Equal(t, "new-reason", c.Reason)
@@ -113,7 +114,7 @@ func TestSetNodeCondition_UpdatesExisting_StatusChanged(t *testing.T) {
 
 	SetNodeStatusCondition(node, corev1.NodeReady, corev1.ConditionFalse, "changed-reason", "changed-msg")
 
-	assert.Len(t, node.Status.Conditions, 1)
+	require.Len(t, node.Status.Conditions, 1)
 	c := node.Status.Conditions[0]
 	assert.Equal(t, corev1.ConditionFalse, c.Status)
 	assert.Equal(t, "changed-reason", c.Reason)
@@ -122,4 +123,32 @@ func TestSetNodeCondition_UpdatesExisting_StatusChanged(t *testing.T) {
 	assert.True(t, c.LastTransitionTime.Time.After(initialTime.Time))
 	// Heartbeat should also be updated.
 	assert.True(t, c.LastHeartbeatTime.Time.After(initialTime.Time))
+}
+
+func Test_RemoveNodeStatusCondition(t *testing.T) {
+	node := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:               NodeConditionTypeMaintenanceMode,
+					Status:             corev1.ConditionTrue,
+					LastHeartbeatTime:  metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+					Reason:             NodeConditionReasonCompleted,
+					Message:            "Maintenance mode enabled",
+				},
+				{
+					Type:               "foo",
+					Status:             corev1.ConditionFalse,
+					LastHeartbeatTime:  metav1.Now(),
+					LastTransitionTime: metav1.Now(),
+					Reason:             "bar",
+					Message:            "Qui aromata regit, universum regit",
+				},
+			},
+		},
+	}
+	removed := RemoveNodeStatusCondition(node, NodeConditionTypeMaintenanceMode)
+	assert.Len(t, node.Status.Conditions, 1)
+	assert.True(t, removed)
 }

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -74,11 +74,11 @@ func (v *nodeValidator) Update(_ *types.Request, oldObj runtime.Object, newObj r
 func validateCordonAndMaintenanceMode(oldNode, newNode *corev1.Node, nodeList []*corev1.Node) error {
 	// if old node already have "maintain-status" annotation or Unscheduleable=true,
 	// it has already been enabled, so we skip it
-	if _, ok := oldNode.Annotations[ctlnode.MaintainStatusAnnotationKey]; ok || oldNode.Spec.Unschedulable {
+	if _, ok := oldNode.Annotations[util.MaintainStatusAnnotation]; ok || oldNode.Spec.Unschedulable {
 		return nil
 	}
 	// if new node doesn't have "maintain-status" annotation and Unscheduleable=false, we skip it
-	if _, ok := newNode.Annotations[ctlnode.MaintainStatusAnnotationKey]; !ok && !newNode.Spec.Unschedulable {
+	if _, ok := newNode.Annotations[util.MaintainStatusAnnotation]; !ok && !newNode.Spec.Unschedulable {
 		return nil
 	}
 
@@ -88,7 +88,7 @@ func validateCordonAndMaintenanceMode(oldNode, newNode *corev1.Node, nodeList []
 		}
 
 		// Return when we find another available node
-		if _, ok := node.Annotations[ctlnode.MaintainStatusAnnotationKey]; !ok && !node.Spec.Unschedulable {
+		if _, ok := node.Annotations[util.MaintainStatusAnnotation]; !ok && !node.Spec.Unschedulable {
 			return nil
 		}
 	}

--- a/pkg/webhook/resources/node/validator_test.go
+++ b/pkg/webhook/resources/node/validator_test.go
@@ -65,7 +65,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Annotations: map[string]string{
-						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+						util.MaintainStatusAnnotation: util.MaintainStatusRunning,
 					},
 				},
 			},
@@ -108,7 +108,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Annotations: map[string]string{
-							ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusComplete,
+							util.MaintainStatusAnnotation: util.MaintainStatusComplete,
 						},
 					},
 				},
@@ -158,7 +158,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Annotations: map[string]string{
-						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+						util.MaintainStatusAnnotation: util.MaintainStatusRunning,
 					},
 				},
 			},
@@ -172,7 +172,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Annotations: map[string]string{
-							ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+							util.MaintainStatusAnnotation: util.MaintainStatusRunning,
 						},
 					},
 				},
@@ -190,7 +190,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Annotations: map[string]string{
-						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+						util.MaintainStatusAnnotation: util.MaintainStatusRunning,
 					},
 				},
 			},

--- a/tests/integration/api/host_apis_test.go
+++ b/tests/integration/api/host_apis_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	nodeapi "github.com/harvester/harvester/pkg/api/node"
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/tests/framework/cluster"
 	"github.com/harvester/harvester/tests/framework/helper"
 )
@@ -94,7 +94,7 @@ var _ = Describe("verify host APIs", func() {
 						return fmt.Errorf("expected node to be unschedulable")
 					}
 
-					_, ok := retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]
+					_, ok := retNode.Annotations[util.MaintainStatusAnnotation]
 					if !ok {
 						return fmt.Errorf("unable to find maintenance annotation")
 					}
@@ -117,7 +117,7 @@ var _ = Describe("verify host APIs", func() {
 					if !Expect(retNode.Spec.Unschedulable).To(BeEquivalentTo(false)) {
 						return false
 					}
-					return Expect(retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]).To(BeEmpty())
+					return Expect(retNode.Annotations[util.MaintainStatusAnnotation]).To(BeEmpty())
 				}, 30*time.Second, 1*time.Second)
 
 			})
@@ -172,7 +172,7 @@ var _ = Describe("verify host APIs", func() {
 						return fmt.Errorf("expected node to be schedulable")
 					}
 
-					_, ok := retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]
+					_, ok := retNode.Annotations[util.MaintainStatusAnnotation]
 					if ok {
 						return fmt.Errorf("should not find maintenance annotation")
 					}


### PR DESCRIPTION
#### Problem:
Right now there are only set several annotations on the node resource when the maintenance mode is activated. There is not much information available for users and the UI to see what is going on.

#### Solution:
Make use of `status.conditions` when the maintenance mode is activated or failing. This way the user and the UI can make use of this information to better understand what is going. Beside that it can be helpful in situations when things go wrong.

The `status.condition` `MaintenanceMode` will be kept until the maintenance mode is deactivated. An error condition is reset at the start of a new maintenance mode cycle. This means that the error message will remain displayed in the `Hosts` view of the UI.

The condition `type` will be named `MaintenanceMode`. The following `reasons` will be available:
- Running
- Completed
- Error

By giving the condition that is set in case of a failure the name `Error`, the [Wrangler code](https://github.com/rancher/wrangler/blob/73fdb33d6a7529e14e2f769b66f717468a09201d/pkg/summary/summarizers.go#L320) will recognize it and the error is displayed in the Harvester `Hosts` page below the node that is going to be put into maintenance mode.

#### Problem:
There's a catch with this PR that I don't know how to resolve: resetting an error. The error remains displayed until maintenance mode is successfully activated. K8s does not provide a way to manually reset status conditions.
Automatic deletion of the error condition was not desired and was removed from the code in the latest commit of the PR.
In the event of an error, the annotations `harvesterhci.io/drain-requested` and `harvesterhci.io/drain-forced` are removed. If these were retained, the system would constantly attempt to activate maintenance mode until the process could be completed. If this behavior is desired, deleting the status condition could be accompanied by removing the `harvesterhci.io/drain-requested` annotation. With this approach, however, the error message is only displayed for a short time—until the next reconciliation run is started (which, in the current implementation, causes the condition to be reset).

No matter how you look at it, the maintenance mode feature just doesn't integrate very well into the UI.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9022

#### Test plan:
Prepare a 3 node test cluster.

***Case 1***:
- Go to the `Hosts` page.
- Choose `Enable Maintenance Mode` in the action menu on `harvester-node-0`.
- Do not check the `Force` checkbox.
- During the time `Cordoned` is displayed in the UI, a `kubectl get node harvester-node-0 -o jsonpath='{.status.conditions[*]}' | jq` will not contain any condition of type `MaintenanceMode`.
- After some time the node should be in maintenance mode.

<img width="1292" height="536" alt="Bildschirmfoto vom 2025-12-15 16-12-24" src="https://github.com/user-attachments/assets/5ec7a868-8392-44a6-88dd-7b0693a46e16" />

- The node `harvester-node-0` should have the annotation `harvesterhci.io/maintain-status=completed`.
- Run `k get node harvester-node-0 -o jsonpath='{.status.conditions[*]}' | jq`. The output should look like:

```
...
{
  "lastHeartbeatTime": "2025-12-15T15:12:05Z",
  "lastTransitionTime": "2025-12-15T15:12:05Z",
  "message": "Maintenance mode enabled",
  "reason": "Completed",
  "status": "True",
  "type": "MaintenanceMode"
}
```
- Choose `Disable Maintenance Mode` in the action menu on `harvester-node-0`.
- Run `kubectl get node harvester-node-0 -o jsonpath='{.status.conditions[*]}' | jq`. The output should not contain any condition of type `MaintenanceMode`.
- The annotation `harvesterhci.io/maintain-status` should have been removed.

***Case 2***:
- Go to the `Hosts` page.
- Add annotation to node: `kubectl annotate node harvester-node-1 harvesterhci.io/maintain-status='completed'`.
- Add annotation to node: `kubectl annotate node harvester-node-2 harvesterhci.io/drain-requested='true'`.
- The error message will remain displayed until maintenance mode is disabled on `harvester-node-1` and enabled on `harvester-node-2`.

<img width="1552" height="717" alt="image" src="https://github.com/user-attachments/assets/46322426-ac32-4c94-a28f-1cfb8c7446b9" />

***Case 3***:
- Create a VM named `vm01`.
- Make sure the VM is running on node `harvester-node-0`. Migrate the VM to this node if necessary.
- Add annotation to node: `kubectl annotate node harvester-node-0 harvesterhci.io/drain-requested='true'`.
- After some time an error message should appear:

<img width="1549" height="612" alt="image" src="https://github.com/user-attachments/assets/e33f0b12-3178-4fe6-8ff9-397d0ccc896c" />

- Choose the `Enable Maintenance Mode` action menu on `harvester-node-0`. Click the `Force` checkbox and press `Save`.
- The error message will disappear shortly.
- The `YAML` of the resource should contain the annotations:
```
    harvesterhci.io/drain-forced: 'true'
    harvesterhci.io/drain-requested: 'true'
```
- Run `kubectl get node harvester-node-0 -o jsonpath='{.status.conditions[*]}' | jq`. The `type=MaintenanceMode` condition should look like this.
```
{
  "lastHeartbeatTime": "2026-05-20T11:58:55Z",
  "lastTransitionTime": "2026-05-20T11:58:55Z",
  "message": "Maintenance mode enabled",
  "reason": "Completed",
  "status": "True",
  "type": "MaintenanceMode"
}
```
- The annotations `harvesterhci.io/drain-forced` and `harvesterhci.io/drain-requested`  need to be removed from the resource. The following annotation need to exist:
```
    harvesterhci.io/maintain-status: completed
```

#### Additional documentation or context
