### PR TITLE
feat: add migration-based hotplug NIC

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -129,6 +129,9 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 
 		if canHotplugNic(vm) {
 			resource.AddAction(request, addNic)
+		}
+
+		if canHotUnplugNic(vm) {
 			resource.AddAction(request, removeNic)
 			resource.AddAction(request, findHotunpluggableNics)
 		}
@@ -477,4 +480,11 @@ func canHotplugNic(vm *kubevirtv1.VirtualMachine) bool {
 		return false
 	}
 	return virtualmachine.SupportHotplugNic(vm)
+}
+
+func canHotUnplugNic(vm *kubevirtv1.VirtualMachine) bool {
+	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
+		return false
+	}
+	return virtualmachine.SupportHotUnplugNic(vm)
 }

--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -41,6 +41,9 @@ const (
 	createTemplate                   = "createTemplate"
 	addVolume                        = "addVolume"
 	removeVolume                     = "removeVolume"
+	addNic                           = "addNic"
+	removeNic                        = "removeNic"
+	findHotunpluggableNics           = "findHotunpluggableNics"
 	cloneVM                          = "clone"
 	forceStopVM                      = "forceStop"
 	dismissInsufficientResourceQuota = "dismissInsufficientResourceQuota"
@@ -122,6 +125,12 @@ func (vf *vmformatter) formatter(request *types.APIRequest, resource *types.RawR
 
 		if canCPUAndMemoryHotplug(vm) {
 			resource.AddAction(request, cpuAndMemoryHotplug)
+		}
+
+		if canHotplugNic(vm) {
+			resource.AddAction(request, addNic)
+			resource.AddAction(request, removeNic)
+			resource.AddAction(request, findHotunpluggableNics)
 		}
 	}
 
@@ -461,4 +470,11 @@ func canCPUAndMemoryHotplug(vm *kubevirtv1.VirtualMachine) bool {
 		}
 	}
 	return !hasRestartRequiredOrHotplugMigration
+}
+
+func canHotplugNic(vm *kubevirtv1.VirtualMachine) bool {
+	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
+		return false
+	}
+	return virtualmachine.SupportHotplugNic(vm)
 }

--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -476,15 +476,9 @@ func canCPUAndMemoryHotplug(vm *kubevirtv1.VirtualMachine) bool {
 }
 
 func canHotplugNic(vm *kubevirtv1.VirtualMachine) bool {
-	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
-		return false
-	}
 	return virtualmachine.SupportHotplugNic(vm)
 }
 
 func canHotUnplugNic(vm *kubevirtv1.VirtualMachine) bool {
-	if vm.Status.PrintableStatus != kubevirtv1.VirtualMachineStatusRunning {
-		return false
-	}
 	return virtualmachine.SupportHotUnplugNic(vm)
 }

--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -476,9 +476,11 @@ func canCPUAndMemoryHotplug(vm *kubevirtv1.VirtualMachine) bool {
 }
 
 func canHotplugNic(vm *kubevirtv1.VirtualMachine) bool {
-	return virtualmachine.SupportHotplugNic(vm)
+	ok, _ := virtualmachine.SupportHotplugNic(vm)
+	return ok
 }
 
 func canHotUnplugNic(vm *kubevirtv1.VirtualMachine) bool {
-	return virtualmachine.SupportHotUnplugNic(vm)
+	ok, _ := virtualmachine.SupportHotUnplugNic(vm)
+	return ok
 }

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1254,6 +1254,8 @@ func (h *vmActionHandler) addNic(ctx context.Context, namespace, name string, in
 		return err
 	}
 
+	logrus.Infof("VM %s/%s has interface %s backed by network %s hot-plugged", namespace, name, input.InterfaceName, input.NetworkName)
+
 	// https://kubevirt.io/user-guide/network/hotplug_interfaces/#migration-based-hotplug
 	// Although it's not required to manually migrate the VM as mentioned in the document,
 	// we still immediately call the migration here for better UX instead of waiting KubeVirt to discover and reconcile.
@@ -1294,6 +1296,8 @@ func (h *vmActionHandler) removeNic(ctx context.Context, namespace, name string,
 	if err != nil {
 		return err
 	}
+
+	logrus.Infof("VM %s/%s has interface %s hot-unplugged", namespace, name, input.InterfaceName)
 
 	// https://kubevirt.io/user-guide/network/hotplug_interfaces/#migration-based-hotplug
 	// Although it's not required to manually migrate the VM as mentioned in the document,

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1243,7 +1243,7 @@ func (h *vmActionHandler) addNic(ctx context.Context, namespace, name string, in
 	if err != nil {
 		return err
 	}
-	return h.migrate(ctx, namespace, name, "")
+	return nil
 }
 
 func (h *vmActionHandler) getHotunpluggableNetworks(vm *kubevirtv1.VirtualMachine) (map[string]struct{}, error) {
@@ -1312,7 +1312,7 @@ func (h *vmActionHandler) removeNic(ctx context.Context, namespace, name string,
 	if err != nil {
 		return err
 	}
-	return h.migrate(ctx, namespace, name, "")
+	return nil
 }
 
 // findHotunpluggableNics return a list of NIC names that could be hot-unplugged

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1238,7 +1238,7 @@ func (h *vmActionHandler) addNic(ctx context.Context, namespace, name string, in
 	newIface := kubevirtv1.Interface{
 		Name:                   input.InterfaceName,
 		MacAddress:             input.MacAddress,
-		Model:                  "virtio",
+		Model:                  kubevirtv1.VirtIO,
 		InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{Bridge: &kubevirtv1.InterfaceBridge{}},
 	}
 	vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces = append(vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces, newIface)

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1243,6 +1243,10 @@ func (h *vmActionHandler) addNic(ctx context.Context, namespace, name string, in
 	if err != nil {
 		return err
 	}
+
+	// https://kubevirt.io/user-guide/network/hotplug_interfaces/#migration-based-hotplug
+	// Manually migrating the VM is not required since we have LiveUpdate roll-out strategy and KubeVirt >= v1.6
+
 	return nil
 }
 
@@ -1280,6 +1284,10 @@ func (h *vmActionHandler) removeNic(ctx context.Context, namespace, name string,
 	if err != nil {
 		return err
 	}
+
+	// https://kubevirt.io/user-guide/network/hotplug_interfaces/#migration-based-hotplug
+	// Manually migrating the VM is not required since we have LiveUpdate roll-out strategy and KubeVirt >= v1.6
+
 	return nil
 }
 

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1191,6 +1191,16 @@ func (h *vmActionHandler) getVmNetwork(name, vmNamespaceFallback string) (*cniv1
 }
 
 func isVmNetworkHotpluggable(nad *cniv1.NetworkAttachmentDefinition) (bool, error) {
+	if nad.DeletionTimestamp != nil {
+		return false, nil
+	}
+
+	// nads from this namespace are reserved and not hotpluggable
+	// they were used for special cases, like migration network or storage network
+	if util.IsNadCreatedBySystem(nad) {
+		return false, nil
+	}
+
 	conf, err := util.DecodeNadConfigToNetConf(nad)
 	if err != nil {
 		return false, err

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1255,9 +1255,9 @@ func (h *vmActionHandler) addNic(ctx context.Context, namespace, name string, in
 	}
 
 	// https://kubevirt.io/user-guide/network/hotplug_interfaces/#migration-based-hotplug
-	// Manually migrating the VM is not required since we have LiveUpdate roll-out strategy and KubeVirt >= v1.6
-
-	return nil
+	// Although it's not required to manually migrate the VM as mentioned in the document,
+	// we still immediately call the migration here for better UX instead of waiting KubeVirt to discover and reconcile.
+	return h.migrate(ctx, namespace, name, "")
 }
 
 // removeNic remove a hotplug NIC by its interface name
@@ -1296,9 +1296,9 @@ func (h *vmActionHandler) removeNic(ctx context.Context, namespace, name string,
 	}
 
 	// https://kubevirt.io/user-guide/network/hotplug_interfaces/#migration-based-hotplug
-	// Manually migrating the VM is not required since we have LiveUpdate roll-out strategy and KubeVirt >= v1.6
-
-	return nil
+	// Although it's not required to manually migrate the VM as mentioned in the document,
+	// we still immediately call the migration here for better UX instead of waiting KubeVirt to discover and reconcile.
+	return h.migrate(ctx, namespace, name, "")
 }
 
 // findHotunpluggableNics return a list of NIC names that could be hot-unplugged

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1267,8 +1267,8 @@ func (h *vmActionHandler) removeNic(ctx context.Context, namespace, name string,
 		return err
 	}
 
-	if !virtualmachine.SupportHotUnplugNic(vm) {
-		return fmt.Errorf("%s/%s doesn't support HotUnplugNic", namespace, name)
+	if _, err := virtualmachine.SupportHotUnplugNic(vm); err != nil {
+		return err
 	}
 
 	vmCopy := vm.DeepCopy()
@@ -1277,7 +1277,7 @@ func (h *vmActionHandler) removeNic(ctx context.Context, namespace, name string,
 	interfaces := vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces
 	for idx := range interfaces {
 		if interfaces[idx].Name == input.InterfaceName {
-			if virtualmachine.IsInterfaceHotUnpluggable(interfaces[idx]) {
+			if ok, _ := virtualmachine.IsInterfaceHotUnpluggable(interfaces[idx]); ok {
 				interfaces[idx].State = kubevirtv1.InterfaceStateAbsent
 				found = true
 				break
@@ -1309,10 +1309,10 @@ func (h *vmActionHandler) findHotunpluggableNics(rw http.ResponseWriter, namespa
 	}
 
 	ifaceNames := make([]string, 0)
-	if virtualmachine.SupportHotUnplugNic(vm) {
+	if ok, _ := virtualmachine.SupportHotUnplugNic(vm); ok {
 		iterfaces := vm.Spec.Template.Spec.Domain.Devices.Interfaces
 		for _, iface := range iterfaces {
-			if virtualmachine.IsInterfaceHotUnpluggable(iface) {
+			if ok, _ := virtualmachine.IsInterfaceHotUnpluggable(iface); ok {
 				ifaceNames = append(ifaceNames, iface.Name)
 			}
 		}

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1195,7 +1195,7 @@ func isVmNetworkHotpluggable(nad *cniv1.NetworkAttachmentDefinition) (bool, erro
 		return false, nil
 	}
 
-	// nads from this namespace are reserved and not hotpluggable
+	// nads created by system are not hotpluggable
 	// they were used for special cases, like migration network or storage network
 	if util.IsNadCreatedBySystem(nad) {
 		return false, nil

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -914,6 +915,22 @@ func Test_isVmNetworkHotpluggable(t *testing.T) {
 					},
 					Spec: cniv1.NetworkAttachmentDefinitionSpec{
 						Config: `{"cniVersion":"0.3.1","type":"bridge","bridge":"storage-br","promiscMode":true,"vlan":99,"ipam":{"type":"whereabouts","range":"10.0.99.0/24"}}`,
+					},
+				},
+			},
+			expected: output{
+				isHotpluggable: false,
+			},
+		},
+		{
+			name: "deletion requested NAD is not hot-pluggable",
+			given: input{
+				nad: &cniv1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: cniv1.NetworkAttachmentDefinitionSpec{
+						Config: `{"cniVersion":"0.3.1","name":"untagged","type":"bridge","bridge":"mgmt-br","promiscMode":true,"ipam":{}}`,
 					},
 				},
 			},

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -36,6 +36,8 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	server.BaseSchemas.MustImportAndCustomize(CreateTemplateInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(AddVolumeInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(RemoveVolumeInput{}, nil)
+	server.BaseSchemas.MustImportAndCustomize(AddNicInput{}, nil)
+	server.BaseSchemas.MustImportAndCustomize(RemoveNicInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(CloneInput{}, nil)
 	server.BaseSchemas.MustImportAndCustomize(CPUAndMemoryHotplugInput{}, nil)
 
@@ -139,6 +141,9 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				createTemplate:                   actionHandler,
 				addVolume:                        actionHandler,
 				removeVolume:                     actionHandler,
+				addNic:                           actionHandler,
+				removeNic:                        actionHandler,
+				findHotunpluggableNics:           actionHandler,
 				cloneVM:                          actionHandler,
 				forceStopVM:                      actionHandler,
 				dismissInsufficientResourceQuota: actionHandler,
@@ -177,6 +182,13 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 				removeVolume: {
 					Input: "removeVolumeInput",
 				},
+				addNic: {
+					Input: "addNicInput",
+				},
+				removeNic: {
+					Input: "removeNicInput",
+				},
+				findHotunpluggableNics: {},
 				cloneVM: {
 					Input: "cloneInput",
 				},

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -39,6 +39,20 @@ type RemoveVolumeInput struct {
 	DiskName string `json:"diskName"`
 }
 
+type AddNicInput struct {
+	InterfaceName string `json:"interfaceName"`
+	NetworkName   string `json:"networkName"`
+	MacAddress    string `json:"macAddress"`
+}
+
+type RemoveNicInput struct {
+	InterfaceName string `json:"interfaceName"`
+}
+
+type FindHotunpluggableNicsOutput struct {
+	Interfaces []string `json:"interfaces"`
+}
+
 type CloneInput struct {
 	TargetVM    string `json:"targetVm"`
 	RunStrategy string `json:"runStrategy"`

--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -10,6 +10,7 @@ import (
 const (
 	vmControllerCreatePVCsFromAnnotationControllerName           = "VMController.CreatePVCsFromAnnotation"
 	vmiControllerReconcileFromHostLabelsControllerName           = "VMIController.ReconcileFromHostLabels"
+	vmControllerBackfillObservedNetworkMac                       = "VMController.BackfillObservedNetworkMacAddress"
 	vmControllerSetDefaultManagementNetworkMac                   = "VMController.SetDefaultManagementNetworkMacAddress"
 	vmControllerStoreRunStrategyControllerName                   = "VMController.StoreRunStrategyToAnnotation"
 	vmControllerSyncLabelsToVmi                                  = "VMController.SyncLabelsToVmi"
@@ -107,6 +108,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		vmiClient: virtualMachineInstanceClient,
 	}
 	virtualMachineInstanceClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
+	virtualMachineInstanceClient.OnRemove(ctx, vmControllerBackfillObservedNetworkMac, vmNetworkCtl.BackfillObservedNetworkMacAddress)
 
 	return nil
 }

--- a/pkg/controller/master/virtualmachine/vmi_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_controller.go
@@ -16,10 +16,6 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 )
 
-const (
-	VirtualMachineCreatorNodeDriver = "docker-machine-driver-harvester"
-)
-
 // hostLabelsReconcileMapping defines the mapping for reconciliation of node labels to virtual machine instance annotations
 var hostLabelsReconcileMapping = []string{
 	corev1.LabelTopologyZone, corev1.LabelTopologyRegion, corev1.LabelHostname,
@@ -40,7 +36,7 @@ func (h *VMIController) ReconcileFromHostLabels(_ string, vmi *kubevirtv1.Virtua
 		return vmi, nil
 	}
 
-	if creator := vmi.Labels[builder.LabelKeyVirtualMachineCreator]; creator != VirtualMachineCreatorNodeDriver {
+	if creator := vmi.Labels[builder.LabelKeyVirtualMachineCreator]; creator != util.VirtualMachineCreatorNodeDriver {
 		return vmi, nil
 	}
 

--- a/pkg/controller/master/virtualmachine/vmi_network_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller.go
@@ -33,7 +33,7 @@ func (h *VMNetworkController) SetDefaultNetworkMacAddress(id string, vmi *kubevi
 		return vmi, nil
 	}
 
-	err := h.updateVMDefaultNetworkMacAddress(vmi)
+	err := h.updateVMMacAddressAnnotation(vmi)
 	if err != nil {
 		return vmi, err
 	}
@@ -41,7 +41,20 @@ func (h *VMNetworkController) SetDefaultNetworkMacAddress(id string, vmi *kubevi
 	return vmi, nil
 }
 
-func (h *VMNetworkController) updateVMDefaultNetworkMacAddress(vmi *kubevirtv1.VirtualMachineInstance) error {
+func (h *VMNetworkController) BackfillObservedNetworkMacAddress(id string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+	if vmi == nil {
+		return vmi, nil
+	}
+
+	err := h.updateVMMacAddressFromAnnotation(vmi)
+	if err != nil {
+		return vmi, err
+	}
+
+	return vmi, nil
+}
+
+func (h *VMNetworkController) updateVMMacAddressAnnotation(vmi *kubevirtv1.VirtualMachineInstance) error {
 	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
 		return err
@@ -81,6 +94,55 @@ func (h *VMNetworkController) updateVMDefaultNetworkMacAddress(vmi *kubevirtv1.V
 		if _, err := h.vmClient.Update(vmCopy); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (h *VMNetworkController) updateVMMacAddressFromAnnotation(vmi *kubevirtv1.VirtualMachineInstance) error {
+	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return err
+	}
+
+	macAddressFromAnnotation, exists := vm.Annotations[util.AnnotationMacAddressName]
+	if !exists {
+		return nil
+	}
+
+	vmiInterfaces := make(map[string]string)
+	if err := json.Unmarshal([]byte(macAddressFromAnnotation), &vmiInterfaces); err != nil {
+		return err
+	}
+
+	vmCopy := vm.DeepCopy()
+	vmInterfaces := vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces
+	for i := range(vmInterfaces) {
+		iface := vmInterfaces[i]
+		macAddress, observed := vmiInterfaces[iface.Name]
+		if iface.MacAddress != "" {
+			if iface.MacAddress != macAddress {
+				logrus.WithFields(logrus.Fields{
+					"name":      vmCopy.Name,
+					"namespace": vmCopy.Namespace,
+				}).Warnf("Detected unmatched MAC address of interface '%s' between annotation '%s' and spec '%s'", iface.Name, macAddress, iface.MacAddress)
+			}
+			continue
+		}
+
+		if !observed {
+			logrus.WithFields(logrus.Fields{
+				"name":      vmCopy.Name,
+				"namespace": vmCopy.Namespace,
+			}).Warnf("MAC address of interface '%s' hasn't been observed yet", iface.Name)
+			continue
+		}
+
+		vmInterfaces[i].MacAddress = macAddress
+	}
+
+	if _, err := h.vmClient.Update(vmCopy); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/controller/master/virtualmachine/vmi_network_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller.go
@@ -105,6 +105,11 @@ func (h *VMNetworkController) updateVMMacAddressFromAnnotation(vmi *kubevirtv1.V
 		return err
 	}
 
+	// no need to patch VM spec when both VM and VMI are registered for deletion
+	if vm.DeletionTimestamp != nil {
+		return nil
+	}
+
 	macAddressFromAnnotation, exists := vm.Annotations[util.AnnotationMacAddressName]
 	if !exists {
 		return nil

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -239,4 +239,6 @@ const (
 	AnnotationStorageProfileVolumeModeAccessModes = AnnotationCDIPrefix + "/storageProfileVolumeModeAccessModes"
 	FSOverheadRegex                               = `^(0(?:\.\d{1,3})?|1)$`
 	PVCExpandErrorPrefix                          = "PVC_EXPAND"
+
+	VirtualMachineCreatorNodeDriver = "docker-machine-driver-harvester"
 )

--- a/pkg/util/nad.go
+++ b/pkg/util/nad.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+)
+
+
+type NetConf struct {
+	cnitypes.PluginConf
+}
+
+func DecodeNadConfigToNetConf(nad *cniv1.NetworkAttachmentDefinition) (*NetConf, error) {
+	conf := &NetConf{}
+	if nad == nil || nad.Spec.Config == "" {
+		return conf, nil
+	}
+
+	if err := json.Unmarshal([]byte(nad.Spec.Config), conf); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal nad %v/%v config %s %w", nad.Namespace, nad.Name, nad.Spec.Config, err)
+	}
+
+	return conf, nil
+}
+
+func (nc *NetConf) IsBridgeCNI() bool {
+	return nc.Type == "bridge"
+}

--- a/pkg/util/nad.go
+++ b/pkg/util/nad.go
@@ -29,3 +29,7 @@ func DecodeNadConfigToNetConf(nad *cniv1.NetworkAttachmentDefinition) (*NetConf,
 func (nc *NetConf) IsBridgeCNI() bool {
 	return nc.Type == "bridge"
 }
+
+func IsNadCreatedBySystem(nad *cniv1.NetworkAttachmentDefinition) bool {
+	return nad.Namespace == HarvesterSystemNamespaceName
+}

--- a/pkg/util/network/common.go
+++ b/pkg/util/network/common.go
@@ -1,5 +1,11 @@
 package network
 
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+)
+
 const (
 	BridgeSuffix = "-br"
 	CNIVersion   = "0.3.1"
@@ -56,4 +62,24 @@ func CreateBridgeConfig(config Config) BridgeConfig {
 	}
 
 	return bridgeConfig
+}
+
+// generates a random Locally Administered Unicast MAC Address.
+func GenerateLAAMacAddress() (net.HardwareAddr, error) {
+	buf := make([]byte, 6)
+
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, fmt.Errorf("error reading random bytes: %w", err)
+	}
+
+	// Set the Local Bit (the 2nd least significant bit) to 1.
+	// Binary: 00000010 (Hex: 0x02).
+	buf[0] |= 0x02
+
+	// Clear the Multicast Bit (the least significant bit) to 0, ensuring Unicast.
+	// Binary: 11111110 (Hex: 0xFE).
+	buf[0] &= 0xFE
+
+	return net.HardwareAddr(buf), nil
 }

--- a/pkg/util/virtualmachine/virtualmachine.go
+++ b/pkg/util/virtualmachine/virtualmachine.go
@@ -96,7 +96,7 @@ func IsInterfaceHotUnpluggable(iface kubevirtv1.Interface) bool {
 		return false
 	}
 
-	if iface.Model != "" && iface.Model != "virtio" {
+	if iface.Model != "" && iface.Model != kubevirtv1.VirtIO {
 		return false
 	}
 

--- a/pkg/util/virtualmachine/virtualmachine.go
+++ b/pkg/util/virtualmachine/virtualmachine.go
@@ -60,3 +60,21 @@ func SupportCPUAndMemoryHotplug(vm *kubevirtv1.VirtualMachine) bool {
 
 	return strings.ToLower(vm.Annotations[util.AnnotationEnableCPUAndMemoryHotplug]) == "true"
 }
+
+func SupportHotplugNic(vm *kubevirtv1.VirtualMachine) bool {
+	if vm == nil {
+		return false
+	}
+
+	if vm.Labels != nil && vm.Labels[util.LabelVMCreator] == util.VirtualMachineCreatorNodeDriver {
+		return false
+	}
+
+	for _, iface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
+		if iface.MacAddress == "" {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -17,6 +17,7 @@ import (
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/network"
 	"github.com/harvester/harvester/pkg/util/virtualmachine"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
@@ -82,6 +83,11 @@ func (m *vmMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch
 		return nil, err
 	}
 
+	patchOps, err = m.patchInterfaceMacAddress(vm, patchOps)
+	if err != nil {
+		return nil, err
+	}
+
 	return patchOps, nil
 }
 
@@ -122,6 +128,11 @@ func (m *vmMutator) Update(_ *types.Request, oldObj runtime.Object, newObj runti
 	}
 
 	patchOps, err = m.patchTerminationGracePeriodSeconds(newVM, patchOps)
+	if err != nil {
+		return nil, err
+	}
+
+	patchOps, err = m.patchInterfaceMacAddress(newVM, patchOps)
 	if err != nil {
 		return nil, err
 	}
@@ -605,4 +616,34 @@ func patchDefaultCPU(vm *kubevirtv1.VirtualMachine, patchOps types.PatchOps) []s
 	}
 
 	return patchOps
+}
+
+func (m *vmMutator) patchInterfaceMacAddress(vm *kubevirtv1.VirtualMachine, patchOps types.PatchOps) (types.PatchOps, error) {
+	if vm == nil || vm.Spec.Template == nil {
+		return patchOps, nil
+	}
+
+	MacAddressInAnnotation := make(map[string]string)
+	if raw, exists := vm.ObjectMeta.Annotations[util.AnnotationMacAddressName]; exists {
+		err := json.Unmarshal([]byte(raw), &MacAddressInAnnotation)
+		if err != nil {
+			logrus.Warnf("unable to unmarshal %s: %s", util.AnnotationMacAddressName, raw)
+		}
+	}
+
+	for idx, iface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
+		if iface.MacAddress == "" {
+			if mac, exists := MacAddressInAnnotation[iface.Name]; exists {
+				logrus.Infof("MAC address (%s) has already been observed in the annotation for %s", mac, iface.Name)
+				continue
+			}
+			mac, err := network.GenerateLAAMacAddress()
+			if err != nil {
+				return patchOps, fmt.Errorf("failed to generated proper MAC address for %s with error: %v", iface.Name, err)
+			}
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/%d/macAddress", "value": "%s"}`, idx, mac))
+		}
+	}
+
+	return patchOps, nil
 }

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -634,7 +634,7 @@ func (m *vmMutator) patchInterfaceMacAddress(vm *kubevirtv1.VirtualMachine, patc
 	for idx, iface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
 		if iface.MacAddress == "" {
 			if mac, exists := MacAddressInAnnotation[iface.Name]; exists {
-				logrus.Infof("MAC address (%s) has already been observed in the annotation for %s", mac, iface.Name)
+				logrus.Debugf("MAC address (%s) has already been observed in the annotation for %s", mac, iface.Name)
 				continue
 			}
 			mac, err := network.GenerateLAAMacAddress()


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Add migration-based NIC hot-plugging / hot-unplugging to Harvester

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Follow the method from [KubeVirt's documentation -  Migration based hotplug](https://kubevirt.io/user-guide/network/hotplug_interfaces/#migration-based-hotplug). Update the VM spec and do the migration.

These 3 actions are added for VM Custom Resource:
- addNic
- removeNic
- findHotunpluggableNics

To prevent unexpected RestartRequired condition [caused by our current MAC address preserving mechanism](https://github.com/harvester/harvester/pull/9295#discussion_r2443964405) (https://github.com/harvester/harvester/pull/8339), MAC addresses would be generated automatically during VM creation. This ensures that VM and VMI would both have the MAC addresses in spec.

For existing VMs, Their MAC addresses would be backfilled from annotation to spec while stopping or restarting. Until then, those VMs would be considered un-hot-pluggable.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8283
https://github.com/harvester/harvester/issues/7042

#### Test plan:
<!-- Describe the test plan by steps. -->

1. MAC addresses should be generated successfully during VM creation
2. Hotplug NICs to a VM that has restart before shouldn't trigger unexpected RestartRequired condition
3. `addNic`, `removeNic` and `findHotunpluggableNics` shouldn't be allowed when the VM is not live-migratable or is in transition state like `migrating`, `starting`.
4. Can hot-plug to a running VM
5. Can hot-unplug to a running VM

Additionally, please refer to the test plan in HEP: https://github.com/harvester/harvester/pull/9295

#### Additional documentation or context

https://kubevirt.io/user-guide/network/hotplug_interfaces/