### PR TITLE
fix(capi): update namespace to cattle-capi-system

### DIFF
--- a/pkg/controller/master/rancher/register.go
+++ b/pkg/controller/master/rancher/register.go
@@ -48,7 +48,7 @@ const (
 	trueStr                           = "true"
 	controllerCAPIDeployment          = "harvester-capi-controller"
 	capiControllerDeploymentName      = "capi-controller-manager"
-	capiControllerDeploymentNamespace = "cattle-provisioning-capi-system"
+	capiControllerDeploymentNamespace = "cattle-capi-system"
 )
 
 type Handler struct {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The CAPI namespace changes from `cattle-provisioning-capi-system` to `cattle-capi-system`, so the Machine / Provisioning Cluster CR cannot be ready.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Fix the namespace.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9414

#### Test plan:
Create a 3-node cluster successfully.

#### Additional documentation or context
