### PR TITLE
Improve node failure

### DIFF
--- a/pkg/controller/master/node/node_down_controller.go
+++ b/pkg/controller/master/node/node_down_controller.go
@@ -3,23 +3,17 @@ package node
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"slices"
 	"time"
 
-	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
-	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/set"
-	kubevirtv1 "kubevirt.io/api/core/v1"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
-	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
-	v1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	ctlstoragev1 "github.com/harvester/harvester/pkg/generated/controllers/storage.k8s.io/v1"
 	"github.com/harvester/harvester/pkg/settings"
 )
 
@@ -27,154 +21,59 @@ const (
 	nodeDownControllerName = "node-down-controller"
 )
 
+// kubevirtDrainTaint is used to trigger migration
+var kubevirtDrainTaint = corev1.Taint{
+	Key:    virtconfig.NodeDrainTaintDefaultKey,
+	Effect: corev1.TaintEffectNoSchedule,
+}
+
+var nonGracefulTaint = corev1.Taint{
+	Key:    corev1.TaintNodeOutOfService,
+	Effect: corev1.TaintEffectNoExecute,
+}
+
+var (
+	// vars for HarvesterNodeDrained condition
+	HarvesterNodeCondDrained               = corev1.NodeConditionType("Drained")
+	HarvesterNodeDrainedCondReasonDraining = "HarvesterNodeIsDraining"
+	HarvesterNodeDrainedCondReasonDrained  = "HarvesterNodeIsDrained"
+	HarvesterNodeDrainedCondMsg            = "Node is draining due to kubelet/node not ready."
+)
+
 // nodeDownHandler force deletes VMI's pod when a node is down, so VMI can be reschduled to anothor healthy node
 type nodeDownHandler struct {
-	nodes                       ctlcorev1.NodeController
-	nodeCache                   ctlcorev1.NodeCache
-	pods                        ctlcorev1.PodClient
-	pvcCache                    ctlcorev1.PersistentVolumeClaimCache
-	vas                         ctlstoragev1.VolumeAttachmentClient
-	vaCache                     ctlstoragev1.VolumeAttachmentCache
-	virtualMachineInstanceCache v1.VirtualMachineInstanceCache
+	nodes     ctlcorev1.NodeController
+	nodeCache ctlcorev1.NodeCache
 }
 
 // DownRegister registers a controller to delete VMI when node is down
 func DownRegister(ctx context.Context, management *config.Management, _ config.Options) error {
 	nodes := management.CoreFactory.Core().V1().Node()
-	pods := management.CoreFactory.Core().V1().Pod()
-	setting := management.HarvesterFactory.Harvesterhci().V1beta1().Setting()
-	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
-	pvcs := management.CoreFactory.Core().V1().PersistentVolumeClaim()
-	vas := management.HarvesterStorageFactory.Storage().V1().VolumeAttachment()
 	nodeDownHandler := &nodeDownHandler{
-		nodes:                       nodes,
-		nodeCache:                   nodes.Cache(),
-		pods:                        pods,
-		pvcCache:                    pvcs.Cache(),
-		vas:                         vas,
-		vaCache:                     vas.Cache(),
-		virtualMachineInstanceCache: vmis.Cache(),
+		nodes:     nodes,
+		nodeCache: nodes.Cache(),
 	}
 
 	nodes.OnChange(ctx, nodeDownControllerName, nodeDownHandler.OnNodeChanged)
-	setting.OnChange(ctx, nodeDownControllerName, nodeDownHandler.OnVMForceResetPolicyChanged)
 
 	return nil
 }
 
-// OnNodeChanged monitors whether a node is ready or not
-// Force delete a pod when all the below conditions are meet:
-// 1. VMForceResetPolicy is enabled.
-// 2. A node has been down for more than VMForceResetPolicy.Period seconds
-// 3. The owner of Pod is VirtualMachineInstance.
-// 4. The Pod is on a down node.
+// OnNodeChanged monitors we focus the following 3 things
+// 2. Kubelet not ready -> after vmForceResetPolicy.Period, add annotation to kickoff VM migration
+// 3. Node not reachable -> add annotation to kickoff VM migration directly
 func (h *nodeDownHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
 	if node == nil || node.DeletionTimestamp != nil {
 		return node, nil
 	}
 
-	// get Ready condition
-	cond := getNodeCondition(node.Status.Conditions, corev1.NodeReady)
-	if cond == nil {
-		return node, fmt.Errorf("can't find %s condition in node %s", corev1.NodeReady, node.Name)
+	// we skip DiskPressure check here because kubelet already have the basic audit.
+	// if you want to do more thing when the node is under disk pressure, you can implement it.
+	if err := h.checkNodeReady(node); err != nil {
+		return node, fmt.Errorf("failed to check node ready for node %s: %w", node.Name, err)
 	}
 
-	// check whether node is healthy
-	if cond.Status == corev1.ConditionTrue {
-		return node, nil
-	}
-
-	// get VMForceResetPolicy setting
-	vmForceResetPolicy, err := settings.DecodeVMForceResetPolicy(settings.VMForceResetPolicySet.Get())
-	if err != nil {
-		return node, err
-	}
-
-	if !vmForceResetPolicy.Enable {
-		return node, nil
-	}
-
-	// if we haven't waited for vmForceResetPolicy.Period seconds, we enqueue event again
-	if time.Since(cond.LastTransitionTime.Time) < time.Duration(vmForceResetPolicy.Period)*time.Second {
-		deadline := cond.LastTransitionTime.Add(time.Duration(vmForceResetPolicy.Period) * time.Second)
-		logrus.Debugf("Enqueue node event again at %v", deadline)
-		h.nodes.EnqueueAfter(node.Name, time.Until(deadline))
-		return node, nil
-	}
-
-	// get VMI pods on unhealthy node
-	pods, err := h.pods.List(corev1.NamespaceAll, metav1.ListOptions{
-		LabelSelector: labels.Set{
-			kubevirtv1.AppLabel: "virt-launcher",
-		}.String(),
-		FieldSelector: "spec.nodeName=" + node.Name,
-	})
-	if err != nil {
-		return node, err
-	}
-
-	var errs error
-	pvcSet := set.New[string]()
-	gracePeriod := int64(0)
-	for i := range pods.Items {
-		pod := pods.Items[i]
-		logrus.Debugf("force delete pod %s/%s and VolumeAttachments", pod.Namespace, pod.Name)
-
-		if err := h.pods.Delete(
-			pod.Namespace,
-			pod.Name,
-			&metav1.DeleteOptions{
-				GracePeriodSeconds: &gracePeriod,
-			}); err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("failed to delete pod %s/%s: %w", pod.Namespace, pod.Name, err))
-			continue
-		}
-
-		names, err := h.getPVCsName(&pod)
-		if err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("failed to get PVCs name of pod %s/%s: %w", pod.Namespace, pod.Name, err))
-			continue
-		}
-		pvcSet.Insert(names...)
-	}
-
-	if err := h.deleteVolumeAttachments(node.Name, pvcSet); err != nil {
-		errs = multierr.Append(errs, fmt.Errorf("failed to delete VolumeAttachments: %w", err))
-	}
-	if errs != nil {
-		return node, errs
-	}
-
-	return h.resetHeartbeat(node)
-}
-
-func (h *nodeDownHandler) OnVMForceResetPolicyChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
-	if setting == nil || setting.DeletionTimestamp != nil ||
-		setting.Name != settings.VMForceResetPolicySettingName || setting.Value == "" {
-		return setting, nil
-	}
-
-	vmForceResetPolicy, err := settings.DecodeVMForceResetPolicy(setting.Value)
-	if err != nil {
-		return setting, err
-	}
-
-	if !vmForceResetPolicy.Enable {
-		return setting, nil
-	}
-
-	nodes, err := h.nodeCache.List(labels.Everything())
-	if err != nil {
-		return setting, err
-	}
-
-	for _, node := range nodes {
-		cond := getNodeCondition(node.Status.Conditions, corev1.NodeReady)
-		if cond != nil && cond.Status != corev1.ConditionTrue {
-			h.nodes.Enqueue(node.Name)
-		}
-	}
-	return setting, nil
+	return node, nil
 }
 
 func getNodeCondition(conditions []corev1.NodeCondition, conditionType corev1.NodeConditionType) *corev1.NodeCondition {
@@ -189,92 +88,258 @@ func getNodeCondition(conditions []corev1.NodeCondition, conditionType corev1.No
 	return cond
 }
 
-func (h *nodeDownHandler) getPVCsName(pod *corev1.Pod) ([]string, error) {
-	names := make([]string, 0)
-	for _, vol := range pod.Spec.Volumes {
-		if vol.VolumeSource.PersistentVolumeClaim == nil {
-			continue
-		}
+// We treat the node not ready (False/Unknown) as node down
+// In this situation, we will wait for the extra timeout and then add taints to trigger migration and cleanup
+func (h *nodeDownHandler) checkNodeReady(node *corev1.Node) error {
+	// get Ready condition
+	cond := getNodeCondition(node.Status.Conditions, corev1.NodeReady)
+	if cond == nil {
+		return fmt.Errorf("can't find %s condition in node %s", corev1.NodeReady, node.Name)
+	}
 
-		pvc, err := h.pvcCache.Get(pod.Namespace, vol.VolumeSource.PersistentVolumeClaim.ClaimName)
+	switch cond.Status {
+	case corev1.ConditionFalse:
+	case corev1.ConditionUnknown:
+		// wait for extra timeout to
+		vmForceResetPolicy, err := h.fetchVMForceResetPolicy()
 		if err != nil {
-			if errors.IsNotFound(err) {
-				continue
-			}
-			return nil, err
-		}
-		names = append(names, pvc.Spec.VolumeName)
-	}
-	return names, nil
-}
-
-// deleteVolumeAttachments deletes all volume attachments of PVCs before post-host failure,
-// due to the long controller-manager CSI processing period,
-// causing the VM to restart to wait a long time.
-// Then we delete VolumeAttachments directly.
-// ref: https://github.com/harvester/harvester/issues/4049
-func (h *nodeDownHandler) deleteVolumeAttachments(nodeName string, pvcSet set.Set[string]) error {
-	if pvcSet.Len() == 0 {
-		return nil
-	}
-
-	volumeAttachments, err := h.vaCache.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-	for i := range volumeAttachments {
-		va := volumeAttachments[i]
-
-		if va.DeletionTimestamp != nil {
-			continue
-		}
-		if va.Spec.NodeName != nodeName {
-			continue
-		}
-		if va.Spec.Attacher != longhorntypes.LonghornDriverName {
-			continue
-		}
-		if va.Spec.Source.PersistentVolumeName == nil {
-			continue
-		}
-		if !pvcSet.Has(*va.Spec.Source.PersistentVolumeName) {
-			continue
+			return fmt.Errorf("failed to fetch VMForceResetPolicy setting: %w", err)
 		}
 
-		if err := h.vas.Delete(va.Name, &metav1.DeleteOptions{}); err != nil {
-			if errors.IsNotFound(err) {
-				continue
-			}
+		if !vmForceResetPolicy.Enable {
+			// skip if the setting is disabled
+			return nil
+		}
+
+		if getNodeTaint(node.Spec.Taints, virtconfig.NodeDrainTaintDefaultKey) != nil && getNodeTaint(node.Spec.Taints, corev1.TaintNodeOutOfService) != nil {
+			// already added both taints, no need to process again
+			return nil
+		}
+
+		// try to add Kubevirt drain taint after waiting extra timeout
+		if waitEnough, err := h.addKubevirtTaintAfterExtraTimeout(node, cond, vmForceResetPolicy.Period); err != nil {
 			return err
+		} else if !waitEnough {
+			return nil
 		}
-		logrus.Infof("deleted volume attachment %v on downed node %v",
-			va.Name,
-			va.Spec.NodeName)
+
+		node, err = h.createOrUpdateNodeCondition(node, HarvesterNodeCondDrained, corev1.ConditionFalse, HarvesterNodeDrainedCondReasonDraining, HarvesterNodeDrainedCondMsg)
+		if err != nil {
+			return fmt.Errorf("failed to create or update HarvesterNodeDrained condition (draining) for node %s: %w", node.Name, err)
+		}
+		cond = getNodeCondition(node.Status.Conditions, HarvesterNodeCondDrained)
+		// before adding out-of-service taint, wait for VM migration timeout
+		if waitEnough, err := h.addOutOfServiceTaintAfterMigrationTimeout(node, cond, vmForceResetPolicy.VMMigrationTimeout); err != nil {
+			return err
+		} else if !waitEnough {
+			return nil
+		}
+
+		// set HarvesterNodeDrained condition to True -> which means the node is drained
+		node, err = h.createOrUpdateNodeCondition(node, HarvesterNodeCondDrained, corev1.ConditionTrue, HarvesterNodeDrainedCondReasonDrained, HarvesterNodeDrainedCondMsg)
+		if err != nil {
+			return fmt.Errorf("failed to create or update HarvesterNodeDrained condition (drained) for node %s: %w", node.Name, err)
+		}
+
+		return nil
+	case corev1.ConditionTrue:
+		// reset taint if node is healthy again
+		if err := h.removeTaints(node, virtconfig.NodeDrainTaintDefaultKey, corev1.TaintNodeOutOfService); err != nil {
+			return fmt.Errorf("failed to remove taints %v from node %s: %w", []string{virtconfig.NodeDrainTaintDefaultKey, corev1.TaintNodeOutOfService}, node.Name, err)
+		}
+
+		// reset HarvesterNodeFailure condition if needed
+		cond := getNodeCondition(node.Status.Conditions, HarvesterNodeCondDrained)
+		if cond != nil {
+			// remove the condition if exists
+			if err := h.removeHarvesterNodeDrainedCond(node); err != nil {
+				return fmt.Errorf("failed to reset HarvesterNodeFailure condition for node %s: %w", node.Name, err)
+			}
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("unknown status %s for condition %s in node %s", cond.Status, corev1.NodeReady, node.Name)
 	}
 	return nil
 }
 
-// resetHeartbeat force reduce node's heartbeat to immediately rebuild VMI,
-// the NodeController in Kubevirt force rebuilds the VMI if the node's heartbeat has no update in 5 minutes(hardcode)
-// Ensure that can take effect here by reducing 6 minutes
-// ref: https://kubevirt.io/user-guide/operations/unresponsive_nodes/#virt-handler-heartbeat
-func (h *nodeDownHandler) resetHeartbeat(node *corev1.Node) (*corev1.Node, error) {
-	if node.Annotations == nil {
-		node.Annotations = map[string]string{}
+func (h *nodeDownHandler) addKubevirtTaintAfterExtraTimeout(node *corev1.Node, cond *corev1.NodeCondition, extraTime int64) (bool, error) {
+	if getNodeTaint(node.Spec.Taints, virtconfig.NodeDrainTaintDefaultKey) != nil {
+		// already added taint
+		return true, nil
+	}
+	waitEnough, err := h.tryWaitForCondTimeout(cond, extraTime)
+	if err != nil {
+		// error case, dont' care about waitEnough
+		return false, err
+	}
+	if !waitEnough {
+		return false, nil
 	}
 
-	if hb, ok := node.Annotations[kubevirtv1.VirtHandlerHeartbeat]; ok {
-		hbt, err := time.Parse(time.RFC3339, hb)
-		if err != nil {
-			return node, err
-		}
-		if time.Since(hbt) > 5*time.Minute {
-			return node, nil
-		}
+	// we wait enough or node is unreachable, add taints to trigger migration
+	if err := h.triggerMigration(node); err != nil {
+		return true, fmt.Errorf("failed to trigger migration for node %s: %w", node.Name, err)
 	}
+	logrus.Infof("triggered migration for node %s", node.Name)
+	return true, nil
+}
+
+func (h *nodeDownHandler) addOutOfServiceTaintAfterMigrationTimeout(node *corev1.Node, cond *corev1.NodeCondition, vmMigrationTimeout int64) (bool, error) {
+	if getNodeTaint(node.Spec.Taints, corev1.TaintNodeOutOfService) != nil {
+		// already added taint
+		return true, nil
+	}
+	waitEnough, err := h.tryWaitForCondTimeout(cond, vmMigrationTimeout)
+	if err != nil {
+		// error case, dont' care about waitEnough
+		return false, err
+	}
+	if !waitEnough {
+		return false, nil
+	}
+
+	// we wait enough, add out-of-service taint to force delete orphan resources
+	if err := h.cleanupResources(node); err != nil {
+		return true, fmt.Errorf("failed to cleanup stuck resources for node %s: %w", node.Name, err)
+	}
+	logrus.Infof("cleaned up stuck resources for node %s", node.Name)
+	return true, nil
+}
+
+func (h *nodeDownHandler) removeHarvesterNodeDrainedCond(node *corev1.Node) error {
+	nodeCpy := node.DeepCopy()
+	conds := nodeCpy.Status.Conditions
+	newConds := slices.DeleteFunc(conds, func(c corev1.NodeCondition) bool {
+		return c.Type == HarvesterNodeCondDrained
+	})
+	nodeCpy.Status.Conditions = newConds
+	if _, err := h.nodes.UpdateStatus(nodeCpy); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *nodeDownHandler) createOrUpdateNodeCondition(node *corev1.Node, condType corev1.NodeConditionType, status corev1.ConditionStatus, reason string, message string) (*corev1.Node, error) {
+	logrus.Debugf("createOrUpdateNodeCondition: %v, %v, %v, %v", condType, status, reason, message)
+	cond := getNodeCondition(node.Status.Conditions, condType)
+	now := metav1.Now()
+	notFound := false
+	if cond == nil {
+		cond = generateNewNodeCondition(condType, status, reason, message, now, now)
+		notFound = true
+	}
+	if cond.Status != status {
+		cond.Status = status
+		cond.LastTransitionTime = now
+	}
+	cond.LastHeartbeatTime = now
+	cond.Reason = reason
+	cond.Message = message
 
 	nodeCpy := node.DeepCopy()
-	nodeCpy.Annotations[kubevirtv1.VirtHandlerHeartbeat] = metav1.Now().Add(-6 * time.Minute).Format(time.RFC3339)
+	if notFound {
+		nodeCpy.Status.Conditions = append(nodeCpy.Status.Conditions, *cond)
+	} else {
+		for id, c := range nodeCpy.Status.Conditions {
+			if c.Type == condType {
+				nodeCpy.Status.Conditions[id] = *cond
+			}
+		}
+	}
+	logrus.Debugf("toUpdated status: %v", nodeCpy.Status.Conditions)
+	return h.nodes.UpdateStatus(nodeCpy)
+}
 
-	return h.nodes.Update(nodeCpy)
+func generateNewNodeCondition(condType corev1.NodeConditionType, status corev1.ConditionStatus, reason string, message string, lastHeartbeatTime metav1.Time, lastTransitionTime metav1.Time) *corev1.NodeCondition {
+	return &corev1.NodeCondition{
+		Type:               condType,
+		Status:             status,
+		LastHeartbeatTime:  lastHeartbeatTime,
+		LastTransitionTime: lastTransitionTime,
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+func (h *nodeDownHandler) fetchVMForceResetPolicy() (*settings.VMForceResetPolicy, error) {
+	vmForceResetPolicy, err := settings.DecodeVMForceResetPolicy(settings.VMForceResetPolicySet.Get())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode VMForceResetPolicy setting: %w", err)
+	}
+	return vmForceResetPolicy, nil
+}
+
+// tryWaitForTimeout assume the condition is not nil, if the condition is nil, return error
+func (h *nodeDownHandler) tryWaitForCondTimeout(cond *corev1.NodeCondition, timeout int64) (bool, error) {
+	targetInterval := time.Duration(timeout) * time.Second
+	if cond == nil {
+		return false, fmt.Errorf("node condition is nil, cannot wait for timeout")
+	}
+
+	if time.Since(cond.LastTransitionTime.Time) < targetInterval {
+		deadline := cond.LastTransitionTime.Add(targetInterval)
+		logrus.Debugf("Enqueue because the corresponding cond (%v) was not timeout at %v", cond.Type, deadline)
+		h.nodes.EnqueueAfter(cond.Reason, time.Until(deadline))
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// we will add kubevirtDrainTaint first to trigger migration then add nonGracefulTaint to force delete orphan resources
+func (h *nodeDownHandler) triggerMigration(node *corev1.Node) error {
+	if err := h.addTaints(node, kubevirtDrainTaint); err != nil {
+		return fmt.Errorf("failed to add kubevirt drain taint to node %s: %w", node.Name, err)
+	}
+	return nil
+}
+
+func (h *nodeDownHandler) cleanupResources(node *corev1.Node) error {
+	if err := h.addTaints(node, nonGracefulTaint); err != nil {
+		return fmt.Errorf("failed to add non-graceful taint to node %s: %w", node.Name, err)
+	}
+	return nil
+}
+
+func (h *nodeDownHandler) addTaints(node *corev1.Node, taints ...corev1.Taint) error {
+	nodeCpy := node.DeepCopy()
+	nodeCpy.Spec.Taints = append(nodeCpy.Spec.Taints, taints...)
+	var err error
+	if !reflect.DeepEqual(node.Spec.Taints, nodeCpy.Spec.Taints) {
+		_, err = h.nodes.Update(nodeCpy)
+	}
+	return err
+}
+
+func (h *nodeDownHandler) removeTaints(node *corev1.Node, taintKeys ...string) error {
+	nodeCpy := node.DeepCopy()
+	taints := nodeCpy.Spec.Taints
+	newTaints := slices.DeleteFunc(taints, func(t corev1.Taint) bool {
+		for _, remove := range taintKeys {
+			if t.Key == remove {
+				return true
+			}
+		}
+		return false
+	})
+	nodeCpy.Spec.Taints = newTaints
+	var err error
+	if !reflect.DeepEqual(node.Spec.Taints, nodeCpy.Spec.Taints) {
+		_, err = h.nodes.Update(nodeCpy)
+	}
+	return err
+}
+
+func getNodeTaint(taints []corev1.Taint, taintKey string) *corev1.Taint {
+	var taint *corev1.Taint
+	for i := range taints {
+		t := taints[i]
+		if t.Key == taintKey {
+			taint = &t
+			break
+		}
+	}
+	return taint
 }

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -32,6 +32,8 @@ type VMForceResetPolicy struct {
 	Enable bool `json:"enable"`
 	// Period means how many seconds to wait for a node get back.
 	Period int64 `json:"period"`
+	// VMMigrationTimeout means how many seconds to wait for a VM to migrate when a node is reported not ready.
+	VMMigrationTimeout int64 `json:"vmMigrationTimeout,omitempty"`
 }
 
 func InitBackupTargetToString() string {
@@ -66,8 +68,9 @@ func (target *BackupTarget) IsDefaultBackupTarget() bool {
 
 func InitVMForceResetPolicy() string {
 	policy := &VMForceResetPolicy{
-		Enable: true,
-		Period: 5 * 60, // 5 minutes
+		Enable:             true,
+		Period:             15,  // 15 seconds for default timeout
+		VMMigrationTimeout: 180, // 180 seconds for default VM migration timeout
 	}
 	policyStr, err := json.Marshal(policy)
 	if err != nil {
@@ -84,6 +87,13 @@ func DecodeVMForceResetPolicy(value string) (*VMForceResetPolicy, error) {
 
 	if policy.Period <= 0 {
 		return nil, fmt.Errorf("period value should be greater than 0, value: %d", policy.Period)
+	}
+
+	if policy.VMMigrationTimeout < 0 {
+		return nil, fmt.Errorf("vmMigrationTimeout value should be greater than 0, value: %d", policy.VMMigrationTimeout)
+	}
+	if policy.VMMigrationTimeout == 0 {
+		policy.VMMigrationTimeout = 180 // set default VM migration timeout to 180 seconds
 	}
 
 	return policy, nil


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Improve our mechanism when node failed

#### Solution:
Improve our mechanism when node failed

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8945

#### Test plan:
1. create 3 node cluster
2. create VM
3. disable the network on the host which the VM is running
4. ensure the VM can be migrated smoothly
5. ensure node which network was disabled have the following taints
`kubevirt.io/drain:NoSchedule`
`node.kubernetes.io/out-of-service`
6. enable the network. Ensure the above taints were removed after the node was back.

#### Additional documentation or context
