### PR TITLE
fix: should also check KubeVirt's condition for LiveMigratable

### DIFF
--- a/pkg/util/virtualmachineinstance/virtualmachineinstance.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance.go
@@ -99,6 +99,13 @@ func ValidateVMMigratable(vmi *kubevirtv1.VirtualMachineInstance) error {
 		return fmt.Errorf("VM %s is not live migratable as CD-ROM or container disk is set", vmiNamespacedName)
 	}
 
+	// Lastly, check the condition reported by KubeVirt
+	for _, cond := range vmi.Status.Conditions {
+		if cond.Type == kubevirtv1.VirtualMachineInstanceIsMigratable && cond.Status == corev1.ConditionFalse {
+			return fmt.Errorf("VM %s is not live migratable as the condition reported with reason: %s", vmiNamespacedName, cond.Reason)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/util/virtualmachineinstance/virtualmachineinstance.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance.go
@@ -101,7 +101,10 @@ func ValidateVMMigratable(vmi *kubevirtv1.VirtualMachineInstance) error {
 
 	// Lastly, check the condition reported by KubeVirt
 	for _, cond := range vmi.Status.Conditions {
-		if cond.Type == kubevirtv1.VirtualMachineInstanceIsMigratable && cond.Status == corev1.ConditionFalse {
+		if cond.Type == kubevirtv1.VirtualMachineInstanceIsMigratable {
+			if cond.Status != corev1.ConditionFalse {
+				break
+			}
 			return fmt.Errorf("VM %s is not live migratable as the condition reported with reason: %s", vmiNamespacedName, cond.Reason)
 		}
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

VMs with bridge-bonded management network should not be able to be migrated/hotplugged.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Since KubeVirt provides the LiveMigratable condition in the status of VM/VMI CRD, we should check it in `ValidateVMMigratable`.

#### Related Issue(s):

#9630 

#### Test plan:
<!-- Describe the test plan by steps. -->

- Follow https://github.com/harvester/harvester/issues/9630#issue-3667712868, and the both actions `Hotplug Network Interface` and `Migrate` shouldn't be there.
- Follow the recording in https://github.com/harvester/harvester/issues/9630#issuecomment-3584430925, and the both actions `Hotplug Network Interface` and `Migrate` shouldn't be there.

#### Additional documentation or context

https://github.com/harvester/harvester/issues/9630#issuecomment-3584564806
