### PR TITLE
fix(upgrade): only do early return when there is an error

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -259,9 +259,8 @@ const (
 	VirtualMachineCreatorNodeDriver = "docker-machine-driver-harvester"
 
 	// Addons
-	AddonPrefix                        = "addon." + prefix
-	AddonExperimentalLabel             = AddonPrefix + "/experimental"
-	AnnotationReenableDeschedulerAddon = prefix + "/reenableDeschedulerAddon"
+	AddonPrefix            = "addon." + prefix
+	AddonExperimentalLabel = AddonPrefix + "/experimental"
 
 	HarvesterUpgradeComponentRepo = "repo"
 )


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The upgrade controller does early return in `cleanup` function for multiple nodes cluster. After `cleanup` function, the controller sets label `"harvesterhci.io/upgradeCleanup=Succeeded"` and it will not get into `cleanup` function in next reconciliation. This makes controller cannot update upgrade-log and re-enable descheduler addon.

#### Solution:
Only return when there is error.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/2311
https://github.com/harvester/harvester/issues/8934

#### Test plan:
1. Create a 2-node v1.6.1 Harvester cluster.
2. Enable descheduler addon.
3. Upgrade to this PR.
4. Check the descheduler can be re-enable after upgrade.

#### Additional documentation or context
https://github.com/harvester/harvester/pull/8941
