### PR TITLE
feat: add NIC with specified static IP for Overlay Network

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -62,6 +62,7 @@ var (
 	UpgradeConfigSet       = NewSetting(UpgradeConfigSettingName, `{"imagePreloadOption":{"strategy":{"type":"sequential"}},"nodeUpgradeOption":{"strategy":{"mode":"auto"}},"restoreVM": false, "logReadyTimeout": "5"}`)
 	MaxHotplugRatio        = NewSetting(MaxHotplugRatioSettingName, "4")
 	VMMigrationNetwork     = NewSetting(VMMigrationNetworkSettingName, "")
+	DefaultNetwork         = NewSetting(DefaultNetworkSettingName, "default")
 	KubeVirtMigration      = NewSetting(KubeVirtMigrationSettingName, `{"parallelOutboundMigrationsPerNode":2,"parallelMigrationsPerCluster":5,"allowAutoConverge":false,"bandwidthPerMigration":0,"completionTimeoutPerGiB":150,"progressTimeout":150,"unsafeMigrationOverride":false,"allowPostCopy":false,"allowWorkloadDisruption":false,"disableTLS":false,"matchSELinuxLevelOnMigration":false}`)
 )
 
@@ -111,6 +112,7 @@ const (
 	DefaultStorageClassSettingName                    = "default-storage-class"
 	MaxHotplugRatioSettingName                        = "max-hotplug-ratio"
 	VMMigrationNetworkSettingName                     = "vm-migration-network"
+	DefaultNetworkSettingName                         = "default-network"
 	RancherClusterSettingName                         = "rancher-cluster"
 	KubeVirtMigrationSettingName                      = "kubevirt-migration"
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -282,4 +282,10 @@ const (
 	AddonExperimentalLabel = AddonPrefix + "/experimental"
 
 	HarvesterUpgradeComponentRepo = "repo"
+	// KubeOVN annotations
+	AnnotationKubeOVNPrefix     = "ovn.kubernetes.io"
+	AnnotationKubeOvnMAC        = AnnotationKubeOVNPrefix + "/mac_address"
+	AnnotationKubeOvnIP         = AnnotationKubeOVNPrefix + "/ip_address"
+	AnnotationPatternKubeOvnIP  = "%s.%s.kubernetes.io/ip_address.%s"
+	AnnotationPatternKubeOvnMAC = "%s.%s.kubernetes.io/mac_address.%s"
 )

--- a/pkg/util/nad.go
+++ b/pkg/util/nad.go
@@ -30,6 +30,10 @@ func (nc *NetConf) IsBridgeCNI() bool {
 	return nc.Type == "bridge"
 }
 
+func (nc *NetConf) IsKubeOVNCNI() bool {
+	return nc.Type == "kube-ovn"
+}
+
 func IsNadCreatedBySystem(nad *cniv1.NetworkAttachmentDefinition) bool {
 	return nad.Namespace == HarvesterSystemNamespaceName
 }


### PR DESCRIPTION
related-to: #8844

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
The problem arises when using static network configuration within the guest OS cloud-init config.
Two distinct issues:

    - The static IP is not correctly reflected in the Harvester UI, it continues to use the kube-ovn IP. The kube-ovn IP does not get updated (though this might just be default behavior)
    - The static IP VM cannot certain IP addresses. It can reach Harvester nodes (10.10.0.0/24) but not the Harvester VIP (10.10.0.10) or the gateway IP (10.10.0.1)

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Parse all static IPs / MACs from the cloud-init network-data (already stored in a secret).
For every network attached to the VM:
        - Primary (net.Multus == nil) and backed by Kube-OVN → write flat annotation
           ovn.kubernetes.io/ip_address / ovn.kubernetes.io/mac_address
        - Secondary (net.Multus != nil) and NAD type == kube-ovn → write per-NIC annotation
           <nadName>.<nadNamespace>.kubernetes.io/ip_address
           <nadName>.<nadNamespace>.kubernetes.io/mac_address
    Kube-OVN upstream already watches those keys and programs the logical-switch-port with the exact IP/MAC; no manual ovn-nbctl required.
    Skip non-Kube-OVN NADs (bridge, macvlan, …) so we never annotate interfaces that are not backed by an OVN logical switch.
refer to kubeovn doc: https://kubeovn.github.io/docs/v1.14.x/en/guide/static-ip-mac/ and  https://kubeovn.github.io/docs/stable/en/advance/multi-nic/

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->
1. Create two subnets and corresponding overlay network in Harvester:

    default (primary, OVN)
    test (secondary, OVN)

2. Create a VM and paste the following into Network Data:

```
#cloud-config
network:
  version: 2
  ethernets:
    eth0:                 # primary, 
      dhcp4: false
      addresses: [10.10.0.100/24]
      gateway4: 10.10.0.1
      nameservers:
        addresses: [8.8.8.8]
    eth1:                 # secondary
      dhcp4: false
      addresses: [192.168.50.60/24]
      macaddress: 02:00:00:00:00:02
```

3. Save & start the VM.
Verify annotations

`kubectl get vm <name> -o jsonpath='{.metadata.annotations}' | jq`

Expected output:

{
  "ovn.kubernetes.io/ip_address": "10.10.0.100",
  "ovn.kubernetes.io/mac_address": "52:54:00:xx:xx:xx",
  "storage.default.kubernetes.io/ip_address": "192.168.50.60",
  "storage.default.kubernetes.io/mac_address": "02:00:00:00:00:02"
}

4. Verify OVN logical-switch-ports

kubectl exec -n kube-system deploy/ovn-central -- \
  ovn-nbctl find logical_switch_port external_ids:pod=<vm-pod-uuid>

IP/MAC must match the annotations exactly.

5. Inside guest
ping VMs of the same subnet

Both interfaces must have the user-defined addresses and  connectivity between VMs under the same subnet must work.

#### Additional documentation or context
