### PR TITLE
fix(restore): set InProgress=true if VM is not ready

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -1258,7 +1258,7 @@ func (h *RestoreHandler) updateStatus(
 	if !vm.Status.Ready {
 		h.recifyProgressBeforeVMStart(restoreCpy)
 		message := "Waiting for target vm to be ready"
-		setCondition(restoreCpy, harvesterv1.BackupConditionProgressing, false, "", message)
+		setCondition(restoreCpy, harvesterv1.BackupConditionProgressing, true, "", message)
 		setCondition(restoreCpy, harvesterv1.BackupConditionReady, false, "", message)
 		if !reflect.DeepEqual(vmRestore, restoreCpy) {
 			if _, err := h.restores.Update(restoreCpy); err != nil {

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -208,7 +208,7 @@ func (v *virtualMachineBackupValidator) Delete(_ *types.Request, obj runtime.Obj
 			continue
 		}
 		if v1beta1.BackupConditionProgressing.IsTrue(vmRestore) {
-			return fmt.Errorf("vmrestore %s/%s is in progress", vmRestore.Namespace, vmRestore.Name)
+			return werror.NewBadRequest(fmt.Sprintf("vmrestore %s/%s is in progress", vmRestore.Namespace, vmRestore.Name))
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
When we restoring a VM, we set InProgress=false during volumes are ready and VM is not ready. The VM can run. However, if user removes the VMBackup, the VMRestore cannot reconcile correctly.

#### Solution:
Set InProgress=true even if the volumes are ready.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/6126

#### Test plan:
1. Create a VMBackup.
2. Create a VMRestore.
3. Wait for message "Waiting for target vm to be ready" and remove the VMBackup. The webhook should deny the request.
<img width="1305" height="634" alt="Screenshot 2025-11-25 at 3 56 41 PM" src="https://github.com/user-attachments/assets/71985b61-6667-4072-a5e3-ff2f985d6e06" />


#### Additional documentation or context
We found the issue during testing a refactor item. However, the issue is not from the refactor PR, because we don't change logic in https://github.com/harvester/harvester/commit/f192270c2bfc04d3fc99fe8051a6d2b929654c8d#diff-3255f37987feb6224175b7683e961f0e2b786f289cff7457f334ea16b0abbed7.
<img width="905" height="199" alt="Screenshot 2025-11-25 at 3 54 22 PM" src="https://github.com/user-attachments/assets/1ee598f7-e408-4e1a-8bd2-c2e969428dd9" />


