### PR TITLE
feat: add new machine validator under webhook

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -141,6 +141,7 @@ const (
 
 	LabelUpgradeReadMessage          = prefix + "/read-message"
 	LabelUpgradeState                = prefix + "/upgradeState"
+	LabelUpgradeLatest		 = prefix + "/latestUpgrade"
 	UpgradeStateLoggingInfraPrepared = "LoggingInfraPrepared"
 
 	AnnotationArchiveName                 = prefix + "/archiveName"

--- a/pkg/webhook/resources/machine/validator.go
+++ b/pkg/webhook/resources/machine/validator.go
@@ -1,0 +1,107 @@
+package machine
+
+import (
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(client client.Client, upgradeCache ctlharvesterv1.UpgradeCache) types.Validator {
+	return &machineValidator{
+		client:       client,
+		upgradeCache: upgradeCache,
+	}
+}
+
+type machineValidator struct {
+	types.DefaultValidator
+	client       client.Client
+	upgradeCache ctlharvesterv1.UpgradeCache
+}
+
+func (v *machineValidator) Resource() types.Resource {
+	return types.Resource{
+		Names:    []string{"machines"},
+		Scope:    admissionregv1.ClusterScope,
+		APIGroup: clusterv1.GroupVersion.Group,
+		APIVersion: clusterv1.GroupVersion.Version,
+		ObjectType: &clusterv1.Machine{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+		},
+	}
+}
+
+func (v *machineValidator) Create(_ *types.Request, newObj runtime.Object) error {
+	machine, ok := newObj.(*clusterv1.Machine)
+	if !ok {
+		return fmt.Errorf("expected Machine, but got %T", newObj)
+	}
+
+	upgrading, err := v.isClusterUpgrading()
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"machine":   machine.Name,
+			"namespace": machine.Namespace,
+			"error":     err,
+		}).Error("failed to check cluster upgrade status")
+		return nil
+	}
+
+	if upgrading {
+		fields := logrus.Fields{
+			"machine":   machine.Name,
+			"namespace": machine.Namespace,
+		}
+
+		if machine.Spec.ProviderID != nil && *machine.Spec.ProviderID != "" {
+			fields["providerID"] = *machine.Spec.ProviderID
+		}
+
+		if len(machine.Status.Addresses) > 0 {
+			addrParts := []string{}
+			for _, addr := range machine.Status.Addresses {
+				// MachineAddressType gives type (HostName, ExternalIP, InternalIP…)
+				addrParts = append(addrParts, fmt.Sprintf("%s=%s", addr.Type, addr.Address))
+			}
+			fields["addresses"] = addrParts
+		}
+
+		logrus.WithFields(fields).Warn("blocking creation of new Harvester Machine: upgrade in progress")
+
+		return fmt.Errorf("cluster upgrade in progress: cannot create machine %s", machine.Name)
+	}
+
+	return nil
+}
+
+func (v *machineValidator) isClusterUpgrading() (bool, error) {
+	selector := labels.Set{
+		util.LabelUpgradeLatest: "true",
+	}.AsSelector()
+
+	upgrades, err := v.upgradeCache.List(util.HarvesterSystemNamespaceName, selector)
+	if err != nil {
+		return false, err
+	}
+
+	for _, upgrade := range upgrades {
+		// UpgradeCompleted == Unknown == upgrade still running
+		if harvesterv1.UpgradeCompleted.IsUnknown(upgrade) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -36,6 +36,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/resources/volumesnapshot"
 	"github.com/harvester/harvester/pkg/webhook/types"
 	"github.com/harvester/harvester/pkg/webhook/util"
+	"github.com/harvester/harvester/pkg/webhook/resources/machine"
 )
 
 func Validation(clients *clients.Clients, options *config.Options) (http.Handler, []types.Resource, error) {
@@ -198,6 +199,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),
 			clients.AppsFactory.Apps().V1().Deployment().Cache(),
 		),
+		machine.NewValidator(client, clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache()),
 	}
 
 	router := webhook.NewRouter()


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Harvester should block addition of new nodes while an upgrade is in progress.

This can have unwanted side effects if a user adds a node during the upgrade process.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
add new machine validator to prevent node registration during upgrade.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/7601

#### Test plan:
<!-- Describe the test plan by steps. -->
1. Install an older version Harvester to create a single node cluster.
2. Trigger upgrade process on the created management node
3. Install Harvester on another machine to create a worker/witness node to join the cluster created in step 1.
4. Check if the node creation can succeed or not.

#### Additional documentation or context
