### PR TITLE
Fix bridge vlan removal for both yaml-v2 and yam-v3 format

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -575,7 +575,10 @@ replace_with_mgmtvlan() {
   else
     echo "VLAN ID: $vlan_id remove bridge vlan"
     sed -i "s/accept all vlan, PVID=1 by default/PVID=1 by default/" $CUSTOM90_FILE
-    sed -i "/bridge vlan add vid/d" $CUSTOM90_FILE
+    # match contents of bridge vlan add vid 2-4094 using yaml/v3 format
+    sed -i '/^[[:space:]]*bridge vlan add vid 2-4094 dev \(\$INTERFACE\|mgmt-bo\)\( self\)\?[[:space:]]*$/d' $CUSTOM90_FILE
+    # match contents of bridge vlan add vid 2-4094 using yaml/v2 format (escape characters and command spanning multiple lines)
+    perl -0777 -i -pe 's/bridge vlan add vid 2-4094.*?(?:\\n|\\t)+//gs' $CUSTOM90_FILE
   fi
 }
 


### PR DESCRIPTION
#### Problem:
https://github.com/harvester/harvester/blob/b85b952b4936632595e57df082e37bd745d5ec57/package/upgrade/upgrade_node.sh#L578 assumed the contents of /oem/90_custom.yaml to be in format as generated from yaml/v3 but if the contents are generated from old harvester-installer, then it is generated using yaml/v2 and contents looks different and the sed operation above can truncate the full line during upgrade from v1.5.x to v1.6.x when mgmt interface is installed with no vid.

yaml/v2 generated /oem/90_custom.yaml

<img width="2026" height="1170" alt="image" src="https://github.com/user-attachments/assets/aa3f1ffc-7604-47fa-9134-32baee627296" />

<img width="2010" height="1208" alt="image" src="https://github.com/user-attachments/assets/488e3301-24b5-4900-8c06-08ec0f5dca8e" />


yaml/v3 generated /oem/90_custom.yaml

```
 - path: /etc/wicked/scripts/setup_bond.sh
              permissions: 493
              owner: 0
              group: 0
              content: |
                #!/bin/sh

                ACTION=$1
                INTERFACE=$2

                case $ACTION in
                        post-up)
                                # inherit MAC address
                                ip link set dev mgmt-bo address $(ip -json link show dev $INTERFACE | jq -j '.[0]["address"]')

                                #skip bridge vlan setting when no vlan id or vlan id=1 specified by user
                                if [ 2021 -eq 0 ] || [ 2021 -eq 1 ]; then
                                    exit 0
                                fi
                                #assign user configured vlan,PVID=1 by default
                                bridge vlan add vid 2021 dev $INTERFACE
                                ;;

                esac
```
There could be cases where older nodes were installed using harvester-installer version (v1.1.2) and harvester version probably v1.2.x and later upgraded to v1.3.x->v1.4.x->v1.5.x, during the upgrade process the harvester-installer versions would have upgraded to newer versions, but the contents of the /oem/90_custom.yaml never changed as we do not update the contents of /oem/90_custom.yaml file during upgrade until v1.5.x.Due to this there is possibility that Harvester nodes could still have 90_custom.yaml using contents generated from old yaml/v2 format.This will cause issue when user upgrades from v1.5.x to v1.6.x and mgmt interface is installed with no vlan id.

#### Solution:
Handle removal of command "bridge vlan add vid 2-4094 ....." for both yaml/v2 and yaml/v3 format

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9033

#### Test plan:
case 1:
1.Harvester node installed v1.5.x on mgmt interface with no vid
2.Contents of /oem/90_custom.yaml in yaml/v2 format generated from older harvester-installer version (or copy older contents to this 90_custom.yaml)
2.Upgrade from v1.5.x to v1.6.x
3.Check if upgrade is successful

case 2:
1.Harvester node installed v1.5.x on mgmt interface with no vid
2.Upgrade from v1.5.x to v1.6.x
3.Check if upgrade is successful

#### Additional documentation or context
