### PR TITLE
Support x-goog-stored-content-length header as fallback for image size detection

### DIFF
--- a/pkg/image/cdi/common.go
+++ b/pkg/image/cdi/common.go
@@ -140,8 +140,14 @@ func fetchImageSize(url string) (int64, error) {
 	}
 	defer rsp.Body.Close()
 
-	contentLengthStr := rsp.Header.Get("Content-Length")
-	if contentLengthStr == "" {
+	var contentLengthStr string
+	if cl := rsp.Header.Get("Content-Length"); cl != "" {
+		contentLengthStr = cl
+	} else if xgcl := rsp.Header.Get("x-goog-stored-content-length"); xgcl != "" {
+		// Fallback to x-goog-stored-content-length if Content-Length is not available
+		contentLengthStr = xgcl
+	} else {
+		// if both headers are missing, return an error
 		return 0, ErrHeaderContentLengthNotFound
 	}
 

--- a/pkg/image/cdi/common.go
+++ b/pkg/image/cdi/common.go
@@ -140,22 +140,27 @@ func fetchImageSize(url string) (int64, error) {
 	}
 	defer rsp.Body.Close()
 
-	var contentLengthStr string
-	if cl := rsp.Header.Get("Content-Length"); cl != "" {
-		contentLengthStr = cl
-	} else if xgcl := rsp.Header.Get("x-goog-stored-content-length"); xgcl != "" {
-		// Fallback to x-goog-stored-content-length if Content-Length is not available
-		contentLengthStr = xgcl
-	} else {
-		// if both headers are missing, return an error
-		return 0, ErrHeaderContentLengthNotFound
+	cl, err := getContentLength(rsp)
+	if err != nil {
+		return 0, err
 	}
 
-	contentLength, err := strconv.ParseInt(contentLengthStr, 10, 64)
+	contentLength, err := strconv.ParseInt(cl, 10, 64)
 	if err != nil {
 		return 0, err
 	}
 	return contentLength, nil
+}
+
+func getContentLength(rsp *http.Response) (string, error) {
+	if cl := rsp.Header.Get("Content-Length"); cl != "" {
+		return cl, nil
+	} else if xgcl := rsp.Header.Get("x-goog-stored-content-length"); xgcl != "" {
+		// fallback to x-goog-stored-content-length if Content-Length is not available
+		return xgcl, nil
+	}
+	// if both headers are missing, return an error
+	return "", ErrHeaderContentLengthNotFound
 }
 
 func fetchImageVirtualSize(url string) (int64, error) {


### PR DESCRIPTION
#### Problem:

see https://github.com/harvester/harvester/issues/9594

#### Solution:

Support x-goog-stored-content-length header as fallback for image size detection

#### Related Issue(s):

https://github.com/harvester/harvester/issues/9594

#### Test plan:

well described in https://github.com/harvester/harvester/issues/9594

#### Additional documentation or context

When the HTTP server doesn't provide a Content-Length header, CDI cannot track the download progress because it doesn't know the total file size. In this case, [NewFormatReaders](https://github.com/kubevirt/containerized-data-importer/blob/main/pkg/importer/format-readers.go#L82-L94) skips creating the ProgressReader wrapper, which means no progress updates are sent during the entire HTTP download phase.

The progress reporting only starts after the download completes and qemu-img conversion begins ([qemu.go:279-291](https://github.com/kubevirt/containerized-data-importer/blob/main/pkg/image/qemu.go#L279-L291)). Since both HTTP download and qemu conversion report progress using the same DataVolume .status.progress field, users see the progress stuck at 0% for an extended period (during the entire download) until conversion starts.

**In short, user will see vm image progress stays in 0% during the entire http download until the import pod starts to perform qemu-conversion.**
