### PR TITLE
Ignore deleting vmimage in storage class validator

### DIFF
--- a/pkg/webhook/resources/storageclass/validator.go
+++ b/pkg/webhook/resources/storageclass/validator.go
@@ -322,7 +322,9 @@ func (v *storageClassValidator) validateVMImageUsage(sc *storagev1.StorageClass)
 
 	usedVMImages := make([]string, 0, len(vmimages))
 	for _, vmimage := range vmimages {
-		usedVMImages = append(usedVMImages, vmimage.Name)
+		if vmimage.DeletionTimestamp == nil {
+			usedVMImages = append(usedVMImages, vmimage.Name)
+		}
 	}
 
 	if len(usedVMImages) > 0 {


### PR DESCRIPTION
#### Problem:

StorageClass validator blocks the storage class deletion even if its related vm image is marked as deleting.

This is a problem when we perform the following operation sequentially:
1. delete vmimage
2. delete the storage class that relates to the vmimage

In step 1 k8s marks vmimage as deleting, but the vm image has not been fully removed yet, then step 2 fails because the storage class validate treat it as still in-use.

#### Solution:

ignore deleting vm images in storage class validator

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9720

#### Test plan:
well-described in issue description, see https://github.com/harvester/harvester/issues/9720

https://github.com/user-attachments/assets/26833d86-7d30-48de-aa70-339edc0c9186

#### Additional documentation or context
