### PR TITLE
improve validation for vcluster addon 

### DIFF
--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -3,7 +3,7 @@ package addon
 import (
 	"fmt"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -23,6 +23,8 @@ import (
 const (
 	vClusterAddonName      = "rancher-vcluster"
 	vClusterAddonNamespace = "rancher-vcluster"
+	vCluster0190           = "v0.19.0"
+	vCluster0300           = "v0.30.0"
 )
 
 func NewValidator(addons ctlharvesterv1.AddonCache, flowCache ctlloggingv1.FlowCache, outputCache ctlloggingv1.OutputCache, clusterFlowCache ctlloggingv1.ClusterFlowCache, clusterOutputCache ctlloggingv1.ClusterOutputCache, upgradeLogCache ctlharvesterv1.UpgradeLogCache) types.Validator {
@@ -117,22 +119,32 @@ func (v *addonValidator) validateUpdatedAddon(newAddon *v1beta1.Addon, oldAddon 
 
 func validateVClusterAddon(newAddon *v1beta1.Addon) error {
 	type contentValues struct {
-		Hostname string `yaml:"hostname"`
+		Hostname string `yaml:"hostname,omitempty"`
+		Global   struct {
+			Hostname string `yaml:"hostname,omitempty"`
+		} `yaml:"global,omitempty"`
 	}
 
 	addonContent := &contentValues{}
-
 	// valuesContent contains a yaml string
 	if err := yaml.Unmarshal([]byte(newAddon.Spec.ValuesContent), addonContent); err != nil {
 		return werror.NewInternalError(fmt.Sprintf("unable to parse contentValues: %v for %s addon", err, vClusterAddonName))
 	}
 
+	// currently we only support v0.19.0 and v0.30.0 of vcluster
+	// the parsing is designed to handle only these two versions for now
+	var hostname string
+	if newAddon.Spec.Version == vCluster0190 {
+		hostname = addonContent.Hostname
+	} else {
+		hostname = addonContent.Global.Hostname
+	}
 	// ip addresses are valid fqdns
 	// this check will return error if hostname is fqdn
 	// but an ip address
-	if fqdnErrs := validationutil.IsFullyQualifiedDomainName(field.NewPath(""), addonContent.Hostname); len(fqdnErrs) == 0 {
-		if ipErrs := validationutil.IsValidIP(field.NewPath(""), addonContent.Hostname); len(ipErrs) == 0 {
-			return werror.NewBadRequest(fmt.Sprintf("%s is not a valid hostname", addonContent.Hostname))
+	if fqdnErrs := validationutil.IsFullyQualifiedDomainName(field.NewPath(""), hostname); len(fqdnErrs) == 0 {
+		if ipErrs := validationutil.IsValidIP(field.NewPath(""), hostname); len(ipErrs) == 0 {
+			return werror.NewBadRequest(fmt.Sprintf("%s is not a valid hostname", hostname))
 		}
 		return nil
 	}

--- a/pkg/webhook/resources/addon/validator_test.go
+++ b/pkg/webhook/resources/addon/validator_test.go
@@ -5,6 +5,7 @@ import (
 
 	loggingv1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -319,7 +320,7 @@ func Test_validateUpdatedAddon(t *testing.T) {
 				Spec: harvesterv1.AddonSpec{
 					Repo:          "repo1",
 					Chart:         "vcluster",
-					Version:       "version1",
+					Version:       vCluster0190,
 					Enabled:       true,
 					ValuesContent: "hostname: rancher.172.19.108.3.sslip.io\nrancherVersion: v2.7.4\nbootstrapPassword: harvesterAdmin\n",
 				},
@@ -349,7 +350,7 @@ func Test_validateUpdatedAddon(t *testing.T) {
 				Spec: harvesterv1.AddonSpec{
 					Repo:          "repo1",
 					Chart:         "vcluster",
-					Version:       "version1",
+					Version:       vCluster0190,
 					Enabled:       true,
 					ValuesContent: "hostname: 172.19.108.3\nrancherVersion: v2.7.4\nbootstrapPassword: harvesterAdmin\n",
 				},
@@ -379,7 +380,7 @@ func Test_validateUpdatedAddon(t *testing.T) {
 				Spec: harvesterv1.AddonSpec{
 					Repo:          "repo1",
 					Chart:         "vcluster",
-					Version:       "version1",
+					Version:       vCluster0190,
 					Enabled:       true,
 					ValuesContent: "hostname: FakeAddress.com\nrancherVersion: v2.7.4\nbootstrapPassword: harvesterAdmin\n",
 				},
@@ -409,7 +410,7 @@ func Test_validateUpdatedAddon(t *testing.T) {
 				Spec: harvesterv1.AddonSpec{
 					Repo:          "repo1",
 					Chart:         "vcluster",
-					Version:       "version1",
+					Version:       vCluster0190,
 					Enabled:       true,
 					ValuesContent: "hostname: \nrancherVersion: v2.7.4\nbootstrapPassword: harvesterAdmin\n",
 				},
@@ -1266,4 +1267,80 @@ func Test_validateRancherLoggingWithUpgradeLog(t *testing.T) {
 			assert.Nil(t, err, tc.name)
 		}
 	}
+}
+
+func Test_validateVersionedVClusterAddon(t *testing.T) {
+	assert := require.New(t)
+	var testCases = []struct {
+		name          string
+		addon         *harvesterv1.Addon
+		expectedError bool
+	}{
+		{
+			name: "v0.19.0 with valid hostname",
+			addon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancher-vcluster",
+					Namespace: "rancher-vcluster",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Version:       vCluster0190,
+					ValuesContent: "hostname: demo.com",
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "v0.19.0 with invalid hostname",
+			addon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancher-vcluster",
+					Namespace: "rancher-vcluster",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Version:       vCluster0190,
+					ValuesContent: "global:\n  hostname: demo.com",
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "v0.30.0 with invalid hostname",
+			addon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancher-vcluster",
+					Namespace: "rancher-vcluster",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Version:       vCluster0300,
+					ValuesContent: `hostname: demo.com`,
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "v0.30.0 with valid hostname",
+			addon: &harvesterv1.Addon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancher-vcluster",
+					Namespace: "rancher-vcluster",
+				},
+				Spec: harvesterv1.AddonSpec{
+					Version:       vCluster0300,
+					ValuesContent: "global:\n  hostname: demo.com",
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validateVClusterAddon(tc.addon)
+		if tc.expectedError {
+			assert.Error(err, tc.name)
+		} else {
+			assert.NoError(err, tc.name)
+		}
+	}
+
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR https://github.com/harvester/experimental-addons/pull/39 bumps vcluster addon to use vcluster v0.30.0

Due to introduction of values schema validation and a new config type within vcluster, we can no longer pass randon values such as `hostname`, `rancherVersion` and `bootstrapPassword` via the values content directly.

These values need to be embedded in a `global` field in values.yaml.

As a result rancher-vcluster addon validation fails since there is no `hostname` field anymore in the valuesContent but rather `global.hostname`

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces a minor change in how we parse valuesContent and evaluate hostname so we can continue to support both vcluster v0.19.0 and vcluster v0.30.0

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9102

#### Test plan:
<!-- Describe the test plan by steps. -->
To test:
* Install the new rancher-vcluster addon once the PR https://github.com/harvester/experimental-addons/pull/39 is merged
* Edit the rancher-vcluster addon as yaml, and change the following fields
  * global.hostname
  * global.bootstrapPassword
* Enable the addon
* Addon should be successfully deployed and user able to login to Rancher
 
#### Additional documentation or context
