### PR TITLE
fix: stringify longhorn numeric defaultValues on upgrade

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -785,6 +785,14 @@ patch_longhorn_settings() {
     echo "longhorn detachManuallyAttachedVolumesWhenCordoned has been set in managedchart, do not patch again"
   fi
 
+  EXIT_CODE=0
+  local value=$(yq -e -r '.spec.values.longhorn.defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit' $target) || EXIT_CODE=$?
+  if [ $EXIT_CODE = 0 ]; then
+    # this works even if it's already a string, because the `yq` above gives us the unquoted value
+    echo "patch longhorn concurrentAutomaticEngineUpgradePerNodeLimit to string"
+    yq ".spec.values.longhorn.defaultSettings.concurrentAutomaticEngineUpgradePerNodeLimit = \"$value\"" -i $target
+  fi
+
   echo "longhorn related config"
   yq -e '.spec.values.longhorn' $target || echo "fail to get info .spec.values.longhorn"
 }


### PR DESCRIPTION
#### Problem:
Since https://github.com/longhorn/longhorn/commit/d41740d1, longhorn's defaultValues must be strings.

#### Solution:
Force concurrentAutomaticEngineUpgradePerNodeLimit to string on upgrade if set

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9223

#### Test plan:
- Install harvester v1.6.0
- Run `kubectl -n fleet-local edit managedchart/harvester` and edit `.spec.values.longhorn.defaultSettings` to set `concurrentAutomaticEngineUpgradePerNodeLimit = 3` (i.e. make sure it's an unquoted number)
- Upgrade to a build that includes this fix
- During the upgrade, the value above should be patched to a quoted string, e.g.:
```
> kubectl -n fleet-local get managedchart/harvester -o yaml | grep -A 5 defaultSettings:
      defaultSettings:
        concurrentAutomaticEngineUpgradePerNodeLimit: "3"
        defaultDataPath: /var/lib/harvester/defaultdisk
        detachManuallyAttachedVolumesWhenCordoned: true
        nodeDrainPolicy: allow-if-replica-is-stopped
        taintToleration: kubevirt.io/drain:NoSchedule
```
- The upgrade should succeed as usual.
