### PR TITLE
Fix concurrency between cdi and upload components

### DIFF
--- a/pkg/api/image/formatter.go
+++ b/pkg/api/image/formatter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apisv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -104,8 +105,13 @@ func (h Handler) uploadImage(_ http.ResponseWriter, req *http.Request) error {
 	if err != nil {
 		return err
 	}
+	err = h.uploaders[util.GetVMIBackend(vmi)].DoUpload(vmi, req)
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
 
-	return h.uploaders[util.GetVMIBackend(vmi)].DoUpload(vmi, req)
+	return nil
 }
 
 func (h Handler) cancelDownloadImage(req *http.Request) error {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
This PR has two purposes:
Improve error logging in the CDI image upload flow.
Address concurrency issues between the cdi.go and upload.go components.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Checking if `sourceType` is `upload` when the DataVolume is not found on `cdi.go`. This is to prevent instant retries from causing conflict with the functions being executed in `upload.go`. If that's the case, retry with a short delay.
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #8636
#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
