### PR TITLE
fix(api-ui): add api-ui folder path

### DIFF
--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -94,7 +94,7 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	vueUI := ui.Vue
 	m.Handle("/dashboard/", vueUI.IndexFile())
 	m.PathPrefix("/dashboard/").Handler(vueUI.IndexFileOnNotFound())
-	m.PathPrefix("/api-ui").Handler(vueUI.ServeAsset())
+	m.PathPrefix("/api-ui").Handler(vueUI.ServeAsset("api-ui"))
 
 	if r.options.RancherURL != "" {
 		host, scheme, err := parseRancherServerURL(r.options.RancherURL)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
When clicking "View in API", the web page shows that `/api-ui/ui.min.js` is not found. This path is served as file server on `ui-path` setting (the default value is `/usr/share/harvester/harvester`). Files in this path are packaged in harvester image.

https://github.com/harvester/harvester/blob/0c47c9c8905e2e2982de564e762a444d58facf92/package/Dockerfile#L33-L42

I check the running container. There're files in `/usr/share/harvester/harvester`. However, the API shows 404 not found. That means the error is in server handler. The last change for `pkg/server/ui/ui.go` was three years ago. I'm not sure why it's broken in Harvester v1.7.0.

#### Solution:
When users get `/api-ui/ui.min.js`, the server handler only retrieves `ui.min.js`, not `api-ui/ui.min.js`. Change the API handler to serve files on `/usr/share/harvester/harvester/api-ui` to fix the error.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9614

#### Test plan:
Use Harvester dashboard to check "View in API" on any resource.

#### Additional documentation or context
