### PR TITLE
Add validator to block disabling CPU manager node with cpu pinned VMs

### DIFF
--- a/pkg/util/fakeclients/virtualmachine.go
+++ b/pkg/util/fakeclients/virtualmachine.go
@@ -15,6 +15,7 @@ import (
 	kubevirtv1api "kubevirt.io/api/core/v1"
 
 	kubevirtv1 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/kubevirt.io/v1"
+	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 	indexerwebhook "github.com/harvester/harvester/pkg/webhook/indexeres"
 )
 
@@ -136,6 +137,17 @@ func (c VirtualMachineCache) GetByIndex(indexName, key string) (vms []*kubevirtv
 				if vmInterface.MacAddress != "" && vmInterface.MacAddress == key {
 					vms = append(vms, &vmList.Items[i])
 				}
+			}
+		}
+	case indexeresutil.VMByCPUPinningIndex:
+		vmList, err = c("").List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, vm := range vmList.Items {
+			if vm.Spec.Template != nil && vm.Spec.Template.Spec.Domain.CPU != nil && vm.Spec.Template.Spec.Domain.CPU.DedicatedCPUPlacement {
+				vms = append(vms, &vm)
 			}
 		}
 

--- a/pkg/util/indexeres/virtualmachine.go
+++ b/pkg/util/indexeres/virtualmachine.go
@@ -10,6 +10,9 @@ import (
 const (
 	VMByPVCIndex        = "harvesterhci.io/vm-by-pvc"
 	VMByHotplugPVCIndex = "harvesterhci.io/vm-by-hp-pvc"
+	VMByCPUPinningIndex = "harvesterhci.io/vm-by-cpu-pinning"
+
+	CPUPinningEnabled = "enabled"
 )
 
 func VMByPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
@@ -42,6 +45,18 @@ func VMByHotplugPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
 		if isVolumeHotplugged(volume) {
 			results = append(results, ref.Construct(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
 		}
+	}
+	return results, nil
+}
+
+func VMByCPUPinning(obj *kubevirtv1.VirtualMachine) ([]string, error) {
+	if obj == nil || obj.Spec.Template == nil {
+		return nil, nil
+	}
+
+	var results []string
+	if obj.Spec.Template.Spec.Domain.CPU != nil && obj.Spec.Template.Spec.Domain.CPU.DedicatedCPUPlacement {
+		return []string{CPUPinningEnabled}, nil
 	}
 	return results, nil
 }

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -56,6 +56,7 @@ func RegisterIndexers(clients *clients.Clients) {
 	vmInformer := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmInformer.AddIndexer(indexeresutil.VMByPVCIndex, indexeresutil.VMByPVC)
 	vmInformer.AddIndexer(indexeresutil.VMByHotplugPVCIndex, indexeresutil.VMByHotplugPVC)
+	vmInformer.AddIndexer(indexeresutil.VMByCPUPinningIndex, indexeresutil.VMByCPUPinning)
 
 	svmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache()
 	svmBackupCache.AddIndexer(ScheduleVMBackupBySourceVM, scheduleVMBackupBySourceVM)

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -7,25 +7,29 @@ import (
 
 	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	schedulinghelper "k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/util"
+	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
-func NewValidator(nodeCache v1.NodeCache, jobCache ctlbatchv1.JobCache, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) types.Validator {
+func NewValidator(nodeCache v1.NodeCache, jobCache ctlbatchv1.JobCache, vmCache ctlkubevirtv1.VirtualMachineCache, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) types.Validator {
 	return &nodeValidator{
 		nodeCache: nodeCache,
 		jobCache:  jobCache,
+		vmCache:   vmCache,
 		vmiCache:  vmiCache,
 	}
 }
@@ -34,6 +38,7 @@ type nodeValidator struct {
 	types.DefaultValidator
 	nodeCache v1.NodeCache
 	jobCache  ctlbatchv1.JobCache
+	vmCache   ctlkubevirtv1.VirtualMachineCache
 	vmiCache  ctlkubevirtv1.VirtualMachineInstanceCache
 }
 
@@ -129,8 +134,12 @@ func (v *nodeValidator) validateCPUManagerOperation(node *corev1.Node) error {
 	if err := checkMasterNodeJobs(node, v.nodeCache, v.jobCache); err != nil {
 		return err
 	}
-	// check if there is any vm that enable cpu pinning while cpu manager is going to be disabled
+	// check if there is any running vmis that enable cpu pinning while cpu manager is going to be disabled
 	if err := checkCPUPinningVMIs(node, policy, v.vmiCache); err != nil {
+		return err
+	}
+	// check if there is at least one node has cpu manager enabled if there is any vm with cpu pinning
+	if err := checkCPUManagerEnabledForPinnedVMs(node, policy, v.nodeCache, v.vmCache); err != nil {
 		return err
 	}
 
@@ -233,7 +242,8 @@ func checkMasterNodeJobs(node *corev1.Node, nodeCache v1.NodeCache, jobCache ctl
 }
 
 func checkCPUPinningVMIs(node *corev1.Node, policy ctlnode.CPUManagerPolicy, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) error {
-	if policy != ctlnode.CPUManagerNonePolicy {
+	// Skip check if the policy is set to 'static'
+	if policy == ctlnode.CPUManagerStaticPolicy {
 		return nil
 	}
 
@@ -260,4 +270,144 @@ func getCPUManagerRunningJobNamesOnNodes(jobCache ctlbatchv1.JobCache, nodeNames
 		jobNames[i] = job.Name
 	}
 	return jobNames, nil
+}
+
+// checkCPUManagerEnabledForPinnedVMs ensures cluster safety when disabling CPU Manager by preventing
+// scenarios that would leave CPU-pinned VMs without a suitable host node. This validation performs
+// two critical checks:
+//
+//  1. VM Binding Check: Identifies VMs with CPU pinning that are bound to the current node via
+//     NodeSelector constraints. These VMs cannot be rescheduled to other nodes, so disabling
+//     CPU Manager would make them unschedulable.
+//
+//  2. Last Node Protection: Prevents disabling CPU Manager on the last enabled node when any
+//     CPU-pinned VMs exist in the cluster, ensuring at least one node remains available for
+//     scheduling these VMs.
+func checkCPUManagerEnabledForPinnedVMs(
+	node *corev1.Node,
+	policy ctlnode.CPUManagerPolicy,
+	nodeCache v1.NodeCache,
+	vmCache ctlkubevirtv1.VirtualMachineCache,
+) error {
+	// Skip check if the policy is set to 'static'
+	if policy == ctlnode.CPUManagerStaticPolicy {
+		return nil
+	}
+
+	// Get all nodes with CPU Manager enabled
+	selector := labels.Set{kubevirtv1.CPUManager: "true"}.AsSelector()
+	nodesWithCPUManager, err := nodeCache.List(selector)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+
+	// Get all VMs with CPU pinning
+	cpuPinnedVMs, err := vmCache.GetByIndex(indexeresutil.VMByCPUPinningIndex, indexeresutil.CPUPinningEnabled)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+
+	if len(cpuPinnedVMs) == 0 {
+		return nil
+	}
+
+	// Check if VMs are bound to this specific node via NodeSelector
+	vmsBoundToCurrentNode := getVMsBoundToNode(cpuPinnedVMs, node, nodesWithCPUManager)
+	if len(vmsBoundToCurrentNode) > 0 {
+		vmList := formatVMList(vmsBoundToCurrentNode)
+		return werror.NewBadRequest(
+			"Cannot disable CPU Manager on this node because the following VM(s) with CPU pinning " +
+				"are bound to this node via Node Scheduling rules and cannot be scheduled on other CPU Manager enabled nodes. " +
+				"Please remove CPU pinning or update Node Scheduling rules for these VM(s): " + vmList)
+	}
+
+	// Check if this is the last node with CPU Manager enabled
+	if len(nodesWithCPUManager) == 1 && nodesWithCPUManager[0].UID == node.UID {
+		vmList := formatVMList(cpuPinnedVMs)
+		return werror.NewBadRequest(
+			"Cannot disable CPU Manager on the last enabled node when VM(s) with CPU pinning exist. " +
+				"Please remove CPU pinning from the following VM(s) to proceed: " + vmList)
+	}
+
+	return nil
+}
+
+func formatVMList(vms []*kubevirtv1.VirtualMachine) string {
+	vmStrs := make([]string, len(vms))
+	for i, vm := range vms {
+		vmStrs[i] = fmt.Sprintf("%s/%s", vm.Namespace, vm.Name)
+	}
+	return strings.Join(vmStrs, ", ")
+}
+
+// getVMsBoundToNode returns VMs that are bound to a specific node via NodeSelector or NodeAffinity
+// A VM is considered "bound" to a node if its scheduling constraints can only be satisfied by this node among CPU Manager enabled nodes.
+func getVMsBoundToNode(vms []*kubevirtv1.VirtualMachine, targetNode *corev1.Node, cpuManagerNodes []*corev1.Node) []*kubevirtv1.VirtualMachine {
+	boundVMs := make([]*kubevirtv1.VirtualMachine, 0)
+
+	for _, vm := range vms {
+		templateSpec := &vm.Spec.Template.Spec
+
+		// Check if VM has any node constraints (NodeSelector or NodeAffinity)
+		hasNodeSelector := len(templateSpec.NodeSelector) > 0
+		hasNodeAffinity := templateSpec.Affinity != nil &&
+			templateSpec.Affinity.NodeAffinity != nil &&
+			templateSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil
+
+		if !hasNodeSelector && !hasNodeAffinity {
+			// No constraints, VM is not bound to any specific node
+			continue
+		}
+
+		// Check if target node matches the VM's constraints
+		if !vmMatchesNode(templateSpec, targetNode) {
+			continue
+		}
+
+		// Count how many CPU Manager enabled nodes can satisfy this VM's constraints
+		matchingNodeCount := 0
+		for _, node := range cpuManagerNodes {
+			if vmMatchesNode(templateSpec, node) {
+				matchingNodeCount++
+			}
+		}
+
+		// VM is bound to this node if it's the only CPU Manager enabled node that matches
+		if matchingNodeCount == 1 {
+			boundVMs = append(boundVMs, vm)
+		}
+	}
+
+	return boundVMs
+}
+
+// vmMatchesNode checks if a VM's scheduling constraints (NodeSelector and NodeAffinity) match a node
+func vmMatchesNode(vmiSpec *kubevirtv1.VirtualMachineInstanceSpec, node *corev1.Node) bool {
+	// Check NodeSelector
+	if len(vmiSpec.NodeSelector) > 0 {
+		selector := labels.SelectorFromSet(vmiSpec.NodeSelector)
+		if !selector.Matches(labels.Set(node.Labels)) {
+			return false
+		}
+	}
+
+	// Check NodeAffinity
+	if vmiSpec.Affinity != nil &&
+		vmiSpec.Affinity.NodeAffinity != nil &&
+		vmiSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+
+		nodeSelector := vmiSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		lazySelector := schedulinghelper.NewLazyErrorNodeSelector(nodeSelector)
+
+		matches, err := lazySelector.Match(node)
+		if err != nil {
+			logrus.WithField("node", node.Name).Warnf("Error matching node affinity: %v", err)
+			return false
+		}
+		if !matches {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -57,6 +57,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		node.NewValidator(
 			clients.Core.Node().Cache(),
 			clients.Batch.Job().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache()),
 		persistentvolumeclaim.NewValidator(
 			clients.Core.PersistentVolumeClaim().Cache(),


### PR DESCRIPTION
#### Problem:
Currently, if a user creates a VM with CPU Pinning enabled and there is no suitable nodes with CPU Manager enabled, the VM will remain in the "Unschedulable" state. Although our documentation mentions this limitation, we still need to address it in the product.

#### Solution:
Add validator to block disabling CPU manager node with cpu pinned VMs with the following considerations:
1. VM Binding Check: Identifies VMs with CPU pinning that are bound to the current node via
    NodeSelector constraints. These VMs cannot be rescheduled to other nodes that not meet the constraints, so disabling
    CPU Manager would make them unschedulable.
2. Last Node Protection: Prevents disabling CPU Manager on the last enabled node when any
    CPU-pinned VMs exist in the cluster, ensuring at least one node remains available for
    scheduling these VMs.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8859

#### Test plan:

Test plan1:
1. prepare a multi-node harvester cluster.
1. enable cpu pinning on one node, harvester-node-0.
1. create test vm
1. edit test vm, enable cpu pining, click save, “DO NOT” click save and restart.
1. create test2 vm, stop the vm
1. edit test2 vm, enable cpu pinning, click save.
1. disable cpu manager on harvester-node-0, you should see error as follows:
    <img width="212" height="72" alt="image" src="https://github.com/user-attachments/assets/d1202e2b-d265-4a94-83d6-8b72b8bf7b86" />
1. disable cpu pinning for test, test2 vms.
1. disable cpu manager successfully.

Test plan2:
1. prepare a multi-node harvester cluster.
1. enable cpu pinning on two nodes, harvester-node-0, harvester-node-1.
1. create 2 cpu pinning vm with additional scheduling rules
  1. test1: click node scheduling > Run virtual machine on node(s) matching scheduling rules > add rule "kubernetes.io/hostname" "in" "harvester-node-1"
  2. test2: click node scheduling > Run virtual machine on specific node - (Live migration is not supported) > select "harvester-node-0"
1. stop test1 and test2.
1. disable cpu manager on harvester-node-0, you should see error as follows: `admission webhook "validator.harvesterhci.io" denied the request: Cannot disable CPU Manager on this node because the following VM(s) with CPU pinning are bound to this node via Node Scheduling rules and cannot be scheduled on other CPU Manager enabled nodes. Please remove CPU pinning or update Node Scheduling rules for these VM(s): default/test1`
1. disable cpu manager on harvester-node-1, you should see error as follows: `admission webhook "validator.harvesterhci.io" denied the request: Cannot disable CPU Manager on this node because the following VM(s) with CPU pinning are bound to this node via Node Scheduling rules and cannot be scheduled on other CPU Manager enabled nodes. Please remove CPU pinning or update Node Scheduling rules for these VM(s): default/test2`
