### PR TITLE
Add webhook check upon addons when creating upgrade object

### DIFF
--- a/pkg/util/addon/addon.go
+++ b/pkg/util/addon/addon.go
@@ -1,0 +1,30 @@
+package addon
+
+import (
+	"fmt"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+)
+
+// the return string shows a meanful message when the second bool param is true
+// the return bool indicates where the addon is still under processing
+func IsAddonOnProcessing(addon *harvesterv1.Addon) (string, bool) {
+	if addon == nil {
+		return "", false
+	}
+	// when it is disabled
+	if !addon.Spec.Enabled {
+		// disabled, the AddonInitState means the addon is created and never enabled/disabled
+		if addon.Status.Status == harvesterv1.AddonDisabled || addon.Status.Status == harvesterv1.AddonInitState {
+			return "", false
+		}
+		// still on processing
+		return fmt.Sprintf("addon %s/%s is disabled but still on status %v", addon.Namespace, addon.Name, addon.Status.Status), true
+	}
+
+	// when it is  enabled
+	if addon.Status.Status == harvesterv1.AddonDeployed {
+		return "", false
+	}
+	return fmt.Sprintf("addon %s/%s is enabled but still on status %v", addon.Namespace, addon.Name, addon.Status.Status), true
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -90,6 +90,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineBackup().Cache()),
 		upgrade.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Addon().Cache(),
 			clients.Core.Node().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta2().Volume().Cache(),
 			clients.ClusterFactory.Cluster().V1beta1().Cluster().Cache(),


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

If any `addon` is in non-healthy status, it might affect following upgrade

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Block the upgrade if any `addons` is not in healthy status

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/9644


#### Test plan:
<!-- Describe the test plan by steps. -->

1. Use an invalid image/chart version to made the addon be in failure status
2. Prepare a version object which is with the same/later version 
3. Click `upgrade`, the webhook should block it

4. When all addons are in good status (enabled/disabled), upgrade can be created

Manually made the addon with an invalid chart version/image

<img width="1906" height="204" alt="image" src="https://github.com/user-attachments/assets/977899b8-30f6-4a85-99c6-b72c23caae19" />

```
    name: pcidevices-controller
    namespace: harvester-system
    resourceVersion: "1852262"
    uid: 8f325a42-8364-479a-a8c5-7631eba0c28b
  spec:
    chart: harvester-pcidevices-controller
    enabled: true
    repo: http://harvester-cluster-repo.cattle-system.svc/charts
    valuesContent: |
      image:
        tag: master-head
      fullnameOverride: harvester-pcidevices-controller
    version: 1.7.0-dev.1.2                    // invalid version
  status:
    conditions:
    - lastUpdateTime: "2025-11-27T11:46:05Z"
      status: "False"
      type: Completed
    - lastUpdateTime: "2025-11-27T11:49:20Z"
      status: "False"
      type: InProgress
    - lastUpdateTime: "2025-11-27T11:49:20Z"
      message: addon deployment job helm-install-pcidevices-controller failed
      reason: Error
      status: "True"
      type: OperationFailed
    status: AddonEnabling
```

Upgrade is blocked

<img width="1508" height="1102" alt="image" src="https://github.com/user-attachments/assets/74412e5e-10fd-4f75-92b1-7cdd16d474ba" />


When `rancher-monitoring` addon is on `enabling` (normal processing)

<img width="1500" height="496" alt="image" src="https://github.com/user-attachments/assets/2adaae21-bafa-436a-81c2-d75cdba5bbc8" />

When `rancher-monitoring` addon is on `disabling`  (normal processing)

<img width="1500" height="576" alt="image" src="https://github.com/user-attachments/assets/b4c1ff05-0241-4b3a-aa7f-4ca49fe4fc99" />


When all addons are in good state, upgrade can be created.
```
$ kubectl get upgrade.harvesterhci -A
NAMESPACE          NAME                 AGE
harvester-system   hvst-upgrade-48bmt   19s

$ kubectl delete upgrade.harvesterhci -n harvester-system hvst-upgrade-48bmt
upgrade.harvesterhci.io "hvst-upgrade-48bmt" deleted from harvester-system namespace
```


#### Additional documentation or context

Some related issues and PRs:

https://github.com/harvester/harvester/issues/9289
https://github.com/harvester/harvester/pull/9471