### PR TITLE
skip witness node during node count calculation running LH Pods

### DIFF
--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/harvester/harvester/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -60,13 +61,13 @@ func (n *NodeBuilder) Harvester() *NodeBuilder {
 }
 
 func (n *NodeBuilder) Witness() *corev1.Node {
-	n.node.Labels[KubeEtcdNodeLabelKey] = "true"
+	n.node.Labels[util.KubeEtcdNodeLabelKey] = "true"
 	n.node.CreationTimestamp = metav1.NewTime(time.Now())
 	return n.node
 }
 
 func (n *NodeBuilder) Management() *corev1.Node {
-	n.node.Labels[KubeMasterNodeLabelKey] = "true"
+	n.node.Labels[util.KubeMasterNodeLabelKey] = "true"
 	n.node.CreationTimestamp = metav1.NewTime(time.Now())
 	return n.node
 }
@@ -77,22 +78,22 @@ func (n *NodeBuilder) Worker() *corev1.Node {
 }
 
 func (n *NodeBuilder) Running() *NodeBuilder {
-	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = PromoteStatusRunning
+	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = util.PromoteStatusRunning
 	return n
 }
 
 func (n *NodeBuilder) Complete() *NodeBuilder {
-	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = PromoteStatusComplete
+	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = util.PromoteStatusComplete
 	return n
 }
 
 func (n *NodeBuilder) Failed() *NodeBuilder {
-	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = PromoteStatusFailed
+	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = util.PromoteStatusFailed
 	return n
 }
 
 func (n *NodeBuilder) Unknown() *NodeBuilder {
-	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = PromoteStatusUnknown
+	n.node.Annotations[HarvesterPromoteStatusAnnotationKey] = util.PromoteStatusUnknown
 	return n
 }
 

--- a/pkg/controller/master/storagenetwork/storage_network.go
+++ b/pkg/controller/master/storagenetwork/storage_network.go
@@ -373,7 +373,7 @@ func (h *Handler) validateIPAddressesAllocations(setting *harvesterv1.Setting) e
 	//Formula - https://docs.harvesterhci.io/v1.4/advanced/storagenetwork/
 	//Dynamic parameters like number of images download/upload, backing-image-manager and backing-image-ds are skipped
 	//and only the number of nodes each running an instance-manager pod is used
-	MinAllocatableIPAddrs := len(nodes)
+	MinAllocatableIPAddrs := util.CountNonWitnessNodes(nodes)
 
 	var config network.Config
 

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/controller/master/upgrade/repoinfo"
 	"github.com/harvester/harvester/pkg/util"
 )
@@ -209,12 +208,12 @@ func prepareCleanupPlan(upgrade *harvesterv1.Upgrade, imageList []string) *upgra
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
 				{
-					Key:      node.KubeControlPlaneNodeLabelKey,
+					Key:      util.KubeControlPlaneNodeLabelKey,
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoExecute,
 				},
 				{
-					Key:      node.KubeEtcdNodeLabelKey,
+					Key:      util.KubeEtcdNodeLabelKey,
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoExecute,
 				},
@@ -288,12 +287,12 @@ func preparePlan(upgrade *harvesterv1.Upgrade, concurrency int) *upgradev1.Plan 
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
 				{
-					Key:      node.KubeControlPlaneNodeLabelKey,
+					Key:      util.KubeControlPlaneNodeLabelKey,
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoExecute,
 				},
 				{
-					Key:      node.KubeEtcdNodeLabelKey,
+					Key:      util.KubeEtcdNodeLabelKey,
 					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoExecute,
 				},
@@ -554,12 +553,12 @@ func getDefaultTolerations() []corev1.Toleration {
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 		{
-			Key:      node.KubeControlPlaneNodeLabelKey,
+			Key:      util.KubeControlPlaneNodeLabelKey,
 			Operator: corev1.TolerationOpExists,
 			Effect:   corev1.TaintEffectNoExecute,
 		},
 		{
-			Key:      node.KubeEtcdNodeLabelKey,
+			Key:      util.KubeEtcdNodeLabelKey,
 			Operator: corev1.TolerationOpExists,
 			Effect:   corev1.TaintEffectNoExecute,
 		},
@@ -826,7 +825,7 @@ func newNodeBuilder(name string) *nodeBuilder {
 }
 
 func (n *nodeBuilder) ControlPlane() *nodeBuilder {
-	n.WithLabel(node.KubeControlPlaneNodeLabelKey, "true")
+	n.WithLabel(util.KubeControlPlaneNodeLabelKey, "true")
 	return n
 }
 

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -4,6 +4,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	KubeNodeRoleLabelPrefix      = "node-role.kubernetes.io/"
+	KubeMasterNodeLabelKey       = KubeNodeRoleLabelPrefix + "master"
+	KubeControlPlaneNodeLabelKey = KubeNodeRoleLabelPrefix + "control-plane"
+	KubeEtcdNodeLabelKey         = KubeNodeRoleLabelPrefix + "etcd"
+
+	PromoteStatusComplete = "complete"
+	PromoteStatusRunning  = "running"
+	PromoteStatusUnknown  = "unknown"
+	PromoteStatusFailed   = "failed"
+)
+
 func ExcludeWitnessNodes(nodes []*corev1.Node) []*corev1.Node {
 	nonWitnessNodes := make([]*corev1.Node, 0, len(nodes))
 	for _, node := range nodes {
@@ -12,4 +24,66 @@ func ExcludeWitnessNodes(nodes []*corev1.Node) []*corev1.Node {
 		}
 	}
 	return nonWitnessNodes
+}
+
+func IsPromoteStatusIn(node *corev1.Node, statuses ...string) bool {
+	status, ok := node.Annotations[HarvesterPromoteStatusAnnotationKey]
+	if !ok {
+		return false
+	}
+
+	for _, s := range statuses {
+		if status == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsWitnessNode(node *corev1.Node, isManagement bool) bool {
+	_, found := node.Labels[HarvesterWitnessNodeLabelKey]
+	if !found {
+		return false
+	}
+
+	// promotion has already been run for this node
+	if found && (isManagement || IsPromoteStatusIn(node, PromoteStatusComplete, PromoteStatusRunning, PromoteStatusFailed, PromoteStatusUnknown)) {
+		return true
+	}
+
+	return false
+}
+
+// IsManagementRole determine whether it's an management node based on the node's label.
+// Management Role included: master, control-plane, etcd
+func IsManagementRole(node *corev1.Node) bool {
+	if value, ok := node.Labels[KubeMasterNodeLabelKey]; ok {
+		return value == "true"
+	}
+
+	// Related to https://github.com/kubernetes/kubernetes/pull/95382
+	if value, ok := node.Labels[KubeControlPlaneNodeLabelKey]; ok {
+		return value == "true"
+	}
+
+	// Now we have the witness node, we need to count it as a management node
+	if value, ok := node.Labels[KubeEtcdNodeLabelKey]; ok {
+		return value == "true"
+	}
+
+	return false
+}
+
+// count the number of nodes running instance manager pod
+func CountNonWitnessNodes(nodes []*corev1.Node) int {
+	count := 0
+
+	for _, node := range nodes {
+		if !IsWitnessNode(node, IsManagementRole(node)) {
+			count++
+		}
+	}
+
+	return count
 }

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -102,7 +102,7 @@ func (v *nodeValidator) validateCPUManagerOperation(node *corev1.Node) error {
 	}
 
 	// check if the node is in witness role
-	if _, found := node.Labels[ctlnode.HarvesterWitnessNodeLabelKey]; found {
+	if _, found := node.Labels[util.HarvesterWitnessNodeLabelKey]; found {
 		return werror.NewBadRequest("The witness node is unable to update the CPU manager policy.")
 	}
 
@@ -199,7 +199,7 @@ func checkCurrentNodeCPUManagerJobs(node *corev1.Node, jobCache ctlbatchv1.JobCa
 
 func checkMasterNodeJobs(node *corev1.Node, nodeCache v1.NodeCache, jobCache ctlbatchv1.JobCache) error {
 	// the node is worker, no need to do validation
-	if !ctlnode.IsManagementRole(node) {
+	if !util.IsManagementRole(node) {
 		return nil
 	}
 
@@ -211,7 +211,7 @@ func checkMasterNodeJobs(node *corev1.Node, nodeCache v1.NodeCache, jobCache ctl
 	// collect master node names except the node itself
 	masterNodeNames := []string{}
 	for _, n := range nodes {
-		if n.Name != node.Name && ctlnode.IsManagementRole(n) {
+		if n.Name != node.Name && util.IsManagementRole(n) {
 			masterNodeNames = append(masterNodeNames, n.Name)
 		}
 	}

--- a/pkg/webhook/resources/node/validator_test.go
+++ b/pkg/webhook/resources/node/validator_test.go
@@ -248,7 +248,7 @@ func TestValidateCPUManagerOperation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "node1",
 				Annotations: map[string]string{util.AnnotationCPUManagerUpdateStatus: `{"status": "requested", "policy": "static"}`},
-				Labels:      map[string]string{ctlnode.HarvesterWitnessNodeLabelKey: "true"},
+				Labels:      map[string]string{util.HarvesterWitnessNodeLabelKey: "true"},
 			},
 		}))
 
@@ -432,7 +432,7 @@ func TestCheckMasterNodeJobs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-0",
 			Labels: map[string]string{
-				ctlnode.KubeMasterNodeLabelKey: "true",
+				util.KubeMasterNodeLabelKey: "true",
 			},
 		},
 	}
@@ -440,7 +440,7 @@ func TestCheckMasterNodeJobs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-1",
 			Labels: map[string]string{
-				ctlnode.KubeMasterNodeLabelKey: "true",
+				util.KubeMasterNodeLabelKey: "true",
 			},
 		},
 	}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -44,7 +44,6 @@ import (
 	"github.com/harvester/harvester-network-controller/pkg/utils"
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/containerd"
-	nodectl "github.com/harvester/harvester/pkg/controller/master/node"
 	settingctl "github.com/harvester/harvester/pkg/controller/master/setting"
 	ctlv1beta1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
@@ -1496,8 +1495,8 @@ func (v *settingValidator) checkVCSpansAllNodes(config *networkutil.Config) erro
 	//check if vlanconfig contains all the nodes in the cluster
 	for _, node := range nodes {
 		//skip witness nodes which do not run LH Pods
-		isManagement := nodectl.IsManagementRole(node)
-		if nodectl.IsWitnessNode(node, isManagement) {
+		isManagement := util.IsManagementRole(node)
+		if util.IsWitnessNode(node, isManagement) {
 			continue
 		}
 


### PR DESCRIPTION

#### Problem:
"IP allocation failure for Longhorn Pods" error msg seen on Harvester UI under storage network settings.
Since witness node does not run LH pod and it is also taken into account for node count calculation and validated against the number of ips allocated from whereabouts, error msg is seen.

#### Solution:
Exclude witness node during node count calculation

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9325

#### Test plan:

To reproduce:
1.Have a harvester cluster with atleast 1 witness node
2.Make sure to have only instance manager pods running and no backing image pods.
3.Create storage network
4.Check the IP allocation failure for Longhorn Pods as mentioned above in Harvester UI or kubectl storage network settings

Example: 1 control plane node and 1 witness node in the cluster

The above cluster will be running only 1 instance manager pod, so whereabouts would have allocated 1 ip address.
But during the validation, number of wherabouts allocated ip addr (1) >= number of nodes(2) fails and error msg is seen.Instead the witness node has to be excluded from number of nodes and the validation will succeed.

With fix:
No error msg should be seen in UI under storage network settings with the above config.
#### Additional documentation or context
