### PR TITLE
feat: add post-upgrade cleanup label to 'upgrade' resource

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -147,6 +147,9 @@ func markComplete(upgrade *harvesterv1.Upgrade) {
 		harvesterv1.NodesUpgraded.IsTrue(upgrade) {
 		harvesterv1.UpgradeCompleted.True(upgrade)
 		upgrade.Labels[upgradeStateLabel] = StateSucceeded
+		if v, exists := upgrade.Labels[upgradeCleanupLabel]; !exists || v != StatePending {
+			upgrade.Labels[upgradeCleanupLabel] = StatePending
+		}
 	}
 	if harvesterv1.ImageReady.IsFalse(upgrade) || harvesterv1.RepoProvisioned.IsFalse(upgrade) ||
 		harvesterv1.SystemServicesUpgraded.IsFalse(upgrade) || harvesterv1.NodesUpgraded.IsFalse(upgrade) {

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -147,14 +147,13 @@ func markComplete(upgrade *harvesterv1.Upgrade) {
 		harvesterv1.NodesUpgraded.IsTrue(upgrade) {
 		harvesterv1.UpgradeCompleted.True(upgrade)
 		upgrade.Labels[upgradeStateLabel] = StateSucceeded
-		if v, exists := upgrade.Labels[upgradeCleanupLabel]; !exists || v != StatePending {
-			upgrade.Labels[upgradeCleanupLabel] = StatePending
-		}
+		upgrade.Labels[upgradeCleanupLabel] = StatePending
 	}
 	if harvesterv1.ImageReady.IsFalse(upgrade) || harvesterv1.RepoProvisioned.IsFalse(upgrade) ||
 		harvesterv1.SystemServicesUpgraded.IsFalse(upgrade) || harvesterv1.NodesUpgraded.IsFalse(upgrade) {
 		harvesterv1.UpgradeCompleted.False(upgrade)
 		upgrade.Labels[upgradeStateLabel] = StateFailed
+		upgrade.Labels[upgradeCleanupLabel] = StatePending
 	}
 }
 

--- a/pkg/controller/master/upgrade/job_controller.go
+++ b/pkg/controller/master/upgrade/job_controller.go
@@ -35,6 +35,7 @@ const (
 	StateUpgradingNodes          = "UpgradingNodes"
 	StateSucceeded               = "Succeeded"
 	StateFailed                  = "Failed"
+	StatePending                 = "Pending"
 
 	nodeStateImagesPreloading       = "Images preloading"
 	nodeStateImagesPreloaded        = "Images preloaded"
@@ -46,6 +47,7 @@ const (
 	upgradeNodeLabel                = "upgrade.cattle.io/node"
 	upgradeStateLabel               = "harvesterhci.io/upgradeState"
 	upgradeJobTypeLabel             = "harvesterhci.io/upgradeJobType"
+	upgradeCleanupLabel             = "harvesterhci.io/upgradeCleanup"
 	upgradeJobTypePreDrain          = "pre-drain"
 	upgradeJobTypePostDrain         = "post-drain"
 	upgradeJobTypeRestoreVM         = "restore-vm"
@@ -182,7 +184,6 @@ func (h *jobHandler) syncNodeJob(job *batchv1.Job) (*batchv1.Job, error) {
 		LabelSelector: fmt.Sprintf("%s=%s", rancherPlanSecretMachineLabel, machineName),
 		FieldSelector: fmt.Sprintf("type=%s", rancherPlanSecretType),
 	})
-
 	if err != nil {
 		return job, err
 	}

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -244,7 +244,8 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 					WithAnnotation(imageCleanupPlanCompletedAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(longhornSettingsRestoredAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(autoCleanupSystemGeneratedSnapshotAnnotation, strconv.FormatBool(true)).
-					WithAnnotation(replicaReplenishmentAnnotation, strconv.Itoa(600)).Build(),
+					WithAnnotation(replicaReplenishmentAnnotation, strconv.Itoa(600)).
+					WithLabel(upgradeCleanupLabel, StateSucceeded).Build(),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Currently, there isn't any mechanism to prevent a new upgrade from starting while a previous upgrade is still undergoing its final post-upgrade cleanup phase. This can cause resource creation and deletion contention between the new and existing upgrades. The post-upgrade cleanup phase starts after the upgrade is marked as completed. The validating webhook can only prevent new upgrades from starting by asserting the `harvesterhci.io/upgradeState` label (`succeeded` or `failed`) of other existing upgrades.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Introduce a new label named `harvesterhci.io/upgradeCleanup` to indicate the state of the post-upgrade cleanup.

This label is first added to an `Upgrade` resource as `pending` when:

i. system services are successfully upgraded
i. nodes are successfully upgraded
i. upgrade is marked completed

This label is updated to `succeeded` when the post-upgrade cleanup phase is completed successfully.

The validating webhook is updated to prevent new upgrades from starting if there is at least one upgrades with a `pending` post-upgrade cleanup label.

The value of this label remains in `pending` when any of the cleanup operations failed. The goal is to prevent a storm of requeuing reconciliation requests as a result of errors and constant updating of the labels.

The current error handling in the cleanup phase remains unchanged. All existing logic around upgrade states and conditions management also remained unchanged.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
#6670

#### Test plan:

Note: Since the cleanup phase happens after the Harvester controller is upgraded and the node rebooted, the upgrade test cases must be run with a target version that contains the enhancements in this PR. The starting version of the test cluster can be any 1.6.x version.

## Test Case 1 - Regression Test

* Start with a single-node 1.6.0 cluster.
* Deploy the following `Version` resource that references the ISO that contains the enhancement in this PR

```sh
cat <<EOF | k create -f -
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master-head
  namespace: harvester-system
spec:
  isoChecksum: 0ca8908b0aacbeb80f5e5302916b7bf26f201d103f8f1600e8985a7def3090a40404612904dd2f48c907766c430dbb3e7bee1108037c048818fbf4b3c5d68ed3
  isoURL: http://<lab-server>/iso/isim/harvester-master-amd64.iso
  releaseDate: "20251003"
EOF
```

* Confirm that the version is ready:

```sh
k -n harvester-system get versions
```

* Trigger the upgrade from the Harvester UI

* Identify the `Upgrade` resource name:

```sh
upgrade_name=`k -n harvester-system get upgrades -lharvesterhci.io/latestUpgrade=true -oname`
```

* Once the upgrade starts, issue a `wait` command (for 60 mins) to wait for the cleanup to *complete*:

```sh
k -n harvester-system wait --for=jsonpath='{.metadata.labels.harvesterhci\.io/upgradeCleanup}=Succeeded' "${upgrade_name}" --timeout=60m
```

(the `wait` command will need to be restarted after the node is upgraded and rebooted)

* Once the wait is over, confirm that the `Upgrade` resource is labeled:

```sh
k -n harvester-system get "${upgrade_name}" -ojsonpath='{.metadata.labels.harvesterhci\.io/upgradeCleanup}'
Succeeded%
```

* Check for post-upgrade clean up start and complete logs:

```sh
$ k -n harvester-system logs deployment/harvester --all-pods=true | grep -i "post-upgrade cleanup"
# ...
[pod/harvester-68d466ccc9-p8vsh/apiserver] time="2025-10-04T18:00:09Z" level=info msg="starting post-upgrade cleanup"
[pod/harvester-68d466ccc9-p8vsh/apiserver] time="2025-10-04T18:01:02Z" level=info msg="starting post-upgrade cleanup"
[pod/harvester-68d466ccc9-p8vsh/apiserver] time="2025-10-04T18:01:02Z" level=info msg="successfully completed post-upgrade cleanup"
[pod/harvester-68d466ccc9-p8vsh/apiserver] time="2025-10-04T18:01:02Z" level=info msg="starting post-upgrade cleanup"
[pod/harvester-68d466ccc9-p8vsh/apiserver] time="2025-10-04T18:01:02Z" level=info msg="post-upgrade cleanup already completed"
```

## Test Case 2 - Assert Validating Webhook New Admission Rule

* Start with a single-node 1.6.0 cluster.
* Deploy the following `Version` resource that references the ISO that contains the enhancement in this PR

```sh
cat <<EOF | k create -f -
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: master-head
  namespace: harvester-system
spec:
  isoChecksum: 0ca8908b0aacbeb80f5e5302916b7bf26f201d103f8f1600e8985a7def3090a40404612904dd2f48c907766c430dbb3e7bee1108037c048818fbf4b3c5d68ed3
  isoURL: http://<lab-server>/iso/isim/harvester-master-amd64.iso
  releaseDate: "20251003"
EOF
```

* Confirm that the version is ready:

```sh
k -n harvester-system get versions
```

* Trigger the upgrade from the Harvester U

* Identify the `Upgrade` resource name:

```sh
upgrade_name=`k -n harvester-system get upgrades -lharvesterhci.io/latestUpgrade=true -oname`
```

* Once the upgrade starts, issue a `wait` command (for 60 mins) to wait for the cleanup to *start* and then attempt to start another concurrent upgrade:

```sh
k -n harvester-system wait --for=jsonpath='{.metadata.labels.harvesterhci\.io/upgradeCleanup}=Pending' "${upgrade_name}" --timeout=60m && cat <<EOF | kubectl create -f -
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: v1.6.1-rc1
  namespace: harvester-system
spec:
  isoChecksum: f9c4bc9e9bf66d859b16b8cccfd7ba197b99d82f68ad4633ca40e4e78f7f08f249e09d3849e97ab7f0fd3ae1966db3ca527d277a60f464db494c1b68754836df
  isoURL: http://<lab-server>/iso/v1.6.1-rc1/harvester-v1.6.1-rc1-amd64.iso
  releaseDate: "20251001"
---
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  generateName: hvst-upgrade-
  namespace: harvester-system
spec:
  image: ""
  logEnabled: true
  version: v1.6.1-rc1
EOF
```

(Although the UI can also be used to start another concurrent upgrade, it requires timing the test steps such that the new version is made available and the concurrent upgrade is triggered from the UI, before the cleanup completes.)

* Expect the webhook to reject the upgrade with the following message:

```sh
upgrade.harvesterhci.io/hvst-upgrade-bqcdv condition met
version.harvesterhci.io/v1.6.1-rc1 created
Error from server (Conflict): error when creating "STDIN": admission webhook "validator.harvesterhci.io" denied the request: cannot proceed until the following upgrades completed their cleanup process: hvst-upgrade-bqcdv
```

#### Additional documentation or context

Per https://github.com/harvester/harvester/issues/6670#issuecomment-3336308796, introducing a new label helps to reduce the scope of the change. All other alternatives either require changing more code or opening up more edge cases.