### PR TITLE
consistent maintenance mode strategy behavior

### DIFF
--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -542,11 +542,7 @@ func getUniqueVMSfromConditionMap(vms map[string][]string) []string {
 // - ShutdownAndRestartAfterDisable
 // - Shutdown
 func (ndc *ControllerHandler) listVMILabelMaintainModeStrategy(node *corev1.Node) ([]*kubevirtv1.VirtualMachineInstance, error) {
-	req, err := labels.NewRequirement(util.LabelMaintainModeStrategy, selection.In, []string{
-		util.MaintainModeStrategyShutdownAndRestartAfterEnable,
-		util.MaintainModeStrategyShutdownAndRestartAfterDisable,
-		util.MaintainModeStrategyShutdown,
-	})
+	req, err := labels.NewRequirement(util.LabelMaintainModeStrategy, selection.In, util.MaintainModeStrategyShutdownValues)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create selector to list VMIs that are to be administratively stopped before migration: %w", err)
 	}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -181,13 +181,32 @@ const (
 
 	RKEControlPlaneRoleLabel = "rke.cattle.io/control-plane-role"
 
-	LabelMaintainModeStrategy                          = prefix + "/maintain-mode-strategy"
-	AnnotationMaintainModeStrategyNodeName             = prefix + "/maintain-mode-strategy-node-name"
+	LabelMaintainModeStrategy              = prefix + "/maintain-mode-strategy"
+	AnnotationMaintainModeStrategyNodeName = prefix + "/maintain-mode-strategy-node-name"
+
 	MaintainModeStrategyMigrate                        = "Migrate"
 	MaintainModeStrategyShutdownAndRestartAfterEnable  = "ShutdownAndRestartAfterEnable"
 	MaintainModeStrategyShutdownAndRestartAfterDisable = "ShutdownAndRestartAfterDisable"
 	MaintainModeStrategyShutdown                       = "Shutdown"
+	MaintainModeStrategyDefault                        = MaintainModeStrategyMigrate
+)
 
+var (
+	MaintenanceModeStrategyValidValues = []string{
+		MaintainModeStrategyMigrate,
+		MaintainModeStrategyShutdownAndRestartAfterEnable,
+		MaintainModeStrategyShutdownAndRestartAfterDisable,
+		MaintainModeStrategyShutdown,
+	}
+
+	MaintainModeStrategyShutdownValues = []string{
+		MaintainModeStrategyShutdownAndRestartAfterEnable,
+		MaintainModeStrategyShutdownAndRestartAfterDisable,
+		MaintainModeStrategyShutdown,
+	}
+)
+
+const (
 	// s3 backup target constants
 	AWSAccessKey       = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey       = "AWS_SECRET_ACCESS_KEY"

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -155,20 +155,21 @@ func maintainModeStrategyFilter(pod corev1.Pod) drain.PodDeleteStatus {
 	// If this label is set, the Pod belongs to a VM. Otherwise we don't need to
 	// skip the Pod.
 	vmName, vmOk := pod.Labels[util.LabelVMName]
-
-	// Ignore Pods of VMs that should not be migrated in maintenance mode. These
-	// VMs are forcibly shut down when maintenance mode is activated.
-	value, ok := pod.Labels[util.LabelMaintainModeStrategy]
-	if vmOk && ok && slices.Contains(util.MaintainModeStrategyShutdownValues, value) {
-		logrus.WithFields(logrus.Fields{
-			"kind":                         "pod",
-			"namespace":                    pod.Namespace,
-			"pod_name":                     pod.Name,
-			util.LabelMaintainModeStrategy: value,
-			util.LabelVMName:               vmName,
-		}).Infof("migration of pod owned by VM %s is skipped because of the label %s with value %s",
-			vmName, util.LabelMaintainModeStrategy, value)
-		return drain.MakePodDeleteStatusSkip()
+	if vmOk {
+		// Ignore Pods of VMs that should not be migrated in maintenance mode. These
+		// VMs are forcibly shut down when maintenance mode is activated.
+		value, ok := pod.Labels[util.LabelMaintainModeStrategy]
+		if ok && slices.Contains(util.MaintainModeStrategyShutdownValues, value) {
+			logrus.WithFields(logrus.Fields{
+				"kind":                         "pod",
+				"namespace":                    pod.Namespace,
+				"pod_name":                     pod.Name,
+				util.LabelMaintainModeStrategy: value,
+				util.LabelVMName:               vmName,
+			}).Infof("migration of pod owned by VM %s is skipped because of the label %s with value %s",
+				vmName, util.LabelMaintainModeStrategy, value)
+			return drain.MakePodDeleteStatusSkip()
+		}
 	}
 	return drain.MakePodDeleteStatusOkay()
 }

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -638,6 +638,7 @@ func (v *vmValidator) checkMaintenanceModeStrategyIsValid(newVM, oldVM *kubevirt
 			"no maintenance-mode strategy for VM, behavior will be equivalent to default `%v`",
 			util.MaintainModeStrategyMigrate,
 		)
+		return nil
 	}
 
 	if oldVM != nil {

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -13,8 +13,244 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
+
+func TestCheckMaintenanceModeStrategyIsValid(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		expectError bool
+		oldVM       *kubevirtv1.VirtualMachine
+		newVM       *kubevirtv1.VirtualMachine
+	}{
+		{
+			name:        "accept new VM if maintenance mode strategy label is not set",
+			expectError: false,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "reject new VM if maintenance mode strategy label is set to invalid value",
+			expectError: true,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "reject update to VM if maintenance mode strategy label is invalid for new VM",
+			expectError: true,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: util.MaintainModeStrategyMigrate,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This case is crucial, so Harvester can still operate existing VMs with
+			// bogus maintenance-mode strategies (i.e. update their status, shut them
+			// down, etc.)
+			name:        "accept update to VM if maintenance mode strategy label was invalid on old VM",
+			expectError: false,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "accept update without maintenance mode strategy label, if VM did not have one before",
+			expectError: false,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This case ensures that IF the maintenance-mode label is updated, it is
+			// updated with a valid value
+			name:        "reject update to VM with invalid maintenance-mode strategy label, even if maintenance mode strategy label was invalid on old VM",
+			expectError: true,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "foobar",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "barfoo",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "accept removal of maintenance mode strategy label",
+			expectError: false,
+			oldVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: "migrate",
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "accept new VM maintenance mode strategy label is set to valid value",
+			expectError: false,
+			oldVM:       nil,
+			newVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						util.LabelMaintainModeStrategy: util.MaintainModeStrategyMigrate,
+					},
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	validator := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*vmValidator)
+
+	for _, tc := range testCases {
+		err := validator.checkMaintenanceModeStrategyIsValid(tc.newVM, tc.oldVM)
+		if tc.expectError {
+			assert.NotNil(t, err, tc.name)
+		} else {
+			assert.Nil(t, err, tc.name)
+		}
+	}
+}
 
 func Test_virtualMachineValidator_duplicateMacAddress(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
The Pod deletion filter identifies the Pods belonging to VMs, which need to be deleted during a node drain by looking at their maintenance-mode strategy label. The default value for this label is `Migrate`, which indicates that the Pod should be deleted during the node drain. Pods with an invalid label, i.e. where the value of the maintenance-mode strategy label is not one of:
  - Migrate
  - ShutdownAndRestartAfterEnable
  - ShutdownAndRestartAfterDisable
  - Shutdown are now also being treated with the default behavior. This fixes the problem that if a VM contains an invalied value in this label, nodes can become stuck in `Cordoned` state when transitioning to maintenance mode, as the node drain controller won't shut down the VM, but it's also not migrated away from the node. Therefore the VM keeps running, preventing the node from completely transitioning into maintenance mode.

Also adds a check to the validating webhook for the VirtualMachine resources.
This check also ensures that updates to virtual machines can not update the label to an invalid value that is none of the above mentioned.
However the check still alows VirtualMachines to be created without the maintenance mode strategy label, since external integrators like Rancher don't always set this label.

For backwards compatibility this webhook allows VirtualMachine updates to a VirtualMachine if the old VirtualMachine had an invalid maintenance mode strategy label and the new VirtualMachine does not change this label.
This case is crucial to allow existing VirtualMachines to continue working as expected. The webhook will emit a suitable log message.

related-to: #6835

#### Problem:

The scope of https://github.com/harvester/harvester/pull/9528 makes review too hard to complete in time for v1.7.0

#### Solution:

This PR contains a smaller and less controversial subset of the changes of PR#9528. This should make review easier and implement at least most of the necessary functionality.

#### Related Issue(s):

#6835

---

# Test plan:

## Scenario 1

Ensure that new VirtualMachines have a valid maintenance-mode strategy or none at all.

### Test 1

No maintenance-mode strategy given.

#### Setup:

Create a new VirtualMachine and specify no maintenance-mode strategy:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/creator: harvester
    harvesterhci.io/os: linux
  name: test
[...]
```

#### Expected Result

The creation of the VM should be accepted.

### Test 2

Valid maintenance-mode strategy given.

#### Setup:

Create a new VirtualMachine and specify a valid maintenance-mode strategy:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: Shutdown
    [...]
  name: test
[...]
```

#### Expected Result

The previously specified maintenance-mode strategy should be persisted in the VirtualMachine resource's metadata:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: Shutdown
    [...]
  name: test
[...]
```

## Scenario 2

If an invalid maintenance-mode strategy is specified, the VirtualMachine resource should be rejected.

### Test 1

Invalid maintenance-mode strategy given.

#### Setup:

Create a new VirtualMachine and specify an invalid maintenance-mode strategy:
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: foobar
    [...]
  name: test
[...]
```

#### Expected Result

The creation should be rejected with a sensible error message

```
The request is invalid: metadata.labels[harvesterhci.io/maintain-mode-strategy]: invalid maintenance mode strategy: foobar
```

## Scenario 3

Updates to a VirtualMachine should be allowed if the new maintenance mode strategy is valid.

### Test 1

Valid maintenance-mode strategy given.
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: Migrate
    [...]
  name: test
[...]
```

#### Expected Result

The maintenance mode strategy should be successfully updated to the new value

### Test 2

Invalid maintenance-mode strategy given.
```
type: kubevirt.io.virtualmachine
metadata:
  namespace: default
  labels:
    harvesterhci.io/maintain-mode-strategy: foobar
    [...]
  name: test
[...]
```

#### Expected Result

The update to the VirtualMachine should be rejected on the basis that the new maintenance mode strategy is invalid

## Scenario 4

Ensure that existing VMs don't break.

Setup:
- Install Harvester without this change
- Create one VirtualMachine (`testvm-no-label`) without a maintenance mode strategy label
- Create one VirtualMachine (`testvm-invalid-label`) with an invalid maintenance mode strategy label
- Update to Harvester with this change

### Test 1

Make an update to both VMs (`testvm-no-label`, `testvm-invalid-label`) that does not modify the maintenance mode strategy label

#### Expected Result

The updates to the VirtualMachines should be successfully accepted and applied

### Test 2

Update the maintenance mode strategy label on both VMs (`testvm-no-label`, `testvm-invalid-label`)  to a new invalid value.

#### Expected Result

The updates to the VirtualMachines should be rejected because the new maintenance mode strategy is invalid

### Test 3

Update the maintenance mode strategy label on both VMs (`testvm-no-label`, `testvm-invalid-label`)  to a new valid value.

#### Expected Result

The updates to the VirtualMachines should be successfully accepted and applied

#### Additional documentation or context
