### PR TITLE
block enabling of rancher-logging addon if an upgradelog object exists

### DIFF
--- a/pkg/util/fakeclients/upgradelog.go
+++ b/pkg/util/fakeclients/upgradelog.go
@@ -31,8 +31,8 @@ func (c UpgradeLogClient) Delete(namespace, name string, options *metav1.DeleteO
 func (c UpgradeLogClient) Get(namespace, name string, options metav1.GetOptions) (*harvesterv1.UpgradeLog, error) {
 	return c(namespace).Get(context.TODO(), name, options)
 }
-func (c UpgradeLogClient) List(_ string, _ metav1.ListOptions) (*harvesterv1.UpgradeLogList, error) {
-	panic("implement me")
+func (c UpgradeLogClient) List(namespace string, options metav1.ListOptions) (*harvesterv1.UpgradeLogList, error) {
+	return c(namespace).List(context.TODO(), options)
 }
 func (c UpgradeLogClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
 	panic("implement me")
@@ -50,9 +50,18 @@ type UpgradeLogCache func(string) harv1type.UpgradeLogInterface
 func (c UpgradeLogCache) Get(namespace, name string) (*harvesterv1.UpgradeLog, error) {
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
-func (c UpgradeLogCache) List(_ string, _ labels.Selector) ([]*harvesterv1.UpgradeLog, error) {
-	panic("implement me")
+func (c UpgradeLogCache) List(namespace string, selector labels.Selector) ([]*harvesterv1.UpgradeLog, error) {
+	list, err := c(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*harvesterv1.UpgradeLog, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, err
 }
+
 func (c UpgradeLogCache) AddIndexer(_ string, _ generic.Indexer[*harvesterv1.UpgradeLog]) {
 	panic("implement me")
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -172,6 +172,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.LoggingFactory.Logging().V1beta1().Output().Cache(),
 			clients.LoggingFactory.Logging().V1beta1().ClusterFlow().Cache(),
 			clients.LoggingFactory.Logging().V1beta1().ClusterOutput().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().UpgradeLog().Cache(),
 		),
 		version.NewValidator(),
 		volumesnapshot.NewValidator(


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
If an upgrade is run with logging enabled, then the upgrade controller creates an associated `upgradelog` object.

The upgradelog controller checks if logging addon is enabled, and if not it creates a managedchart using the logging addon and deploys the chart as a managedchart. 

If a user attempts to enable rancher logging addon before the upgrade has been completed, the addon deployment fails since the rancher logging chart contains cluster scoped objects which already exist in the cluster as part of the managedchart deployment of rancher-logging

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add a minor webhook validation which blocks a user from enabling rancher-logging addon if an upgrade is running.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->
https://github.com/harvester/harvester/issues/9289

#### Additional documentation or context
