### PR TITLE
enhancement: check internal storageclasses when creating new volumes

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -190,8 +190,11 @@ const (
 	LablelVClusterAppNameKey   = "app"
 	LablelVClusterAppNameValue = "vcluster"
 
-	StorageClassHarvesterLonghorn = "harvester-longhorn" // the initial & default storageclass
-	HarvesterChartReleaseName     = "harvester"          // the release name
+	StorageClassHarvesterLonghorn  = "harvester-longhorn"  // the initial & default storageclass
+	StorageClassLonghornStatic     = "longhorn-static"     // internal storageclass used for management of existing Longhorn volumes
+	StorageClassVmstatePersistence = "vmstate-persistence" // internal storageclass used for TPM and UEFI persistence
+
+	HarvesterChartReleaseName = "harvester" // the release name
 
 	// copied from helm pkg/action/validate.go
 	HelmReleaseNameAnnotation      = "meta.helm.sh/release-name"


### PR DESCRIPTION
#### Problem:
Storageclasses longhorn-static and vmstate-persistence must be used only for internal purpose and so can't be used directly by users when creating new volumes.

#### Solution:
Added a check in the pvc webhook validator to check if the new pvc to be created is related to one one of these internal storageclasses.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8561

#### Test plan:

1. Create a `volume.yaml` file like the following one
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    volume.beta.kubernetes.io/storage-provisioner: driver.longhorn.io
    volume.kubernetes.io/storage-provisioner: driver.longhorn.io
  name: my-vol
  namespace: default
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
  storageClassName: longhorn-static
  volumeMode: Block
  volumeName: pvc-my-vol
 ```

2. Apply the yaml with the command
```
kubectl apply -f volume.yaml
```
3. Check that the output of the command is the following one
```
The request is invalid: spec.storageClassName: can not create volume with the reserved storage class longhorn-static
```

4. Check that the pvc has not been created with the command
```
kubectl get pvc my-vol
```

5. Try again setting the `storageClassName`  to `vmstate-persistence`, the result must be same

