### PR TITLE
feat: support snapshot rbac for harvester csi

### DIFF
--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -202,3 +202,13 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  - volumesnapshotcontents
+  - volumesnapshotclasses
+  - volumesnapshots/status
+  - volumesnapshotcontents/status
+  verbs:
+  - '*'


### PR DESCRIPTION
**Problem:**
Support volume snapshot for guest cluster

**Solution:**
Implement CSI snapshot creation and PVC provisioning from a snapshot for the Harvester CSI driver.

**Related Issue:**
https://github.com/harvester/harvester/issues/3778

**Test plan:**

**Prerequisite:**

* Option1
   - Update the host Harvester deployment with [this PR](https://github.com/harvester/harvester/pull/9104).
   - Update the guest cluster Harvester CSI driver chart with [this PR](https://github.com/harvester/charts/pull/411).
   - Update the Harvester CSI driver DaemonSet with [this PR](https://github.com/harvester/harvester-csi-driver/pull/63)

* Option 2
  - Update the host Harvester deployment with [this PR](https://github.com/harvester/harvester/pull/9104).
  - Add the repo `https://github.com/WebberHuang1118/rancher-charts.git` with the branch `v2.10-bump-harvester-csi-driver-0.1.25-trial` to the guest cluster’s app repositories.
    - I’ve released a tarball [here](https://github.com/WebberHuang1118/charts/releases/tag/harvester-csi-driver-0.1.25), based on:
      - Harvester CSI driver PR [#63](https://github.com/harvester/harvester-csi-driver/pull/63)
      - Harvester chart PR [#411](https://github.com/harvester/charts/pull/411)
  - Upgrade Harvester CSI driver to `105.0.4+up0.1.25`.

**Case 1: CSI snapshot based on host’s Longhorn volume**

* Create a block PVC.
  ```
  apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    name: blk-vol
    namespace: default
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 2Gi
    volumeMode: Block
  ```
* Mount the block PVC to a pod, write some data, ensure the data is persisted, then remove the pod.
  ```
  apiVersion: v1
  kind: Pod
  metadata:
    name: pod-blk-vol
    namespace: default
  spec:
    containers:
    - name: volume-test
      image: ubuntu
      imagePullPolicy: IfNotPresent
      securityContext:
        privileged: true  
      command: ["/bin/sleep"]
      args: ["3600"]
      volumeDevices:
      - devicePath: /dev/blk-vol
        name: blk-vol
    volumes:
      - name: blk-vol
        persistentVolumeClaim:
          claimName: blk-vol
   ```
* Take a snapshot of the block PVC.
  ```
  apiVersion: snapshot.storage.k8s.io/v1
  kind: VolumeSnapshot
  metadata:
    name: snapshot-blk-vol
    namespace: default
  spec:
    volumeSnapshotClassName: harvester-snapshot
    source:
      persistentVolumeClaimName: blk-vol
  ```
* Restore the snapshot to a new PVC.
  ```
  apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    name: restore-blk-vol
    namespace: default
  spec:
    accessModes:
      - ReadWriteOnce
    resources:
      requests:
        storage: 2Gi
    storageClassName: harvester
    dataSource:
      apiGroup: snapshot.storage.k8s.io  
      kind: VolumeSnapshot
      name: snapshot-blk-vol
    volumeMode: Block
  ```
* Mount both the source and restored PVCs to a pod.
  ```
  apiVersion: v1
  kind: Pod
  metadata:
    name: pod-restore-blk-vol
    namespace: default
  spec:
    containers:
    - name: volume-test
      image: ubuntu
      imagePullPolicy: IfNotPresent
      securityContext:
        privileged: true  
      command: ["/bin/sleep"]
      args: ["3600"]
      volumeDevices:
      - devicePath: /dev/blk-vol
        name: blk-vol
      - devicePath: /dev/restore-blk-vol
        name: restore-blk-vol
    volumes:
      - name: blk-vol
        persistentVolumeClaim:
          claimName: blk-vol
      - name: restore-blk-vol
        persistentVolumeClaim:
          claimName: restore-blk-vol
  ```
* Compare the content between the two PVCs within the pod.
* The two PVCs should have identical content.

**Case 2: CSI snapshot based on host’s NFS filesystem volume**

* Deploy the NFS CSI driver on Harvester.
* In the guest cluster, create a custom StorageClass as described [here](https://docs.harvesterhci.io/v1.7/rancher/csi-driver#passthrough-custom-storageclass) that points to the host’s NFS StorageClass, and set the custom StorageClass as default.
* Create a filesystem PVC.
  ```
  apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    name: fs-vol
  spec:
    accessModes:
      - ReadWriteOnce
    volumeMode: Filesystem
    resources:
      requests:
        storage: 2Gi
  ```
* Mount the filesystem PVC to a pod, write some data, ensure the data is persisted, then remove the pod.
  ```
  apiVersion: v1
  kind: Pod
  metadata:
    name: pod-fs-vol
  spec:
    containers:
      - name: ubuntu
        image: ubuntu:latest
        command: ["/bin/bash", "-c", "sleep infinity"]
        volumeMounts:
          - name: fs-vol
            mountPath: /data-fs-vol
    volumes:
      - name: fs-vol
        persistentVolumeClaim:
          claimName: fs-vol
  ```
* Take a snapshot of the filesystem PVC.
  ```
  apiVersion: snapshot.storage.k8s.io/v1
  kind: VolumeSnapshot
  metadata:
    name: snapshot-fs-vol
    namespace: default
  spec:
    volumeSnapshotClassName: harvester-snapshot
    source:
      persistentVolumeClaimName: fs-vol
  ```
* Restore the snapshot to a new PVC.
  ```
  apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    name: restore-fs-vol
    namespace: default
  spec:
    accessModes:
      - ReadWriteOnce
    resources:
      requests:
        storage: 2Gi
    storageClassName: harvester
    dataSource:
      apiGroup: snapshot.storage.k8s.io  
      kind: VolumeSnapshot
      name: snapshot-fs-vol
    volumeMode: Filesystem
  ```
* Mount both the source and restored PVCs to a pod.
  ```
  apiVersion: v1
  kind: Pod
  metadata:
    name: pod-fs-vol
  spec:
    containers:
      - name: ubuntu
        image: ubuntu:latest
        command: ["/bin/bash", "-c", "sleep infinity"]
        volumeMounts:
          - name: fs-vol
            mountPath: /data-fs-vol
          - name: restore-fs-vol
            mountPath: /data-restore-fs-vol
    volumes:
      - name: fs-vol
        persistentVolumeClaim:
          claimName: fs-vol
      - name: restore-fs-vol
        persistentVolumeClaim:
          claimName: restore-fs-vol
  ```
* Compare the content between the two PVCs within the pod.
* The two PVCs should have identical content.