### PR TITLE
test: buffer 1mb on ext4 vmimage

### DIFF
--- a/pkg/image/cdi/upload.go
+++ b/pkg/image/cdi/upload.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	CDIUploadURLRaw = "cdi-uploadproxy.harvester-system"
-	UploadProxyURI  = "/v1alpha1/upload"
+	CDIUploadURLRaw  = "cdi-uploadproxy.harvester-system"
+	UploadProxyURI   = "/v1alpha1/upload"
+	uploadSizeBuffer = 1 * 1024 * 1024 // 1 MiB
 )
 
 type Uploader struct {
@@ -117,6 +118,7 @@ func (cu *Uploader) DoUpload(vmImg *harvesterv1.VirtualMachineImage, req *http.R
 	logrus.Debugf("first 1024 bytes: %v", string(rawContent))
 	if qcowHeaderIndex == -1 {
 		logrus.Infof("Magic number is not correct: %v, this image is not qcow format", rawContent)
+		virtualSize = virtualSize + uploadSizeBuffer // virtualSize + buffer to prevent upload failure
 	} else {
 		// The virtual size is at 24-31 bytes (from the qcow image header)
 		virtualSizeRaw := rawContent[qcowHeaderIndex+24 : qcowHeaderIndex+32]


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
This PR is currently only a draft solution for issue #9843.
I found that ext4.raw breaks in the issue scenario because the volume size we specify during DataVolume creation is shorter than required.
```log
kc logs cdi-upload-prime-23ae7bf9-da31-46c9-b17c-88ad2d1d2b98
I1022 23:31:16.629070       1 uploadserver.go:81] Running server on 0.0.0.0:8443
I1022 23:31:18.966250       1 uploadserver.go:422] Content type header is ""
I1022 23:31:18.966271       1 data-processor.go:348] Calculating available size
I1022 23:31:18.967297       1 data-processor.go:356] Checking out block volume size.
I1022 23:31:18.967311       1 data-processor.go:373] Target size 104857600.
I1022 23:31:18.967382       1 data-processor.go:247] New phase: TransferDataFile
I1022 23:31:18.968217       1 util.go:96] Writing data...
E1022 23:31:19.250027       1 util.go:98] Unable to write file from dataReader: write /dev/cdi-block-volume: no space left on device
E1022 23:31:19.250123       1 data-processor.go:243] write /dev/cdi-block-volume: no space left on device
unable to write to file
kubevirt.io/containerized-data-importer/pkg/importer.streamDataToFile
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/util.go:101
kubevirt.io/containerized-data-importer/pkg/importer.(*UploadDataSource).TransferFile
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/upload-datasource.go:98
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).initDefaultPhases.func4
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/data-processor.go:190
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessDataWithPause
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/data-processor.go:240
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessData
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/data-processor.go:149
kubevirt.io/containerized-data-importer/pkg/uploadserver.newUploadStreamProcessor
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:484
kubevirt.io/containerized-data-importer/pkg/uploadserver.(*uploadServerApp).processUpload
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:429
kubevirt.io/containerized-data-importer/pkg/uploadserver.NewUploadServer.(*uploadServerApp).uploadHandler.func1
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:455
net/http.HandlerFunc.ServeHTTP
	/usr/lib64/go/1.24/src/net/http/server.go:2294
net/http.(*ServeMux).ServeHTTP
	/usr/lib64/go/1.24/src/net/http/server.go:2822
kubevirt.io/containerized-data-importer/pkg/uploadserver.(*uploadServerApp).ServeHTTP
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:287
net/http.serverHandler.ServeHTTP
	/usr/lib64/go/1.24/src/net/http/server.go:3301
net/http.(*conn).serve
	/usr/lib64/go/1.24/src/net/http/server.go:2102
runtime.goexit
	/usr/lib64/go/1.24/src/runtime/asm_amd64.s:1700
Unable to transfer source data to target file
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).initDefaultPhases.func4
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/data-processor.go:192
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessDataWithPause
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/data-processor.go:240
kubevirt.io/containerized-data-importer/pkg/importer.(*DataProcessor).ProcessData
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/importer/data-processor.go:149
kubevirt.io/containerized-data-importer/pkg/uploadserver.newUploadStreamProcessor
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:484
kubevirt.io/containerized-data-importer/pkg/uploadserver.(*uploadServerApp).processUpload
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:429
kubevirt.io/containerized-data-importer/pkg/uploadserver.NewUploadServer.(*uploadServerApp).uploadHandler.func1
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:455
net/http.HandlerFunc.ServeHTTP
	/usr/lib64/go/1.24/src/net/http/server.go:2294
net/http.(*ServeMux).ServeHTTP
	/usr/lib64/go/1.24/src/net/http/server.go:2822
kubevirt.io/containerized-data-importer/pkg/uploadserver.(*uploadServerApp).ServeHTTP
	/home/abuild/rpmbuild/BUILD/go/src/kubevirt.io/containerized-data-importer/pkg/uploadserver/uploadserver.go:287
net/http.serverHandler.ServeHTTP
	/usr/lib64/go/1.24/src/net/http/server.go:3301
net/http.(*conn).serve
	/usr/lib64/go/1.24/src/net/http/server.go:2102
runtime.goexit
	/usr/lib64/go/1.24/src/runtime/asm_amd64.s:1700
E1022 23:31:19.250256       1 uploadserver.go:436] Saving stream failed: Unable to transfer source data to target file: unable to write to file: write /dev/cdi-block-volume: no space left on device
```
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Adding a 1MiB buffer seems to be enough to prevent the issue. 

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #8636

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
Even though this PR solves the issue, I'm not sure if that's the proper way of handling it. Please let me know if you have any inputs.