### PR TITLE
feat: disable descheduler during upgrade

### DIFF
--- a/pkg/controller/master/upgrade/addon_controller.go
+++ b/pkg/controller/master/upgrade/addon_controller.go
@@ -17,7 +17,7 @@ type addonHandler struct {
 }
 
 func (h *addonHandler) OnChanged(_ string, addon *harvesterv1.Addon) (*harvesterv1.Addon, error) {
-	if addon == nil || addon.DeletionTimestamp != nil || addon.Name != util.DeschedulerName || addon.Labels == nil {
+	if addon == nil || addon.DeletionTimestamp != nil || addon.Name != util.DeschedulerName || addon.Labels == nil || !addon.Spec.Enabled {
 		return addon, nil
 	}
 

--- a/pkg/controller/master/upgrade/addon_controller.go
+++ b/pkg/controller/master/upgrade/addon_controller.go
@@ -1,0 +1,42 @@
+package upgrade
+
+import (
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+type addonHandler struct {
+	namespace    string
+	upgradeCache ctlharvesterv1.UpgradeCache
+	addonClient  ctlharvesterv1.AddonClient
+	addonCache   ctlharvesterv1.AddonCache
+}
+
+func (h *addonHandler) OnChanged(_ string, addon *harvesterv1.Addon) (*harvesterv1.Addon, error) {
+	if addon == nil || addon.DeletionTimestamp != nil || addon.Name != util.DeschedulerName || addon.Labels == nil {
+		return addon, nil
+	}
+
+	upgradeControllerLock.Lock()
+	defer upgradeControllerLock.Unlock()
+
+	upgrade, err := h.upgradeCache.Get(upgradeNamespace, addon.Labels[harvesterUpgradeLabel])
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if upgrade != nil && upgrade.Annotations != nil && upgrade.Annotations[reenableDeschedulerAddonAnnotation] == "true" {
+		toUpdate := addon.DeepCopy()
+		logrus.Infof("Disabling %s addon during upgrade", toUpdate.Name)
+		toUpdate.Spec.Enabled = false
+		if _, err := h.addonClient.Update(toUpdate); err != nil {
+			return nil, err
+		}
+	}
+
+	return addon, nil
+}

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -262,10 +262,6 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 			return h.upgradeClient.Update(toUpdate)
 		}
 
-		if err := h.reenableAddons(upgrade); err != nil {
-			return nil, err
-		}
-
 		return upgrade, nil
 	}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -245,6 +245,7 @@ const (
 	VirtualMachineCreatorNodeDriver = "docker-machine-driver-harvester"
 
 	// Addons
-	AddonPrefix            = "addon." + prefix
-	AddonExperimentalLabel = AddonPrefix + "/experimental"
+	AddonPrefix                        = "addon." + prefix
+	AddonExperimentalLabel             = AddonPrefix + "/experimental"
+	AnnotationReenableDeschedulerAddon = prefix + "/reenableDeschedulerAddon"
 )


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Solution:
Disable descheduler during upgrade to avoid unexpected eviction.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/2311

#### Test plan:
1. Create a Harvester cluster.
2. Enable descheduler addon.
3. Upgrade to this branch.
4. Check the descheduler addon is disabled before node upgrade.
5. Check the descheduler addon is enabled after upgrade complete.
