### PR TITLE
 Switch to SL Micro 6.1

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,5 +1,5 @@
 ARG HARVESTER_INSTALLER_REF=master-head
-FROM registry.opensuse.org/isv/rancher/harvester/os/v1.6/main/baseos:v1.6 as baseos
+FROM registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.1/main/baseos:latest as baseos
 FROM rancher/harvester-installer:${HARVESTER_INSTALLER_REF} as installer
 FROM registry.suse.com/bci/bci-base:15.7
 

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -675,6 +675,12 @@ stages:
 EOF
   fi
 
+  # SLE Micro 5.5 uses /usr/lib/ssh/sftp-server
+  # SL Micro 6.1 uses /usr/libexec/ssh/sftp-server
+  if [ -e ${HOST_DIR}/etc/ssh/sshd_config.d/sftp.conf ]; then
+    sed -i 's%/usr/lib/ssh/sftp-server%/usr/libexec/ssh/sftp-server%' ${HOST_DIR}/etc/ssh/sshd_config.d/sftp.conf
+  fi
+
   umount $tmp_rootfs_mount
   rm -rf $tmp_rootfs_squashfs
 


### PR DESCRIPTION
#### Problem:
Need to bump the base OS to SL Micro 6.1

#### Solution:
The installer changes in https://github.com/harvester/harvester-installer/pull/1163, plus this PR which pulls in the elemental-toolkit build from registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.1/main/baseos:latest.

The scary thing here is that elemental-toolkit built against SL Micro 6.1 needs a newer glibc than is available in the SLE Micro 5.5 host. I've worked around this by bind mounting `/lib64` from the upgrade container over the host environment for the duration of `elemental upgrade`. Incredibly, this works.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7025

#### Test plan:
TBD (basically: upgrade Harvester and make sure it works)

#### Additional documentation or context
This PR plus https://github.com/harvester/harvester-installer/pull/1163 will let you upgrade an existing v1.6.x system to v1.7.0-dev based on SL Micro 6.1, provided you don't run into https://github.com/harvester/harvester/issues/9349 while trying to upgrade :-/

As mentioned in https://github.com/harvester/harvester-installer/pull/1163, my plan is to merge the os2 sl-micro-6.1 branch back to the sle-micro branch, but I thought it might be least disruptive to daily builds and QA and other folks, to merge this and the related harvester PR, including the switch to the os2 sl-micro-6 branch image, then do the os2 and OBS merges, then open another PR to switch harvester-installer back to using the sle-micro branch once that's settled.

Please ignore the CodeFactor complaint. I'll fix that once we have a separate v1.7 project on OBS and can set tags appropriately.