### PR TITLE
Filter migration nodes based on VMI pod's node selectors

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -653,6 +653,9 @@ func (h *vmActionHandler) getNodeSelectorRequirementFromVMI(vmi *kubevirtv1.Virt
 
 	nodeFilter := labels.NewSelector()
 	for key, value := range latestPod.Spec.NodeSelector {
+		if key == corev1.LabelHostname {
+			continue
+		}
 		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create requirement for %s=%s: %w", key, value, err)

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -644,7 +644,7 @@ func (h *vmActionHandler) getNodeSelectorRequirementFromVMI(vmi *kubevirtv1.Virt
 
 	vmiPod, err := h.getVMIPod(vmi)
 	if err != nil {
-		return labels.Everything(), err
+		return labels.Nothing(), err
 	}
 
 	nodeFilter := labels.NewSelector()

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -642,17 +642,14 @@ func (h *vmActionHandler) getNodeSelectorRequirementFromVMI(vmi *kubevirtv1.Virt
 		return labels.Everything(), nil
 	}
 
-	latestPod, err := h.getVMIPod(vmi)
+	vmiPod, err := h.getVMIPod(vmi)
 	if err != nil {
 		return labels.Everything(), err
-	}
-	if latestPod == nil {
-		return labels.Everything(), nil
 	}
 
 	nodeFilter := labels.NewSelector()
 
-	for key, value := range latestPod.Spec.NodeSelector {
+	for key, value := range vmiPod.Spec.NodeSelector {
 		if key == corev1.LabelHostname {
 			continue
 		}
@@ -663,8 +660,8 @@ func (h *vmActionHandler) getNodeSelectorRequirementFromVMI(vmi *kubevirtv1.Virt
 		nodeFilter = nodeFilter.Add(*requirement)
 	}
 
-	if isRequiredAffinityFilterPresent(latestPod) {
-		required := latestPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if isRequiredAffinityFilterPresent(vmiPod) {
+		required := vmiPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 		var err error
 		nodeFilter, err = addNodeAffinityFilters(nodeFilter, required.NodeSelectorTerms)
 		if err != nil {

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -856,6 +856,42 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 				"node2", "node3", "node4",
 			},
 		},
+
+		{
+			name: "Hostname label should be skipped from pod node selector",
+			args: args{
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-hostname-skip",
+						Namespace: "default",
+						UID:       "vmi-hostname-skip-uid",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						NodeName: "node1",
+					},
+				},
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "virt-launcher-test-hostname-skip",
+						Namespace: "default",
+						Labels: map[string]string{
+							kubevirtv1.CreatedByLabel: "vmi-hostname-skip-uid",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+						NodeSelector: map[string]string{
+							corev1.LabelHostname:       "node1",
+							"network":                  "a",
+							kubevirtv1.NodeSchedulable: "true",
+						},
+					},
+				},
+			},
+			want: []string{
+				"node2",
+			},
+		},
 	}
 
 	fakeNodeList := []*corev1.Node{

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -413,7 +413,7 @@ func TestAbortMigrateAction(t *testing.T) {
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{
 						VMIName: "test",
 					},
-					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{ //nolint:dupl
 						Phase: kubevirtv1.MigrationRunning,
 					},
 				},
@@ -495,7 +495,7 @@ func TestAbortMigrateAction(t *testing.T) {
 					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{
 						VMIName: "test",
 					},
-					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{ //nolint:dupl
 						Phase: kubevirtv1.MigrationFailed,
 					},
 				},
@@ -693,8 +693,8 @@ func TestRemoveVolume(t *testing.T) {
 
 func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 	type args struct {
-		vmi *kubevirtv1.VirtualMachineInstance
-		pod *corev1.Pod
+		vmi  *kubevirtv1.VirtualMachineInstance
+		pods []*corev1.Pod
 	}
 	tests := []struct {
 		name string
@@ -718,7 +718,7 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
+				pods: []*corev1.Pod{{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "virt-launcher-test-network",
 						Namespace: "default",
@@ -734,7 +734,7 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 							kubevirtv1.NodeSchedulable: "true",
 						},
 					},
-				},
+				}},
 			},
 			want: []string{
 				"node2",
@@ -756,21 +756,23 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "virt-launcher-test-zone",
-						Namespace: "default",
-						UID:       "pod-zone-uid",
-						Labels: map[string]string{
-							kubevirtv1.CreatedByLabel: "vmi-zone-uid",
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-zone",
+							Namespace: "default",
+							UID:       "pod-zone-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-zone-uid",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node1",
-						NodeSelector: map[string]string{
-							"network":                  "a",
-							"zone":                     "zone2",
-							kubevirtv1.NodeSchedulable: "true",
+						Spec: corev1.PodSpec{
+							NodeName: "node1",
+							NodeSelector: map[string]string{
+								"network":                  "a",
+								"zone":                     "zone2",
+								kubevirtv1.NodeSchedulable: "true",
+							},
 						},
 					},
 				},
@@ -795,7 +797,7 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
+				pods: []*corev1.Pod{{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "virt-launcher-test-custom",
 						Namespace: "default",
@@ -811,7 +813,7 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 							kubevirtv1.NodeSchedulable: "true",
 						},
 					},
-				},
+				}},
 			},
 			want: []string{
 				"node3",
@@ -833,21 +835,23 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "virt-launcher-test-cpu",
-						Namespace: "default",
-						UID:       "pod-cpu-uid",
-						Labels: map[string]string{
-							kubevirtv1.CreatedByLabel: "vmi-cpu-uid",
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-cpu",
+							Namespace: "default",
+							UID:       "pod-cpu-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-cpu-uid",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node4",
-						NodeSelector: map[string]string{
-							kubevirtv1.CPUModelLabel + "EPYC-Rome": "true",
-							kubevirtv1.CPUFeatureLabel + "xsaves":  "true",
-							kubevirtv1.NodeSchedulable:             "true",
+						Spec: corev1.PodSpec{
+							NodeName: "node4",
+							NodeSelector: map[string]string{
+								kubevirtv1.CPUModelLabel + "EPYC-Rome": "true",
+								kubevirtv1.CPUFeatureLabel + "xsaves":  "true",
+								kubevirtv1.NodeSchedulable:             "true",
+							},
 						},
 					},
 				},
@@ -855,7 +859,7 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 			want: []string{},
 		},
 		{
-			name: "No pod found returns error when ActivePods is empty",
+			name: "No pod found returns error when no active pods",
 			args: args{
 				vmi: &kubevirtv1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -864,14 +868,64 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						UID:       "vmi-no-pod-uid",
 					},
 					Status: kubevirtv1.VirtualMachineInstanceStatus{
-						NodeName:   "node1",
-						ActivePods: map[types.UID]string{},
+						NodeName: "node1",
 					},
 				},
-				pod: nil,
+				pods: nil,
 			},
 			want: nil,
 			err:  errors.New("there are no active pods for VMI: default/test-no-pod, migration target cannot be picked unless only 1 pod is active"),
+		},
+		{
+			name: "Multiple active pods returns error during migration",
+			args: args{
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-multi-pod",
+						Namespace: "default",
+						UID:       "vmi-multi-pod-uid",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						NodeName: "node1",
+					},
+				},
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-multi-pod-1",
+							Namespace: "default",
+							UID:       "pod-multi-1-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-multi-pod-uid",
+							},
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "node1",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-multi-pod-2",
+							Namespace: "default",
+							UID:       "pod-multi-2-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-multi-pod-uid",
+							},
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "node2",
+						},
+						Status: corev1.PodStatus{
+							Phase: corev1.PodRunning,
+						},
+					},
+				},
+			},
+			want: nil,
+			err:  errors.New("there are multiple active pods for VMI: default/test-multi-pod, migration target can be picked only when at most 1 pod is active"),
 		},
 		{
 			name: "Hostname label should be skipped from pod node selector",
@@ -889,21 +943,23 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "virt-launcher-test-hostname-skip",
-						Namespace: "default",
-						UID:       "pod-hostname-skip-uid",
-						Labels: map[string]string{
-							kubevirtv1.CreatedByLabel: "vmi-hostname-skip-uid",
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-hostname-skip",
+							Namespace: "default",
+							UID:       "pod-hostname-skip-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-hostname-skip-uid",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node1",
-						NodeSelector: map[string]string{
-							corev1.LabelHostname:       "node1",
-							"network":                  "a",
-							kubevirtv1.NodeSchedulable: "true",
+						Spec: corev1.PodSpec{
+							NodeName: "node1",
+							NodeSelector: map[string]string{
+								corev1.LabelHostname:       "node1",
+								"network":                  "a",
+								kubevirtv1.NodeSchedulable: "true",
+							},
 						},
 					},
 				},
@@ -928,30 +984,32 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "virt-launcher-test-affinity-zone",
-						Namespace: "default",
-						UID:       "pod-affinity-zone-uid",
-						Labels: map[string]string{
-							kubevirtv1.CreatedByLabel: "vmi-affinity-zone-uid",
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-affinity-zone",
+							Namespace: "default",
+							UID:       "pod-affinity-zone-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-affinity-zone-uid",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node1",
-						NodeSelector: map[string]string{
-							kubevirtv1.NodeSchedulable: "true",
-						},
-						Affinity: &corev1.Affinity{
-							NodeAffinity: &corev1.NodeAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-									NodeSelectorTerms: []corev1.NodeSelectorTerm{
-										{
-											MatchExpressions: []corev1.NodeSelectorRequirement{
-												{
-													Key:      "zone",
-													Operator: corev1.NodeSelectorOpIn,
-													Values:   []string{"zone2"},
+						Spec: corev1.PodSpec{
+							NodeName: "node1",
+							NodeSelector: map[string]string{
+								kubevirtv1.NodeSchedulable: "true",
+							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "zone",
+														Operator: corev1.NodeSelectorOpIn,
+														Values:   []string{"zone2"},
+													},
 												},
 											},
 										},
@@ -982,30 +1040,32 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "virt-launcher-test-affinity-notin",
-						Namespace: "default",
-						UID:       "pod-affinity-notin-uid",
-						Labels: map[string]string{
-							kubevirtv1.CreatedByLabel: "vmi-affinity-notin-uid",
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-affinity-notin",
+							Namespace: "default",
+							UID:       "pod-affinity-notin-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-affinity-notin-uid",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node1",
-						NodeSelector: map[string]string{
-							kubevirtv1.NodeSchedulable: "true",
-						},
-						Affinity: &corev1.Affinity{
-							NodeAffinity: &corev1.NodeAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-									NodeSelectorTerms: []corev1.NodeSelectorTerm{
-										{
-											MatchExpressions: []corev1.NodeSelectorRequirement{
-												{
-													Key:      "zone",
-													Operator: corev1.NodeSelectorOpNotIn,
-													Values:   []string{"zone1"},
+						Spec: corev1.PodSpec{
+							NodeName: "node1",
+							NodeSelector: map[string]string{
+								kubevirtv1.NodeSchedulable: "true",
+							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "zone",
+														Operator: corev1.NodeSelectorOpNotIn,
+														Values:   []string{"zone1"},
+													},
 												},
 											},
 										},
@@ -1036,30 +1096,32 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "virt-launcher-test-combined",
-						Namespace: "default",
-						UID:       "pod-combined-uid",
-						Labels: map[string]string{
-							kubevirtv1.CreatedByLabel: "vmi-combined-uid",
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-combined",
+							Namespace: "default",
+							UID:       "pod-combined-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-combined-uid",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node1",
-						NodeSelector: map[string]string{
-							"network":                  "a",
-							kubevirtv1.NodeSchedulable: "true",
-						},
-						Affinity: &corev1.Affinity{
-							NodeAffinity: &corev1.NodeAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-									NodeSelectorTerms: []corev1.NodeSelectorTerm{
-										{
-											MatchExpressions: []corev1.NodeSelectorRequirement{
-												{
-													Key:      "user.custom/label",
-													Operator: corev1.NodeSelectorOpExists,
+						Spec: corev1.PodSpec{
+							NodeName: "node1",
+							NodeSelector: map[string]string{
+								"network":                  "a",
+								kubevirtv1.NodeSchedulable: "true",
+							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "user.custom/label",
+														Operator: corev1.NodeSelectorOpExists,
+													},
 												},
 											},
 										},
@@ -1088,22 +1150,24 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 						},
 					},
 				},
-				pod: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "virt-launcher-test-host-model",
-						Namespace: "default",
-						UID:       "pod-host-model-uid",
-						Labels: map[string]string{
-							kubevirtv1.CreatedByLabel: "vmi-host-model-uid",
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "virt-launcher-test-host-model",
+							Namespace: "default",
+							UID:       "pod-host-model-uid",
+							Labels: map[string]string{
+								kubevirtv1.CreatedByLabel: "vmi-host-model-uid",
+							},
 						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node4",
-						NodeSelector: map[string]string{
-							kubevirtv1.CPUFeatureLabel + "spec-ctrl": "true",
-							kubevirtv1.CPUFeatureLabel + "ssbd":      "true",
-							kubevirtv1.CPUModelLabel + "EPYC-Rome":   "true",
-							kubevirtv1.NodeSchedulable:               "true",
+						Spec: corev1.PodSpec{
+							NodeName: "node4",
+							NodeSelector: map[string]string{
+								kubevirtv1.CPUFeatureLabel + "spec-ctrl": "true",
+								kubevirtv1.CPUFeatureLabel + "ssbd":      "true",
+								kubevirtv1.CPUModelLabel + "EPYC-Rome":   "true",
+								kubevirtv1.NodeSchedulable:               "true",
+							},
 						},
 					},
 				},
@@ -1224,12 +1288,14 @@ func Test_vmActionHandler_findMigratableNodesByVMI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.args.pod != nil {
-				err := coreclientset.Tracker().Add(tt.args.pod)
+			// Create fresh clientset for each test to avoid pod interference
+			testClientset := corefake.NewSimpleClientset()
+			for _, pod := range tt.args.pods {
+				err := testClientset.Tracker().Add(pod)
 				assert.Nil(t, err, "Mock pod should add into fake controller tracker")
 			}
 
-			var podCache = fakeclients.PodCache(coreclientset.CoreV1().Pods)
+			var podCache = fakeclients.PodCache(testClientset.CoreV1().Pods)
 
 			h := &vmActionHandler{
 				nodeCache: nodeCache,

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -52,6 +52,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	nodes := scaled.CoreFactory.Core().V1().Node()
 	pvcs := scaled.CoreFactory.Core().V1().PersistentVolumeClaim()
 	pvs := scaled.CoreFactory.Core().V1().PersistentVolume()
+	pods := scaled.CoreFactory.Core().V1().Pod()
 	secrets := scaled.CoreFactory.Core().V1().Secret()
 	vmt := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplate()
 	vmtv := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineTemplateVersion()
@@ -101,6 +102,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		storageClassCache:         storageClasses.Cache(),
 		resourceQuotaClient:       resourceQuotas,
 		clientSet:                 *scaled.Management.ClientSet,
+		podCache:                  pods.Cache(),
 	})
 
 	vmformatter := vmformatter{

--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -15,14 +15,12 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
-	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 const (
 	PVCByDataSourceVolumeSnapshotIndex = "harvesterhci.io/pvc-by-data-source-volume-snapshot"
 	PodByNodeNameIndex                 = "harvesterhci.io/pod-by-nodename"
 	PodByPVCIndex                      = "harvesterhci.io/pod-by-pvc"
-	PodByVMIUIDIndex                   = "harvesterhci.io/pod-by-vmi-uid"
 	VolumeByNodeIndex                  = "harvesterhci.io/volume-by-node"
 	VMBackupBySourceVMUIDIndex         = "harvesterhci.io/vmbackup-by-source-vm-uid"
 	VMBackupBySourceVMNameIndex        = "harvesterhci.io/vmbackup-by-source-vm-name"
@@ -41,7 +39,6 @@ func Setup(ctx context.Context, _ *server.Server, _ *server.Controllers, _ confi
 	podInformer.AddIndexer(PodByNodeNameIndex, PodByNodeName)
 	podInformer.AddIndexer(PodByPVCIndex, PodByPVC)
 	podInformer.AddIndexer(indexeresutil.PodByVMNameIndex, indexeresutil.PodByVMName)
-	podInformer.AddIndexer(PodByVMIUIDIndex, PodByVMIUID)
 
 	volumeInformer := management.LonghornFactory.Longhorn().V1beta2().Volume().Cache()
 	volumeInformer.AddIndexer(VolumeByNodeIndex, VolumeByNodeName)
@@ -77,14 +74,6 @@ func PodByPVC(obj *corev1.Pod) ([]string, error) {
 		}
 	}
 	return pvcNames, nil
-}
-
-func PodByVMIUID(obj *corev1.Pod) ([]string, error) {
-	vmiUID, exists := obj.Labels[kubevirtv1.CreatedByLabel]
-	if !exists || vmiUID == "" {
-		return []string{}, nil
-	}
-	return []string{vmiUID}, nil
 }
 
 func pvcByDataSourceVolumeSnapshot(obj *corev1.PersistentVolumeClaim) ([]string, error) {

--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -15,12 +15,14 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 const (
 	PVCByDataSourceVolumeSnapshotIndex = "harvesterhci.io/pvc-by-data-source-volume-snapshot"
 	PodByNodeNameIndex                 = "harvesterhci.io/pod-by-nodename"
 	PodByPVCIndex                      = "harvesterhci.io/pod-by-pvc"
+	PodByVMIUIDIndex                   = "harvesterhci.io/pod-by-vmi-uid"
 	VolumeByNodeIndex                  = "harvesterhci.io/volume-by-node"
 	VMBackupBySourceVMUIDIndex         = "harvesterhci.io/vmbackup-by-source-vm-uid"
 	VMBackupBySourceVMNameIndex        = "harvesterhci.io/vmbackup-by-source-vm-name"
@@ -39,6 +41,7 @@ func Setup(ctx context.Context, _ *server.Server, _ *server.Controllers, _ confi
 	podInformer.AddIndexer(PodByNodeNameIndex, PodByNodeName)
 	podInformer.AddIndexer(PodByPVCIndex, PodByPVC)
 	podInformer.AddIndexer(indexeresutil.PodByVMNameIndex, indexeresutil.PodByVMName)
+	podInformer.AddIndexer(PodByVMIUIDIndex, PodByVMIUID)
 
 	volumeInformer := management.LonghornFactory.Longhorn().V1beta2().Volume().Cache()
 	volumeInformer.AddIndexer(VolumeByNodeIndex, VolumeByNodeName)
@@ -74,6 +77,14 @@ func PodByPVC(obj *corev1.Pod) ([]string, error) {
 		}
 	}
 	return pvcNames, nil
+}
+
+func PodByVMIUID(obj *corev1.Pod) ([]string, error) {
+	vmiUID, exists := obj.Labels[kubevirtv1.CreatedByLabel]
+	if !exists || vmiUID == "" {
+		return []string{}, nil
+	}
+	return []string{vmiUID}, nil
 }
 
 func pvcByDataSourceVolumeSnapshot(obj *corev1.PersistentVolumeClaim) ([]string, error) {

--- a/pkg/util/fakeclients/pod.go
+++ b/pkg/util/fakeclients/pod.go
@@ -1,0 +1,97 @@
+package fakeclients
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/harvester/harvester/pkg/indexeres"
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+type PodClient func(string) v1.PodInterface
+
+func (c PodClient) Create(pod *corev1.Pod) (*corev1.Pod, error) {
+	return c(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+}
+
+func (c PodClient) Update(pod *corev1.Pod) (*corev1.Pod, error) {
+	return c(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+}
+
+func (c PodClient) UpdateStatus(*corev1.Pod) (*corev1.Pod, error) {
+	panic("implement me")
+}
+
+func (c PodClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return c(namespace).Delete(context.TODO(), name, *options)
+}
+
+func (c PodClient) Get(namespace, name string, options metav1.GetOptions) (*corev1.Pod, error) {
+	return c(namespace).Get(context.TODO(), name, options)
+}
+
+func (c PodClient) List(namespace string, opts metav1.ListOptions) (*corev1.PodList, error) {
+	return c(namespace).List(context.TODO(), opts)
+}
+
+func (c PodClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	return c(namespace).Watch(context.TODO(), opts)
+}
+
+func (c PodClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *corev1.Pod, err error) {
+	return c(namespace).Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}
+
+func (c PodClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*corev1.Pod, *corev1.PodList], error) {
+	panic("implement me")
+}
+
+type PodCache func(string) v1.PodInterface
+
+func (c PodCache) Get(namespace, name string) (*corev1.Pod, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c PodCache) List(namespace string, selector labels.Selector) ([]*corev1.Pod, error) {
+	list, err := c(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*corev1.Pod, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, nil
+}
+
+func (c PodCache) AddIndexer(_ string, _ generic.Indexer[*corev1.Pod]) {
+	panic("implement me")
+}
+
+func (c PodCache) GetByIndex(indexName, key string) ([]*corev1.Pod, error) {
+	// Simple implementation that returns pods matching the VMI UID label
+	if indexName == indexeres.PodByVMIUIDIndex {
+		list, err := c("").List(context.TODO(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", kubevirtv1.CreatedByLabel, key),
+		})
+		if err != nil {
+			return nil, err
+		}
+		result := make([]*corev1.Pod, 0, len(list.Items))
+		for i := range list.Items {
+			result = append(result, &list.Items[i])
+		}
+		return result, nil
+	}
+	panic("implement me for index: " + indexName)
+}

--- a/pkg/util/fakeclients/pod.go
+++ b/pkg/util/fakeclients/pod.go
@@ -2,9 +2,7 @@ package fakeclients
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/harvester/harvester/pkg/indexeres"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 type PodClient func(string) v1.PodInterface
@@ -79,19 +76,5 @@ func (c PodCache) AddIndexer(_ string, _ generic.Indexer[*corev1.Pod]) {
 }
 
 func (c PodCache) GetByIndex(indexName, key string) ([]*corev1.Pod, error) {
-	// Simple implementation that returns pods matching the VMI UID label
-	if indexName == indexeres.PodByVMIUIDIndex {
-		list, err := c("").List(context.TODO(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", kubevirtv1.CreatedByLabel, key),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result := make([]*corev1.Pod, 0, len(list.Items))
-		for i := range list.Items {
-			result = append(result, &list.Items[i])
-		}
-		return result, nil
-	}
 	panic("implement me for index: " + indexName)
 }


### PR DESCRIPTION
Filtering nodes for migration based on VMI pod's nodeSelection field. We construct label selector based on pod's node selector when picking up available nodes for migration

#### Problem:
Currently we omit filtering of nodes based on criteria like whether node is schedulable, what is the CPU model of the node and what is the CPU which the VM requires if any. We don't respect VMI's pod nodeSelectors when figuring out compatible nodes for VM migration.

#### Solution:
When listing possible nodes for migration we use label selector built using the virtual machine instance pod's nodeSelectors.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8797

#### Test plan:
Unit tests - added new nodes and new test case with the fields

Basic E2E test validation on virtualization:
1. Create 2 node harvester cluster `node-1` and `node-2`
2. Create VM - `vm-1` on the cluster
3. By default since nodes are similar - created on virtualization you should be able to see the other node and be able to migrate to it
4. Adding affinity rules to vm should make it unschedulable, and then once you label the nodes the vm will be scheduled and each node which contains the labels should be seen as migration target as well

Validate Node Scheduling works:
1. Create a VM
2. By default VM is on - `Run virtual machine on any available node` so migration button was present
3. Enabled VM to be hosted only on the current node - `Run virtual machine on specific node - (Live migration is not supported)`
4. Migration button dissapeared
5. Reverted VM to original state of - `Run virtual machine on any available node`
6. Migrated VM to another node
7. After migration enabled - `Run virtual machine on specific node - (Live migration is not supported)`
8. Migration button dissapeared

Results for Basic E2E test validation on virtualization:

<details>
<summary>Built cluster with this change and custom image to replace the controller and used it on 2 node cluster</summary>
<br>

```
node-1:/home/rancher # kubectl get deployment harvester -n harvester-system -o yaml | grep image
          value: '{"repository":"rancher/support-bundle-kit","tag":"master-head","imagePullPolicy":"IfNotPresent"}'
        image: rancher/harvester:cpufilter8797-head-1
        imagePullPolicy: IfNotPresent
```
</details>

<details>
<summary>Virtual machine on one node allows migration to another node</summary>
<br>
<img width="2288" height="655" alt="image" src="https://github.com/user-attachments/assets/6be07461-20b8-46a7-a72c-d21851fb39dd" />
<img width="2288" height="850" alt="image" src="https://github.com/user-attachments/assets/ccfc483c-8f1a-4a78-9695-e3887a74f657" />
</details>



<details>
<summary>Adding affinity while vm is on node-1 makes node-2 dissapear as potential target</summary>
<br>
<img width="2288" height="850" alt="image" src="https://github.com/user-attachments/assets/ad532033-9866-49e9-b85c-3109c6449741" />
<img width="2559" height="505" alt="image" src="https://github.com/user-attachments/assets/2af36874-a2b8-4b28-aad4-f7980f2be249" />
<img width="2559" height="505" alt="image" src="https://github.com/user-attachments/assets/d082b989-ac0d-4a74-9e03-65bebc817dc5" />
<img width="2559" height="794" alt="image" src="https://github.com/user-attachments/assets/3de50fe7-37ff-44ba-8d4c-7322afaae2bf" />
<img width="2559" height="794" alt="image" src="https://github.com/user-attachments/assets/5f073800-8493-4585-a401-943f83e89f60" />
<img width="2559" height="794" alt="image" src="https://github.com/user-attachments/assets/2e79ed9f-27b9-45c5-b061-03e14c0acf16" />
</details>

<details>
<summary>While migration is running you migration button dissapears</summary>
<br>
<img width="2288" height="850" alt="image" src="https://github.com/user-attachments/assets/461f8980-9121-4695-8d9d-1057de9aaee6" />
</details>

Results for Validate Node Scheduling works:
<details>
<summary>Create VM by default schedulable to all nodes so migratable</summary>
<br>

<img width="1134" height="552" alt="image" src="https://github.com/user-attachments/assets/aee3104b-e231-4482-b0ef-6c3408b69e56" />
<img width="1638" height="491" alt="image" src="https://github.com/user-attachments/assets/70d58ccc-d0ef-4f83-9cb9-6a19279eea8a" />

```
node-1:/home/rancher # kubectl get pod virt-launcher-vm-1-rrgzp -n default -o jsonpath='{.spec.nodeSelector}' | jq
{
  "kubernetes.io/arch": "amd64",
  "kubevirt.io/schedulable": "true",
  "machine-type.node.kubevirt.io/q35": "true"
}
```
</details>


<details>
<summary>Make VM schedulable on specific node - current one and migration button dissapears</summary>
<br>
<img width="1283" height="430" alt="image" src="https://github.com/user-attachments/assets/a7eea831-275b-48cf-9596-a9cc20989037" />
<img width="2274" height="731" alt="image" src="https://github.com/user-attachments/assets/63ff2548-509e-44c2-a728-c44c8bee309e" />

```
node-1:/home/rancher # kubectl get pod virt-launcher-vm-1-cbjpd -n default -o jsonpath='{.spec.nodeSelector}' | jq
{
  "kubernetes.io/arch": "amd64",
  "kubernetes.io/hostname": "node-2",
  "kubevirt.io/schedulable": "true",
  "machine-type.node.kubevirt.io/q35": "true"
}
```
</details>

<details>
<summary>Revert vm schedulable to all nodes, migrate it and see migration back and forth is allowed</summary>
<br>
<img width="1646" height="480" alt="image" src="https://github.com/user-attachments/assets/165fb57e-1881-41ca-badd-90cc66688ded" />

```
node-1:/home/rancher # kubectl get pod virt-launcher-vm-1-cbx4r -n default -o jsonpath='{.spec.nodeSelector}' | jq
{
  "cpu-feature.node.kubevirt.io/arch-capabilities": "true",
  "cpu-feature.node.kubevirt.io/cmp_legacy": "true",
  "cpu-feature.node.kubevirt.io/flush-l1d": "true",
  "cpu-feature.node.kubevirt.io/flushbyasid": "true",
  "cpu-feature.node.kubevirt.io/gds-no": "true",
  "cpu-feature.node.kubevirt.io/hypervisor": "true",
  "cpu-feature.node.kubevirt.io/ibpb-brtype": "true",
  "cpu-feature.node.kubevirt.io/lbrv": "true",
  "cpu-feature.node.kubevirt.io/mds-no": "true",
  "cpu-feature.node.kubevirt.io/overflow-recov": "true",
  "cpu-feature.node.kubevirt.io/pause-filter": "true",
  "cpu-feature.node.kubevirt.io/perfmon-v2": "true",
  "cpu-feature.node.kubevirt.io/pfthreshold": "true",
  "cpu-feature.node.kubevirt.io/pschange-mc-no": "true",
  "cpu-feature.node.kubevirt.io/rdctl-no": "true",
  "cpu-feature.node.kubevirt.io/rfds-no": "true",
  "cpu-feature.node.kubevirt.io/sbpb": "true",
  "cpu-feature.node.kubevirt.io/skip-l1dfl-vmentry": "true",
  "cpu-feature.node.kubevirt.io/ssbd": "true",
  "cpu-feature.node.kubevirt.io/stibp": "true",
  "cpu-feature.node.kubevirt.io/succor": "true",
  "cpu-feature.node.kubevirt.io/tsc-deadline": "true",
  "cpu-feature.node.kubevirt.io/tsc-scale": "true",
  "cpu-feature.node.kubevirt.io/tsc_adjust": "true",
  "cpu-feature.node.kubevirt.io/vgif": "true",
  "cpu-feature.node.kubevirt.io/virt-ssbd": "true",
  "cpu-feature.node.kubevirt.io/vmcb-clean": "true",
  "cpu-feature.node.kubevirt.io/x2apic": "true",
  "cpu-model-migration.node.kubevirt.io/EPYC-Genoa": "true",
  "kubernetes.io/arch": "amd64",
  "kubernetes.io/hostname": "node-1",
  "kubevirt.io/schedulable": "true",
  "machine-type.node.kubevirt.io/pc-q35-9.2": "true"
}
node-1:/home/rancher # kubectl get pod virt-launcher-vm-1-dwjrf -n default -o jsonpath='{.spec.nodeSelector}' | jq
{
  "kubernetes.io/arch": "amd64",
  "kubevirt.io/schedulable": "true",
  "machine-type.node.kubevirt.io/q35": "true"
}
```
</details>

<details>
<summary>Enabling vm to be ran on specific node after migration removes ability to migrate</summary>
<br>
<img width="1275" height="690" alt="image" src="https://github.com/user-attachments/assets/23f5419a-ee02-4445-8c8d-f275ac13ef6f" />
<img width="2291" height="728" alt="image" src="https://github.com/user-attachments/assets/df7370d6-1d30-42bb-aff4-1bba5dd9fa54" />

```
node-1:/home/rancher # kubectl get pods
NAME                       READY   STATUS    RESTARTS   AGE
virt-launcher-vm-1-nxqn4   2/2     Running   0          2m23s
node-1:/home/rancher # kubectl get pod virt-launcher-vm-1-nxqn4 -n default -o jsonpath='{.spec.nodeSelector}' | jq
{
  "kubernetes.io/arch": "amd64",
  "kubernetes.io/hostname": "node-1",
  "kubevirt.io/schedulable": "true",
  "machine-type.node.kubevirt.io/q35": "true"
}
```
</details>

#### Additional documentation or context
N/A