### PR TITLE
enhancement: exclude VM workload from LH's automatic deletion mechanism

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -498,7 +498,8 @@ longhorn:
     priorityClass: &longhornPriorityClass system-cluster-critical
     autoCleanupSnapshotWhenDeleteBackup: true
     orphanResourceAutoDeletion: instance
-    autoDeletePodWhenVolumeDetachedUnexpectedly: false
+    autoDeletePodWhenVolumeDetachedUnexpectedly: true
+    blacklistForAutoDeletePodWhenVolumeDetachedUnexpectedly: "kubevirt.io/VirtualMachineInstance"
 
   # after upgrade to longhorn 1.6.0, we need to set the priorityClass for longhorn-manager, longhorn-driver and longhorn-ui
   # or it will be default one longhorn-critical


### PR DESCRIPTION
#### Problem:
Exclude VM workload from LH's automatic deletion mechanism

#### Solution:
Exclude VM workload from LH's automatic deletion mechanism via the blacklist

#### Related Issue(s):
#9467 

#### Test plan:
1. Build Harvester using the ISO from this PR.
2. Check the LH setting `auto-delete-pod-when-volume-detached-unexpectedly` is set to `true`.
3. Check the LH setting `blacklist-for-auto-delete-pod-when-volume-detached-unexpectedly` is set to `kubevirt.io/VirtualMachineInstance`.
4. Create a VM with a Longhorn volume root disk and set the RunStrategy to manual.
5. Delete the root disk VM's Instance Manager (IM) pod. The VM should remain in a Paused state, and the corresponding virt-launcher pod will not be deleted.

#### Additional documentation or context
