### PR TITLE
Ignore resource version changes

### DIFF
--- a/pkg/server/customizers/vm.go
+++ b/pkg/server/customizers/vm.go
@@ -1,0 +1,42 @@
+package customizers
+
+import (
+	"strings"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/rancher/steve/pkg/schema"
+	"github.com/sirupsen/logrus"
+)
+
+/*
+	 wrangler summarizers generate a generating warning as follows and we need to hide it if needed
+		{
+		  "error": false,
+		  "message": "VirtualMachine generation is 5, but latest observed generation is 4",
+		  "name": "in-progress",
+		  "transitioning": true
+		}
+*/
+
+func DropRevisionStateIfNeeded(_ *types.APIRequest, resource *types.RawResource) {
+	data := resource.APIObject.Data()
+	state := data.Map("metadata", "state")
+	name := data.String("metadata", "name")
+	message, ok := state["message"]
+	if !ok {
+		return
+	}
+	if strings.Contains(message.(string), "but latest observed generation is") {
+		logrus.Debugf("patching state for vm %s: %v\n", name, state)
+		state["error"] = false
+		state["transitioning"] = false
+		state["message"] = ""
+		state["name"] = "running"
+		data.SetNested(state, "metadata", "state")
+	}
+}
+
+var VMCustomizerTemplate = schema.Template{
+	ID:        "kubevirt.io.virtualmachine",
+	Formatter: DropRevisionStateIfNeeded,
+}

--- a/pkg/server/customizers/vm_test.go
+++ b/pkg/server/customizers/vm_test.go
@@ -1,0 +1,18 @@
+package customizers
+
+import (
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_DropRevisionStateIfNeededWithEmptyState(t *testing.T) {
+	resource := &types.RawResource{
+		APIObject: types.APIObject{
+			Object: &corev1.ConfigMap{},
+		},
+	}
+
+	DropRevisionStateIfNeeded(nil, resource)
+}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -36,6 +36,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master"
 	"github.com/harvester/harvester/pkg/data"
 	"github.com/harvester/harvester/pkg/indexeres"
+	"github.com/harvester/harvester/pkg/server/customizers"
 	"github.com/harvester/harvester/pkg/server/ui"
 )
 
@@ -290,6 +291,8 @@ func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 		scaled.Start,
 	}
 
+	// add custom templates if needed
+	s.steve.SchemaFactory.AddTemplate(customizers.VMCustomizerTemplate)
 	return s.start(options)
 }
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
VM Hot plug operations result in VM objects generation vs observed generation being no longer in sync.

As a result when the steve executes wrangler summarizers, it finds a discrepancy between the objects generation and observedGeneration fields and generates a warning in the steve state.

Though the message is benign, it just results in a poor UX, since it may confuse users about the health of the VM or if a restart is needed.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The PR introduces a customizer which patches the vm state to clear the state of generation related warning messages.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9629
#### Test plan:
<!-- Describe the test plan by steps. -->
To test we need a minimal 2 node cluster to ensure VM can be migrated to verify hot plug operations:
* Install a build of harvester which contains this change.
* Run a VM
* Once VM is running, hot plug cpu/disk/nic to this VM
* The VM should successfully migrate without any `observed generation` messages in the UI

#### Additional documentation or context
