### PR TITLE
fix: storage class name conflict

### DIFF
--- a/pkg/api/image/schema.go
+++ b/pkg/api/image/schema.go
@@ -26,7 +26,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 	vmImageDownloader := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImageDownloader()
 	scClient := scaled.StorageFactory.Storage().V1().StorageClass()
 
-	vmio, err := common.GetVMIOperator(vmi, vmi.Cache(), http.Client{})
+	vmio, err := common.GetVMIOperator(vmi, vmi.Cache(), scClient.Cache(), http.Client{})
 	if err != nil {
 		return err
 	}

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -48,6 +48,7 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	vmicommon "github.com/harvester/harvester/pkg/image/common"
 	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
@@ -74,6 +75,7 @@ type vmActionHandler struct {
 	clientSet                 kubernetes.Interface
 	virtRestClient            rest.Interface
 	virtSubresourceRestClient rest.Interface
+	vmio                      vmicommon.VMIOperator
 
 	backupClient            ctlharvesterv1.VirtualMachineBackupClient
 	datavolumeClient        ctlcdiv1.DataVolumeClient

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
 	virtv1 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/image/common"
 	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 )
 
@@ -62,6 +63,11 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	nads := scaled.CniFactory.K8s().V1().NetworkAttachmentDefinition()
 	resourceQuotas := scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().ResourceQuota()
 
+	vmiOperator, err := common.GetVMIOperator(vmImages, vmImages.Cache(), storageClasses.Cache(), http.Client{})
+	if err != nil {
+		return err
+	}
+
 	copyConfig := rest.CopyConfig(server.RESTConfig)
 	copyConfig.GroupVersion = &kubevirtSubResouceGroupVersion
 	copyConfig.APIPath = "/apis"
@@ -79,6 +85,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		clientSet:                 scaled.Management.ClientSet,
 		virtRestClient:            virtv1Client.RESTClient(),
 		virtSubresourceRestClient: virtSubresourceClient,
+		vmio:                      vmiOperator,
 
 		backupClient:            backups,
 		datavolumeClient:        dataVolumeClient,

--- a/pkg/api/vm/template.go
+++ b/pkg/api/vm/template.go
@@ -162,7 +162,7 @@ func (h *vmActionHandler) sanitizeVolumes(templateVersion *harvesterv1.VirtualMa
 			continue
 		}
 
-		volumeClaimTemplate := generateVolumeClaimTemplate(index, templateVersion.Name, templateVersion.Namespace, volume.PersistentVolumeClaim.ClaimName, pvcMap, vmImageMap)
+		volumeClaimTemplate := h.generateVolumeClaimTemplate(index, templateVersion.Name, templateVersion.Namespace, volume.PersistentVolumeClaim.ClaimName, pvcMap, vmImageMap)
 		volumeClaimTemplates = append(volumeClaimTemplates, volumeClaimTemplate)
 		vmSource.Spec.Template.Spec.Volumes[index].PersistentVolumeClaim.ClaimName = volumeClaimTemplate.Name
 	}
@@ -187,7 +187,7 @@ func (h *vmActionHandler) sanitizeVolumes(templateVersion *harvesterv1.VirtualMa
 	return nil
 }
 
-func generateVolumeClaimTemplate(index int, tvName, tvNamespace, claimName string, pvcMap map[string]corev1.PersistentVolumeClaim, vmImageMap map[string]harvesterv1.VirtualMachineImage) (pvc corev1.PersistentVolumeClaim) {
+func (h *vmActionHandler) generateVolumeClaimTemplate(index int, tvName, tvNamespace, claimName string, pvcMap map[string]corev1.PersistentVolumeClaim, vmImageMap map[string]harvesterv1.VirtualMachineImage) (pvc corev1.PersistentVolumeClaim) {
 	// generate new volume template
 	// - longhorn v1, we need to use the new storageclass Name (for backingImage)
 	// - others, use the pvc StorageClassName
@@ -195,7 +195,7 @@ func generateVolumeClaimTemplate(index int, tvName, tvNamespace, claimName strin
 	vmImage := vmImageMap[vmImageName]
 
 	claim := pvcMap[claimName]
-	targetStorageClassName := util.GenerateStorageClassName(string(vmImage.UID))
+	targetStorageClassName := h.vmio.GetStorageClassName(&vmImage)
 	if _, ok := pvc.Annotations[cdicommon.AnnCreatedForDataVolume]; ok {
 		targetStorageClassName = *claim.Spec.StorageClassName
 	}

--- a/pkg/api/vm/template.go
+++ b/pkg/api/vm/template.go
@@ -352,7 +352,7 @@ func (h *vmActionHandler) createVMImages(templateVersion *harvesterv1.VirtualMac
 }
 
 func (h *vmActionHandler) createVMImage(namespace, name string, backend harvesterv1.VMIBackend, targetSCName, claimName string, owner metav1.OwnerReference) (*harvesterv1.VirtualMachineImage, error) {
-	vmImage, err := h.vmImages.Create(&harvesterv1.VirtualMachineImage{
+	vmImage, err := h.vmImageClient.Create(&harvesterv1.VirtualMachineImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -504,7 +504,7 @@ func (h *vmActionHandler) cleanupVMImage(vmi *harvesterv1.VirtualMachineImage) (
 		return nil
 	}
 
-	if err = h.vmImages.Delete(vmi.Namespace, vmi.Name, &metav1.DeleteOptions{}); err != nil {
+	if err = h.vmImageClient.Delete(vmi.Namespace, vmi.Name, &metav1.DeleteOptions{}); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}

--- a/pkg/api/vm/template.go
+++ b/pkg/api/vm/template.go
@@ -1,0 +1,429 @@
+package vm
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/util/retry"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdicommon "kubevirt.io/containerized-data-importer/pkg/controller/common"
+)
+
+// createTemplate creates a VirtualMachineTemplate and VirtualMachineTemplateVersion
+// that are derived from the given VirtualMachine.
+func (h *vmActionHandler) createTemplate(namespace, name string, input CreateTemplateInput) (err error) {
+	var (
+		keyPairIDs []string
+		vm         *kubevirtv1.VirtualMachine
+		vmt        *harvesterv1.VirtualMachineTemplate
+		vmtv       *harvesterv1.VirtualMachineTemplateVersion
+	)
+	defer func() {
+		var cleanupErr error
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"namespace": namespace,
+				"name":      name,
+			}).Errorf("failed to create VM Template and associated resources: %w", err)
+
+			if cleanupErr = h.cleanupVMTemplateVersion(vmtv); cleanupErr != nil {
+				err = fmt.Errorf("failed to clean up VM template version while dealing with error %w: %s", err, cleanupErr.Error())
+			}
+
+			if cleanupErr = h.cleanupVMTemplate(vmt); cleanupErr != nil {
+				err = fmt.Errorf("failed to clean up VM template while dealing with error %w: %s", err, cleanupErr.Error())
+			}
+		}
+	}()
+
+	vm, err = h.vmCache.Get(namespace, name)
+	if err != nil {
+		return err
+	}
+
+	keyPairIDs, err = getSSHKeysFromVMITemplateSpec(vm.Spec.Template)
+	if err != nil {
+		return err
+	}
+
+	vmt, err = h.createVMTemplate(namespace, input)
+	if err != nil {
+		return err
+	}
+
+	vmtv, err = h.createVMTemplateVersion(namespace, vm, vmt, keyPairIDs)
+	if err != nil {
+		return err
+	}
+
+	if input.WithData {
+		vmtv, err = h.createTemplateWithData(vm, vmtv)
+		if err != nil {
+			return err
+		}
+	}
+
+	return h.createSecrets(vmtv, vm)
+}
+
+func (h *vmActionHandler) createTemplateWithData(vm *kubevirtv1.VirtualMachine, vmtvIn *harvesterv1.VirtualMachineTemplateVersion) (vmtv *harvesterv1.VirtualMachineTemplateVersion, err error) {
+	var (
+		pvcMap             map[string]corev1.PersistentVolumeClaim
+		pvcStorageClassMap map[string]string
+		vmImageMap         map[string]harvesterv1.VirtualMachineImage
+	)
+
+	pvcMap, pvcStorageClassMap, err = h.getPVCStorageClassMap(vm)
+	if err != nil {
+		return vmtv, err
+	}
+	vmImageMap, err = h.createVMImages(vmtv, vm, pvcStorageClassMap)
+	if err != nil {
+		return vmtv, err
+	}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		vmtv, err = h.vmTemplateVersionClient.Get(vmtv.Namespace, vmtv.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		return h.sanitizeVolumes(vmtv, pvcMap, vmImageMap)
+	})
+	if err != nil {
+		return vmtv, err
+	}
+	return vmtv, nil
+}
+
+func (h *vmActionHandler) getPVCStorageClassMap(vm *kubevirtv1.VirtualMachine) (map[string]corev1.PersistentVolumeClaim, map[string]string, error) {
+	pvcMap := map[string]corev1.PersistentVolumeClaim{}
+	pvcStorageClassMap := map[string]string{}
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvc, err := h.pvcCache.Get(vm.Namespace, volume.PersistentVolumeClaim.ClaimName)
+		if err != nil {
+			return pvcMap, pvcStorageClassMap, err
+		}
+		pvcMap[pvc.Name] = *pvc
+
+		pvcStorageClass, err := h.storageClassCache.Get(*pvc.Spec.StorageClassName)
+		if err != nil {
+			return pvcMap, pvcStorageClassMap, err
+		}
+		var sc *storagev1.StorageClass
+		if _, ok := pvcStorageClass.Parameters["backingImage"]; ok {
+			// If "backingImage" is set, the storage class is from a VM image.
+			// We can't use it directly. We need to find storageClassName annotation.
+			if imageID, ok := pvc.Annotations[util.AnnotationImageID]; ok {
+				imageIDSplit := strings.Split(imageID, "/")
+				if len(imageIDSplit) == 2 {
+					vmImage, err := h.vmImageCache.Get(imageIDSplit[0], imageIDSplit[1])
+					if err != nil {
+						return pvcMap, pvcStorageClassMap, err
+					}
+					if storageClassName, ok := vmImage.Annotations[util.AnnotationStorageClassName]; ok {
+						sc, err = h.storageClassCache.Get(storageClassName)
+						if err != nil {
+							return pvcMap, pvcStorageClassMap, err
+						}
+					}
+				}
+			}
+		} else {
+			sc = pvcStorageClass
+		}
+
+		if sc == nil {
+			pvcStorageClassMap[pvc.Name] = ""
+			continue
+		}
+		pvcStorageClassMap[pvc.Name] = sc.Name
+	}
+	return pvcMap, pvcStorageClassMap, nil
+}
+
+func (h *vmActionHandler) sanitizeVolumes(templateVersion *harvesterv1.VirtualMachineTemplateVersion, pvcMap map[string]corev1.PersistentVolumeClaim, vmImageMap map[string]harvesterv1.VirtualMachineImage) error {
+	templateVersionCopy := templateVersion.DeepCopy()
+	vmSource := &templateVersionCopy.Spec.VM
+	volumeClaimTemplates := []corev1.PersistentVolumeClaim{}
+	for index, volume := range vmSource.Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		// generate new volume template
+		// - longhorn v1, we need to use the new storageclass Name (for backingImage)
+		// - others, use the pvc StorageClassName
+		vmImageName := getTemplateVersionVMImageName(templateVersion.Name, index)
+		vmImage := vmImageMap[vmImageName]
+		pvc := pvcMap[volume.PersistentVolumeClaim.ClaimName]
+		targetStorageClassName := util.GenerateStorageClassName(string(vmImage.UID))
+		if _, find := pvc.Annotations[cdicommon.AnnCreatedForDataVolume]; find {
+			targetStorageClassName = *pvc.Spec.StorageClassName
+		}
+		annoImageID := fmt.Sprintf("%s/%s", templateVersion.Namespace, vmImageName)
+		pvcName := getTemplateVersionPvcName(templateVersion.Name, index)
+		volumeClaimTemplates = append(volumeClaimTemplates, corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: pvcName,
+				Annotations: map[string]string{
+					util.AnnotationImageID: annoImageID,
+				},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      pvc.Spec.AccessModes,
+				Resources:        pvc.Spec.Resources,
+				VolumeMode:       pvc.Spec.VolumeMode,
+				StorageClassName: &targetStorageClassName,
+			},
+		})
+		vmSource.Spec.Template.Spec.Volumes[index].PersistentVolumeClaim.ClaimName = pvcName
+	}
+
+	volumeCliamTemplatesJSON, err := json.Marshal(volumeClaimTemplates)
+	if err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"namespace":       templateVersion.Namespace,
+			"templateVersion": templateVersion.Name,
+			"volumeClaim":     volumeClaimTemplates,
+		}).Error("Failed to json.Marshal volume claim templates")
+		return err
+	}
+
+	if vmSource.ObjectMeta.Annotations == nil {
+		vmSource.ObjectMeta.Annotations = map[string]string{}
+	}
+	vmSource.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = string(volumeCliamTemplatesJSON)
+	if _, err := h.vmTemplateVersionClient.Update(templateVersionCopy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *vmActionHandler) createSecrets(templateVersion *harvesterv1.VirtualMachineTemplateVersion, vm *kubevirtv1.VirtualMachine) error {
+	for index, credential := range vm.Spec.Template.Spec.AccessCredentials {
+		if sshPublicKey := credential.SSHPublicKey; sshPublicKey != nil && sshPublicKey.Source.Secret != nil {
+			toCreateSecretName := getTemplateVersionSSHPublicKeySecretName(templateVersion.Name, index)
+			if err := h.copySecret(sshPublicKey.Source.Secret.SecretName, toCreateSecretName, templateVersion); err != nil {
+				return err
+			}
+		}
+		if userPassword := credential.UserPassword; userPassword != nil && userPassword.Source.Secret != nil {
+			toCreateSecretName := getTemplateVersionUserPasswordSecretName(templateVersion.Name, index)
+			if err := h.copySecret(userPassword.Source.Secret.SecretName, toCreateSecretName, templateVersion); err != nil {
+				return err
+			}
+		}
+	}
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		if volume.CloudInitNoCloud == nil {
+			continue
+		}
+		if volume.CloudInitNoCloud.UserDataSecretRef != nil {
+			toCreateSecretName := getTemplateVersionUserDataSecretName(templateVersion.Name, volume.Name)
+			if err := h.copySecret(volume.CloudInitNoCloud.UserDataSecretRef.Name, toCreateSecretName, templateVersion); err != nil {
+				return err
+			}
+		}
+		if volume.CloudInitNoCloud.NetworkDataSecretRef != nil {
+			toCreateSecretName := getTemplateVersionNetworkDataSecretName(templateVersion.Name, volume.Name)
+			if err := h.copySecret(volume.CloudInitNoCloud.NetworkDataSecretRef.Name, toCreateSecretName, templateVersion); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (h *vmActionHandler) copySecret(sourceName, targetName string, templateVersion *harvesterv1.VirtualMachineTemplateVersion) error {
+	secret, err := h.secretCache.Get(templateVersion.Namespace, sourceName)
+	if err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"namespace":       templateVersion.Namespace,
+			"templateVersion": templateVersion.Name,
+			"secret":          sourceName,
+		}).Error("Failed to get secret")
+		return err
+	}
+	toCreate := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName,
+			Namespace: secret.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: templateVersion.APIVersion,
+					Kind:       templateVersion.Kind,
+					Name:       templateVersion.Name,
+					UID:        templateVersion.UID,
+				},
+			},
+		},
+		Data: secret.Data,
+	}
+	_, err = h.secretClient.Create(toCreate)
+	return err
+
+}
+
+func (h *vmActionHandler) createVMImages(templateVersion *harvesterv1.VirtualMachineTemplateVersion, vm *kubevirtv1.VirtualMachine, pvcStorageClassMap map[string]string) (map[string]harvesterv1.VirtualMachineImage, error) {
+	var err error
+	vmImageMap := map[string]harvesterv1.VirtualMachineImage{}
+	for index, volume := range vm.Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			continue
+		}
+		targetSCName := pvcStorageClassMap[volume.PersistentVolumeClaim.ClaimName]
+		// 3 cases here:
+		// Root volume with backingImage, check SC name starts with "longhorn-templateversion-", use backingImage backend
+		// volume with non longhorn provisioner, use CDI backend
+		// volume with longhorn provisioner, use backingImage backend
+		// we use CDI as default, so we need to check other two cases
+		vmImageBackend := harvesterv1.VMIBackendCDI
+		if strings.HasPrefix(targetSCName, "longhorn-templateversion-") {
+			vmImageBackend = harvesterv1.VMIBackendBackingImage
+		} else {
+			// checking SC
+			targetSC, err := h.storageClassCache.Get(targetSCName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get storage class %s, error: %v", targetSCName, err)
+			}
+			if targetSC.Provisioner == util.CSIProvisionerLonghorn {
+				if dataEngineVers, find := targetSC.Parameters["dataEngine"]; find {
+					if dataEngineVers == string(longhorn.DataEngineTypeV1) {
+						vmImageBackend = harvesterv1.VMIBackendBackingImage
+					}
+				} else {
+					vmImageBackend = harvesterv1.VMIBackendBackingImage
+				}
+			}
+		}
+		if vmImageBackend == "" {
+			return nil, fmt.Errorf("failed to configure vm image backend for volume %s", volume.Name)
+		}
+		vmImageName := getTemplateVersionVMImageName(templateVersion.Name, index)
+		vmImage := &harvesterv1.VirtualMachineImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmImageName,
+				Namespace: vm.Namespace,
+				Annotations: map[string]string{
+					util.AnnotationStorageClassName: targetSCName,
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: templateVersion.APIVersion,
+						Kind:       templateVersion.Kind,
+						Name:       templateVersion.Name,
+						UID:        templateVersion.UID,
+					},
+				},
+			},
+			Spec: harvesterv1.VirtualMachineImageSpec{
+				Backend:                vmImageBackend,
+				DisplayName:            vmImageName,
+				SourceType:             harvesterv1.VirtualMachineImageSourceTypeExportVolume,
+				PVCName:                volume.PersistentVolumeClaim.ClaimName,
+				PVCNamespace:           vm.Namespace,
+				TargetStorageClassName: targetSCName,
+			},
+		}
+
+		vmImage, err = h.vmImages.Create(vmImage)
+		if err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"namespace":       templateVersion.Namespace,
+				"templateVersion": templateVersion.Name,
+				"pvc":             volume.PersistentVolumeClaim.ClaimName,
+			}).Error("Failed to create VM image")
+			return nil, err
+		}
+		vmImageMap[vmImage.Name] = *vmImage
+	}
+	return vmImageMap, nil
+}
+
+func (h *vmActionHandler) createVMTemplate(namespace string, input CreateTemplateInput) (vmt *harvesterv1.VirtualMachineTemplate, err error) {
+	vmt, err = h.vmTemplateClient.Create(
+		&harvesterv1.VirtualMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      input.Name,
+				Namespace: namespace,
+			},
+			Spec: harvesterv1.VirtualMachineTemplateSpec{
+				Description: input.Description,
+			},
+		})
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"namespace": namespace,
+			"name":      input.Name,
+		}).Errorf("failed to create VM Template: %w", err)
+		return nil, err
+	}
+	return vmt, nil
+}
+
+func (h *vmActionHandler) createVMTemplateVersion(namespace string, vm *kubevirtv1.VirtualMachine, vmt *harvesterv1.VirtualMachineTemplate, keyPairIDs []string) (vmtv *harvesterv1.VirtualMachineTemplateVersion, err error) {
+	name := fmt.Sprintf("%s-%s", vmt.Name, rand.String(6))
+	vmtID := fmt.Sprintf("%s/%s", vmt.Namespace, vmt.Name)
+	vmSourceSpec := h.sanitizeVirtualMachineForTemplateVersion(name, vm)
+	vmtv, err = h.vmTemplateVersionClient.Create(
+		&harvesterv1.VirtualMachineTemplateVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: harvesterv1.VirtualMachineTemplateVersionSpec{
+				TemplateID:  vmtID,
+				Description: fmt.Sprintf("Template derived from virtual machine [%s]", vmtID),
+				VM:          vmSourceSpec,
+				KeyPairIDs:  keyPairIDs,
+			},
+		})
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"namespace": namespace,
+			"name":      name,
+		}).Errorf("failed to reate VM Template Version: %w", err)
+		return nil, err
+	}
+	return vmtv, nil
+}
+
+// cleanup the VirtualMachineTemplate in case we hold a non-nil reference
+func (h *vmActionHandler) cleanupVMTemplate(vmt *harvesterv1.VirtualMachineTemplate) (err error) {
+	if vmt != nil {
+		if err = h.vmTemplateClient.Delete(vmt.Namespace, vmt.Name, &metav1.DeleteOptions{}); err != nil {
+			logrus.WithFields(logrus.Fields{
+				"namespace": vmt.Namespace,
+				"name":      vmt.Name,
+			}).Errorf("failed to clean up template version: %w", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanup the VirtualMachineTemplateVersion in case we hold a non-nil reference
+func (h *vmActionHandler) cleanupVMTemplateVersion(vmtv *harvesterv1.VirtualMachineTemplateVersion) (err error) {
+	if vmtv != nil {
+		if err = h.vmTemplateVersionClient.Delete(vmtv.Namespace, vmtv.Name, &metav1.DeleteOptions{}); err != nil {
+			logrus.WithFields(logrus.Fields{
+				"namespace": vmtv.Namespace,
+				"name":      vmtv.Name,
+			}).Errorf("failed to clean up template version: %w", err)
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/api/vm/template.go
+++ b/pkg/api/vm/template.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdicommon "kubevirt.io/containerized-data-importer/pkg/controller/common"
 )
@@ -212,24 +213,28 @@ func (h *vmActionHandler) sanitizeVolumes(templateVersion *harvesterv1.VirtualMa
 	return nil
 }
 
+// generate new volume template
+// - longhorn v1, we need to use the new storageclass Name (for backingImage)
+// - others, use the pvc StorageClassName
 func (h *vmActionHandler) generateVolumeClaimTemplate(index int, tvName, tvNamespace, claimName string, pvcMap map[string]corev1.PersistentVolumeClaim, vmImageMap map[string]harvesterv1.VirtualMachineImage) (pvc corev1.PersistentVolumeClaim) {
-	// generate new volume template
-	// - longhorn v1, we need to use the new storageclass Name (for backingImage)
-	// - others, use the pvc StorageClassName
+	var targetSCName *string
+
 	vmImageName := getTemplateVersionVMImageName(tvName, index)
 	vmImage := vmImageMap[vmImageName]
 
 	claim := pvcMap[claimName]
-	// target storage class name
-	targetSCName := h.vmio.GetStorageClassName(&vmImage)
-	if _, ok := pvc.Annotations[cdicommon.AnnCreatedForDataVolume]; ok {
-		targetSCName = *claim.Spec.StorageClassName
+	if _, ok := claim.Annotations[cdicommon.AnnCreatedForDataVolume]; ok {
+		// no nil check, because if claim.Spec.StorageClassName is nil, it needs to
+		// be copied to the PVC template as well, so the PVC template can also use
+		// the default storage class
+		targetSCName = claim.Spec.StorageClassName
+	} else {
+		targetSCName = ptr.To(h.vmio.GetStorageClassName(&vmImage))
 	}
-	pvcName := getTemplateVersionPvcName(tvName, index)
 
 	pvc = corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: pvcName,
+			Name: getTemplateVersionPvcName(tvName, index),
 			Annotations: map[string]string{
 				util.AnnotationImageID: fmt.Sprintf("%s/%s", tvNamespace, vmImageName),
 			},
@@ -238,7 +243,7 @@ func (h *vmActionHandler) generateVolumeClaimTemplate(index int, tvName, tvNames
 			AccessModes:      claim.Spec.AccessModes,
 			Resources:        claim.Spec.Resources,
 			VolumeMode:       claim.Spec.VolumeMode,
-			StorageClassName: &targetSCName,
+			StorageClassName: targetSCName,
 		},
 	}
 	return pvc

--- a/pkg/api/vm/template.go
+++ b/pkg/api/vm/template.go
@@ -87,15 +87,15 @@ func (h *vmActionHandler) createTemplateWithData(vm *kubevirtv1.VirtualMachine, 
 
 	defer func() {
 		var cleanupErr error
+		if err == nil {
+			return
+		}
 
 		logrus.WithFields(logrus.Fields{
 			"namespace": vm.Namespace,
 			"name":      vm.Name,
 		}).Errorf("failed to create VM images while trying to create VM Template with data: %v", err)
 
-		if err == nil {
-			return
-		}
 		if cleanupErr = h.cleanupVMImages(vmtv, vm); cleanupErr != nil {
 			err = fmt.Errorf("failed to clean up VM images while dealing with error %w: %s", err, cleanupErr.Error())
 		}
@@ -135,7 +135,7 @@ func (h *vmActionHandler) getPVCMap(vm *kubevirtv1.VirtualMachine) (pvcMap map[s
 
 		pvc, err = h.pvcCache.Get(vm.Namespace, volume.PersistentVolumeClaim.ClaimName)
 		if err != nil {
-			return pvcMap, err
+			return nil, err
 		}
 		pvcMap[pvc.Name] = *pvc
 	}
@@ -150,6 +150,11 @@ func (h *vmActionHandler) getSCNameFromPVC(pvc *corev1.PersistentVolumeClaim) (s
 	if imageId, ok := pvc.Annotations[util.AnnotationImageID]; ok {
 		return h.getSCNameFromImgID(imageId)
 	}
+	if pvc.Spec.StorageClassName == nil {
+		return "", fmt.Errorf("failed to get the storage class name from PVC")
+	}
+	// There should really be a bit more logic here to deal with default storage
+	// classes properly.
 	return *pvc.Spec.StorageClassName, nil
 }
 
@@ -198,7 +203,7 @@ func (h *vmActionHandler) sanitizeVolumes(templateVersion *harvesterv1.VirtualMa
 	}
 
 	if vmSource.ObjectMeta.Annotations == nil {
-		vmSource.ObjectMeta.Annotations = map[string]string{}
+		vmSource.ObjectMeta.Annotations = make(map[string]string)
 	}
 	vmSource.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = string(volumeCliamTemplatesJSON)
 	if _, err := h.vmTemplateVersionClient.Update(templateVersionCopy); err != nil {

--- a/pkg/api/vm/template_test.go
+++ b/pkg/api/vm/template_test.go
@@ -1,0 +1,6 @@
+package vm
+
+import "testing"
+
+func TestCreateVMTemplateAction(t *testing.T) {
+}

--- a/pkg/api/vm/template_test.go
+++ b/pkg/api/vm/template_test.go
@@ -8,8 +8,12 @@ import (
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestGetSCNameFromImgID(t *testing.T) {
@@ -132,6 +136,182 @@ func TestGetSCNameFromImgID(t *testing.T) {
 		res.scname, res.err = handler.getSCNameFromImgID(tc.in.imageId)
 
 		assert.Equal(t, res.scname, tc.ex.scname, "case %q", tc.desc)
+		if tc.ex.err != nil && res.err != nil {
+			assert.Equal(t, res.err.Error(), tc.ex.err.Error(), "case %q", tc.desc)
+		} else {
+			assert.Equal(t, res.err, tc.ex.err, "case %q", tc.desc)
+		}
+	}
+}
+
+func TestGetVMImageBackend(t *testing.T) {
+	type input struct {
+		storageclasses []*storagev1.StorageClass
+		targetSCName   string
+		pvc            *corev1.PersistentVolumeClaim
+	}
+	type output struct {
+		vmiBackend harvesterv1.VMIBackend
+		err        error
+	}
+	testcases := []struct {
+		desc string
+		in   input
+		ex   output
+	}{
+		{
+			desc: "PVC \"longhorn-templateversion-.*\" use backend \"BackingImage\"",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{},
+				targetSCName:   "longhorn-templateversion-foobar-abcdef",
+				pvc:            &corev1.PersistentVolumeClaim{},
+			},
+			ex: output{
+				vmiBackend: harvesterv1.VMIBackendBackingImage,
+				err:        nil,
+			},
+		},
+		{
+			desc: "PVC with non-Longhorn storage class use CDI backend",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "foobar",
+						},
+						Provisioner: "foobar-provisioner",
+					},
+				},
+				targetSCName: "foobar",
+				pvc: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foobar-pvc",
+						Namespace: "foobar",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: ptr.To("foobar"),
+					},
+				},
+			},
+			ex: output{
+				vmiBackend: harvesterv1.VMIBackendCDI,
+				err:        nil,
+			},
+		},
+		{
+			desc: "PVC using Longhorn storage class with v2 data engine use CDI backend",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-v2",
+						},
+						Provisioner: "driver.longhorn.io",
+						Parameters: map[string]string{
+							util.ParamDataEngine: string(longhorn.DataEngineTypeV2),
+						},
+					},
+				},
+				targetSCName: "longhorn-v2",
+				pvc: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: ptr.To("longhorn-v2"),
+					},
+				},
+			},
+			ex: output{
+				vmiBackend: harvesterv1.VMIBackendCDI,
+				err:        nil,
+			},
+		},
+		{
+			desc: "PVC using Longhorn storage class with v1 data engine use BackingImage backend",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-v1",
+						},
+						Provisioner: "driver.longhorn.io",
+						Parameters: map[string]string{
+							util.ParamDataEngine: string(longhorn.DataEngineTypeV1),
+						},
+					},
+				},
+				targetSCName: "longhorn-v1",
+				pvc: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: ptr.To("longhorn-v1"),
+					},
+				},
+			},
+			ex: output{
+				vmiBackend: harvesterv1.VMIBackendBackingImage,
+				err:        nil,
+			},
+		},
+		{
+			desc: "PVC using Longhorn storage class with no data engine specified use BackingImage backend",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-v1-no-de",
+						},
+						Provisioner: "driver.longhorn.io",
+						Parameters:  map[string]string{},
+					},
+				},
+				targetSCName: "longhorn-v1-no-de",
+				pvc: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: ptr.To("longhorn-v1-no-de"),
+					},
+				},
+			},
+			ex: output{
+				vmiBackend: harvesterv1.VMIBackendBackingImage,
+				err:        nil,
+			},
+		},
+		{
+			desc: "error case: storage class not found",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{},
+				targetSCName:   "no-exist",
+				pvc: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: ptr.To("no-exist"),
+					},
+				},
+			},
+			ex: output{
+				vmiBackend: "",
+				err:        fmt.Errorf("storageclasses.storage.k8s.io \"no-exist\" not found"),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		var res output
+		var clientset = fake.NewSimpleClientset()
+
+		for _, sc := range tc.in.storageclasses {
+			err := clientset.Tracker().Add(sc)
+			assert.Nil(t, err, "failed creating mock resources")
+		}
+
+		var handler = &vmActionHandler{
+			storageClassCache: fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+		}
+
+		res.vmiBackend, res.err = handler.getVMImageBackend(tc.in.targetSCName, tc.in.pvc)
+
+		assert.Equal(t, res.vmiBackend, tc.ex.vmiBackend)
 		if tc.ex.err != nil && res.err != nil {
 			assert.Equal(t, res.err.Error(), tc.ex.err.Error(), "case %q", tc.desc)
 		} else {

--- a/pkg/api/vm/template_test.go
+++ b/pkg/api/vm/template_test.go
@@ -31,7 +31,7 @@ func TestGetSCNameFromImgID(t *testing.T) {
 			in: input{
 				imageId: "default/test",
 				images: []*harvesterv1.VirtualMachineImage{
-					&harvesterv1.VirtualMachineImage{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "notthisone",
 							Namespace: "default",
@@ -40,7 +40,7 @@ func TestGetSCNameFromImgID(t *testing.T) {
 							},
 						},
 					},
-					&harvesterv1.VirtualMachineImage{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "default",
@@ -49,7 +49,7 @@ func TestGetSCNameFromImgID(t *testing.T) {
 							},
 						},
 					},
-					&harvesterv1.VirtualMachineImage{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "alsonotthisone",
@@ -70,7 +70,7 @@ func TestGetSCNameFromImgID(t *testing.T) {
 			in: input{
 				imageId: "default/test",
 				images: []*harvesterv1.VirtualMachineImage{
-					&harvesterv1.VirtualMachineImage{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "notthisone",
 							Namespace: "default",
@@ -79,7 +79,7 @@ func TestGetSCNameFromImgID(t *testing.T) {
 							},
 						},
 					},
-					&harvesterv1.VirtualMachineImage{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "alsonotthisone",
@@ -100,7 +100,7 @@ func TestGetSCNameFromImgID(t *testing.T) {
 			in: input{
 				imageId: "default/test",
 				images: []*harvesterv1.VirtualMachineImage{
-					&harvesterv1.VirtualMachineImage{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "test",
 							Namespace:   "default",

--- a/pkg/api/vm/template_test.go
+++ b/pkg/api/vm/template_test.go
@@ -1,6 +1,141 @@
 package vm
 
-import "testing"
+import (
+	"fmt"
+	"testing"
 
-func TestCreateVMTemplateAction(t *testing.T) {
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetSCNameFromImgID(t *testing.T) {
+	type input struct {
+		imageId string
+		images  []*harvesterv1.VirtualMachineImage
+	}
+	type output struct {
+		scname string
+		err    error
+	}
+	testcases := []struct {
+		desc string
+		in   input
+		ex   output
+	}{
+		{
+			desc: "all good",
+			in: input{
+				imageId: "default/test",
+				images: []*harvesterv1.VirtualMachineImage{
+					&harvesterv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "notthisone",
+							Namespace: "default",
+							Annotations: map[string]string{
+								util.AnnotationStorageClassName: "barfoo",
+							},
+						},
+					},
+					&harvesterv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "default",
+							Annotations: map[string]string{
+								util.AnnotationStorageClassName: "foobar",
+							},
+						},
+					},
+					&harvesterv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "alsonotthisone",
+							Annotations: map[string]string{
+								util.AnnotationStorageClassName: "barfoo",
+							},
+						},
+					},
+				},
+			},
+			ex: output{
+				scname: "foobar",
+				err:    nil,
+			},
+		},
+		{
+			desc: "image not found",
+			in: input{
+				imageId: "default/test",
+				images: []*harvesterv1.VirtualMachineImage{
+					&harvesterv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "notthisone",
+							Namespace: "default",
+							Annotations: map[string]string{
+								util.AnnotationStorageClassName: "barfoo",
+							},
+						},
+					},
+					&harvesterv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "alsonotthisone",
+							Annotations: map[string]string{
+								util.AnnotationStorageClassName: "barfoo",
+							},
+						},
+					},
+				},
+			},
+			ex: output{
+				scname: "",
+				err:    fmt.Errorf("virtualmachineimages.harvesterhci.io \"test\" not found"),
+			},
+		},
+		{
+			desc: "image doesn't have annotation",
+			in: input{
+				imageId: "default/test",
+				images: []*harvesterv1.VirtualMachineImage{
+					&harvesterv1.VirtualMachineImage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "test",
+							Namespace:   "default",
+							Annotations: map[string]string{},
+						},
+					},
+				},
+			},
+			ex: output{
+				scname: "",
+				err:    fmt.Errorf("VMImage default/test does not have an annotation %s", util.AnnotationStorageClassName),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		var res output
+		var clientset = fake.NewSimpleClientset()
+
+		for _, img := range tc.in.images {
+			err := clientset.Tracker().Add(img)
+			assert.Nil(t, err, "failed creating mock resources")
+		}
+
+		var handler = &vmActionHandler{
+			vmImageCache: fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
+		}
+
+		res.scname, res.err = handler.getSCNameFromImgID(tc.in.imageId)
+
+		assert.Equal(t, res.scname, tc.ex.scname, "case %q", tc.desc)
+		if tc.ex.err != nil && res.err != nil {
+			assert.Equal(t, res.err.Error(), tc.ex.err.Error(), "case %q", tc.desc)
+		} else {
+			assert.Equal(t, res.err, tc.ex.err, "case %q", tc.desc)
+		}
+	}
 }

--- a/pkg/controller/master/image/register.go
+++ b/pkg/controller/master/image/register.go
@@ -25,7 +25,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	secrets := management.CoreFactory.Core().V1().Secret()
 	ctlcdi := management.CdiFactory.Cdi().V1beta1().DataVolume()
 
-	vmio, err := common.GetVMIOperator(vmi, vmi.Cache(), http.Client{Timeout: 15 * time.Second})
+	vmio, err := common.GetVMIOperator(vmi, vmi.Cache(), sc.Cache(), http.Client{Timeout: 15 * time.Second})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/master/image/vm_image_controller_test.go
+++ b/pkg/controller/master/image/vm_image_controller_test.go
@@ -141,6 +141,7 @@ func TestVMImageHandler_OnChanged_UploadImageInitialization(t *testing.T) {
 			vmio, err := common.GetVMIOperator(
 				fakeclients.VirtualMachineImageClient(clientset.HarvesterhciV1beta1().VirtualMachineImages),
 				fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
+				fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
 				http.Client{},
 			)
 			assert.Nil(t, err, "should create VMIOperator")

--- a/pkg/image/backingimage/backing_image_controller_test.go
+++ b/pkg/image/backingimage/backing_image_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 const (
@@ -147,12 +148,14 @@ func TestBackingImageHandler_OnChanged_RetryLimitExceeded(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup fake clients
 			var harvFakeClient = fakegenerated.NewSimpleClientset()
+			var kubeFakeClient = kubefake.NewSimpleClientset()
 			require.NoError(t, harvFakeClient.Tracker().Add(tt.vmImage))
 
 			// Create VMIOperator
 			vmio, err := common.GetVMIOperator(
 				fakeclients.VirtualMachineImageClient(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
 				fakeclients.VirtualMachineImageCache(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				fakeclients.StorageClassCache(kubeFakeClient.StorageV1().StorageClasses),
 				http.Client{},
 			)
 			require.Nil(t, err, "should create VMIOperator")

--- a/pkg/image/backingimage/backingimage.go
+++ b/pkg/image/backingimage/backingimage.go
@@ -83,11 +83,7 @@ func (bib *Backend) deleteBackingImage(vmi *harvesterv1.VirtualMachineImage) err
 }
 
 func (bib *Backend) deleteStorageClass(vmi *harvesterv1.VirtualMachineImage) error {
-	storageClassName, err := util.GetImageStorageClassName(bib.scCache, vmi)
-	if err != nil {
-		return err
-	}
-
+	storageClassName := bib.vmio.GetStorageClassName(vmi)
 	return bib.scClient.Delete(storageClassName, &metav1.DeleteOptions{})
 }
 
@@ -179,11 +175,7 @@ func (bib *Backend) createBackingImage(vmi *harvesterv1.VirtualMachineImage) err
 }
 
 func (bib *Backend) createStorageClass(vmi *harvesterv1.VirtualMachineImage) error {
-	storageClassName, err := util.GetImageStorageClassName(bib.scCache, vmi)
-	if err != nil {
-		return err
-	}
-
+	storageClassName := bib.vmio.GetStorageClassName(vmi)
 	if cachedSC, _ := bib.scCache.Get(storageClassName); cachedSC != nil && cachedSC.DeletionTimestamp != nil {
 		return fmt.Errorf("storage class %s is being deleted", cachedSC.Name)
 	}
@@ -258,11 +250,7 @@ func (bib *Backend) Check(vmi *harvesterv1.VirtualMachineImage) error {
 		}
 	}
 
-	storageClassName, err := util.GetImageStorageClassName(bib.scCache, vmi)
-	if err != nil {
-		return err
-	}
-
+	storageClassName := bib.vmio.GetStorageClassName(vmi)
 	sc, err := bib.scCache.Get(storageClassName)
 	if errors.IsNotFound(err) {
 		return err

--- a/pkg/image/common/operator.go
+++ b/pkg/image/common/operator.go
@@ -189,7 +189,7 @@ func (vmio *vmiOperator) GetStorageClassName(vmi *harvesterv1.VirtualMachineImag
 	}
 
 	return lhutil.AutoCorrectName(
-		fmt.Sprintf("longhorn-%s", vmio.GetUID(vmi)),
+		fmt.Sprintf("lh-%s", vmio.GetUID(vmi)),
 		lhdatastore.NameMaximumLength,
 	)
 }

--- a/pkg/image/common/operator_test.go
+++ b/pkg/image/common/operator_test.go
@@ -1,0 +1,119 @@
+package common
+
+import (
+	"testing"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+	"github.com/stretchr/testify/assert"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetStorageClassName(t *testing.T) {
+	type input struct {
+		storageclasses []*storagev1.StorageClass
+		vmi            *harvesterv1.VirtualMachineImage
+	}
+	type output struct {
+		name string
+	}
+	testcases := []struct {
+		desc string
+		in   input
+		ex   output
+	}{
+		{
+			desc: "CDI Backend with foobar StorageClass",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{},
+				vmi: &harvesterv1.VirtualMachineImage{
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend:                harvesterv1.VMIBackendCDI,
+						TargetStorageClassName: "foobar",
+					},
+				},
+			},
+			ex: output{name: "foobar"},
+		},
+		{
+			desc: "StoageClass lh-$UID",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "lh-abcdefghi-jklmno-pqrstu-123456",
+						},
+					},
+				},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "image-foobar",
+						UID:  "abcdefghi-jklmno-pqrstu-123456",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend: harvesterv1.VMIBackendBackingImage,
+					},
+				},
+			},
+			ex: output{name: "lh-abcdefghi-jklmno-pqrstu-123456"},
+		},
+		{
+			desc: "StoageClass longhorn-$NAME",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-image-foobar",
+						},
+					},
+				},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "image-foobar",
+						UID:  "abcdefghi-jklmno-pqrstu-123456",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend: harvesterv1.VMIBackendBackingImage,
+					},
+				},
+			},
+			ex: output{name: "longhorn-image-foobar"},
+		},
+		{
+			desc: "StoageClass not found",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "image-foobar",
+						UID:  "abcdefghi-jklmno-pqrstu-123456",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend: harvesterv1.VMIBackendBackingImage,
+					},
+				},
+			},
+			ex: output{name: "lh-abcdefghi-jklmno-pqrstu-123456"},
+		},
+	}
+
+	for _, tc := range testcases {
+		var res output
+		var clientset = fake.NewSimpleClientset()
+
+		for _, sc := range tc.in.storageclasses {
+			err := clientset.Tracker().Add(sc)
+			assert.Nil(t, err, "failed creating mock resources")
+		}
+
+		var vmio = &vmiOperator{
+			scCache: fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+		}
+
+		res.name = vmio.GetStorageClassName(tc.in.vmi)
+
+		assert.Equal(t, res.name, tc.ex.name, tc.desc)
+	}
+}

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -72,49 +72,6 @@ func GetBackingImageDataSourceName(backingImageCache ctllhv1.BackingImageCache, 
 	return GetBackingImageName(backingImageCache, image)
 }
 
-func legacyStorageClassName(imageName string) string {
-	return fmt.Sprintf("longhorn-%s", imageName)
-}
-
-func GenerateStorageClassName(imageUID string) string {
-	return lhutil.AutoCorrectName(fmt.Sprintf("longhorn-%s", imageUID), lhdatastore.NameMaximumLength)
-}
-
-func GetStorageClass(storageClassCache ctlstoragev1.StorageClassCache, image *harvesterv1.VirtualMachineImage) (*storagev1.StorageClass, error) {
-	// For backward compatibility, try to get the storage class with legacy name first.
-	// If it exists, return it directly.
-	// If not, try with a new name format based on the image UID, which can avoid name conflict. Because
-	// the legacy name is based on image name, so two images with the same name but in different namespaces
-	// would generate the same storage class name (StorageClass doesn't have namespace).
-	sc, err := storageClassCache.Get(legacyStorageClassName(image.Name))
-	if err == nil {
-		return sc, nil
-	}
-
-	if !errors.IsNotFound(err) {
-		return nil, err
-	}
-
-	return storageClassCache.Get(GenerateStorageClassName(string(image.UID)))
-}
-
-func GetImageStorageClassName(storageClassCache ctlstoragev1.StorageClassCache, image *harvesterv1.VirtualMachineImage) (string, error) {
-	if image.Spec.Backend == harvesterv1.VMIBackendCDI {
-		return image.Spec.TargetStorageClassName, nil
-	}
-
-	sc, err := GetStorageClass(storageClassCache, image)
-	if err == nil {
-		return sc.Name, nil
-	}
-
-	if !errors.IsNotFound(err) {
-		return "", err
-	}
-
-	return GenerateStorageClassName(string(image.UID)), nil
-}
-
 func GetImageStorageClassParameters(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (map[string]string, error) {
 	biName, err := GetBackingImageName(backingImageCache, image)
 	if err != nil {

--- a/pkg/util/owner.go
+++ b/pkg/util/owner.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Get OnwerReference for an object
+// This function extracts all necessary TypeMeta and ObjectMeta information from
+// the struct of a Kubernetes API object and constructs an OwnerReference struct
+// with that data.
+func GetOwnerReferenceFor(obj any) (*metav1.OwnerReference, error) {
+	t, err := apimeta.TypeAccessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	m, err := apimeta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &metav1.OwnerReference{
+		APIVersion: t.GetAPIVersion(),
+		Kind:       t.GetKind(),
+		Name:       m.GetName(),
+		UID:        m.GetUID(),
+	}, nil
+}

--- a/pkg/util/owner_test.go
+++ b/pkg/util/owner_test.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+)
+
+func TestGetOnwerReference(t *testing.T) {
+	obj1 := &harvesterv1.VirtualMachineTemplateVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foobar",
+			UID:  "abcdef-foobar-xabcdefghijkl",
+		},
+	}
+
+	ref1, err := GetOwnerReferenceFor(obj1)
+	assert.Nil(t, err)
+	assert.NotNil(t, ref1)
+	assert.Equal(t, obj1.APIVersion, ref1.APIVersion, "api version mismatch")
+	assert.Equal(t, obj1.Kind, ref1.Kind, "kind mismatch")
+	assert.Equal(t, obj1.Name, ref1.Name, "name mismatch")
+	assert.Equal(t, obj1.UID, ref1.UID, "uid mismatch")
+
+	obj2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "barfoo",
+			UID:  "defghi-abcdef-foobarbarfoo",
+		},
+	}
+
+	ref2, err := GetOwnerReferenceFor(obj2)
+	assert.Nil(t, err)
+	assert.NotNil(t, ref2)
+	assert.Equal(t, obj2.APIVersion, ref2.APIVersion, "api version mismatch")
+	assert.Equal(t, obj2.Kind, ref2.Kind, "kind mismatch")
+	assert.Equal(t, obj2.Name, ref2.Name, "name mismatch")
+	assert.Equal(t, obj2.UID, ref2.UID, "uid mismatch")
+
+	ref3, err := GetOwnerReferenceFor(&struct{ Foo string }{Foo: "bar"})
+	assert.Nil(t, ref3)
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "struct struct { Foo string } lacks embedded TypeMeta type")
+}

--- a/pkg/util/storageclass.go
+++ b/pkg/util/storageclass.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	longhorn "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	storagev1 "k8s.io/api/storage/v1"
+)
+
+const (
+	ParamDataEngine = "dataEngine"
+)
+
+func GetLonghornDataEngineType(sc *storagev1.StorageClass) longhorn.DataEngineType {
+	v, ok := sc.Parameters[ParamDataEngine]
+	if ok {
+		return longhorn.DataEngineType(v)
+	}
+	return longhorn.DataEngineTypeAll
+}


### PR DESCRIPTION
#### Problem:
We use `longhorn-<vmimage name>` as storage class name. The StorageClass doesn't have namesapce, but vmimage has. If there are same vmimage name in different namespace, storage class name will be conflicts.

#### Solution:
Use `namespace` and image `UID` as name format.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5165

- - -

# Test plan:

## Basic Tests

### Case 1: Reproducer from #5165
1. Create two VirtualMachineImages: `default/test-image` and `harvester-public/test-image`
2. After the two VirtualMachineImages are ready, delete `default/test-image`
3. Create a VirtualMachine from VirtualMachineImage `harvester-public/test-image`

## Regression Tests

### Case 1: VM basic operations (create / backup /restore) without error.
1. Create a VMImage.
2. Create a VM without error.
3.. Write some data.
4. Setup backup-target.
5. Backup the VM.
6. Restore a new VM. New VM can start without error.

### Case 2: VMImage with a same name in different namespaces can work
1. Create a VMImage `thisistest` in `default` and `harvester-public` namespaces.
2. Both images can be created without error.

### Case 3: An old VMImage can work without error.
1. Create a Harvester cluster v1.4.0.
2. Create a VMImage.
3. Replace harvester and harvester-webhook deployment with this PR.
4. The VMImage can work without error.

### Case 4: Create VM Template without error
1. Follow case 1.
2. Generate Template with data.
3. After template is ready, launch a new VM and we can see default image name starts with `templateversion-`. New VM can start without error and data is in the new VM.

## Rancher Tests

### Case 1: Guest Cluster with Reproducer from #5165
1. Install Rancher, register Harvester cluster in Rancher
2. Create two VirtualMachineImages: `default/test-image` and `harvester-public/test-image`
3. After the two VirtualMachineImages are ready, delete `default/test-image`
4. Create a new guest cluster on Harvester from VirtualMachineImage `harvester-public/test-image`