### PR TITLE
feat: support LH v2 online expansion

### DIFF
--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -17,7 +17,6 @@ import (
 	harvesterv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
@@ -31,7 +30,6 @@ func NewValidator(pvcCache v1.PersistentVolumeClaimCache,
 	vmCache ctlkv1.VirtualMachineCache,
 	kubevirtCache ctlkv1.KubeVirtCache,
 	imageCache ctlharvesterv1.VirtualMachineImageCache,
-	engineCache ctllonghornv1.EngineCache,
 	scCache ctlstoragev1.StorageClassCache,
 	settingCache ctlharvesterv1.SettingCache) types.Validator {
 	return &pvcValidator{
@@ -39,7 +37,6 @@ func NewValidator(pvcCache v1.PersistentVolumeClaimCache,
 		vmCache:       vmCache,
 		kubevirtCache: kubevirtCache,
 		imageCache:    imageCache,
-		engineCache:   engineCache,
 		scCache:       scCache,
 		settingCache:  settingCache,
 	}
@@ -51,7 +48,6 @@ type pvcValidator struct {
 	vmCache       ctlkv1.VirtualMachineCache
 	imageCache    ctlharvesterv1.VirtualMachineImageCache
 	kubevirtCache ctlkv1.KubeVirtCache
-	engineCache   ctllonghornv1.EngineCache
 	scCache       ctlstoragev1.StorageClassCache
 	settingCache  ctlharvesterv1.SettingCache
 }
@@ -153,7 +149,7 @@ func (v *pvcValidator) Update(_ *types.Request, oldObj runtime.Object, newObj ru
 		return nil
 	}
 
-	return webhookutil.CheckExpand(newPVC, v.vmCache, v.kubevirtCache, v.engineCache, v.scCache, v.settingCache)
+	return webhookutil.CheckExpand(newPVC, v.vmCache, v.kubevirtCache, v.scCache, v.settingCache)
 }
 
 func (v *pvcValidator) checkGoldenImageAnno(pvc *corev1.PersistentVolumeClaim) error {

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -20,7 +20,6 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
@@ -42,7 +41,6 @@ func NewValidator(
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
 	nadCache ctlcniv1.NetworkAttachmentDefinitionCache,
 	kubevirtCache ctlkubevirtv1.KubeVirtCache,
-	engineCache ctllonghornv1.EngineCache,
 	scCache ctlstoragev1.StorageClassCache,
 	settingCache ctlharvesterv1.SettingCache,
 ) types.Validator {
@@ -53,7 +51,6 @@ func NewValidator(
 		vmiCache:      vmiCache,
 		nadCache:      nadCache,
 		kubevirtCache: kubevirtCache,
-		engineCache:   engineCache,
 		scCache:       scCache,
 		settingCache:  settingCache,
 
@@ -69,7 +66,6 @@ type vmValidator struct {
 	vmiCache      ctlkubevirtv1.VirtualMachineInstanceCache
 	nadCache      ctlcniv1.NetworkAttachmentDefinitionCache
 	kubevirtCache ctlkubevirtv1.KubeVirtCache
-	engineCache   ctllonghornv1.EngineCache
 	scCache       ctlstoragev1.StorageClassCache
 	settingCache  ctlharvesterv1.SettingCache
 	rqCalculator  *resourcequota.Calculator
@@ -475,7 +471,7 @@ func (v *vmValidator) checkPVCStorageRequestChange(newPvc, oldPvc *corev1.Persis
 		return err
 	}
 
-	return webhookutil.CheckExpand(pvc, v.vmCache, v.kubevirtCache, v.engineCache, v.scCache, v.settingCache)
+	return webhookutil.CheckExpand(pvc, v.vmCache, v.kubevirtCache, v.scCache, v.settingCache)
 }
 
 func (v *vmValidator) checkGoldenImage(vm *kubevirtv1.VirtualMachine) error {

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -651,7 +651,7 @@ func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
 	fakeVMCache := fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines)
 	fakeNadCache := fakeclients.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
 
-	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache, nil, nil, nil, nil).(*vmValidator)
+	validator := NewValidator(nil, nil, nil, nil, nil, nil, fakeVMCache, nil, fakeNadCache, nil, nil, nil).(*vmValidator)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -825,7 +825,7 @@ func TestVmValidator_Update(t *testing.T) {
 	}})
 	assert.NoError(t, err)
 	fakeNSCache := fakeclients.NamespaceCache(corefakeclientset.CoreV1().Namespaces)
-	validator := NewValidator(fakeNSCache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*vmValidator)
+	validator := NewValidator(fakeNSCache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*vmValidator)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -63,7 +63,6 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().KubeVirt().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage().Cache(),
-			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
 			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		keypair.NewValidator(clients.HarvesterFactory.Harvesterhci().V1beta1().KeyPair().Cache()),
@@ -78,7 +77,6 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 			clients.CNIFactory.K8s().V1().NetworkAttachmentDefinition().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().KubeVirt().Cache(),
-			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
 			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()),
 		virtualmachineimage.NewValidator(

--- a/pkg/webhook/util/volume.go
+++ b/pkg/webhook/util/volume.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"slices"
 
-	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
-	lhtypes "github.com/longhorn/longhorn-manager/types"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	corev1 "k8s.io/api/core/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -13,7 +11,6 @@ import (
 
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
@@ -22,7 +19,6 @@ import (
 
 func checkOnlineExpand(
 	pvc *corev1.PersistentVolumeClaim,
-	engineCache ctllonghornv1.EngineCache,
 	scCache ctlstoragev1.StorageClassCache,
 	settingCache ctlharvesterv1.SettingCache,
 ) (bool, error) {
@@ -31,16 +27,7 @@ func checkOnlineExpand(
 		return false, fmt.Errorf("error determining provisioner for PVC %s/%s: %w", pvc.Namespace, pvc.Name, err)
 	}
 
-	expandable, err := util.GetCSIOnlineExpandValidation(provisioner, settingCache)
-	if err != nil {
-		return false, err
-	}
-
-	if provisioner != lhtypes.LonghornDriverName || !expandable {
-		return expandable, nil
-	}
-
-	return checkLonghornExpandability(pvc, engineCache)
+	return util.GetCSIOnlineExpandValidation(provisioner, settingCache)
 }
 
 func getPVCProvisioner(pvc *corev1.PersistentVolumeClaim, scCache ctlstoragev1.StorageClassCache) (string, error) {
@@ -49,23 +36,6 @@ func getPVCProvisioner(pvc *corev1.PersistentVolumeClaim, scCache ctlstoragev1.S
 		return "", fmt.Errorf("failed to determine provisioner for PVC %s/%s", pvc.Namespace, pvc.Name)
 	}
 	return provisioner, nil
-}
-
-func checkLonghornExpandability(pvc *corev1.PersistentVolumeClaim, engineCache ctllonghornv1.EngineCache) (bool, error) {
-	if pvc.Spec.VolumeName == "" {
-		return false, fmt.Errorf("PVC %s/%s volume name is empty", pvc.Namespace, pvc.Name)
-	}
-
-	engine, err := GetLHEngine(engineCache, pvc.Spec.VolumeName)
-	if err != nil {
-		return false, fmt.Errorf("error getting Longhorn engine for volume %s: %w", pvc.Spec.VolumeName, err)
-	}
-
-	if engine.Spec.DataEngine == lhv1beta2.DataEngineTypeV2 {
-		return false, nil
-	}
-
-	return true, nil
 }
 
 func isOnlineExpandNeeded(pvc *corev1.PersistentVolumeClaim, vmCache ctlkv1.VirtualMachineCache) (bool, error) {
@@ -107,7 +77,6 @@ func isKubevirtExpandEnabled(kubevirt *kubevirtv1.KubeVirt) bool {
 func CheckExpand(pvc *corev1.PersistentVolumeClaim,
 	vmCache ctlkv1.VirtualMachineCache,
 	kubevirtCache ctlkv1.KubeVirtCache,
-	engineCache ctllonghornv1.EngineCache,
 	scCache ctlstoragev1.StorageClassCache,
 	settingCache ctlharvesterv1.SettingCache) error {
 
@@ -143,7 +112,7 @@ func CheckExpand(pvc *corev1.PersistentVolumeClaim,
 		)
 	}
 
-	expandable, err := checkOnlineExpand(pvc, engineCache, scCache, settingCache)
+	expandable, err := checkOnlineExpand(pvc, scCache, settingCache)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Problem:
Support online expansion for Longhorn v2 volumes

#### Solution:
Adjust the Harvester webhook to allow online expansion for Longhorn v2 volumes.

#### Related Issue(s):
#9162 

#### Test plan:
* Start a VM with an LHv2 volume
* Expand the size of the related PVCs
  * By editing the manifest, if operating via GUI, the Harvester GUI blocks expansion for the LHv2 volumes
* The volume should be expanded
