### PR TITLE
fix: Add /var/lib/NetworkManager to persistent paths on upgrade

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -540,6 +540,10 @@ generate_networkmanager_config() {
       if ! [[ "$current_paths_line" =~ "/var/lib/NetworkManager" ]]; then
         echo "Adding /var/lib/NetworkManager to PERSISTENT_STATE_PATHS in $CUSTOM90_FILE"
         sed -i 's%PERSISTENT_STATE_PATHS:.*/var/lib/wicked%& /var/lib/NetworkManager%' $CUSTOM90_FILE
+        local updated_paths_line=$(grep 'PERSISTENT_STATE_PATHS:.*/var/lib/wicked' $CUSTOM90_FILE)
+        if ! [[ "$updated_paths_line" =~ "/var/lib/NetworkManager" ]]; then
+          echo "Failed to add /var/lib/NetworkManager to PERSISTENT_STATE_PATHS in $CUSTOM90_FILE"
+        fi
       fi
     else
       echo "Unable to find expected PERSISTENT_STATE_PATHS line in $CUSTOM90_FILE"

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -532,6 +532,22 @@ generate_networkmanager_config() {
     return
   fi
 
+  local CUSTOM90_FILE="${HOST_DIR}/oem/90_custom.yaml"
+  if [[ -f "$CUSTOM90_FILE" ]]; then
+    # We need to ensure /var/lib/NetworkManager is in the list of persistent paths
+    local current_paths_line=$(grep 'PERSISTENT_STATE_PATHS:.*/var/lib/wicked' $CUSTOM90_FILE)
+    if [ -n "$current_paths_line" ]; then
+      if ! [[ "$current_paths_line" =~ "/var/lib/NetworkManager" ]]; then
+        echo "Adding /var/lib/NetworkManager to PERSISTENT_STATE_PATHS in $CUSTOM90_FILE"
+        sed -i 's%PERSISTENT_STATE_PATHS:.*/var/lib/wicked%& /var/lib/NetworkManager%' $CUSTOM90_FILE
+      fi
+    else
+      echo "Unable to find expected PERSISTENT_STATE_PATHS line in $CUSTOM90_FILE"
+    fi
+  else
+    echo "File not found: $CUSTOM90_FILE"
+  fi
+
   # Just in case NetworkManager config has already been generated
   # and/or potentially modified by the user, let's not overwrite it.
   if [ -e ${HOST_DIR}/oem/91_networkmanager.yaml ]; then


### PR DESCRIPTION
#### Problem:
`/oem/90_custom.yaml` includes a "Rootfs layout override" stage, which writes out the list of `PERSISTENT_STATE_PATHS`.  This overwrites the list of paths defined in `/system/oem/00_rootfs.yaml`, which means that even though `/var/lib/NetworkManager` has been added to that latter file, on pre-v1.7.0 systems that are upgraded, this will have no effect and `/var/lib/NetworkManager` won't persist.

#### Solution:
We need to also edit the `PERSISTENT_STATE_PATHS` line in `/oem/90_custom.yaml` to add `/var/lib/NetworkManager` to fix this.  Note that we are _not_ removing `/var/lib/wicked` from the list of paths, in case we need to read the old DHCP client ID out of there.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9298

#### Test plan:
Upgrade from Harvester v1.6.0. After upgrade, check to ensure `PERSISTENT_STATE_PATHS` includes both `/var/lib/wicked` and `/var/lib/NetworkManager`, and that both are mounted correctly:

```
# cat /run/cos/cos-layout.env 
OVERLAY="tmpfs:25%"
PERSISTENT_STATE_BIND="true"
PERSISTENT_STATE_PATHS="/etc/systemd /etc/rancher /etc/ssh /etc/iscsi /etc/nvme /etc/cni /etc/pki/trust/anchors /home /opt /root /usr/libexec /var/log /var/lib/rancher /var/lib/kubelet /var/lib/wicked /var/lib/NetworkManager /var/lib/cni /var/lib/third-party /var/crash /var/lib/longhorn"
RW_PATHS="/var /etc /srv /boot /lib/firmware"
VOLUMES="LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local LABEL=HARV_LH_DEFAULT:/var/lib/harvester/defaultdisk"

# grep 'wicked\|NetworkManager' /etc/fstab
/usr/local/.state/var-lib-wicked.bind /var/lib/wicked none defaults,bind 0 0
/usr/local/.state/var-lib-NetworkManager.bind /var/lib/NetworkManager none defaults,bind 0 0

# mount|grep 'wicked\|NetworkManager'
/dev/vda5 on /var/lib/wicked type ext4 (rw,relatime,seclabel)
/dev/vda5 on /var/lib/NetworkManager type ext4 (rw,relatime,seclabel)
```

#### Additional documentation or context
