### PR TITLE
ci: fix scan-and-notify-testing message format [skip ci]

### DIFF
--- a/.github/workflows/scan-and-notify-testing-items.py
+++ b/.github/workflows/scan-and-notify-testing-items.py
@@ -1,12 +1,41 @@
 import requests
 import os
 import sys
-import time
 import json
 from datetime import datetime, timedelta
 
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+# Add emoji reactions to Slack message for better visibility
+def add_emoji_reactions(channel_id, message_ts, headers):
+    """Add emoji reactions to a Slack message"""
+    reactions_api_url = "https://slack.com/api/reactions.add"
+    emojis = ["white_check_mark", "+1", "pray"]
+
+    for emoji in emojis:
+        reaction_payload = {
+            "channel": channel_id,
+            "timestamp": message_ts,
+            "name": emoji
+        }
+
+        try:
+            reaction_response = requests.post(reactions_api_url,
+                                              json=reaction_payload,
+                                              headers=headers)
+            if reaction_response.status_code == 200:
+                reaction_data = reaction_response.json()
+                if not reaction_data.get('ok'):
+                    print(f"Failed to add {emoji} reaction: " +
+                          f"{reaction_data.get('error')}")
+                else:
+                    print(f"✅ Added {emoji} reaction successfully")
+            else:
+                print(f"HTTP error adding {emoji} reaction: " +
+                      f"{reaction_response.status_code}")
+        except Exception as e:
+            print(f"Error adding {emoji} reaction: {e}")
 
 
 def get_github_project_info(github_token, github_org, github_project):
@@ -228,8 +257,8 @@ def flatten_issues(title, blocks, issues, user_mapping, issue_template_url):
 
             issue_texts.append(f"- *<{issue_url}|{number}>* - {title} - {', '.join(assignees)}")
 
-            # Add a block for every 5 issues for avoiding bad request error
-            if (i + 1) % 5 == 0 or (i + 1) == len(issues):
+            # Add a block for every 2 issues for avoiding bad request error
+            if (i + 1) % 2 == 0 or (i + 1) == len(issues):
                 blocks.append({
                     "type": "section",
                     "text": {
@@ -242,52 +271,165 @@ def flatten_issues(title, blocks, issues, user_mapping, issue_template_url):
     return blocks
 
 
-def send_slack_notification(webhook_url, user_mapping,
-                            current_issues, non_current_issues,
-                            group_id, group_name, issue_template_url):
+def send_slack_notification(user_mapping, current_issues, non_current_issues,
+                            group_id, group_name, issue_template_url,
+                            slack_bot_token, slack_channel):
     if len(current_issues) == 0 and len(non_current_issues) == 0:
         print("Nothing to notify")
         return
 
-    # Initialize blocks as an empty list
-    blocks = []
-
-    blocks.append({
+    # Send summary message first using chat.postMessage API
+    total_issues = len(current_issues) + len(non_current_issues)
+    summary_blocks = [{
         "type": "section",
         "text": {
             "type": "mrkdwn",
-            "text": f"Hello <!subteam^{group_id}|{group_name}>, this is a reminder. \n\n" +
-                    "There are 'Ready for Testing' or 'Testing' issues. Please finish verifying them using the corresponding sprint release soon. \n\n" +
-                    "  - If passed, move them to 'Closed' and DO NOT change the sprint. \n" +
-                    "  - If not passed, move them to 'Implementation' and update the sprint to the current one. \n\n" +
-                    "Thanks for your efforts!"
+            "text": f"Hello <!subteam^{group_id}|{group_name}>, " +
+                    "this is a reminder. \n\n" +
+                    f"There are *{total_issues}* 'Ready for Testing' " +
+                    "or 'Testing' issues:\n" +
+                    f"  - {len(current_issues)} from previous sprint\n" +
+                    f"  - {len(non_current_issues)} from older sprints\n\n" +
+                    "Please finish verifying them using the corresponding " +
+                    "sprint release soon. Details in thread 👇"
         }
-    })
+    }]
 
-    blocks = flatten_issues("Ready for Testing Issues from the Previous Sprint",
-                            blocks, current_issues, user_mapping, issue_template_url)
-    blocks = flatten_issues("Ready for Testing Issues from older Sprints",
-                            blocks, non_current_issues, user_mapping, issue_template_url)
-
-    payload = {
-        "blocks": blocks
+    summary_payload = {
+        "channel": slack_channel,
+        "blocks": summary_blocks
     }
 
     headers = {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {slack_bot_token}'
     }
 
-    response = requests.post(webhook_url, json=payload, headers=headers)
+    # Send summary message using Slack API
+    slack_api_url = "https://slack.com/api/chat.postMessage"
+    response = requests.post(slack_api_url, json=summary_payload,
+                             headers=headers)
     response.raise_for_status()
+
+    # Get the timestamp of the summary message to reply in thread
+    response_data = response.json()
+
+    if not response_data.get('ok'):
+        print(f"Slack API error: {response_data.get('error')}")
+        return
+
+    thread_ts = response_data.get('ts')
+
+    if thread_ts:
+        # Send instructions message in thread first
+        instruction_blocks = [{
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Instructions:*\n" +
+                        "  - If passed, move them to 'Closed' and " +
+                        "DO NOT change the sprint. \n" +
+                        "  - If not passed, move them to 'Implementation' " +
+                        "and update the sprint to the current one. \n\n" +
+                        "Thanks for your efforts!"
+            }
+        }]
+
+        instruction_payload = {
+            "channel": slack_channel,
+            "blocks": instruction_blocks,
+            "thread_ts": thread_ts
+        }
+
+        # Send instructions message
+        response = requests.post(slack_api_url, json=instruction_payload,
+                                 headers=headers)
+        response.raise_for_status()
+
+        instruction_response_data = response.json()
+        if instruction_response_data.get('ok'):
+            instruction_ts = instruction_response_data.get('ts')
+            instruction_channel_id = instruction_response_data.get('channel')
+            add_emoji_reactions(instruction_channel_id,
+                                instruction_ts, headers)
+        else:
+            print("Slack API error for instruction thread message: " +
+                  f"{instruction_response_data.get('error')}")
+
+        # Send previous sprint issues in separate thread message
+        if current_issues:
+            previous_sprint_blocks = []
+            previous_sprint_blocks.append({"type": "divider"})
+            previous_sprint_blocks = flatten_issues(
+                "Ready for Testing Issues from Previous Sprint",
+                previous_sprint_blocks, current_issues, user_mapping,
+                issue_template_url)
+
+            previous_sprint_payload = {
+                "channel": slack_channel,
+                "blocks": previous_sprint_blocks,
+                "thread_ts": thread_ts
+            }
+
+            response = requests.post(slack_api_url,
+                                     json=previous_sprint_payload,
+                                     headers=headers)
+            response.raise_for_status()
+
+            previous_sprint_response_data = response.json()
+            if previous_sprint_response_data.get('ok'):
+                previous_sprint_ts = previous_sprint_response_data.get('ts')
+                prev_channel_id = previous_sprint_response_data.get('channel')
+                add_emoji_reactions(slack_bot_token, prev_channel_id,
+                                    previous_sprint_ts, headers)
+            else:
+                print("Slack API error for previous sprint thread message: " +
+                      f"{previous_sprint_response_data.get('error')}")
+
+        # Send older sprints issues in separate thread message
+        if non_current_issues:
+            older_sprints_blocks = []
+            older_sprints_blocks.append({"type": "divider"})
+            older_sprints_blocks = flatten_issues(
+                "Ready for Testing Issues from Older Sprints",
+                older_sprints_blocks, non_current_issues, user_mapping,
+                issue_template_url)
+
+            older_sprints_payload = {
+                "channel": slack_channel,
+                "blocks": older_sprints_blocks,
+                "thread_ts": thread_ts
+            }
+
+            response = requests.post(slack_api_url,
+                                     json=older_sprints_payload,
+                                     headers=headers)
+            response.raise_for_status()
+
+            older_sprints_response_data = response.json()
+            if older_sprints_response_data.get('ok'):
+                older_sprints_ts = older_sprints_response_data.get('ts')
+                older_channel_id = older_sprints_response_data.get('channel')
+                add_emoji_reactions(slack_bot_token, older_channel_id,
+                                    older_sprints_ts, headers)
+            else:
+                print("Slack API error for older sprints thread message: " +
+                      f"{older_sprints_response_data.get('error')}")
 
 
 def scan_and_notify(github_org, github_repo, github_project):
     github_token = os.getenv("GITHUB_TOKEN")
-    webhook_url = os.getenv("SLACK_WEBHOOK_URL")
     value = os.getenv("USER_MAPPING")
+    slack_bot_token = os.getenv("SLACK_BOT_TOKEN")
+    slack_channel = os.getenv("SLACK_CHANNEL")
     issue_template_url = os.getenv("ISSUE_TEMPLATE_URL")
     group_id = os.getenv("GROUP_ID")
     group_name = os.getenv("GROUP_NAME")
+
+    if not slack_bot_token or not slack_channel:
+        print("SLACK_BOT_TOKEN and SLACK_CHANNEL must be provided " +
+              "for thread functionality")
+        return
 
     user_mapping = {}
     if value is not None:
@@ -298,27 +440,33 @@ def scan_and_notify(github_org, github_repo, github_project):
     project = get_github_project_info(github_token, github_org, github_project)
     print(f"GitHub Project Details: {project}")
 
-    # last_day = is_today_is_in_last_day_of_current_sprint(github_token, project.get("id"))
-    # if not last_day:
-    #     print("Today %s is not in last day of current sprint" % datetime.now().date())
-    #     return
+    last_day = is_today_is_in_last_day_of_current_sprint(
+        github_token, project.get("id"))
+    if not last_day:
+        print("Today %s is not in last day of current sprint" %
+              datetime.now().date())
+        return
 
     project_id = project.get("id")
-    current_issues, non_current_issues = list_issues_in_project(github_token,
-                                                                project_id,
-                                                                ["Ready For Testing", "Testing"])
+    current_issues, non_current_issues = list_issues_in_project(
+        github_token,
+        project_id,
+        ["Ready For Testing", "Testing"])
 
-    print("Number of \"Ready For Testing\" and \"Testing\" issues for current sprint:", len(current_issues))
-    print("Number of \"Ready For Testing\" and \"Testing\" issues for non-current sprint:", len(non_current_issues))
+    print("Number of \"Ready For Testing\" and \"Testing\" issues " +
+          "for current sprint:", len(current_issues))
+    print("Number of \"Ready For Testing\" and \"Testing\" issues " +
+          "for non-current sprint:", len(non_current_issues))
 
-    send_slack_notification(webhook_url,
-                            user_mapping, current_issues, non_current_issues,
-                            group_id, group_name, issue_template_url)
+    send_slack_notification(user_mapping, current_issues, non_current_issues,
+                            group_id, group_name, issue_template_url,
+                            slack_bot_token, slack_channel)
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 4:
-        print('Usage: python scan-and-notify-testing-items.py <github_org> <github_repo> <github_project>')
+        print('Usage: python scan-and-notify-testing-items.py ' +
+              '<github_org> <github_repo> <github_project>')
         sys.exit(1)
 
     scan_and_notify(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/.github/workflows/scan-and-notify-testing-items.yml
+++ b/.github/workflows/scan-and-notify-testing-items.yml
@@ -44,10 +44,11 @@ jobs:
     - name: Scan and Notify Testing Items
       env:
         GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HARVESTER_QA_WEBHOOK_URL }}
         USER_MAPPING: ${{ secrets.USER_MAPPING_FOR_GITHUB_SLACK }}
         GROUP_ID: ${{ secrets.HARVESTER_QA_GROUP_ID }}
         GROUP_NAME: ${{ secrets.HARVESTER_QA_GROUP_NAME }}
+        SLACK_BOT_TOKEN: ${{ secrets.HARVESTER_QA_SLACK_BOT_TOKEN }}
+        SLACK_CHANNEL: ${{ secrets.HARVESTER_QA_SLACK_CHANNEL }}
         ISSUE_TEMPLATE_URL: "https://github.com/harvester/harvester/issues/"
       run: |
         github_org="${GITHUB_ORG}"


### PR DESCRIPTION
Secrets are set. Related Issue: https://github.com/harvester/harvester/issues/9253.

- [x] Separate summary and details
- [x] Prevent showing `read more` hint with two blocks as a group. It was five blocks as a group before.

<img width="583" height="925" alt="image" src="https://github.com/user-attachments/assets/e3116678-5095-43f2-a90c-37ee64bd8238" />
