### PR TITLE
fix: patch maxSockets if enableCPUAndMemoryHotplug is false

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -317,10 +317,16 @@ func generateMemoryPatch(vm *kubevirtv1.VirtualMachine, mem *resource.Quantity, 
 		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "%s"}`, quantity))
 	}
 
+	// patch guest memory
 	if vm.Spec.Template.Spec.Domain.Memory == nil {
 		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"%s"}}`, &guestMemory))
 	} else if !enableCPUAndMemoryHotplug {
 		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/memory/guest", "value": "%s"}`, &guestMemory))
+	}
+
+	// patch maxSockets
+	if !enableCPUAndMemoryHotplug {
+		patchOps = append(patchOps, `{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`)
 	}
 
 	return patchOps, nil

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -54,6 +54,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "256Mi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"924Mi"}}`, // 1Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			setting: "",
 		},
@@ -71,6 +72,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "1Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"3996Mi"}}`, // 4Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			setting: "",
 		},
@@ -88,6 +90,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "4Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"16284Mi"}}`, // 16Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			setting: "",
 		},
@@ -118,6 +121,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			memory: nil,
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"924Mi"}}`, // 1Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"500m","memory":"256Mi"}}`,
 			},
 		},
@@ -132,6 +136,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			memory: nil,
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"924Mi"}}`, // 1Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"100m","memory":"102Mi"}}`,
 			},
 			setting: `{"cpu":1000,"memory":1000,"storage":800}`,
@@ -149,6 +154,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			},
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory/guest", "value": "924Mi"}`, // 1Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests", "value": {"cpu":"100m","memory":"102Mi"}}`,
 			},
 			setting: `{"cpu":1000,"memory":1000,"storage":800}`,
@@ -182,6 +188,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "256Mi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"640Mi"}}`, // 1Gi - 384Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			setting: "",
 		},
@@ -199,6 +206,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "1Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"3712Mi"}}`, // 4Gi - 384Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			setting: "",
 		},
@@ -435,6 +443,7 @@ func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testin
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "1Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"3996Mi"}}`, // 4Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			overcommitSetting:    "",
 			overheadRatio:        "invalid",
@@ -457,6 +466,7 @@ func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testin
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "2Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"7Gi"}}`, // 8Gi - 1Gi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			overcommitSetting:    "",
 			overheadRatio:        "invalid",
@@ -480,6 +490,7 @@ func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testin
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "1Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"4Gi"}}`, // 4Gi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			overcommitSetting:    "",
 			overheadRatio:        settings.AdditionalGuestMemoryOverheadRatioDefault,
@@ -502,6 +513,7 @@ func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testin
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "1Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"3Gi"}}`, // 3Gi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			overcommitSetting:    "",
 			overheadRatio:        "4.8",
@@ -524,6 +536,7 @@ func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testin
 			patchOps: []string{
 				`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "1Gi"}`,
 				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"3996Mi"}}`, // 4Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
 			},
 			overcommitSetting:    "",
 			overheadRatio:        "0.0", // means clear current setting
@@ -757,6 +770,7 @@ func TestPatchResourceOvercommitWithDedicatedCPUPlacement(t *testing.T) {
 	assert.Equal(t,
 		[]string{
 			"{\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/memory\", \"value\": {\"guest\":\"924Mi\"}}",
+			"{\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/cpu/maxSockets\", \"value\": 1}",
 			"{\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/resources/requests\", \"value\": {\"cpu\":\"8\",\"memory\":\"1Gi\"}}"},
 		actual)
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Solution:
If users don't enable cpu and memory hotplug, patch `maxSockets` as `1`, so we don't get default `maxHotplugRatio` from the KubeVirt CR.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9059

#### Test plan:
<!-- Describe the test plan by steps. -->
1. Create a VM without enabling cpu and memory hotplug. The `maxSockets` in the VM spec must be 1.
2. Create a VM with enabling cpu and memory hotplug. The `maxSockets` in the VM spec should be same as user definition.

#### Additional documentation or context
