### PR TITLE
Check if a node is witnessnode without promotion status

### DIFF
--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -41,6 +41,15 @@ func IsPromoteStatusIn(node *corev1.Node, statuses ...string) bool {
 	return false
 }
 
+func IsWitnessNodeWithoutPromotionStatus(node *corev1.Node) bool {
+	val, found := node.Labels[HarvesterWitnessNodeLabelKey]
+	if found && val == "true" {
+		return true
+	}
+
+	return false
+}
+
 func IsWitnessNode(node *corev1.Node, isManagement bool) bool {
 	_, found := node.Labels[HarvesterWitnessNodeLabelKey]
 	if !found {
@@ -80,7 +89,7 @@ func CountNonWitnessNodes(nodes []*corev1.Node) int {
 	count := 0
 
 	for _, node := range nodes {
-		if !IsWitnessNode(node, IsManagementRole(node)) {
+		if !IsWitnessNodeWithoutPromotionStatus(node) {
 			count++
 		}
 	}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1499,8 +1499,7 @@ func (v *settingValidator) checkVCSpansAllNodes(config *networkutil.Config) erro
 	//check if vlanconfig contains all the nodes in the cluster
 	for _, node := range nodes {
 		//skip witness nodes which do not run LH Pods
-		isManagement := util.IsManagementRole(node)
-		if util.IsWitnessNode(node, isManagement) {
+		if util.IsWitnessNodeWithoutPromotionStatus(node) {
 			continue
 		}
 


### PR DESCRIPTION
#### Problem:
The existing logic in harvester code returns true for a node as witness node only if both witness label ( node-role.harvesterhci.io/witness) and promote-status is set.
Ref: https://github.com/harvester/harvester/blob/bdd8042958e2bb7b09b3524b5d4a2b849a724b33/pkg/util/node.go#L44

But this is not the case always.A node can be created with just witness label set to true

#### Solution:
Introduce a new function to return true for a node as witness node only if witness node label is set to true

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9325

#### Test plan:
case 1:
1.Have a harvester cluster 2 nodes (1 witness node and 1 master node)
2.Make sure to have only instance manager pods running and no backing image pods.
3.Create storage network
4.Check if "IP allocation failure for Longhorn Pods" msg not seen in Harvester UI under storage network settings and storage network creation and allocation of secondary IP to instance manager pod is successful.

case 2:
1.Have a harvester cluster 2 nodes ( 1 witness node and 1 master node)
2.Create a cluster network cluster-1
3.Create a vlan config vlancluster-1 spanning all nodes
4.3.Create storage network
4.Check if there are no webhook errors seen and storage network creation and allocation of secondary IP to instance manager pod is successful

#### Additional documentation or context
