### PR TITLE
Fix codegen lint error

### DIFF
--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -238,14 +237,14 @@ func main() {
 // `networkattachementdefinitions` that will raises crd not found exception of the NAD controller.
 func nadControllerInterfaceRefactor() {
 	absPath, _ := filepath.Abs("pkg/generated/controllers/k8s.cni.cncf.io/v1/interface.go")
-	input, err := ioutil.ReadFile(absPath)
+	input, err := os.ReadFile(absPath)
 	if err != nil {
 		logrus.Fatalf("failed to read the network-attachment-definition file: %v", err)
 	}
 
 	output := bytes.ReplaceAll(input, []byte("networkattachmentdefinitions"), []byte("network-attachment-definitions"))
 
-	if err = ioutil.WriteFile(absPath, output, 0644); err != nil {
+	if err = os.WriteFile(absPath, output, 0600); err != nil {
 		logrus.Fatalf("failed to update the network-attachment-definition file: %v", err)
 	}
 }
@@ -262,13 +261,13 @@ func capiWorkaround() {
 
 	// Replace the variable `SchemeGroupVersion` with `GroupVersion` in the above files path
 	for _, absPath := range files {
-		input, err := ioutil.ReadFile(absPath)
+		input, err := os.ReadFile(absPath)
 		if err != nil {
 			logrus.Fatalf("failed to read the clusters.cluster.x-k8s.io client file: %v", err)
 		}
 		output := bytes.ReplaceAll(input, []byte("v1beta1.SchemeGroupVersion"), []byte("v1beta1.GroupVersion"))
 
-		if err = ioutil.WriteFile(absPath, output, 0644); err != nil {
+		if err = os.WriteFile(absPath, output, 0600); err != nil {
 			logrus.Fatalf("failed to update the clusters.cluster.x-k8s.io client file: %v", err)
 		}
 	}
@@ -290,13 +289,13 @@ func loggingWorkaround() {
 
 	// Replace the variable `SchemeGroupVersion` with `GroupVersion` in the above files path
 	for _, absPath := range files {
-		input, err := ioutil.ReadFile(absPath)
+		input, err := os.ReadFile(absPath)
 		if err != nil {
 			logrus.Fatalf("failed to read the logging.banzaicloud.io client file: %v", err)
 		}
 		output := bytes.ReplaceAll(input, []byte("v1beta1.SchemeGroupVersion"), []byte("v1beta1.GroupVersion"))
 
-		if err = ioutil.WriteFile(absPath, output, 0644); err != nil {
+		if err = os.WriteFile(absPath, output, 0600); err != nil {
 			logrus.Fatalf("failed to update the logging.banzaicloud.io client file: %v", err)
 		}
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

In PR https://github.com/harvester/network-controller-harvester/pull/217, it copied code from Harvester code gen, and following errors are encountered

```

first:

pkg/codegen/main.go:77:11: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	if err = ioutil.WriteFile(absPath, output, 0644); err != nil {
	         ^
pkg/codegen/main.go:5:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
2 issues:
* gosec: 1

then:

Running validation
Running: golangci-lint
pkg/codegen/main.go:78:11: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	if err = os.WriteFile(absPath, output, 0644); err != nil {
	         ^
1 issues:
* gosec: 1
FATA[0118] exit status 1                                
make: *** [Makefile:11: ci] Error 1


```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9359
https://github.com/harvester/harvester/issues/9338

#### Test plan:
<!-- Describe the test plan by steps. -->

Both `make generate` and `make ci` are successful.

QA validation is not required.

#### Additional documentation or context
