### PR TITLE
fix: enhance the VM webhook for volume expansion

### DIFF
--- a/pkg/controller/master/virtualmachine/vm_controller.go
+++ b/pkg/controller/master/virtualmachine/vm_controller.go
@@ -151,7 +151,7 @@ func (h *VMController) createPVCsFromAnnotation(_ string, vm *kubevirtv1.Virtual
 		}
 
 		if strings.Contains(err.Error(), util.PVCExpandErrorPrefix) {
-			logrus.Warnf("PVC expand error: %v", err)
+			logrus.Warnf("in VM controller, PVC expand error: %v", err)
 			continue
 		}
 

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -13,7 +13,6 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cdicommon "kubevirt.io/containerized-data-importer/pkg/controller/common"
-	kvirtfeatures "kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	harvesterv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
@@ -131,92 +130,6 @@ func (v *pvcValidator) Delete(request *types.Request, oldObj runtime.Object) err
 	return nil
 }
 
-func (v *pvcValidator) isOnlineExpandNeeded(pvc *corev1.PersistentVolumeClaim) (bool, error) {
-	vms, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, ref.Construct(pvc.Namespace, pvc.Name))
-	if err != nil {
-		return false, werror.NewInternalError(fmt.Sprintf("failed to get VMs by index: %s, PVC: %s/%s, err: %s", indexeresutil.VMByPVCIndex, pvc.Namespace, pvc.Name, err))
-	}
-	for _, vm := range vms {
-		if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (v *pvcValidator) isHotpluggedFilesystemPVC(pvc *corev1.PersistentVolumeClaim) (bool, error) {
-	// Check if the PVC is in Filesystem mode
-	if pvc.Spec.VolumeMode == nil || *pvc.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
-		return false, nil
-	}
-
-	// Check if the PVC is hotplugged to any VM
-	vms, err := v.vmCache.GetByIndex(indexeresutil.VMByHotplugPVCIndex, ref.Construct(pvc.Namespace, pvc.Name))
-	if err != nil {
-		return false, werror.NewInternalError(err.Error())
-	}
-
-	return len(vms) > 0, nil
-}
-
-func isKubevirtExpandEnabled(kubevirt *kubevirtv1.KubeVirt) bool {
-	featureGates := kubevirt.Spec.Configuration.DeveloperConfiguration.FeatureGates
-	for _, f := range featureGates {
-		if f == kvirtfeatures.ExpandDisksGate {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (v *pvcValidator) checkExpand(pvc *corev1.PersistentVolumeClaim) error {
-	// we will have an early return if there is no related VMs or all related VMs are stopped
-	if onlineExpand, err := v.isOnlineExpandNeeded(pvc); err != nil || !onlineExpand {
-		return err
-	}
-
-	kubevirt, err := v.kubevirtCache.Get(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)
-	if err != nil {
-		return err
-	}
-	if !isKubevirtExpandEnabled(kubevirt) {
-		return werror.NewInvalidError(util.PVCExpandErrorPrefix+": kubevirt ExpandDisks not included in featureGate", "")
-	}
-
-	hotpluggedFSPVC, err := v.isHotpluggedFilesystemPVC(pvc)
-	if err != nil {
-		return err
-	}
-	if hotpluggedFSPVC {
-		return werror.NewInvalidError(
-			fmt.Sprintf(
-				util.PVCExpandErrorPrefix+": Expansion of hotplugged PVC '%s/%s' in filesystem mode is not supported",
-				pvc.Namespace,
-				pvc.Name,
-			),
-			"",
-		)
-	}
-
-	expandable, err := webhookutil.CheckOnlineExpand(pvc, v.engineCache, v.scCache, v.settingCache)
-	if err != nil {
-		return err
-	}
-	if !expandable {
-		return werror.NewInvalidError(
-			fmt.Sprintf(
-				util.PVCExpandErrorPrefix+": pvc %s/%s is not online expandable with its provider",
-				pvc.Namespace,
-				pvc.Name,
-			),
-			"",
-		)
-	}
-
-	return nil
-}
-
 func (v *pvcValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldPVC := oldObj.(*corev1.PersistentVolumeClaim)
 	newPVC := newObj.(*corev1.PersistentVolumeClaim)
@@ -240,7 +153,7 @@ func (v *pvcValidator) Update(_ *types.Request, oldObj runtime.Object, newObj ru
 		return nil
 	}
 
-	return v.checkExpand(newPVC)
+	return webhookutil.CheckExpand(newPVC, v.vmCache, v.kubevirtCache, v.engineCache, v.scCache, v.settingCache)
 }
 
 func (v *pvcValidator) checkGoldenImageAnno(pvc *corev1.PersistentVolumeClaim) error {

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -3,14 +3,12 @@ package virtualmachine
 import (
 	"testing"
 
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	corefake "k8s.io/client-go/kubernetes/fake"
-
-	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -653,7 +651,7 @@ func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
 	fakeVMCache := fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines)
 	fakeNadCache := fakeclients.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
 
-	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache, nil).(*vmValidator)
+	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache, nil, nil, nil, nil).(*vmValidator)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -827,7 +825,7 @@ func TestVmValidator_Update(t *testing.T) {
 	}})
 	assert.NoError(t, err)
 	fakeNSCache := fakeclients.NamespaceCache(corefakeclientset.CoreV1().Namespaces)
-	validator := NewValidator(fakeNSCache, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*vmValidator)
+	validator := NewValidator(fakeNSCache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*vmValidator)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -71,6 +71,9 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 			clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().KubeVirt().Cache(),
+			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
+			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		virtualmachineimage.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),

--- a/pkg/webhook/util/volume.go
+++ b/pkg/webhook/util/volume.go
@@ -2,18 +2,25 @@ package util
 
 import (
 	"fmt"
+	"slices"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhtypes "github.com/longhorn/longhorn-manager/types"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	corev1 "k8s.io/api/core/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	kvirtfeatures "kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	ctlkv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
+	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
+	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
 )
 
-func CheckOnlineExpand(
+func checkOnlineExpand(
 	pvc *corev1.PersistentVolumeClaim,
 	engineCache ctllonghornv1.EngineCache,
 	scCache ctlstoragev1.StorageClassCache,
@@ -59,4 +66,97 @@ func checkLonghornExpandability(pvc *corev1.PersistentVolumeClaim, engineCache c
 	}
 
 	return true, nil
+}
+
+func isOnlineExpandNeeded(pvc *corev1.PersistentVolumeClaim, vmCache ctlkv1.VirtualMachineCache) (bool, error) {
+	indexKey := ref.Construct(pvc.Namespace, pvc.Name)
+	vms, err := vmCache.GetByIndex(indexeresutil.VMByPVCIndex, indexKey)
+	if err != nil {
+		return false, werror.NewInternalError(fmt.Sprintf("failed to get VMs by index: %s, PVC: %s/%s, err: %s", indexeresutil.VMByPVCIndex, pvc.Namespace, pvc.Name, err))
+	}
+
+	for _, vm := range vms {
+		if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusStopped {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func isHotpluggedFilesystemPVC(pvc *corev1.PersistentVolumeClaim, vmCache ctlkv1.VirtualMachineCache) (bool, error) {
+	// Check if the PVC is in Filesystem mode
+	if pvc.Spec.VolumeMode == nil || *pvc.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
+		return false, nil
+	}
+
+	// Check if the PVC is hotplugged to any VM
+	vms, err := vmCache.GetByIndex(indexeresutil.VMByHotplugPVCIndex, ref.Construct(pvc.Namespace, pvc.Name))
+	if err != nil {
+		return false, werror.NewInternalError(err.Error())
+	}
+
+	return len(vms) > 0, nil
+}
+
+func isKubevirtExpandEnabled(kubevirt *kubevirtv1.KubeVirt) bool {
+	featureGates := kubevirt.Spec.Configuration.DeveloperConfiguration.FeatureGates
+	return slices.Contains(featureGates, kvirtfeatures.ExpandDisksGate)
+}
+
+func CheckExpand(pvc *corev1.PersistentVolumeClaim,
+	vmCache ctlkv1.VirtualMachineCache,
+	kubevirtCache ctlkv1.KubeVirtCache,
+	engineCache ctllonghornv1.EngineCache,
+	scCache ctlstoragev1.StorageClassCache,
+	settingCache ctlharvesterv1.SettingCache) error {
+
+	// Check if online expand is needed first
+	onlineExpand, err := isOnlineExpandNeeded(pvc, vmCache)
+	if err != nil {
+		return err
+	}
+	if !onlineExpand {
+		return nil
+	}
+
+	kubevirt, err := kubevirtCache.Get(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)
+	if err != nil {
+		return err
+	}
+	if !isKubevirtExpandEnabled(kubevirt) {
+		return werror.NewInvalidError(util.PVCExpandErrorPrefix+": kubevirt ExpandDisks not included in featureGate", "")
+	}
+
+	hotpluggedFSPVC, err := isHotpluggedFilesystemPVC(pvc, vmCache)
+	if err != nil {
+		return err
+	}
+	if hotpluggedFSPVC {
+		return werror.NewInvalidError(
+			fmt.Sprintf(
+				util.PVCExpandErrorPrefix+": Expansion of hotplugged PVC '%s/%s' in filesystem mode is not supported",
+				pvc.Namespace,
+				pvc.Name,
+			),
+			"",
+		)
+	}
+
+	expandable, err := checkOnlineExpand(pvc, engineCache, scCache, settingCache)
+	if err != nil {
+		return err
+	}
+	if !expandable {
+		return werror.NewInvalidError(
+			fmt.Sprintf(
+				util.PVCExpandErrorPrefix+": pvc %s/%s is not online expandable with its provider",
+				pvc.Namespace,
+				pvc.Name,
+			),
+			"",
+		)
+	}
+
+	return nil
 }


### PR DESCRIPTION
#### Problem:
Volume can’t be expanded online from the VM page.

#### Solution:
Enhance the VM webhook for volume expansion

#### Related Issue(s):
#8669 

#### Test plan:
* Install the NFS CSI driver or another third-party storage driver.
* Create a VM with the third-party volume as the root disk.
* After the VM is running, change the volume size using a VM annotation.
  - e.q. 
    ```
    harvesterhci.io/volumeClaimTemplates: '[{"metadata":{"name":"vm-nfs-disk-0-hq6rz","annotations":{"harvesterhci.io/imageId":"default/image-lvsrb"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"8Gi"}},"volumeMode":"Block","storageClassName":"nfs-csi"}}]'
    ``` 
    to
    ```
    harvesterhci.io/volumeClaimTemplates: '[{"metadata":{"name":"vm-nfs-disk-0-hq6rz","annotations":{"harvesterhci.io/imageId":"default/image-lvsrb"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"16Gi"}},"volumeMode":"Block","storageClassName":"nfs-csi"}}]'
    ```
* This update will be rejected by the Harvester webhook.
* Enable `csi-online-expand-validation` as described [here](https://docs.harvesterhci.io/v1.7/advanced/index#csi-online-expand-validation) for the third-party driver.
* Change the volume size using a VM annotation again.
* The volume should be expanded.

#### Additional documentation or context
