### PR TITLE
feat(upgrade): add descheduler addon

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1081,6 +1081,8 @@ upgrade_addons()
     upgrade_addon $addon "harvester-system"
   done
 
+  upgrade_addon descheduler "kube-system"
+
   # the rancher-monitoring and rancher-logging addon have flexible user-configurable fields
   # from v1.2.0, they are upgraded per following
   upgrade_addon_rancher_monitoring


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Upgrade from v1.6.1 to v1.7.0 doesn't see descheduler addon.

#### Solution:
Apply descheduler addon during upgrade.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9697

#### Test plan:
1. Create a v1.6.1 cluster.
2. Upgrade to this branch.
3. There is descheduler addon.
