### PR TITLE
fix elemental image used in upgrade image packaging

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:v1.6 as baseos
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.5/main/baseos:v1.5 as baseos
 FROM registry.suse.com/bci/bci-base:15.6
 
 ARG ARCH=amd64


### PR DESCRIPTION


<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR fixes the elemental image used for copy `elemental` binary as part of the upgrade image packaging.

Both v1.5 and v1.6 harvester os images contain the same elemental binary version.

```
builder::➜  ~ docker run -it --rm registry.opensuse.org/isv/rancher/harvester/os/v1.5/main/baseos:v1.5 elemental version
1.1.7+gd6f7ff8
builder::➜  ~ docker run -it --rm registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:v1.6 elemental version
1.1.7+gd6f7ff8
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
