### PR TITLE
Allow aborting of pending migrations

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -552,16 +552,18 @@ func (h *vmActionHandler) abortMigration(namespace, name string) error {
 }
 
 func isVmimAbortable(vmim *kubevirtv1.VirtualMachineInstanceMigration) bool {
-	if vmim.Status.Phase == kubevirtv1.MigrationPhaseUnset ||
-		vmim.Status.Phase == kubevirtv1.MigrationPending ||
-		vmim.Status.Phase == kubevirtv1.MigrationScheduling ||
-		vmim.Status.Phase == kubevirtv1.MigrationScheduled ||
-		vmim.Status.Phase == kubevirtv1.MigrationPreparingTarget ||
-		vmim.Status.Phase == kubevirtv1.MigrationTargetReady ||
-		vmim.Status.Phase == kubevirtv1.MigrationRunning {
+	switch vmim.Status.Phase {
+	case kubevirtv1.MigrationPhaseUnset,
+		kubevirtv1.MigrationPending,
+		kubevirtv1.MigrationScheduling,
+		kubevirtv1.MigrationScheduled,
+		kubevirtv1.MigrationPreparingTarget,
+		kubevirtv1.MigrationTargetReady,
+		kubevirtv1.MigrationRunning:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func (h *vmActionHandler) findMigratableNodes(rw http.ResponseWriter, namespace, name string) error {

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -538,7 +538,7 @@ func (h *vmActionHandler) abortMigration(namespace, name string) error {
 	migrationUID := getMigrationUID(vmi)
 	for _, vmim := range vmims {
 		if migrationUID == string(vmim.UID) {
-			if !vmim.IsRunning() && vmim.Status.Phase != kubevirtv1.MigrationPending {
+			if !isVmimAbortable(vmim) {
 				return fmt.Errorf("cannot abort the migration as it is in %q phase", vmim.Status.Phase)
 			}
 			// Migration is aborted by deleting the VMIM object
@@ -549,6 +549,19 @@ func (h *vmActionHandler) abortMigration(namespace, name string) error {
 		}
 	}
 	return nil
+}
+
+func isVmimAbortable(vmim *kubevirtv1.VirtualMachineInstanceMigration) bool {
+	if vmim.Status.Phase == kubevirtv1.MigrationPhaseUnset ||
+		vmim.Status.Phase == kubevirtv1.MigrationPending ||
+		vmim.Status.Phase == kubevirtv1.MigrationScheduling ||
+		vmim.Status.Phase == kubevirtv1.MigrationScheduled ||
+		vmim.Status.Phase == kubevirtv1.MigrationPreparingTarget ||
+		vmim.Status.Phase == kubevirtv1.MigrationTargetReady ||
+		vmim.Status.Phase == kubevirtv1.MigrationRunning {
+		return true
+	}
+	return false
 }
 
 func (h *vmActionHandler) findMigratableNodes(rw http.ResponseWriter, namespace, name string) error {

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -538,7 +538,7 @@ func (h *vmActionHandler) abortMigration(namespace, name string) error {
 	migrationUID := getMigrationUID(vmi)
 	for _, vmim := range vmims {
 		if migrationUID == string(vmim.UID) {
-			if !vmim.IsRunning() {
+			if !vmim.IsRunning() && vmim.Status.Phase != kubevirtv1.MigrationPending {
 				return fmt.Errorf("cannot abort the migration as it is in %q phase", vmim.Status.Phase)
 			}
 			// Migration is aborted by deleting the VMIM object

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -422,6 +422,47 @@ func TestAbortMigrateAction(t *testing.T) {
 				err:                  nil,
 			},
 		},
+		{
+			name: "Abort VMI migration successfully in pending state",
+			given: input{
+				namespace: "default",
+				name:      "test",
+				vmInstance: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test",
+						Annotations: map[string]string{
+							util.AnnotationMigrationTarget: "test-uid",
+							util.AnnotationMigrationState:  migration.StatePending,
+						},
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Phase: kubevirtv1.Running,
+						MigrationState: &kubevirtv1.VirtualMachineInstanceMigrationState{
+							Completed:    false,
+							MigrationUID: "test-uid",
+						},
+					},
+				},
+				vmInstanceMigration: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-migration",
+						UID:       "test-uid",
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{
+						VMIName: "test",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+					},
+				},
+			},
+			expected: output{
+				vmInstanceMigrations: []*kubevirtv1.VirtualMachineInstanceMigration{},
+				err:                  nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -873,16 +914,16 @@ func Test_isVmNetworkHotpluggable(t *testing.T) {
 			given: input{
 				nad: &cniv1.NetworkAttachmentDefinition{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "vm-migration-network-rqmmg",
+						Name:      "vm-migration-network-rqmmg",
 						Namespace: "harvester-system",
 						Annotations: map[string]string{
 							"vm-migration-network.settings.harvesterhci.io": "true",
 						},
 						Labels: map[string]string{
-							"network.harvesterhci.io/clusternetwork": "migration",
-							"network.harvesterhci.io/ready": "true",
-							"network.harvesterhci.io/type": "L2VlanNetwork",
-							"network.harvesterhci.io/vlan-id": "1",
+							"network.harvesterhci.io/clusternetwork":             "migration",
+							"network.harvesterhci.io/ready":                      "true",
+							"network.harvesterhci.io/type":                       "L2VlanNetwork",
+							"network.harvesterhci.io/vlan-id":                    "1",
 							"vm-migration-network.settings.harvesterhci.io/hash": "194c07126764f0ebcd996eee3c7c4c0735fa3145",
 						},
 					},
@@ -900,16 +941,16 @@ func Test_isVmNetworkHotpluggable(t *testing.T) {
 			given: input{
 				nad: &cniv1.NetworkAttachmentDefinition{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "storagenetwork-bz9vj",
+						Name:      "storagenetwork-bz9vj",
 						Namespace: "harvester-system",
 						Annotations: map[string]string{
 							"storage-network.settings.harvesterhci.io": "true",
 						},
 						Labels: map[string]string{
-							"network.harvesterhci.io/clusternetwork": "storage",
-							"network.harvesterhci.io/ready": "true",
-							"network.harvesterhci.io/type": "L2VlanNetwork",
-							"network.harvesterhci.io/vlan-id": "99",
+							"network.harvesterhci.io/clusternetwork":        "storage",
+							"network.harvesterhci.io/ready":                 "true",
+							"network.harvesterhci.io/type":                  "L2VlanNetwork",
+							"network.harvesterhci.io/vlan-id":               "99",
 							"storage-network.settings.harvesterhci.io/hash": "c8c41cfbdc1a85e7cbd0d3204b441fd13cc109e3",
 						},
 					},


### PR DESCRIPTION
Allowing aborting migrations in pending state. As well as kubevirt's definition of running migration. Covered the addition with test case.

#### Problem:
Migration stuck in `Pending` state cannot be aborted.

#### Solution:
Allow aborting migration in that state by adding it as addition to the check.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9435

#### Test plan:

<details>
  <summary>1. On 2 node harvester cluster each node built with this change:</summary>

<img width="1283" height="1064" alt="image" src="https://github.com/user-attachments/assets/74778cf3-8d24-4926-8a80-798526a361d7" />
</details>

2. Created 3 VMs on `node-1`

<details>
  <summary>3. Migrated all 3 on `node-2` where we allow only 2 migrations at once so 1 was stuck in Pending state</summary>

<img width="2298" height="429" alt="image" src="https://github.com/user-attachments/assets/0cf24f6b-a128-4174-b1fd-28105f3f8136" />
</details>

<details>
  <summary>4. Was able to abort migration of the third VM which was pending migration of the other 2</summary>

<img width="2298" height="429" alt="image" src="https://github.com/user-attachments/assets/67c226f7-a841-4b99-931a-9e20c5c89b2c" />
</details>



#### Additional documentation or context
N/A