### PR TITLE
chore: Use dev baseos image in upgrade container

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,5 +1,5 @@
 ARG HARVESTER_INSTALLER_REF=master-head
-FROM registry.opensuse.org/isv/rancher/harvester/os/sl-micro-6.1/main/baseos:latest as baseos
+FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos:latest as baseos
 FROM rancher/harvester-installer:${HARVESTER_INSTALLER_REF} as installer
 FROM registry.suse.com/bci/bci-base:15.7
 


### PR DESCRIPTION
#### Problem:
Now that the dev project on OBS builds against SL Micro 6.1, we can use that as the source of baseos in the upgrade container, rather than the temporary sl-micro-6.1 project.

#### Solution:
Update the appropriate FROM line in package/upgrade/Dockerfile

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7025

#### Test plan:
N/A