### PR TITLE
chore: unify go version to match harvester-installer repo

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,6 @@
 FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 AS grub2-mbr
 FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 AS grub2-efi
-
-FROM golang:1.25-bookworm
+FROM registry.suse.com/bci/golang:1.25
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH


### PR DESCRIPTION
#### Problem:
The harvester and harvester-installer repos need to work together to build our ISO images, so it's important that they have the exact same golang version to avoid occasional weird build issues, for example as reported in https://github.com/harvester/harvester-installer/pull/1170#issuecomment-3516260269

#### Solution:
This commit switches from golang:1.25-bookworm to registry.suse.com/bci/golang:1.25 as is used in the harvester-installer repo. go.mod already specifies `go 1.25` so this means it will build using the latest in the v1.25 series as provided by the registry.suse.com/bci/golang:1.25 image (currently v1.25.3).


#### Related Issue(s):
https://github.com/harvester/harvester/issues/9279

#### Test plan:
N/A

#### Additional documentation or context
See also https://github.com/harvester/harvester-installer/pull/1188