### PR TITLE
fix(storage-network): check whether string function are same

### DIFF
--- a/pkg/util/network/common.go
+++ b/pkg/util/network/common.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"fmt"
 	"net"
+	"reflect"
+	"slices"
 )
 
 const (
@@ -82,4 +84,16 @@ func GenerateLAAMacAddress() (net.HardwareAddr, error) {
 	buf[0] &= 0xFE
 
 	return net.HardwareAddr(buf), nil
+}
+
+func IsConfigEqual(oldConfig, config *Config) bool {
+	if oldConfig == nil && config == nil {
+		return true
+	}
+	if oldConfig == nil || config == nil {
+		return false
+	}
+	slices.Sort(oldConfig.Exclude)
+	slices.Sort(config.Exclude)
+	return reflect.DeepEqual(oldConfig, config)
 }

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1167,9 +1167,24 @@ func (v *settingValidator) validateUpdateStorageNetwork(oldSetting *v1beta1.Sett
 	}
 
 	var (
-		config *networkutil.Config
-		err    error
+		oldConfig networkutil.Config
+		config    *networkutil.Config
+		err       error
 	)
+	if oldSetting.Default != "" {
+		if err = json.Unmarshal([]byte(oldSetting.Default), &oldConfig); err != nil {
+			logrus.WithError(err).
+				WithField("oldSetting.Default", oldSetting.Default).
+				Warn("Failed to unmarshal old storage-network setting")
+		}
+	}
+	if oldSetting.Value != "" {
+		if err = json.Unmarshal([]byte(oldSetting.Value), &oldConfig); err != nil {
+			logrus.WithError(err).
+				WithField("oldSetting.Value", oldSetting.Value).
+				Warn("Failed to unmarshal old storage-network setting")
+		}
+	}
 	if config, err = v.validateNetworkHelper(settings.StorageNetworkName, newSetting.Default); err != nil {
 		return werror.NewInvalidError(err.Error(), settings.KeywordDefault)
 	}
@@ -1178,6 +1193,10 @@ func (v *settingValidator) validateUpdateStorageNetwork(oldSetting *v1beta1.Sett
 		return werror.NewInvalidError(err.Error(), settings.KeywordValue)
 	} else if valueConfig != nil {
 		config = valueConfig
+	}
+
+	if networkutil.IsConfigEqual(&oldConfig, config) {
+		return nil
 	}
 
 	vmMigraionNetworkConfig, err := v.getNetworkConfig(settings.VMMigrationNetworkSettingName)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
In previous implementation, following two setting are different in `storage-network` setting webhook.

```
{"clusterNetwork":"new-cn","exclude":["172.16.0.4/32","172.16.0.3/32"],"range":"172.16.0.0/24","vlan":1}
```

```
{"clusterNetwork":"new-cn","exclude":["172.16.0.3/32","172.16.0.4/32"],"range":"172.16.0.0/24","vlan":1}
```

However, this two value should be logically same, so we don't need to do further check.

#### Solution:
Webhook should not reject the change if the change just has different order.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9558

#### Test plan:
1. Create a Harvester cluster.
2. Set up a new cluster network `new-cn`.
3. Set the `storage-setting` as `{"clusterNetwork":"new-cn","exclude":["172.16.0.4/32","172.16.0.3/32"],"range":"172.16.0.0/24","vlan":1}`.
4. Create a VM.
5. Set the `storage-setting` as `{"clusterNetwork":"new-cn","exclude":["172.16.0.3/32","172.16.0.4/32"],"range":"172.16.0.0/24","vlan":1}`. The webhook should not reject it.

#### Additional documentation or context
