### PR TITLE
feat: use addedNodeSelector from virtualmachineinstancemigrations

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -475,9 +475,6 @@ func (h *vmActionHandler) migrate(ctx context.Context, namespace, vmName string,
 		if toUpdateVmi.Annotations == nil {
 			toUpdateVmi.Annotations = make(map[string]string)
 		}
-		if toUpdateVmi.Spec.NodeSelector == nil {
-			toUpdateVmi.Spec.NodeSelector = make(map[string]string)
-		}
 		toUpdateVmi.Annotations[util.AnnotationMigrationTarget] = nodeName
 
 		if err := util.VirtClientUpdateVmi(ctx, h.virtRestClient, h.namespace, namespace, vmName, toUpdateVmi); err != nil {
@@ -485,19 +482,8 @@ func (h *vmActionHandler) migrate(ctx context.Context, namespace, vmName string,
 			return err
 		}
 
-		vm, err := h.vmCache.Get(namespace, vmName)
-		if err != nil {
-			return fmt.Errorf("failed to get virtual machine %s/%s: %v", namespace, vmName, err)
-		}
-		toUpdateVM := vm.DeepCopy()
-		if toUpdateVM.Spec.Template.Spec.NodeSelector == nil {
-			toUpdateVM.Spec.Template.Spec.NodeSelector = make(map[string]string)
-		}
-
-		toUpdateVM.Spec.Template.Spec.NodeSelector[corev1.LabelHostname] = nodeName
-		if _, err := h.vms.Update(toUpdateVM); err != nil {
-			logrus.Errorf("failed to update VM %s/%s with migration target %s: %v", namespace, vmName, nodeName, err)
-			return err
+		vmim.Spec.AddedNodeSelector = map[string]string{
+			corev1.LabelHostname: nodeName,
 		}
 	}
 

--- a/pkg/controller/master/migration/vmim_controller.go
+++ b/pkg/controller/master/migration/vmim_controller.go
@@ -105,7 +105,6 @@ func (h *Handler) syncVM(vmi *kubevirtv1.VirtualMachineInstance) error {
 		toUpdateVM.Annotations = make(map[string]string)
 	}
 	toUpdateVM.Annotations[util.AnnotationTimestamp] = time.Now().Format(time.RFC3339)
-	delete(toUpdateVM.Spec.Template.Spec.NodeSelector, corev1.LabelHostname)
 
 	_, err = h.vms.Update(toUpdateVM)
 	return err


### PR DESCRIPTION
#### Problem:
Currently, we hack the VMI node selector during migration ([Ref. 1](https://github.com/harvester/harvester/commit/0f960117c906262d534eb5b4c412bf61c5ca21a4) and [Ref. 2](https://github.com/harvester/harvester/commit/719a5960fff7f73a69e14f1bb731c8f30e5c1ec8)), which is not a official way.

#### Solution:
Our kubevirt chart has been updated ([Ref.](https://github.com/harvester/harvester/pull/9094)).

Now, kubevirt supports adding node selector in virtualmachineinstancemigrations. Hence, we can use native way to migrate the VM. But, I still keep the annotations in the VMI.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8703

#### Test plan:

Prepare a three node clusters

Case 1: Migrate the VM to another node.
Case 2: Abort migration after starting migration.
Case 3: Start a virtual machine on a specific node, the VM is not allowed for migration.

#### Additional documentation or context
None.
