### PR TITLE
Fix harvester crash when performing cdi vmimage download

### DIFF
--- a/pkg/api/image/schema.go
+++ b/pkg/api/image/schema.go
@@ -26,7 +26,10 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, _ config.Optio
 	vmImageDownloader := scaled.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImageDownloader()
 	scClient := scaled.StorageFactory.Storage().V1().StorageClass()
 
-	vmio := common.GetVMIOperator(vmi, vmi.Cache(), http.Client{})
+	vmio, err := common.GetVMIOperator(vmi, vmi.Cache(), http.Client{})
+	if err != nil {
+		return err
+	}
 	downloaders := map[harvesterv1.VMIBackend]backend.Downloader{
 		harvesterv1.VMIBackendBackingImage: backingimage.GetDownloader(bi.Cache(), http.Client{}, vmio),
 		harvesterv1.VMIBackendCDI:          cdi.GetDownloader(vmImageDownloader, http.Client{}, vmio),

--- a/pkg/controller/master/image/register.go
+++ b/pkg/controller/master/image/register.go
@@ -25,7 +25,10 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	secrets := management.CoreFactory.Core().V1().Secret()
 	ctlcdi := management.CdiFactory.Cdi().V1beta1().DataVolume()
 
-	vmio := common.GetVMIOperator(vmi, nil, http.Client{Timeout: 15 * time.Second})
+	vmio, err := common.GetVMIOperator(vmi, vmi.Cache(), http.Client{Timeout: 15 * time.Second})
+	if err != nil {
+		return err
+	}
 	backends := map[harvesterv1.VMIBackend]backend.Backend{
 		harvesterv1.VMIBackendBackingImage: backingimage.GetBackend(
 			ctx, sc, sc.Cache(),

--- a/pkg/image/common/operator.go
+++ b/pkg/image/common/operator.go
@@ -95,8 +95,14 @@ type vmiOperator struct {
 	httpClient http.Client
 }
 
-func GetVMIOperator(client ctlharvesterv1.VirtualMachineImageClient, cache ctlharvesterv1.VirtualMachineImageCache, httpClient http.Client) VMIOperator {
-	return &vmiOperator{client, cache, httpClient}
+func GetVMIOperator(client ctlharvesterv1.VirtualMachineImageClient, cache ctlharvesterv1.VirtualMachineImageCache, httpClient http.Client) (VMIOperator, error) {
+	if client == nil {
+		return nil, fmt.Errorf("failed to get VMI operator: client is nil")
+	}
+	if cache == nil {
+		return nil, fmt.Errorf("failed to get VMI operator: cache is nil")
+	}
+	return &vmiOperator{client, cache, httpClient}, nil
 }
 
 func (vmio *vmiOperator) UpdateVMI(oldVMI, newVMI *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {


### PR DESCRIPTION
#### Problem:

https://github.com/harvester/harvester/blob/master/pkg/controller/master/image/register.go#L28 send nil vmi cache and cause harvester crash when entering the retry mechanism implemented in https://github.com/harvester/harvester/commit/feef4a1e1e787da814af7570521a989b62745ff0

#### Solution:

#### Related Issue(s):

#### Test plan:
- test lhv2 download vmiage
- test lhv2 upload vmimage
<img width="1488" height="534" alt="截圖 2025-12-01 晚上11 35 43" src="https://github.com/user-attachments/assets/830069d7-073c-4b73-a240-d53c5745a472" />

#### Additional documentation or context
