### PR TITLE
add extra check to skip error during job creation if job already exists

### DIFF
--- a/pkg/controller/master/upgrade/secret_controller.go
+++ b/pkg/controller/master/upgrade/secret_controller.go
@@ -6,6 +6,7 @@ import (
 	jobV1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -112,7 +113,7 @@ func (h *secretHandler) createHookJob(upgrade *harvesterv1.Upgrade, nodeName str
 	}
 
 	_, err = h.jobClient.Create(applyNodeJob(upgrade, repoInfo, nodeName, jobType))
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Upgrade has a node stuck in `pre-draining` phase and following messages are observed in the harvester pod logs

```
ntroller: jobs.batch \"hvst-upgrade-7zqp7-post-drain-hp-113-tink-system\" already exists, requeuing"
harvester-899b4df79-mzgkx apiserver W1011 07:26:44.330452       7 warnings.go:70] v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
harvester-899b4df79-mzgkx apiserver time="2025-10-11T07:27:17Z" level=error msg="error syncing 'fleet-local/custom-a8796656aa4c-machine-plan': handler harvester-upgrade-secret-controller: jobs.batch \"hvst-upgrade-7zqp7-post-drain-hp-113-tink-system\" already exists, requeuing"
harvester-899b4df79-mzgkx apiserver W1011 07:28:07.277242       7 warnings.go:70] cdi.kubevirt.io/v1beta1 is now deprecated and will be removed in v1.
harvester-899b4df79-mzgkx apiserver W1011 07:28:21.278844       7 warnings.go:70] kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2.
harvester-899b4df79-mzgkx apiserver W1011 07:28:42.283309       7 warnings.go:70] v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
harvester-899b4df79-mzgkx apiserver time="2025-10-11T07:29:17Z" level=error msg="error syncing 'fleet-local/custom-a8796656aa4c-machine-plan': handler harvester-upgrade-secret-controller: jobs.batch \"hvst-upgrade-7zqp7-post-drain-hp-113-tink-system\" already exists, requeuing"
harvester-899b4df79-mzgkx apiserver time="2025-10-11T07:31:17Z" level=error msg="error syncing 'fleet-local/custom-a8796656aa4c-machine-plan': handler harvester-upgrade-secret-controller: jobs.batch \"hvst-upgrade-7zqp7-post-drain-hp-113-tink-system\" already exists, requeuing"
harvester-899b4df79-mzgkx apiserver W1011 07:32:36.335038       7 warnings.go:70] v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
harvester-899b4df79-mzgkx apiserver time="2025-10-11T07:33:17Z" level=error msg="error syncing 'fleet-local/custom-a8796656aa4c-machine-plan': handler harvester-upgrade-secret-controller: jobs.batch \"hvst-upgrade-7zqp7-post-drain-hp-113-tink-system\" already exists, requeuing"
harvester-899b4df79-mzgkx apiserver W1011 07:34:15.278646       7 warnings.go:70] cdi.kubevirt.io/v1beta1 is now deprecated and will be removed in v1.
harvester-899b4df79-mzgkx apiserver time="2025-10-11T07:35:17Z" level=error msg="error syncing 'fleet-local/custom-a8796656aa4c-machine-plan': handler harvester-upgrade-secret-controller: jobs.batch \"hvst-upgrade-7zqp7-post-drain-hp-113-tink-system\" already exists, requeuing"
harvester-899b4df79-mzgkx apiserver time="2025-10-11T07:37:17Z" level=error msg="error syncing 'fleet-local/custom-a8796656aa4c-machine-plan': handler harvester-upgrade-secret-controller: jobs.batch \"hvst-upgrade-7zqp7-post-drain-hp-113-tink-system\" already exists, requeuing"
```

Based on this error it seems like there was an issue after `post-drain` job was created but the `upgrade` object was not updated.

As a result the upgrade controller keeps attempting to create a job which has not been reconciled with upgrade object status

https://github.com/harvester/harvester/blob/master/pkg/controller/master/upgrade/secret_controller.go#L103

This results in the upgrade being stuck in the pre-drain stage.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Minor check to ignore error if object already exists, to allow upgrade object status to be updated to reflect the correct upgrade state.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9293

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
