### PR TITLE
feat: generate NetworkManager config on upgrade

### DIFF
--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -152,6 +152,7 @@ jobs:
         build-args: |
           ARCH=${{ env.arch }}
           VERSION=${{ inputs.build_version }}
+          HARVESTER_INSTALLER_REF=${{ inputs.image_tag }}
   
   manifest-images:
     name: Manifest images

--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,4 +1,6 @@
+ARG HARVESTER_INSTALLER_REF=master-head
 FROM registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:v1.6 as baseos
+FROM rancher/harvester-installer:${HARVESTER_INSTALLER_REF} as installer
 FROM registry.suse.com/bci/bci-base:15.7
 
 ARG ARCH=amd64
@@ -16,6 +18,8 @@ RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.4.0/virt
     curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.8/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 # Copy elemental binary to be used for upgrades
 COPY --from=baseos /usr/bin/elemental /usr/local/bin/elemental
+# Copy harvester-installer binary to be used to generate networkmanager config
+COPY --from=installer /usr/bin/harvester-installer /usr/local/bin/harvester-installer
 COPY do_upgrade_node.sh /usr/local/bin/
 COPY upgrade_node.sh /usr/local/bin/
 COPY upgrade_manifests.sh /usr/local/bin/

--- a/scripts/package-upgrade
+++ b/scripts/package-upgrade
@@ -25,7 +25,11 @@ fi
 
 cp ../../bin/upgrade-helper .
 
-docker build -f ${DOCKERFILE} --build-arg ARCH=${ARCH} -t ${IMAGE} .
+BUILD_ARGS="--build-arg ARCH=${ARCH}"
+if [ -n "${HARVESTER_INSTALLER_REF}" ]; then
+    BUILD_ARGS="${BUILD_ARGS} --build-arg HARVESTER_INSTALLER_REF=${HARVESTER_INSTALLER_REF}"
+fi
+docker build -f ${DOCKERFILE} ${BUILD_ARGS} -t ${IMAGE} .
 echo Built ${IMAGE}
 
 IMAGE_PUSH=${REPO}/harvester-upgrade:${IMAGE_PUSH_TAG}


### PR DESCRIPTION
#### Problem:
We need to generate a YAML file in /oem containing NetworkManager connection profiles during upgrade.

#### Solution:
Pull the harvester-installer binary into the upgrade container then use it to generate the relevant YAML on upgrade

#### Related Issue(s):
https://github.com/harvester/harvester/issues/3418

#### Test plan:
TBD

#### Additional documentation or context
This depends on:
- https://github.com/harvester/harvester-installer/pull/1150
- https://github.com/rancherlabs/eio/issues/3619

This is still a bit rough (see the comments in the source) but if possible I'd like to merge this just so the essential parts of the whole upgrade story are in place, even if some things still need some subsequent tweaks.