### PR TITLE
Webhooks to protect addon and managedchart

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -243,4 +243,8 @@ const (
 	PVCExpandErrorPrefix                          = "PVC_EXPAND"
 
 	VirtualMachineCreatorNodeDriver = "docker-machine-driver-harvester"
+
+	// Addons
+	AddonPrefix            = "addon." + prefix
+	AddonExperimentalLabel = AddonPrefix + "/experimental"
 )

--- a/pkg/webhook/resources/managedchart/validator.go
+++ b/pkg/webhook/resources/managedchart/validator.go
@@ -7,6 +7,7 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/harvester/harvester/pkg/util"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
@@ -34,12 +35,15 @@ func (v *managedChartValidator) Resource() types.Resource {
 func (v *managedChartValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	managedChart := oldObj.(*managementv3.ManagedChart)
 
+	if managedChart == nil || managedChart.Namespace != util.FleetLocalNamespaceName {
+		return nil
+	}
+
 	// ManagedChart namespaces and names are from:
 	// https://github.com/harvester/harvester-installer/blob/f36c8cfaa68626c85cf4c35f681dd382880f2aa7/pkg/config/templates/rancherd-10-harvester.yaml#L65-L69
 	// https://github.com/harvester/harvester-installer/blob/f36c8cfaa68626c85cf4c35f681dd382880f2aa7/pkg/config/templates/rancherd-10-harvester.yaml#L129-L133
-	if managedChart != nil &&
-		managedChart.Namespace == "fleet-local" &&
-		(managedChart.Name == "harvester" || managedChart.Name == "harvester-crd") {
+	// rancher-monitoring-crd, rancher-logging-crd are also protected
+	if managedChart.Name == util.HarvesterManagedChart || managedChart.Name == util.HarvesterCRDManagedChart || managedChart.Name == util.RancherLoggingCRDManagedChart || managedChart.Name == util.RancherMonitoringCRDManagedChart {
 		message := fmt.Sprintf("Delete managedchart %s/%s is prohibited", managedChart.Namespace, managedChart.Name)
 		return werror.NewInvalidError(message, "")
 	}

--- a/pkg/webhook/resources/managedchart/validator_test.go
+++ b/pkg/webhook/resources/managedchart/validator_test.go
@@ -1,0 +1,94 @@
+package managedchart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+func Test_validateDeleteManagedChart(t *testing.T) {
+
+	var testCases = []struct {
+		name          string
+		mc            *managementv3.ManagedChart
+		expectedError bool
+	}{
+		{
+			name: "user cannot delete managedchart harvester ",
+			mc: &managementv3.ManagedChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.HarvesterManagedChart,
+					Namespace: util.FleetLocalNamespaceName,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "user cannot delete managedchart harvester-crd",
+			mc: &managementv3.ManagedChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.HarvesterCRDManagedChart,
+					Namespace: util.FleetLocalNamespaceName,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "user cannot delete managedchart rancher-monitoring-crd",
+			mc: &managementv3.ManagedChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.RancherMonitoringCRDManagedChart,
+					Namespace: util.FleetLocalNamespaceName,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "user cannot delete managedchart rancher-logging-crd",
+			mc: &managementv3.ManagedChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.RancherLoggingCRDManagedChart,
+					Namespace: util.FleetLocalNamespaceName,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "user can delete managedchart fleet-local/test",
+			mc: &managementv3.ManagedChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: util.FleetLocalNamespaceName,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "user can delete managedchart test/test",
+			mc: &managementv3.ManagedChart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+
+		validator := NewValidator().(*managedChartValidator)
+
+		err := validator.Delete(nil, tc.mc)
+		if tc.expectedError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

https://github.com/harvester/harvester/issues/9289 had a fix https://github.com/harvester/harvester/pull/9304, but a scenario is missing https://github.com/harvester/harvester/issues/8930#issuecomment-3499021408

When `rancher-logging` is enabled before upgrade;  while `apply_manifest`, the addon is updated to new version, and the `enabled` is kept, this will hit the current webhook and is blocked.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. If rancher-logging is enabled and upgradeLog uses it, block disabling
2. If rancher-logging is disabled and upgradeLog is running, block enabling
3. Protect `rancher-monitoring`, `rancher-logging` and other non-experimental addons from being deleted
4. Protect additional managedchart `rancher-logging-crd` and `rancher-monitoring-crd` from being deleted

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/9289

#### Test plan:
<!-- Describe the test plan by steps. -->

Per test plan on https://github.com/harvester/harvester/issues/9289 and
https://github.com/harvester/harvester/issues/8930


Deletion protection upon `managedchart`, can on be validated via kubectl:

```
$ kubectl delete managedchart -n fleet-local harvester
The request is invalid: : Delete managedchart fleet-local/harvester is prohibited

$ kubectl delete managedchart -n fleet-local harvester-crd
The request is invalid: : Delete managedchart fleet-local/harvester-crd is prohibited

$ kubectl delete managedchart -n fleet-local rancher-monitoring-crd
The request is invalid: : Delete managedchart fleet-local/rancher-monitoring-crd is prohibited

$ kubectl delete managedchart -n fleet-local rancher-logging-crd
The request is invalid: : Delete managedchart fleet-local/rancher-logging-crd is prohibited
```

Deletion protection upon `addon`, can only be validated via kubectl:

`non-experimental` addons cannot be deleted.

```
$ kubectl delete addons.harvesterhci.io -n cattle-monitoring-system rancher-monitoring
Error from server (BadRequest): admission webhook "validator.harvesterhci.io" denied the request: cattle-monitoring-system/rancher-monitoring addon cannot be deleted

$ kubectl delete addons.harvesterhci.io -n cattle-logging-system rancher-logging
Error from server (BadRequest): admission webhook "validator.harvesterhci.io" denied the request: cattle-logging-system/rancher-logging addon cannot be deleted

$ kubectl delete addons.harvesterhci.io -n harvester-system pcidevices-controller
Error from server (BadRequest): admission webhook "validator.harvesterhci.io" denied the request: harvester-system/pcidevices-controller addon cannot be deleted
```


Test the `enable/disable` upon `rancher-logging` w/wo upgrade:

Local test:

(1) Enable an empty rancher-logging, pass

(2) Create a dangling clusterflow before enable it, get such error, pass (existing features)
<img width="3198" height="1066" alt="image" src="https://github.com/user-attachments/assets/96660e07-45e7-460b-89e3-1e96b397ef24" />


Test when upgrading v170->v170 cluster;  or v16*->v170 cluster after `harvester` has been upgraded.

(3.1) Enable `rancher-logging`, enable `upgradeLog`

During the upgrade,  disable rancher-logging addon when upgradeLog has already been there, webhook blocks it, if rancher-logging is disabled, then the `upgradeLog` will break.

<img width="2808" height="1288" alt="image" src="https://github.com/user-attachments/assets/07411b49-8c18-4fc1-a5ed-54ef81abb936" />

(3.2) Disable `rancher-logging`, enable `upgradeLog`

During the upgrade,  enable the `rancher-logging` addon when upgradeLog has already been there, webhook blocks it, if rancher-logging is enabled, then the `helm install` job will fail as a managedchart based logging-operator has been deployed.

<img width="2826" height="1070" alt="image" src="https://github.com/user-attachments/assets/51e72ddb-9e95-4e94-b716-c3b3e9ef1275" />


#### Additional documentation or context
