### PR TITLE
Ensure upgrade object's annotations map is created before write

### DIFF
--- a/pkg/controller/master/upgrade/job_controller.go
+++ b/pkg/controller/master/upgrade/job_controller.go
@@ -198,6 +198,9 @@ func (h *jobHandler) syncNodeJob(job *batchv1.Job) (*batchv1.Job, error) {
 
 	if preDrained {
 		toUpdate := secret.DeepCopy()
+		if toUpdate.Annotations == nil {
+			toUpdate.Annotations = make(map[string]string)
+		}
 		toUpdate.Annotations[preDrainAnnotation] = secret.Annotations[rke2PreDrainAnnotation]
 		if _, err := h.secretClient.Update(toUpdate); err != nil {
 			return nil, err
@@ -206,6 +209,9 @@ func (h *jobHandler) syncNodeJob(job *batchv1.Job) (*batchv1.Job, error) {
 
 	if postDrained {
 		toUpdate := secret.DeepCopy()
+		if toUpdate.Annotations == nil {
+			toUpdate.Annotations = make(map[string]string)
+		}
 		toUpdate.Annotations[postDrainAnnotation] = secret.Annotations[rke2PostDrainAnnotation]
 		if _, err := h.secretClient.Update(toUpdate); err != nil {
 			return nil, err
@@ -296,6 +302,9 @@ func (h *jobHandler) syncManifestJob(job *batchv1.Job) (*batchv1.Job, error) {
 
 func (h *jobHandler) setNodeWaitRebootLabel(node *v1.Node, repoInfo *repoinfo.RepoInfo) error {
 	nodeUpdate := node.DeepCopy()
+	if nodeUpdate.Annotations == nil {
+		nodeUpdate.Annotations = make(map[string]string)
+	}
 	nodeUpdate.Annotations[harvesterNodePendingOSImage] = repoInfo.Release.OS
 	_, err := h.nodeClient.Update(nodeUpdate)
 	return err

--- a/pkg/controller/master/upgrade/node_controller.go
+++ b/pkg/controller/master/upgrade/node_controller.go
@@ -91,6 +91,9 @@ func (h *nodeHandler) OnChanged(_ string, node *corev1.Node) (*corev1.Node, erro
 		if upgrade.Status.SingleNode == "" {
 			logrus.Infof("Adding post-hook done annotation on %s/%s", secret.Namespace, secret.Name)
 			secretUpdate := secret.DeepCopy()
+			if secretUpdate.Annotations == nil {
+				secretUpdate.Annotations = make(map[string]string)
+			}
 			secretUpdate.Annotations[postDrainAnnotation] = secret.Annotations[rke2PostDrainAnnotation]
 			if _, err := h.secretClient.Update(secretUpdate); err != nil {
 				return nil, err

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -502,6 +502,9 @@ func (h *upgradeHandler) cleanup(upgrade *harvesterv1.Upgrade, cleanJobs bool) (
 			if err := h.loadReplicaReplenishmentFromUpgradeAnnotation(upgrade); err != nil {
 				return nil, err
 			}
+			if toUpdate.Annotations == nil {
+				toUpdate.Annotations = make(map[string]string)
+			}
 			toUpdate.Annotations[longhornSettingsRestoredAnnotation] = strconv.FormatBool(true)
 			return h.upgradeClient.Update(toUpdate)
 		}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Panic is observed on upgrade-controller.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Ensure upgrade object's annotations map is created before write

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/9470,  https://github.com/harvester/harvester/issues/9333

PR: https://github.com/harvester/harvester/pull/8941

#### Test plan:
<!-- Describe the test plan by steps. -->

Per issue https://github.com/harvester/harvester/issues/9470 description


local test: delete the `upgrade.harvesterhci` object does not cause panic.  original issue: https://github.com/harvester/harvester/issues/9470#issue-3612898013
```
...
time="2025-11-12T09:40:09Z" level=info msg="Delete upgrade repo vm, image and service"
time="2025-11-12T09:40:09Z" level=info msg="Delete upgrade repo image harvester-system/hvst-upgrade-8jkkr"
time="2025-11-12T09:40:09Z" level=info msg="Reset RKEConfig and set provisionGeneration to 0"
time="2025-11-12T09:40:09Z" level=warning msg="no original replica-replenishment-wait-interval value set"  // related log
time="2025-11-12T09:40:09Z" level=info msg="Delete upgrade repo vm, image and service"
time="2025-11-12T09:40:09Z" level=info msg="Delete upgrade repo image harvester-system/hvst-upgrade-8jkkr"
time="2025-11-12T09:40:09Z" level=info msg="Delete UpgradeLog harvester-system/hvst-upgrade-8jkkr-upgradelog"
time="2025-11-12T09:40:09Z" level=info msg="Removing all other related resources"
time="2025-11-12T09:40:09Z" level=info msg="Tearing down the logging infrastructure for upgrade procedure"
time="2025-11-12T09:40:09Z" level=info msg="Reset RKEConfig and set provisionGeneration to 0"
...
```


#### Additional documentation or context

This related issue was observed while testing PR https://github.com/harvester/harvester/issues/9289 for issue https://github.com/harvester/harvester/issues/9289.