### PR TITLE
feat: patch prefer-no-eviction if vmi is non-migratable

### DIFF
--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -11,6 +11,7 @@ const (
 	vmControllerCreatePVCsFromAnnotationControllerName           = "VMController.CreatePVCsFromAnnotation"
 	vmiControllerReconcileFromHostLabelsControllerName           = "VMIController.ReconcileFromHostLabels"
 	vmControllerSetDefaultManagementNetworkMac                   = "VMController.SetDefaultManagementNetworkMacAddress"
+	vmControllerIgnoreNonMigratableVMI                           = "VMController.IgnoreNonMigratableVMI"
 	vmControllerStoreRunStrategyControllerName                   = "VMController.StoreRunStrategyToAnnotation"
 	vmControllerSyncLabelsToVmi                                  = "VMController.SyncLabelsToVmi"
 	vmControllerSetHaltIfInsufficientResourceQuotaControllerName = "VMController.SetHaltIfInsufficientResourceQuota"
@@ -108,5 +109,10 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	}
 	virtualMachineInstanceClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
 
+	var vmiDeschedulerCtrl = &VMIDeschedulerController{
+		vmClient: vmClient,
+		vmCache:  vmCache,
+	}
+	virtualMachineInstanceClient.OnChange(ctx, vmControllerIgnoreNonMigratableVMI, vmiDeschedulerCtrl.IgnoreNonMigratableVM)
 	return nil
 }

--- a/pkg/controller/master/virtualmachine/vmi_descheduler_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_descheduler_controller.go
@@ -1,0 +1,50 @@
+package virtualmachine
+
+import (
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	vmv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+)
+
+const (
+	deschedulerPreferNoEvictionAnnotationKey = "descheduler.alpha.kubernetes.io/prefer-no-eviction"
+)
+
+type VMIDeschedulerController struct {
+	vmCache  vmv1.VirtualMachineCache
+	vmClient vmv1.VirtualMachineClient
+}
+
+func (h *VMIDeschedulerController) IgnoreNonMigratableVM(id string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+	if id == "" || vmi == nil || vmi.DeletionTimestamp != nil {
+		return vmi, nil
+	}
+
+	if vmi.Status.Phase != kubevirtv1.Running {
+		return vmi, nil
+	}
+
+	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return vmi, err
+	}
+
+	if !vmi.IsMigratable() {
+		logrus.Infof("VM %s/%s is non-migratable, skipping descheduling", vm.Namespace, vm.Name)
+		vmCopy := vm.DeepCopy()
+		if vmCopy.Annotations == nil {
+			vmCopy.Annotations = make(map[string]string)
+		}
+		vmCopy.Annotations[deschedulerPreferNoEvictionAnnotationKey] = "true"
+		if !reflect.DeepEqual(vm.Annotations, vmCopy.Annotations) {
+			_, err = h.vmClient.Update(vmCopy)
+			if err != nil {
+				return vmi, err
+			}
+		}
+	}
+	return vmi, nil
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Currently, we use `LiveMigrateIfPossible` for all VMs. Users cannot update it via UI. If we evict VM with `LiveMigrateIfPossible`, it will be shutdown.

#### Solution:
Use `descheduler.alpha.kubernetes.io/prefer-no-eviction=true` annotation to avoid evict non-migratable VM.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/2311

#### Test plan:
1. Create a VM with PCI device.
2. Check there is `descheduler.alpha.kubernetes.io/prefer-no-eviction=true` on the VM.

#### Additional documentation or context
