### PR TITLE
feat: allow LHv2 backup and snapshot

### DIFF
--- a/pkg/webhook/util/snapshot.go
+++ b/pkg/webhook/util/snapshot.go
@@ -142,7 +142,7 @@ func (s snapshotBackupAbility) IsSupported(backupType v1beta1.BackupType) bool {
 func genAbilityMatrix() map[string]snapshotBackupAbility {
 	return map[string]snapshotBackupAbility{
 		string(lhv1beta2.DataEngineTypeV1) + "." + lhtypes.LonghornDriverName: {true, true},
-		string(lhv1beta2.DataEngineTypeV2) + "." + lhtypes.LonghornDriverName: {false, false},
+		string(lhv1beta2.DataEngineTypeV2) + "." + lhtypes.LonghornDriverName: {true, true},
 	}
 }
 


### PR DESCRIPTION
#### Problem:
Now that Longhorn supports volume clone with the V2 data engine, we can enable backups and snapshots.

#### Solution:
Adjust the snapshot/backup ability matrix appropriately

#### Related Issue(s):
https://github.com/harvester/harvester/issues/6710

#### Test plan:
- Verify volume snapshot/restore works
- Verify it's possible to backup/restore a VM with an LHv2 volume attached (note that the root disk still needs to be from a V1 image, because we don't support backup of CDI volumes)

#### Additional documentation or context
