### PR TITLE
fix vm image upload issues

### DIFF
--- a/pkg/image/cdi/common.go
+++ b/pkg/image/cdi/common.go
@@ -32,6 +32,8 @@ const (
 type ProgressUpdater struct {
 	totalBytes  int64
 	targetBytes int64
+	imageNS     string
+	imageName   string
 	lastTime    time.Time
 	rwlock      sync.RWMutex
 
@@ -50,7 +52,7 @@ func (pu *ProgressUpdater) Write(p []byte) (n int, err error) {
 
 	now := time.Now()
 	if now.Sub(pu.lastTime) > 1*time.Second || almostCompleted {
-		logrus.Infof("Downloaded %d bytes", pu.totalBytes)
+		logrus.Infof("Downloaded %d bytes for image %s/%s", pu.totalBytes, pu.imageNS, pu.imageName)
 		pu.vmImgUpdateLocker.Lock()
 		pu.vmImgCond.Signal()
 		pu.vmImgUpdateLocker.Unlock()


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The VM Image will be stuck on 0%/99% and will see the context canceled error.

#### Solution:
improve the upload behavior

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9313

#### Test plan:

1. create harvester cluster
2. configure 3rd-party storage (using LHv2 would be easy for setup)

case 1:
1. upload the VM image with the above 3rd-party storage
  1.1. cancel the upload when you saw the progress
2. upload another VM Image with the above 3rd-party storage

case 2
1. upload the VM image with larger qcow2 image (the source qcow2 image should be more 4GB)

The above cases should pass w/o any errors

#### Additional documentation or context
