### PR TITLE
fix(upgrade): bump the bci image used by skip-restart-rsa plan

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1015,7 +1015,7 @@ spec:
   tolerations:
   - operator: "Exists"
   upgrade:
-    image: registry.suse.com/bci/bci-base:15.6
+    image: registry.suse.com/bci/bci-base:15.7
     command:
     - chroot
     - /host


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The BCI image used by the `*-skip-restart-rancher-system-agent-*` plan is outdated (15.6).

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Bump it to 15.7.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#9605 

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Prepare a single-node cluster in the latest v1.7.0 RC
2. Upgrade to master-head (given the fix in the PR is included)
3. The upgrade should not get stuck and should finish successfully

#### Additional documentation or context
