### PR TITLE
feat: add webhook for descheduler addon

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -37,6 +37,7 @@ const (
 	AnnotationEnableCPUAndMemoryHotplug = prefix + "/enableCPUAndMemoryHotplug"
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
+	AnnotationSkipDeschedulerAddonWebhookCheck    = prefix + "/skipDeschedulerAddonWebhookCheck"
 
 	// AnnotationSkipResourceQuotaAutoScaling is used to disable to resourcequota auto scaling
 	AnnotationSkipResourceQuotaAutoScaling = prefix + "/skipResourceQuotaAutoScaling"
@@ -87,6 +88,7 @@ const (
 	LocalClusterName                    = "local"
 	HarvesterSystemNamespaceName        = "harvester-system"
 	RancherLoggingName                  = "rancher-logging"
+	DeschedulerName                     = "descheduler"
 	RancherMonitoringPrometheus         = "rancher-monitoring-prometheus"
 	RancherMonitoringAlertmanager       = "rancher-monitoring-alertmanager"
 	RancherMonitoring                   = "rancher-monitoring"

--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harvester/harvester/pkg/util/logging"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
+	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 )
 
 const (
@@ -25,7 +26,7 @@ const (
 	vClusterAddonNamespace = "rancher-vcluster"
 )
 
-func NewValidator(addons ctlharvesterv1.AddonCache, flowCache ctlloggingv1.FlowCache, outputCache ctlloggingv1.OutputCache, clusterFlowCache ctlloggingv1.ClusterFlowCache, clusterOutputCache ctlloggingv1.ClusterOutputCache, upgradeLogCache ctlharvesterv1.UpgradeLogCache) types.Validator {
+func NewValidator(addons ctlharvesterv1.AddonCache, flowCache ctlloggingv1.FlowCache, outputCache ctlloggingv1.OutputCache, clusterFlowCache ctlloggingv1.ClusterFlowCache, clusterOutputCache ctlloggingv1.ClusterOutputCache, upgradeLogCache ctlharvesterv1.UpgradeLogCache, nodeCache ctlcorev1.NodeCache) types.Validator {
 	return &addonValidator{
 		addons:             addons,
 		flowCache:          flowCache,
@@ -33,6 +34,7 @@ func NewValidator(addons ctlharvesterv1.AddonCache, flowCache ctlloggingv1.FlowC
 		clusterFlowCache:   clusterFlowCache,
 		clusterOutputCache: clusterOutputCache,
 		upgradeLogCache:    upgradeLogCache,
+		nodeCache:          nodeCache,
 	}
 }
 
@@ -45,6 +47,7 @@ type addonValidator struct {
 	clusterFlowCache   ctlloggingv1.ClusterFlowCache
 	clusterOutputCache ctlloggingv1.ClusterOutputCache
 	upgradeLogCache    ctlharvesterv1.UpgradeLogCache
+	nodeCache          ctlcorev1.NodeCache
 }
 
 func (v *addonValidator) Resource() types.Resource {
@@ -112,6 +115,14 @@ func (v *addonValidator) validateUpdatedAddon(newAddon *v1beta1.Addon, oldAddon 
 		return v.validateRancherLoggingAddon(newAddon)
 	}
 
+	if newAddon.Name == util.DeschedulerName && newAddon.Spec.Enabled {
+		if newAddon.Annotations != nil && newAddon.Annotations[util.AnnotationSkipDeschedulerAddonWebhookCheck] == "true" {
+			return nil
+		}
+
+		return v.validateDeschedulerAddon(newAddon)
+	}
+
 	return nil
 }
 
@@ -162,5 +173,17 @@ func (v *addonValidator) validateRancherLoggingAddon(newAddon *v1beta1.Addon) er
 		return werror.NewBadRequest("rancher-logging addon cannot be enabled as upgradeLog objects exist in the cluster, fix or delete before enabling addon")
 	}
 
+	return nil
+}
+
+func (v *addonValidator) validateDeschedulerAddon(newAddon *v1beta1.Addon) error {
+	nodes, err := v.nodeCache.List(labels.Everything())
+	if err != nil {
+		return werror.NewBadRequest(fmt.Sprintf("error listing nodes: %v", err.Error()))
+	}
+
+	if len(nodes) <= 1 {
+		return werror.NewBadRequest("descheduler addon cannot be enabled as not enough nodes exist in the cluster")
+	}
 	return nil
 }

--- a/pkg/webhook/resources/addon/validator_test.go
+++ b/pkg/webhook/resources/addon/validator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	harvesterFake "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -419,6 +420,7 @@ func Test_validateUpdatedAddon(t *testing.T) {
 	}
 
 	harvesterClientSet := harvesterFake.NewSimpleClientset()
+	k8sclientset := k8sfake.NewClientset()
 
 	fakeAddonCache := fakeclients.AddonCache(harvesterClientSet.HarvesterhciV1beta1().Addons)
 	fakeFlowCache := fakeclients.FlowCache(harvesterClientSet.LoggingV1beta1().Flows)
@@ -426,7 +428,8 @@ func Test_validateUpdatedAddon(t *testing.T) {
 	fakeClusterFlowCache := fakeclients.ClusterFlowCache(harvesterClientSet.LoggingV1beta1().ClusterFlows)
 	fakeClusterOutputCache := fakeclients.ClusterOutputCache(harvesterClientSet.LoggingV1beta1().ClusterOutputs)
 	upgradeLogCache := fakeclients.UpgradeLogCache(harvesterClientSet.HarvesterhciV1beta1().UpgradeLogs)
-	validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache).(*addonValidator)
+	fakeNodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
+	validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache).(*addonValidator)
 
 	for _, tc := range testCases {
 		err := validator.validateUpdatedAddon(tc.newAddon, tc.oldAddon)
@@ -496,13 +499,16 @@ func Test_validateNewAddon(t *testing.T) {
 
 	for _, tc := range testCases {
 		harvesterClientSet := harvesterFake.NewSimpleClientset()
+		k8sclientset := k8sfake.NewClientset()
 		fakeAddonCache := fakeclients.AddonCache(harvesterClientSet.HarvesterhciV1beta1().Addons)
 		fakeFlowCache := fakeclients.FlowCache(harvesterClientSet.LoggingV1beta1().Flows)
 		fakeOutputCache := fakeclients.OutputCache(harvesterClientSet.LoggingV1beta1().Outputs)
 		fakeClusterFlowCache := fakeclients.ClusterFlowCache(harvesterClientSet.LoggingV1beta1().ClusterFlows)
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(harvesterClientSet.LoggingV1beta1().ClusterOutputs)
+		fakeNodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(harvesterClientSet.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache).(*addonValidator)
+
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache).(*addonValidator)
 		for _, addon := range tc.addonList {
 			err := harvesterClientSet.Tracker().Add(addon)
 			assert.Nil(t, err)
@@ -857,13 +863,15 @@ func Test_validateRancherLoggingAddonWithClusterFlow(t *testing.T) {
 
 	for _, tc := range testCases {
 		harvesterClientSet := harvesterFake.NewSimpleClientset()
+		k8sclientset := k8sfake.NewClientset()
 		fakeAddonCache := fakeclients.AddonCache(harvesterClientSet.HarvesterhciV1beta1().Addons)
 		fakeFlowCache := fakeclients.FlowCache(harvesterClientSet.LoggingV1beta1().Flows)
 		fakeOutputCache := fakeclients.OutputCache(harvesterClientSet.LoggingV1beta1().Outputs)
 		fakeClusterFlowCache := fakeclients.ClusterFlowCache(harvesterClientSet.LoggingV1beta1().ClusterFlows)
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(harvesterClientSet.LoggingV1beta1().ClusterOutputs)
+		fakeNodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(harvesterClientSet.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache).(*addonValidator)
 		for _, cf := range tc.clusterFlows {
 			err := harvesterClientSet.Tracker().Add(cf)
 			assert.Nil(t, err)
@@ -1138,13 +1146,15 @@ func Test_validateRancherLoggingAddonWithFlow(t *testing.T) {
 
 	for _, tc := range testCases {
 		harvesterClientSet := harvesterFake.NewSimpleClientset()
+		k8sclientset := k8sfake.NewClientset()
 		fakeAddonCache := fakeclients.AddonCache(harvesterClientSet.HarvesterhciV1beta1().Addons)
 		fakeFlowCache := fakeclients.FlowCache(harvesterClientSet.LoggingV1beta1().Flows)
 		fakeOutputCache := fakeclients.OutputCache(harvesterClientSet.LoggingV1beta1().Outputs)
 		fakeClusterFlowCache := fakeclients.ClusterFlowCache(harvesterClientSet.LoggingV1beta1().ClusterFlows)
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(harvesterClientSet.LoggingV1beta1().ClusterOutputs)
+		fakeNodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(harvesterClientSet.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache).(*addonValidator)
 		for _, cf := range tc.flows {
 			err := harvesterClientSet.Tracker().Add(cf)
 			assert.Nil(t, err)
@@ -1247,13 +1257,15 @@ func Test_validateRancherLoggingWithUpgradeLog(t *testing.T) {
 	for _, tc := range testCases {
 
 		harvesterClientSet := harvesterFake.NewSimpleClientset()
+		k8sclientset := k8sfake.NewClientset()
 		fakeAddonCache := fakeclients.AddonCache(harvesterClientSet.HarvesterhciV1beta1().Addons)
 		fakeFlowCache := fakeclients.FlowCache(harvesterClientSet.LoggingV1beta1().Flows)
 		fakeOutputCache := fakeclients.OutputCache(harvesterClientSet.LoggingV1beta1().Outputs)
 		fakeClusterFlowCache := fakeclients.ClusterFlowCache(harvesterClientSet.LoggingV1beta1().ClusterFlows)
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(harvesterClientSet.LoggingV1beta1().ClusterOutputs)
+		fakeNodeCache := fakeclients.NodeCache(k8sclientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(harvesterClientSet.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache).(*addonValidator)
 		for _, upgradeLog := range tc.upgradeLogs {
 			err := harvesterClientSet.Tracker().Add(upgradeLog)
 			assert.Nil(t, err)

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -171,6 +171,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.LoggingFactory.Logging().V1beta1().ClusterFlow().Cache(),
 			clients.LoggingFactory.Logging().V1beta1().ClusterOutput().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().UpgradeLog().Cache(),
+			clients.Core.Node().Cache(),
 		),
 		version.NewValidator(),
 		volumesnapshot.NewValidator(


### PR DESCRIPTION
#### Problem:
Single node cannot enable descheduler. It will show error like `"The cluster size is 0 or 1 meaning eviction causes service disruption or degradation. So aborting.."`.

#### Solution:
Add webhook to deny the request.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9431
https://github.com/harvester/harvester/issues/2311

#### Test plan:
1. Use single node to enable descheduler addon. It should be denied.
2. Use multiple nodes to enable descheduler addon. There should not have error.

