### PR TITLE
feat: deny empty memory and patch default cpu

### DIFF
--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -6,6 +6,7 @@ import (
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	corefake "k8s.io/client-go/kubernetes/fake"
@@ -698,6 +699,9 @@ func TestVmValidator_Update(t *testing.T) {
 									MacAddress: "00:00:00:00:00:01",
 								},
 							},
+						},
+						Memory: &kubevirtv1.Memory{
+							Guest: resource.NewQuantity(1024*1024*1024, resource.BinarySI),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Currently, we allowed users to create following VMs:
* VM without memory in `resources.limits.memory` and `memory.guest`. This kind of VM cannot start.
* VM with null value in `cpu`. This kind of VM can start with default value `1`.

#### Solution:
* VM without memory in `resources.limits.memory` and `memory.guest`. Deny the request.
* VM with null value in `cpu`. Use mutator to patch default value to it.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9302

#### Test plan:
* Create a VM without memory in `resources.limits.memory` and `memory.guest`. Webhook should deny the request.

<img width="975" height="211" alt="Screenshot 2025-10-13 at 3 06 16 PM" src="https://github.com/user-attachments/assets/5837feec-408b-4be4-abc9-edcd39477660" />

* Create a VM with null value in `cpu`. Webhook should patch default value to it.

#### Additional documentation or context
