### PR TITLE
feat: persist NetworkManager connection profiles on upgrade

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -539,7 +539,7 @@ generate_networkmanager_config() {
     if [ -n "$current_paths_line" ]; then
       if ! [[ "$current_paths_line" =~ "/var/lib/NetworkManager" ]]; then
         echo "Adding /var/lib/NetworkManager to PERSISTENT_STATE_PATHS in $CUSTOM90_FILE"
-        sed -i 's%PERSISTENT_STATE_PATHS:.*/var/lib/wicked%& /var/lib/NetworkManager%' $CUSTOM90_FILE
+        sed -i 's%PERSISTENT_STATE_PATHS:.*/var/lib/wicked%& /var/lib/NetworkManager /etc/NetworkManager%' $CUSTOM90_FILE
         local updated_paths_line=$(grep 'PERSISTENT_STATE_PATHS:.*/var/lib/wicked' $CUSTOM90_FILE)
         if ! [[ "$updated_paths_line" =~ "/var/lib/NetworkManager" ]]; then
           echo "Failed to add /var/lib/NetworkManager to PERSISTENT_STATE_PATHS in $CUSTOM90_FILE"
@@ -552,16 +552,9 @@ generate_networkmanager_config() {
     echo "File not found: $CUSTOM90_FILE"
   fi
 
-  # Just in case NetworkManager config has already been generated
-  # and/or potentially modified by the user, let's not overwrite it.
-  if [ -e ${HOST_DIR}/oem/91_networkmanager.yaml ]; then
-    echo "skipping NetworkManager config generation (${HOST_DIR}/oem/91_networkmanager.yaml already exists)"
-    return
-  fi
-
   echo "Generating NetworkManager config..."
   # Whether this succeeds or fails, it will print a message either way...
-  /usr/local/bin/harvester-installer generate-network-yaml --config ${HOST_DIR}/oem/harvester.config --cloud-init ${HOST_DIR}/oem/91_networkmanager.yaml 2>&1
+  /usr/local/bin/harvester-installer generate-network-config --config ${HOST_DIR}/oem/harvester.config --connection-path ${HOST_DIR}/usr/local/.state/etc-NetworkManager.bind/system-connections 2>&1
   # ...but because we're running with set -e, if the above fails, the script
   # will abort, and the rest of the OS upgrade will not proceed.  If that
   # happens, the upgrade job will probably be re-run indefinitely.  Is it


### PR DESCRIPTION
#### Problem:
See https://github.com/harvester/harvester-installer/pull/1201
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
See https://github.com/harvester/harvester-installer/pull/1201

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9581

#### Test plan:
- Install Harvester v1.6.0
- Upgrade to a version with this PR applied
- Make a network configuration change with `nmcli`
- Reboot, verify the change persists

#### Additional documentation or context
Note: in order to test this, you need to be build harvester using the rancher/harvester-installer image that's built from https://github.com/harvester/harvester-installer/pull/1201. My process for local testing looks like this:

- Do a build of harvester-installer
- Tag your rancher/harvester-installer:master image, and push it to a local repo
- Tweak the installer FROM line in package/upgrade/Dockerfile to point to your harvester-installer image
- Build harvester
- Build the ISO from harvester-installer, making sure it pulls in your local harvester-upgrade image

(This is all a PITA, there must be a better way)