### PR TITLE
fix: stringify longhorn numeric defaultValues

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -494,7 +494,7 @@ longhorn:
 
   defaultSettings:
     ## Specify the concurrent automatic engine upgrade per node limit
-    concurrentAutomaticEngineUpgradePerNodeLimit: 3
+    concurrentAutomaticEngineUpgradePerNodeLimit: "3"
     priorityClass: &longhornPriorityClass system-cluster-critical
     autoCleanupSnapshotWhenDeleteBackup: true
     orphanResourceAutoDeletion: instance


### PR DESCRIPTION
#### Problem:
Since https://github.com/longhorn/longhorn/commit/d41740d1, longhorn's defaultValues must be strings.

#### Solution:
Quote the numeric values.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9223

#### Test plan:
Deploy harvester, make sure there are no errors as in the description of the related issue
