### PR TITLE
minor changes to check evaluating if volume is resizing

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -51,8 +51,8 @@ import (
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/drainhelper"
-	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
 	"github.com/harvester/harvester/pkg/util/virtualmachine"
+	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
@@ -335,7 +335,7 @@ func (h *vmActionHandler) startPreCheck(namespace, name string) error {
 			if err != nil {
 				return err
 			}
-			if volumeapi.IsResizing(pvc) {
+			if volumeapi.IsResizing(pvc, h.storageClassCache) {
 				return fmt.Errorf("can not start the VM %s/%s which has a resizing volume %s/%s", vm.Namespace, vm.Name, pvcNamespace, pvcName)
 			}
 		}

--- a/pkg/api/volume/formatter_test.go
+++ b/pkg/api/volume/formatter_test.go
@@ -1,0 +1,105 @@
+package volume
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_IsResizing(t *testing.T) {
+	var testCases = []struct {
+		Name       string
+		PVC        *corev1.PersistentVolumeClaim
+		IsResizing bool
+	}{
+		{
+			Name: "longhorn pvc which is not resizing",
+			PVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"volume.kubernetes.io/storage-provisioner": "driver.longhorn.io",
+					},
+				},
+				Status: corev1.PersistentVolumeClaimStatus{},
+			},
+			IsResizing: false,
+		},
+		{
+			Name: "longhorn pvc which is resizing",
+			PVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"volume.kubernetes.io/storage-provisioner": "driver.longhorn.io",
+					},
+				},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Conditions: []corev1.PersistentVolumeClaimCondition{
+						{
+							Type:   corev1.PersistentVolumeClaimResizing,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			IsResizing: true,
+		},
+		{
+			Name: "lvm pvc which is resizing",
+			PVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"volume.kubernetes.io/storage-provisioner": "lvm.driver.harvesterhci.io",
+					},
+				},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Conditions: []corev1.PersistentVolumeClaimCondition{
+						{
+							Type:   corev1.PersistentVolumeClaimResizing,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   corev1.PersistentVolumeClaimFileSystemResizePending,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			IsResizing: false,
+		},
+		{
+			Name: "lvm pvc which is not resizing",
+			PVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"volume.kubernetes.io/storage-provisioner": "lvm.driver.harvesterhci.io",
+					},
+				},
+				Status: corev1.PersistentVolumeClaimStatus{},
+			},
+			IsResizing: false,
+		},
+		{
+			Name: "pending pvc",
+			PVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Phase: corev1.ClaimPending,
+				},
+			},
+			IsResizing: false,
+		},
+	}
+
+	assert := require.New(t)
+	for _, tc := range testCases {
+		ok := IsResizing(tc.PVC, nil)
+		if tc.IsResizing {
+			assert.True(ok, tc.Name)
+		} else {
+			assert.False(ok, tc.Name)
+		}
+	}
+
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
When a PVC is resized, the csi expands the PV. The PVC will not reflect the correct size until its attached to a pod so the associated filesystem can be resized. Till then the PVC has the following condition

```
  - lastProbeTime: null
    lastTransitionTime: "2025-11-10T15:38:04Z"
    status: "True"
    type: Resizing
  - lastProbeTime: null
    lastTransitionTime: "2025-11-10T15:38:04Z"
    message: Waiting for user to (re-)start a pod to finish file system resize of
      volume on node.
    status: "True"
    type: FileSystemResizePending
```

We have a check in harvester which is verifying of any PVC is being resized.

Unfortunately this results in a deadlock since the PVC will not have its FS resized until the VM is booted.

We need to change the check to validate the size of PV after a resizing operation.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR changes the `IsResizing` check to only perform validation if provisioner is Longhorn.

The check was originally added in case users defined a pvc size which could not be satisifed by longhorn disks, and aim was to stop the vm from consuming the volume and avoid data corruption.

With 3rd party CSI, we can leave this for the CSI to manage.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9454

#### Test plan:
<!-- Describe the test plan by steps. -->
To test:

For Longhorn backed pvc:
* Create a VM booting off a longhorn based vmimage
* Stop the VM
* Edit the VM and expand the disk
* After saving the changes try and start the VM
* VM start action should fail with an error "can not start the VM $VMName which has a resizing volume $VolumeName"
* Once the disk is expanded successfully, the VM will start fine

For 3rd party csi backed pvc:
* Create a VM booting off a 3rd party csi based vmimage
* Stop the VM
* Edit the VM and expand the disk
* After saving the changes try and start the VM
* VM should start successfully

#### Additional documentation or context
