### PR TITLE
fix: reinstate wait_for_fleet_agent in upgrade_manifests.sh

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -645,6 +645,7 @@ upgrade_rancher() {
   wait_rollout_with_loop cattle-fleet-local-system deployment fleet-agent
   pre_patch_timestamp=$(fleet_agent_timestamp)
   patch_fleet_cluster
+  wait_for_fleet_agent $pre_patch_timestamp
   wait_rollout_with_loop cattle-fleet-local-system deployment fleet-agent
 
   # After fleet-controller POD is restarted, it will check until the local cluster is imported, after that, redeploy the fleet-agent


### PR DESCRIPTION
#### Problem:
During upgrade when the apply-manifests job runs, it's possible to hit a race condition where the fleet-agent isn't redeployed yet, before we try to watch its status.  This causes the apply-manifests job to fail and restart, but then the upgrade gets stuck indefinitely a bit later, presumably because fleet hadn't stabilized properly yet?

#### Solution:
This may not be the whole story, but we can at least fix the apply-manifests job failure by reinstating a call to wait_for_fleet_agent which appears to have been removed in commit 4c350fda0 in https://github.com/harvester/harvester/pull/7845.

#### Related Issue(s):
Related-to: https://github.com/harvester/harvester/issues/9349

#### Test plan:
This doesn't appear to actually fix the problem, it just makes it a little bit better, in that the apply-manifests job no longer fails-and-restarts with `Error from server (NotFound): deployments.apps "fleet-agent" not found`  as mentioned in https://github.com/harvester/harvester/issues/9349#issuecomment-3430546513. So, I guess the test plan for this PR is "make sure you don't see that error when the apply-manifests job is running" :-/