### PR TITLE
Fix: Enforce consistent Maintenance Mode Strategy behavior (rebase of #7160)

### DIFF
--- a/pkg/controller/master/virtualmachine/vmi_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_controller.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -13,7 +15,13 @@ import (
 
 	"github.com/harvester/harvester/pkg/builder"
 	kubevirtctrl "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/indexeres"
 	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	VirtualMachineCreatorNodeDriver = "docker-machine-driver-harvester"
+	HarvesterLabelPrefix            = "harvesterhci.io"
 )
 
 // hostLabelsReconcileMapping defines the mapping for reconciliation of node labels to virtual machine instance annotations
@@ -22,12 +30,79 @@ var hostLabelsReconcileMapping = []string{
 }
 
 type VMIController struct {
+	podClient           ctlcorev1.PodClient
+	podCache            ctlcorev1.PodCache
 	vmClient            kubevirtctrl.VirtualMachineClient
 	virtualMachineCache kubevirtctrl.VirtualMachineCache
 	vmiClient           kubevirtctrl.VirtualMachineInstanceClient
 	nodeCache           ctlcorev1.NodeCache
 	pvcClient           ctlcorev1.PersistentVolumeClaimClient
 	recorder            record.EventRecorder
+}
+
+// SyncHarvesterVMILabelsToPod ensures that all Harvester labels (i.e. those
+// with the harvesterhci.io/ prefix) from the VirtualMachineInstance are synced
+// to the Pod
+func (h *VMIController) SyncHarvesterVMILabelsToPod(_ string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+	if vmi == nil || vmi.DeletionTimestamp != nil {
+		return vmi, nil
+	}
+
+	logrus.Debugf("Syncing labels %v for VMI %v to Pod", vmi.Labels, vmi.Name)
+
+	harvesterVMILabels := map[string]string{}
+	for label := range vmi.Labels {
+		if strings.HasPrefix(label, HarvesterLabelPrefix) {
+			harvesterVMILabels[label] = vmi.Labels[label]
+		}
+	}
+
+	activePods := vmi.Status.ActivePods
+	if len(activePods) < 1 {
+		logrus.Debugf("VMI %v does not have active Pods", vmi.Name)
+		return vmi, nil
+	}
+
+	nodeName := vmi.Status.NodeName
+	if nodeName == "" {
+		logrus.Debugf("Could not identify which node VMI %v runs on", vmi.Name)
+		return vmi, nil
+	}
+
+	pods, err := h.podCache.GetByIndex(indexeres.PodByNodeNameIndex, nodeName)
+	if err != nil {
+		return vmi, fmt.Errorf("failed to find pods for VMI %v, %v", vmi.Name, err)
+	}
+
+	var toUpdate = make([]*corev1.Pod, 0)
+	for _, pod := range pods {
+		for active := range activePods {
+			if pod.UID == active {
+				toUpdate = append(toUpdate, pod.DeepCopy())
+			}
+		}
+	}
+
+	for _, pod := range toUpdate {
+		// delete Harvester labels from Pod, if they are deleted from VMI
+		for podLabel := range pod.Labels {
+			_, ok := harvesterVMILabels[podLabel]
+			if strings.HasPrefix(podLabel, HarvesterLabelPrefix) && !ok {
+				delete(pod.Labels, podLabel)
+			}
+		}
+
+		// copy labels from VMI to Pod
+		for label := range harvesterVMILabels {
+			pod.Labels[label] = harvesterVMILabels[label]
+		}
+
+		_, err := h.podClient.Update(pod)
+		if err != nil {
+			return vmi, fmt.Errorf("failed to sync Harvester VMI labels to pod, %v", err)
+		}
+	}
+	return vmi, nil
 }
 
 // ReconcileFromHostLabels handles the propagation of metadata from node labels to VirtualMachineInstance annotations.

--- a/pkg/controller/master/virtualmachine/vmi_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_controller.go
@@ -2,7 +2,9 @@ package virtualmachine
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -10,13 +12,15 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/builder"
 	kubevirtctrl "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	"github.com/harvester/harvester/pkg/indexeres"
+	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/indexeres"
 )
 
 const (
@@ -40,6 +44,17 @@ type VMIController struct {
 	recorder            record.EventRecorder
 }
 
+// Golang standard library's "maps" module contains the "Keys" function only for
+// Golang <v1.21 and >= v1.23
+// This function returns a sequence of keys of a map
+func mapKeys(m map[apitypes.UID]string) []apitypes.UID {
+	keys := make([]apitypes.UID, 0)
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // SyncHarvesterVMILabelsToPod ensures that all Harvester labels (i.e. those
 // with the harvesterhci.io/ prefix) from the VirtualMachineInstance are synced
 // to the Pod
@@ -51,57 +66,57 @@ func (h *VMIController) SyncHarvesterVMILabelsToPod(_ string, vmi *kubevirtv1.Vi
 	logrus.Debugf("Syncing labels %v for VMI %v to Pod", vmi.Labels, vmi.Name)
 
 	harvesterVMILabels := map[string]string{}
-	for label := range vmi.Labels {
+	for label, value := range vmi.Labels {
 		if strings.HasPrefix(label, HarvesterLabelPrefix) {
-			harvesterVMILabels[label] = vmi.Labels[label]
+			harvesterVMILabels[label] = value
 		}
 	}
 
-	activePods := vmi.Status.ActivePods
-	if len(activePods) < 1 {
+	activePodUIDs := vmi.Status.ActivePods
+	if len(activePodUIDs) < 1 {
 		logrus.Debugf("VMI %v does not have active Pods", vmi.Name)
 		return vmi, nil
 	}
 
-	nodeName := vmi.Status.NodeName
-	if nodeName == "" {
-		logrus.Debugf("Could not identify which node VMI %v runs on", vmi.Name)
-		return vmi, nil
+	vmName, ok := vmi.Labels["harvesterhci.io/vmName"]
+	if !ok {
+		return vmi, fmt.Errorf("failed to determind VM name of VMI %v", vmi.Name)
 	}
 
-	pods, err := h.podCache.GetByIndex(indexeres.PodByNodeNameIndex, nodeName)
-	if err != nil {
+	pods, err := h.podCache.GetByIndex(indexeres.PodByVMNameIndex, ref.Construct(vmi.Namespace, vmName))
+	if err != nil || len(pods) < 1 {
 		return vmi, fmt.Errorf("failed to find pods for VMI %v, %v", vmi.Name, err)
 	}
 
-	var toUpdate = make([]*corev1.Pod, 0)
 	for _, pod := range pods {
-		for active := range activePods {
-			if pod.UID == active {
-				toUpdate = append(toUpdate, pod.DeepCopy())
-			}
+		// TODO: Replace with maps.Keys(activePodUIDs) after migrating to Golang
+		// v1.23
+		if !slices.Contains(mapKeys(activePodUIDs), pod.UID) {
+			continue
 		}
-	}
 
-	for _, pod := range toUpdate {
+		newLabels := maps.Clone(pod.Labels)
 		// delete Harvester labels from Pod, if they are deleted from VMI
-		for podLabel := range pod.Labels {
-			_, ok := harvesterVMILabels[podLabel]
-			if strings.HasPrefix(podLabel, HarvesterLabelPrefix) && !ok {
-				delete(pod.Labels, podLabel)
+
+		maps.DeleteFunc(newLabels, func(k, _ string) bool {
+			if _, ok := harvesterVMILabels[k]; !ok && strings.HasPrefix(k, HarvesterLabelPrefix) {
+				return true
+			}
+			return false
+		})
+
+		maps.Copy(newLabels, harvesterVMILabels)
+
+		if !maps.Equal(pod.Labels, newLabels) {
+			newPod := pod.DeepCopy()
+			newPod.Labels = newLabels
+			_, err := h.podClient.Update(newPod)
+			if err != nil {
+				return vmi, fmt.Errorf("failed to sync Harvester VMI labels to pod, %v", err)
 			}
 		}
-
-		// copy labels from VMI to Pod
-		for label := range harvesterVMILabels {
-			pod.Labels[label] = harvesterVMILabels[label]
-		}
-
-		_, err := h.podClient.Update(pod)
-		if err != nil {
-			return vmi, fmt.Errorf("failed to sync Harvester VMI labels to pod, %v", err)
-		}
 	}
+
 	return vmi, nil
 }
 

--- a/pkg/controller/master/virtualmachine/vmi_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_controller.go
@@ -12,7 +12,6 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
@@ -42,17 +41,6 @@ type VMIController struct {
 	nodeCache           ctlcorev1.NodeCache
 	pvcClient           ctlcorev1.PersistentVolumeClaimClient
 	recorder            record.EventRecorder
-}
-
-// Golang standard library's "maps" module contains the "Keys" function only for
-// Golang <v1.21 and >= v1.23
-// This function returns a sequence of keys of a map
-func mapKeys(m map[apitypes.UID]string) []apitypes.UID {
-	keys := make([]apitypes.UID, 0)
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }
 
 // SyncHarvesterVMILabelsToPod ensures that all Harvester labels (i.e. those
@@ -89,9 +77,7 @@ func (h *VMIController) SyncHarvesterVMILabelsToPod(_ string, vmi *kubevirtv1.Vi
 	}
 
 	for _, pod := range pods {
-		// TODO: Replace with maps.Keys(activePodUIDs) after migrating to Golang
-		// v1.23
-		if !slices.Contains(mapKeys(activePodUIDs), pod.UID) {
+		if !slices.Contains(slices.Collect(maps.Keys(activePodUIDs)), pod.UID) {
 			continue
 		}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -176,13 +176,25 @@ const (
 
 	RKEControlPlaneRoleLabel = "rke.cattle.io/control-plane-role"
 
-	LabelMaintainModeStrategy                          = prefix + "/maintain-mode-strategy"
-	AnnotationMaintainModeStrategyNodeName             = prefix + "/maintain-mode-strategy-node-name"
+	LabelMaintainModeStrategy              = prefix + "/maintain-mode-strategy"
+	AnnotationMaintainModeStrategyNodeName = prefix + "/maintain-mode-strategy-node-name"
+
 	MaintainModeStrategyMigrate                        = "Migrate"
 	MaintainModeStrategyShutdownAndRestartAfterEnable  = "ShutdownAndRestartAfterEnable"
 	MaintainModeStrategyShutdownAndRestartAfterDisable = "ShutdownAndRestartAfterDisable"
 	MaintainModeStrategyShutdown                       = "Shutdown"
+)
 
+var (
+	ValidMaintenanceModeStrategyValues = []string{
+		MaintainModeStrategyMigrate,
+		MaintainModeStrategyShutdownAndRestartAfterEnable,
+		MaintainModeStrategyShutdownAndRestartAfterDisable,
+		MaintainModeStrategyShutdown,
+	}
+)
+
+const (
 	// s3 backup target constants
 	AWSAccessKey       = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey       = "AWS_SECRET_ACCESS_KEY"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -183,6 +183,7 @@ const (
 	MaintainModeStrategyShutdownAndRestartAfterEnable  = "ShutdownAndRestartAfterEnable"
 	MaintainModeStrategyShutdownAndRestartAfterDisable = "ShutdownAndRestartAfterDisable"
 	MaintainModeStrategyShutdown                       = "Shutdown"
+	DefaultMaintainModeStrategy                        = MaintainModeStrategyMigrate
 )
 
 var (

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -152,7 +152,7 @@ func DrainPossible(nodeCache ctlcorev1.NodeCache, node *corev1.Node) error {
 }
 
 func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
-	// Ignore VMs that should not be migrated in maintenance mode. These
+	// Ignore Pods of VMs that should not be migrated in maintenance mode. These
 	// VMs are forcibly shut down when maintenance mode is activated.
 	// They are identified by the maintenance-mode strategy label
 	// `harvesterhci.io/maintain-mode-strategy` having any of these values:
@@ -180,5 +180,7 @@ func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
 	// VMs which don't have the maintenance-mode strategy label set or have it set
 	// to any value other than the ones named above, the behavior will be the same
 	// as the default.
+	// It's ok as well to mark all other pods for deletion here, because if they
+	// shouldn't be deleted, a different filter should mark them to be skipped.
 	return drain.MakePodDeleteStatusOkay()
 }

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/selection"
@@ -153,14 +154,31 @@ func DrainPossible(nodeCache ctlcorev1.NodeCache, node *corev1.Node) error {
 func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
 	// Ignore VMs that should not be migrated in maintenance mode. These
 	// VMs are forcibly shut down when maintenance mode is activated.
+	// They are identified by the maintenance-mode strategy label
+	// `harvesterhci.io/maintain-mode-strategy` having any of these values:
+	// - ShutdownAndRestartAfterEnable
+	// - ShutdownAndRestartAfterDisable
+	// - Shutdown
 	value, ok := pod.Labels[util.LabelMaintainModeStrategy]
-	if ok && value != util.MaintainModeStrategyMigrate {
+	if ok && slices.Contains([]string{
+		util.MaintainModeStrategyShutdownAndRestartAfterEnable,
+		util.MaintainModeStrategyShutdownAndRestartAfterDisable,
+		util.MaintainModeStrategyShutdown,
+	}, value) {
 		logrus.WithFields(logrus.Fields{
-			"namespace": pod.Namespace,
-			"pod_name":  pod.Name,
-		}).Infof("migration of pod owned by VM %s is skipped because of the label %s",
-			pod.Labels[util.LabelVMName], util.LabelMaintainModeStrategy)
+			"kind":           "pod",
+			"namespace":      pod.Namespace,
+			"name":           pod.Name,
+			"label":          util.LabelMaintainModeStrategy,
+			"value":          value,
+			util.LabelVMName: pod.Labels[util.LabelVMName],
+		}).Infof("migration of VM pod skipped because of label")
 		return drain.MakePodDeleteStatusSkip()
 	}
+
+	// The default setting for the maintenance-mode strategy label is `Migrate`.
+	// VMs which don't have the maintenance-mode strategy label set or have it set
+	// to any value other than the ones named above, the behavior will be the same
+	// as the default.
 	return drain.MakePodDeleteStatusOkay()
 }

--- a/pkg/util/patch.go
+++ b/pkg/util/patch.go
@@ -1,0 +1,21 @@
+package util
+
+// Structs for generating Kubernetes PATCH requests with json.Marshal
+// Generating the patch request by serializing a struct guarantees that the JSON
+// data in the request will not be malformed.
+//
+// Utilize like this:
+//
+// op := json.Marshall(
+//   PatchStringValue{
+//     Op:    "replace",
+//     Path:  "/spec/property",
+//     Value: "newValue",
+//   },
+// )
+
+type PatchStringValue struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -661,35 +661,35 @@ func (v *vmValidator) checkEmptyMemory(vm *kubevirtv1.VirtualMachine) error {
 func checkMaintenanceModeStrategyIsValid(newVM, oldVM *kubevirtv1.VirtualMachine) error {
 	labels := newVM.ObjectMeta.Labels
 	newStrategy, ok := labels[util.LabelMaintainModeStrategy]
-	if ok {
-		// Don't deny updates on an existing VM with an invalid maintenance-mode
-		// strategy label, if the label stays the same, but complain with a warning.
-		// If the maintenance-mode strategy label is updated, its new value needs to
-		// be valid regardless.
-		if oldVM != nil {
-			oldVMLabels := oldVM.ObjectMeta.Labels
-			oldStrategy, ok := oldVMLabels[util.LabelMaintainModeStrategy]
-			if ok && oldStrategy == newStrategy {
-				if !slices.Contains(util.ValidMaintenanceModeStrategyValues, oldStrategy) {
-					logrus.WithFields(logrus.Fields{
-						"name":      oldVM.Name,
-						"namespace": oldVM.Namespace,
-					}).Warnf("invalid maintenance-mode strategy for VM, behavior will be equivalent to default `%v`", util.MaintainModeStrategyMigrate)
-
-					return nil
-				}
-			}
-		}
-
-		if !slices.Contains(util.ValidMaintenanceModeStrategyValues, newStrategy) {
-			return werror.NewInvalidError(
-				fmt.Sprintf("invalid maintenance mode strategy: %v", newStrategy),
-				fmt.Sprintf("metadata.labels[%v]", util.LabelMaintainModeStrategy),
-			)
-		}
-	} else {
+	if !ok {
 		return werror.NewInvalidError(
 			fmt.Sprintf("label `%v` not found", util.LabelMaintainModeStrategy),
+			fmt.Sprintf("metadata.labels[%v]", util.LabelMaintainModeStrategy),
+		)
+	}
+
+	// Don't deny updates on an existing VM with an invalid maintenance-mode
+	// strategy label, if the label stays the same, but complain with a warning.
+	// If the maintenance-mode strategy label is updated, its new value needs to
+	// be valid regardless.
+	if oldVM != nil {
+		oldVMLabels := oldVM.ObjectMeta.Labels
+		oldStrategy, ok := oldVMLabels[util.LabelMaintainModeStrategy]
+		if ok && oldStrategy == newStrategy {
+			if !slices.Contains(util.ValidMaintenanceModeStrategyValues, oldStrategy) {
+				logrus.WithFields(logrus.Fields{
+					"name":      oldVM.Name,
+					"namespace": oldVM.Namespace,
+				}).Warnf("invalid maintenance-mode strategy for VM, behavior will be equivalent to default `%v`", util.MaintainModeStrategyMigrate)
+
+				return nil
+			}
+		}
+	}
+
+	if !slices.Contains(util.ValidMaintenanceModeStrategyValues, newStrategy) {
+		return werror.NewInvalidError(
+			fmt.Sprintf("invalid maintenance mode strategy: %v", newStrategy),
 			fmt.Sprintf("metadata.labels[%v]", util.LabelMaintainModeStrategy),
 		)
 	}

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -13,8 +13,184 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
+
+func TestCheckMaintenanceModeStrategyIsValid(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		expectError bool
+		oldVM       *kubevirtv1.VirtualMachine
+		newVM       *kubevirtv1.VirtualMachine
+	}{
+		{
+			name:        "reject new VM if maintenance mode strategy label is not set",
+			expectError: true,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "reject new VM if maintenance mode strategy label is set to invalid value",
+			expectError: true,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "reject update to VM if maintenance mode strategy label is invalid for new VM",
+			expectError: true,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: util.MaintainModeStrategyMigrate,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This case is crucial, so Harvester can still operate existing VMs with
+			// bogus maintenance-mode strategies (i.e. update their status, shut them
+			// down, etc.)
+			name:        "accept update to VM if maintenance mode strategy label was invalid on old VM",
+			expectError: false,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This case ensures that IF the maintenance-mode label is updated, it is
+			// updated with a valid value
+			name:        "reject update to VM with invalid maintenance-mode strategy label, even if maintenance mode strategy label was invalid on old VM",
+			expectError: true,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "barfoo",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "accept new VM maintenance mode strategy label is set to valid value",
+			expectError: false,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: util.MaintainModeStrategyMigrate,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		err := checkMaintenanceModeStrategyIsValid(tc.newVM, tc.oldVM)
+		if tc.expectError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}
 
 func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Rebase of https://github.com/harvester/harvester/pull/7160

#### Problem:
As described in https://github.com/harvester/harvester/issues/6835, there are several problems to be considered here:

 -  Ensuring that the maintenance-mode strategy is specified
 -  Ensuring that only a valid maintenance-mode strategy can be specified
 -  Ensuring that the specified maintenance-mode strategy label is propagated all the way to all resources where it's expected
 -  Ensuring that default behavior is applied in all cases where a maintenance-mode strategy either isn't specified or isn't valid

#### Solution:

The solution to the problem consists of a modification to the node drain helper and modifications both the mutating admission webhook and the validating admission webhook for the VirtualMachine resource

## The Node Drain Helper

The node drain helper was only marking Pods of VMs which had the maintenance-mode strategy label set to Migrate for deletion (i.e. migration off of the node).
This behavior would omit all Pods which didn't have this label set at all, or the ones which had it set to an invalid value. Similarly, Pods of VMs which didn't have one of the three other maintenance-mode strategies set would not be shut down. Thereby any VM without a maintenance-mode strategy, or with an invalid maintenance-mode strategy would be left running, preventing the node from entering the maintenance mode successfully. As a result the node would remain stuck in "Cordoned" state, waiting for an operator to intervene and deal with the VMs.
The new behavior of the drain helper is to migrate any VMs off of the node, if the associated Pod either has no maintenance-mode strategy label, the maintenance-mode strategy label is invalid, or the maintenance-mode strategy is specified as Migrate. This is the documented default behavior for VMs.
All other VMs will have a different maintenance-mode strategy specified and they will thus be shut down (and later restarted according to their maintenance-mode strategy).

## Admission Webhook

The admission webhook for the VirtualMachine resource plays a crucial role in making sure that VirtualMachiness have a sane maintenance-mode strategy specified.
First, the mutating webhook ensures that the maintenance-mode strategy label is set on the VirtualMachine resource. If it isn't, it will be set to Migrate, which is the default.
Then the mutating webhook ensures that the maintenance-mode strategy label that is set on the VirtualMachine resource is propagated into the .spec.templates.metadata.labels, which is to ensure that the label is propagated throughout both the VirtualMachineInstance as well as the Pod belonging to that VirtualMachine.
The mutating webhook will not modify exising maintenance-mode strategy labels on existing VirtualMachine resources. While the node drain helper will apply the default strategy to these virtual machines, this is to ensure that the user will not be faced with inexplicably changing maintenance-mode strategy labels, if they have an invalid value in their cluster.
The webhook will however log an appropriate message, allowing the user to identify VirtualMachine resources affected by invalid values in the maintenance-mode strategy label and correct it.

The validating webhook takes the role of a safe guard, ensuring that no VirtualMachine can be created or updated with an ill-specified maintenance-mode strategy.
It will reject the creation of VirtualMachine resources without a maintenance-mode strategy label or with an invalid value in the maintenance-mode strategy label.
This ensures that the label can not accidentally be filled with bogus data and that the user is informed.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/6835

#### Test plan:
See https://github.com/harvester/harvester/pull/7160

#### Additional documentation or context
