### PR TITLE
chore: Use v1.7 baseos image in upgrade container

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -1,5 +1,5 @@
 ARG HARVESTER_INSTALLER_REF=master-head
-FROM registry.opensuse.org/isv/rancher/harvester/os/dev/main/baseos:latest as baseos
+FROM registry.opensuse.org/isv/rancher/harvester/os/v1.7/main/baseos:v1.7 as baseos
 FROM rancher/harvester-installer:${HARVESTER_INSTALLER_REF} as installer
 FROM registry.suse.com/bci/bci-base:15.7
 


### PR DESCRIPTION
#### Problem:
The v1.7 branch should use the baseos container image from the v1.7 project on OBS.

#### Solution:
Update the `FROM` line in `package/upgrade/Dockerfile` appropriately

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9422

#### Test plan:
N/A