### PR TITLE
Align the checking for addVolume operation

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -54,6 +54,7 @@ const (
 
 type vmformatter struct {
 	vmiCache      ctlkubevirtv1.VirtualMachineInstanceCache
+	vmCache       ctlkubevirtv1.VirtualMachineCache
 	pvcCache      ctlcorev1.PersistentVolumeClaimCache
 	nodeCache     ctlcorev1.NodeCache
 	scCache       ctlstoragev1.StorageClassCache

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -106,6 +106,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	vmformatter := vmformatter{
 		pvcCache:      pvcs.Cache(),
 		vmiCache:      vmis.Cache(),
+		vmCache:       vms.Cache(),
 		nodeCache:     nodes.Cache(),
 		scCache:       storageClasses.Cache(),
 		vmBackupCache: backups.Cache(),

--- a/pkg/indexeres/indexer.go
+++ b/pkg/indexeres/indexer.go
@@ -55,6 +55,7 @@ func Setup(ctx context.Context, _ *server.Server, _ *server.Controllers, _ confi
 
 	vmInformer := management.VirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmInformer.AddIndexer(indexeresutil.VMByPVCIndex, indexeresutil.VMByPVC)
+	vmInformer.AddIndexer(indexeresutil.VMByNonShareablePVCIndex, indexeresutil.VMByNonShareablePVC)
 
 	scInformer := management.StorageFactory.Storage().V1().StorageClass().Cache()
 	scInformer.AddIndexer(indexeresutil.StorageClassBySecretIndex, indexeresutil.StorageClassBySecret)

--- a/pkg/util/indexeres/virtualmachine.go
+++ b/pkg/util/indexeres/virtualmachine.go
@@ -1,6 +1,8 @@
 package indexeres
 
 import (
+	"slices"
+
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/ref"
@@ -8,8 +10,9 @@ import (
 
 // The file contains the indexers which are used by controller and webhook.
 const (
-	VMByPVCIndex        = "harvesterhci.io/vm-by-pvc"
-	VMByHotplugPVCIndex = "harvesterhci.io/vm-by-hp-pvc"
+	VMByPVCIndex             = "harvesterhci.io/vm-by-pvc"
+	VMByHotplugPVCIndex      = "harvesterhci.io/vm-by-hp-pvc"
+	VMByNonShareablePVCIndex = "harvesterhci.io/vm-by-non-shareable-pvc"
 )
 
 func VMByPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
@@ -40,6 +43,31 @@ func VMByHotplugPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
 	var results []string
 	for _, volume := range obj.Spec.Template.Spec.Volumes {
 		if isVolumeHotplugged(volume) {
+			results = append(results, ref.Construct(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
+		}
+	}
+	return results, nil
+}
+
+func VMByNonShareablePVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
+	var results []string
+	if obj == nil || obj.Spec.Template == nil {
+		return results, nil
+	}
+
+	nonShareableDisks := []string{}
+	for _, disk := range obj.Spec.Template.Spec.Domain.Devices.Disks {
+		// default is non-shareable
+		if disk.Shareable != nil && *disk.Shareable {
+			continue
+		}
+		nonShareableDisks = append(nonShareableDisks, disk.Name)
+	}
+
+	for _, volume := range obj.Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil &&
+			volume.PersistentVolumeClaim.ClaimName != "" &&
+			slices.Contains(nonShareableDisks, volume.Name) {
 			results = append(results, ref.Construct(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
 		}
 	}

--- a/pkg/webhook/indexeres/indexer.go
+++ b/pkg/webhook/indexeres/indexer.go
@@ -56,6 +56,7 @@ func RegisterIndexers(clients *clients.Clients) {
 	vmInformer := clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache()
 	vmInformer.AddIndexer(indexeresutil.VMByPVCIndex, indexeresutil.VMByPVC)
 	vmInformer.AddIndexer(indexeresutil.VMByHotplugPVCIndex, indexeresutil.VMByHotplugPVC)
+	vmInformer.AddIndexer(indexeresutil.VMByNonShareablePVCIndex, indexeresutil.VMByNonShareablePVC)
 
 	svmBackupCache := clients.HarvesterFactory.Harvesterhci().V1beta1().ScheduleVMBackup().Cache()
 	svmBackupCache.AddIndexer(ScheduleVMBackupBySourceVM, scheduleVMBackupBySourceVM)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
While UI relaxes the add volume filter with issue https://github.com/harvester/harvester/issues/9604, we need to align the webhook validator to have a better UX.

#### Solution:
Use the same validator for both webhook/api side

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9604

#### Test plan:
1. create 3 node cluster with v1.7.0-rc3
2. update the UI settings to use latest UI
3. create two VM and one volume
4. The addVolume can find the volume, but it would fail with the second try.

#### Additional documentation or context
