### PR TITLE
charts: add `repository` to patch image

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -504,6 +504,7 @@ longhorn:
     # patch the hotfix image for longhorn manager
     longhorn:
       manager:
+        repository: longhornio/longhorn-manager
         tag: v1.10.1-hotfix-1
 
   # after upgrade to longhorn 1.6.0, we need to set the priorityClass for longhorn-manager, longhorn-driver and longhorn-ui


### PR DESCRIPTION
    - that we can ensure the image can be packaged into ISO

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Missing the Longhorn hotfix image.

#### Solution:
Add the `repository` to patched image

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9664

#### Test plan:
Ensure we have `longhornio/longhorn-manager:v1.10.1-hotfix-1` on image list

#### Additional documentation or context
