### PR TITLE
fix: revert wrongly bumped sub-components

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
 FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 AS grub2-mbr
 FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 AS grub2-efi
 
-FROM golang:1.25-bookworm
+FROM golang:1.23-bookworm
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH

--- a/deploy/charts/harvester/Chart.lock
+++ b/deploy/charts/harvester/Chart.lock
@@ -10,33 +10,33 @@ dependencies:
   version: 0.1.1
 - name: harvester-network-controller
   repository: https://charts.harvesterhci.io
-  version: 1.6.0
+  version: 1.5.2-rc1
 - name: harvester-networkfs-manager
   repository: https://charts.harvesterhci.io
-  version: 1.6.0
+  version: 1.5.2-rc1
 - name: harvester-node-disk-manager
   repository: https://charts.harvesterhci.io
-  version: 1.6.0
+  version: 1.5.2-rc1
 - name: csi-snapshotter
   repository: file://dependency_charts/csi-snapshotter
   version: 0.2.0
 - name: longhorn
   repository: https://charts.longhorn.io
-  version: 1.9.1
+  version: 1.8.2
 - name: kube-vip
   repository: https://kube-vip.github.io/helm-charts
-  version: 0.8.1
+  version: 0.6.1
 - name: harvester-load-balancer
   repository: https://charts.harvesterhci.io
-  version: 1.6.0
+  version: 1.5.2-rc1
 - name: whereabouts
   repository: file://dependency_charts/whereabouts
   version: 0.1.1
 - name: harvester-node-manager
   repository: https://charts.harvesterhci.io
-  version: 1.6.0
+  version: 1.5.2-rc1
 - name: snapshot-validation-webhook
   repository: file://dependency_charts/snapshot-validation-webhook
   version: 0.2.0
-digest: sha256:825e39acbb97117e9d886ee0b99880a54ca4a54d9253d2c1a99761cb9a54b623
-generated: "2025-09-07T09:44:55.761670888Z"
+digest: sha256:1ec5bdf27695e11da0fee2f2c9c999eddde74e72af8c18cacae2b522c09d3400
+generated: "2025-09-10T11:23:03.797015+08:00"

--- a/deploy/charts/harvester/Chart.yaml
+++ b/deploy/charts/harvester/Chart.yaml
@@ -34,15 +34,15 @@ dependencies:
       - cdi
       - crd
   - name: harvester-network-controller
-    version: 1.6.0
+    version: 1.5.2-rc1
     repository: https://charts.harvesterhci.io
     condition: harvester-network-controller.enabled
   - name: harvester-networkfs-manager
-    version: 1.6.0
+    version: 1.5.2-rc1
     repository: https://charts.harvesterhci.io
     condition: harvester-networkfs-manager.enabled
   - name: harvester-node-disk-manager
-    version: 1.6.0
+    version: 1.5.2-rc1
     repository: https://charts.harvesterhci.io
     condition: harvester-node-disk-manager.enabled
   - name: csi-snapshotter
@@ -50,21 +50,21 @@ dependencies:
     repository: file://dependency_charts/csi-snapshotter
     condition: csi-snapshotter.enabled
   - name: longhorn
-    version: 1.9.1
+    version: 1.8.2
     repository: https://charts.longhorn.io
     condition: longhorn.enabled
   - name: kube-vip
-    version: 0.8.1
+    version: 0.6.1
     repository: https://kube-vip.github.io/helm-charts
   - name: harvester-load-balancer
-    version: 1.6.0
+    version: 1.5.2-rc1
     repository: https://charts.harvesterhci.io
   - name: whereabouts
     version: 0.1.1
     repository: file://dependency_charts/whereabouts
     condition: whereabouts.enabled
   - name: harvester-node-manager
-    version: 1.6.0
+    version: 1.5.2-rc1
     repository: https://charts.harvesterhci.io
   - name: snapshot-validation-webhook
     version: 0.2.0

--- a/deploy/charts/harvester/dependency_charts/cdi/values.yaml
+++ b/deploy/charts/harvester/dependency_charts/cdi/values.yaml
@@ -14,7 +14,7 @@ cdi:
     nodeSelector:
       kubernetes.io/os: linux
 
-hookImage: rancher/kubectl:v1.34.0
+hookImage: rancher/kubectl:v1.32.3
 hookRestartPolicy: OnFailure
 hookSecurityContext:
   seccompProfile:

--- a/deploy/charts/harvester/dependency_charts/whereabouts/values.yaml
+++ b/deploy/charts/harvester/dependency_charts/whereabouts/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: ghcr.io/k8snetworkplumbingwg/whereabouts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.6.3-amd64"
+  tag: "v0.5.4-amd64"
 
 updateStrategy: RollingUpdate
 imagePullSecrets: []

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -149,7 +149,7 @@ cdi:
     hook:
       image:
         repository: rancher/kubectl
-        tag: v1.34.0
+        tag: v1.32.3
   
   spec:
     cloneStrategyOverride: copy
@@ -227,7 +227,7 @@ containers:
 
       ## Specify the tag of image.
       ##
-      tag: v1.6-head
+      tag: v1.5-head
 
     ## Specify whether to run in HCI mode. This option enables additional controllers.
     ## defaults to "false", this will be enabled in ISO mode installation.
@@ -412,16 +412,16 @@ harvester-network-controller:
     repository: rancher/harvester-network-controller
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v1.6.0-rc1
+    tag: v1.5.2-rc1
   helper:
     image:
       repository: rancher/harvester-network-helper
-      tag: v1.6.0-rc1
+      tag: v1.5.2-rc1
   webhook:
     image:
       repository: rancher/harvester-network-webhook
       pullPolicy: IfNotPresent
-      tag: v1.6.0-rc1
+      tag: v1.5.2-rc1
 
 harvester-networkfs-manager:
   ## Specify to install harvester networkfs manager,
@@ -432,7 +432,7 @@ harvester-networkfs-manager:
     repository: rancher/harvester-networkfs-manager
     pullPolicy: IfNotPresent 
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v1.6.0-rc1
+    tag: v1.5.2-rc1
 
 harvester-node-disk-manager:
   ## Specify to install harvester node disk manager,
@@ -446,14 +446,14 @@ harvester-node-disk-manager:
     repository: rancher/harvester-node-disk-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v1.6.0-rc1
+    tag: v1.5.2-rc1
   
   webhook:
     image:
       repository: rancher/harvester-node-disk-manager-webhook
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: v1.6.0-rc1
+      tag: v1.5.2-rc1
 
 csi-snapshotter:
   ## Specify whether to install the csi-snapshotter
@@ -521,7 +521,7 @@ webhook:
 
     ## Specify the tag of image.
     ##
-    tag: v1.6-head
+    tag: v1.5-head
 
   httpsPort: 9443
 
@@ -535,25 +535,25 @@ webhook:
 upgrade:
   image:
     repository: rancher/harvester-upgrade
-    tag: v1.6-head
+    tag: v1.5-head
 
 harvester-load-balancer:
   enabled: false
   image:
     imagePullPolicy: Always
     repository: rancher/harvester-load-balancer
-    tag: v1.6.0-rc1
+    tag: v1.5.2-rc1
   webhook:
     image:
       imagePullPolicy: IfNotPresent
       repository: rancher/harvester-load-balancer-webhook
-      tag: v1.6.0-rc1
+      tag: v1.5.2-rc1
 
 kube-vip:
   enabled: false
   image:
     repository: ghcr.io/kube-vip/kube-vip-iptables
-    tag: v0.9.2
+    tag: v0.8.1
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
   # https://github.com/kube-vip/kube-vip/blob/main/pkg/kubevip/config_envvar.go
@@ -581,25 +581,25 @@ generalJob:
     # In the Golang limitation, we couldn't parse like "tag": 12.20.
     # So, we must use "tag": "12.20" instead.
     # More details in PR-4896 (https://github.com/harvester/harvester/pull/4896)
-    tag: 15.7
+    tag: 15.6
 
 whereabouts:
   enabled: true
   image:
     pullPolicy: IfNotPresent
     repository: ghcr.io/k8snetworkplumbingwg/whereabouts
-    tag: "v0.9.2"
+    tag: "v0.8.0"
 
 harvester-node-manager:
   image:
     pullPolicy: IfNotPresent
     repository: rancher/harvester-node-manager
-    tag: v1.6.0-rc1
+    tag: v1.5.2-rc1
   webhook:
     image:
       pullPolicy: IfNotPresent
       repository: rancher/harvester-node-manager-webhook
-      tag: v1.6.0-rc1
+      tag: v1.5.2-rc1
 
 snapshot-validation-webhook:
   enabled: true

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.7
+FROM registry.suse.com/bci/bci-base:15.6
 
 # nfs-client is needed by the dep https://github.com/longhorn/backupstore to check backup store availability.
 RUN zypper -n rm container-suseconnect && \

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.7
+FROM registry.suse.com/bci/bci-base:15.6
 
 RUN zypper -n rm container-suseconnect && \
     zypper -n install curl nfs-client && \

--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:v1.6 as baseos
-FROM registry.suse.com/bci/bci-base:15.7
+FROM registry.suse.com/bci/bci-base:15.6
 
 ARG ARCH=amd64
 ENV ARCH=${ARCH}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Most of the sub-components should follow the main Harvester version. They were wrongly bumped by the Renovate bot.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Reverting the following PRs in one shot:
- https://github.com/harvester/harvester/pull/9068
- https://github.com/harvester/harvester/pull/9069
- https://github.com/harvester/harvester/pull/9070
- https://github.com/harvester/harvester/pull/9071
- https://github.com/harvester/harvester/pull/9072
- https://github.com/harvester/harvester/pull/9073
- https://github.com/harvester/harvester/pull/9074
- https://github.com/harvester/harvester/pull/9075

I left a few component bumps, such as support-bundle-kit, as is, since they're just patch version bumps.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
