### PR TITLE
VM builder: add setter methods for two fields

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -240,6 +240,16 @@ func (v *VMBuilder) RunStrategy(runStrategy kubevirtv1.VirtualMachineRunStrategy
 	return v
 }
 
+func (v *VMBuilder) DedicatedCPUPlacement(pinned bool) *VMBuilder {
+	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.DedicatedCPUPlacement = pinned
+	return v
+}
+
+func (v *VMBuilder) IsolateEmulatorThread(isolated bool) *VMBuilder {
+	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.IsolateEmulatorThread = isolated
+	return v
+}
+
 func (v *VMBuilder) VM() (*kubevirtv1.VirtualMachine, error) {
 	if v.VirtualMachine.Spec.Template.ObjectMeta.Annotations == nil {
 		v.VirtualMachine.Spec.Template.ObjectMeta.Annotations = make(map[string]string)

--- a/pkg/builder/vm_test.go
+++ b/pkg/builder/vm_test.go
@@ -1,0 +1,67 @@
+package builder
+
+import (
+	"testing"
+)
+
+type testcase struct {
+	name        string
+	builder     *VMBuilder
+	expectation bool
+}
+
+func TestDedicatedCPUPlacement(t *testing.T) {
+	testcases := []testcase{
+		{
+			name:        "default value",
+			builder:     NewVMBuilder("test"),
+			expectation: false,
+		},
+		{
+			name:        "dedicated cpu placement true",
+			builder:     NewVMBuilder("test").DedicatedCPUPlacement(true),
+			expectation: true,
+		},
+		{
+			name:        "dedicated cpu placement false",
+			builder:     NewVMBuilder("test").DedicatedCPUPlacement(false),
+			expectation: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		testVM, err := tc.builder.VM()
+
+		if err != nil || testVM.Spec.Template.Spec.Domain.CPU.DedicatedCPUPlacement != tc.expectation {
+			t.Error("generated VM object did not match expectations")
+		}
+	}
+}
+
+func TestIsolateEmulatorThread(t *testing.T) {
+	testcases := []testcase{
+		{
+			name:        "default value",
+			builder:     NewVMBuilder("test"),
+			expectation: false,
+		},
+		{
+			name:        "isolated emulator thread true",
+			builder:     NewVMBuilder("test").IsolateEmulatorThread(true),
+			expectation: true,
+		},
+		{
+			name:        "isolated emulator thread false",
+			builder:     NewVMBuilder("test").IsolateEmulatorThread(false),
+			expectation: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		testVM, err := tc.builder.VM()
+
+		if err != nil || testVM.Spec.Template.Spec.Domain.CPU.IsolateEmulatorThread != tc.expectation {
+			t.Error("generated VM object did not match expectations")
+		}
+	}
+}


### PR DESCRIPTION
Add setter methods for two more fields:
- DedicatedCPUPlacement
- IsolateEmulatorThread and tests

#### Problem:

The VMBuilder is a factory module that makes it easy to generate a `VirtualMachine` structure in Golang programs. It is used e.g. in the node driver.

The lack of some methods in the VMBuilder leads to an accumulation of fragile custom logic in the various repositories that consume the VMBuilder.

#### Solution:

Add missing methods and ensure complete feature coverage of the VMBuilder library.

#### Related Issue(s):

related-to: https://github.com/harvester/harvester/issues/8391

#### Test plan:

Unit tests included.

#### Additional documentation or context
