### PR TITLE
feat: check whether vms use hostdevice or gpu before disbling pcidevices-controller and nvidia-driver-toolkit

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -39,8 +39,9 @@ const (
 	AnnotationMacAddressName            = prefix + "/mac-address"
 	AnnotationEnableCPUAndMemoryHotplug = prefix + "/enableCPUAndMemoryHotplug"
 
-	AnnotationSkipRancherLoggingAddonWebhookCheck = prefix + "/skipRancherLoggingAddonWebhookCheck"
-	AnnotationSkipDeschedulerAddonWebhookCheck    = prefix + "/skipDeschedulerAddonWebhookCheck"
+	AnnotationSkipRancherLoggingAddonWebhookCheck       = prefix + "/skipRancherLoggingAddonWebhookCheck"
+	AnnotationSkipDeschedulerAddonWebhookCheck          = prefix + "/skipDeschedulerAddonWebhookCheck"
+	AnnotationSkipPCIDevicesControllerAddonWebhookCheck = prefix + "/skipPCIDevicesControllerAddonWebhookCheck"
 
 	// AnnotationSkipResourceQuotaAutoScaling is used to disable to resourcequota auto scaling
 	AnnotationSkipResourceQuotaAutoScaling = prefix + "/skipResourceQuotaAutoScaling"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -42,6 +42,7 @@ const (
 	AnnotationSkipRancherLoggingAddonWebhookCheck       = prefix + "/skipRancherLoggingAddonWebhookCheck"
 	AnnotationSkipDeschedulerAddonWebhookCheck          = prefix + "/skipDeschedulerAddonWebhookCheck"
 	AnnotationSkipPCIDevicesControllerAddonWebhookCheck = prefix + "/skipPCIDevicesControllerAddonWebhookCheck"
+	AnnotationSkipNvidiaDriverToolkitAddonWebhookCheck  = prefix + "/skipNvidiaDriverToolkitAddonWebhookCheck"
 
 	// AnnotationSkipResourceQuotaAutoScaling is used to disable to resourcequota auto scaling
 	AnnotationSkipResourceQuotaAutoScaling = prefix + "/skipResourceQuotaAutoScaling"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -103,6 +103,8 @@ const (
 	HarvesterSystemNamespaceName        = "harvester-system"
 	RancherLoggingName                  = "rancher-logging"
 	DeschedulerName                     = "descheduler"
+	PCIDevicesControllerName            = "pcidevices-controller"
+	NvidiaDriverToolkitName             = "nvidia-driver-toolkit"
 	RancherMonitoringPrometheus         = "rancher-monitoring-prometheus"
 	RancherMonitoringAlertmanager       = "rancher-monitoring-alertmanager"
 	RancherMonitoring                   = "rancher-monitoring"

--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -314,16 +314,17 @@ func (v *addonValidator) validatePCIDevicesControllerAddon() error {
 
 	var vmsWithDevices []string
 	for _, vm := range vms {
-		if vm.Spec.Template != nil {
-			// Check for HostDevices (PCI devices and USB devices)
-			if len(vm.Spec.Template.Spec.Domain.Devices.HostDevices) > 0 {
-				vmsWithDevices = append(vmsWithDevices, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
-				continue
-			}
-			// Check for GPUs (vGPU devices)
-			if len(vm.Spec.Template.Spec.Domain.Devices.GPUs) > 0 {
-				vmsWithDevices = append(vmsWithDevices, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
-			}
+		if vm.Spec.Template == nil {
+			continue
+		}
+		// Check for HostDevices (PCI devices and USB devices)
+		if len(vm.Spec.Template.Spec.Domain.Devices.HostDevices) > 0 {
+			vmsWithDevices = append(vmsWithDevices, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
+			continue
+		}
+		// Check for GPUs (vGPU devices)
+		if len(vm.Spec.Template.Spec.Domain.Devices.GPUs) > 0 {
+			vmsWithDevices = append(vmsWithDevices, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
 		}
 	}
 
@@ -343,11 +344,12 @@ func (v *addonValidator) validateNvidiaDriverToolkitAddon() error {
 
 	var vmsWithGPUs []string
 	for _, vm := range vms {
-		if vm.Spec.Template != nil {
-			// Check for GPUs (vGPU devices and SR-IOV GPU devices)
-			if len(vm.Spec.Template.Spec.Domain.Devices.GPUs) > 0 {
-				vmsWithGPUs = append(vmsWithGPUs, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
-			}
+		if vm.Spec.Template == nil {
+			continue
+		}
+		// Check for GPUs (vGPU devices and SR-IOV GPU devices)
+		if len(vm.Spec.Template.Spec.Domain.Devices.GPUs) > 0 {
+			vmsWithGPUs = append(vmsWithGPUs, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
 		}
 	}
 

--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -177,7 +177,7 @@ func (v *addonValidator) validateDeschedulerAddonUpdate(newAddon *v1beta1.Addon,
 func (v *addonValidator) validatePCIDevicesControllerAddonUpdate(newAddon *v1beta1.Addon, oldAddon *v1beta1.Addon) error {
 	// check when pcidevices-controller addon is being disabled
 	if oldAddon.Spec.Enabled && !newAddon.Spec.Enabled {
-		return v.validatePCIDevicesControllerAddon(newAddon)
+		return v.validatePCIDevicesControllerAddon()
 	}
 	return nil
 }
@@ -185,7 +185,7 @@ func (v *addonValidator) validatePCIDevicesControllerAddonUpdate(newAddon *v1bet
 func (v *addonValidator) validateNvidiaDriverToolkitAddonUpdate(newAddon *v1beta1.Addon, oldAddon *v1beta1.Addon) error {
 	// check when nvidia-driver-toolkit addon is being disabled
 	if oldAddon.Spec.Enabled && !newAddon.Spec.Enabled {
-		return v.validateNvidiaDriverToolkitAddon(newAddon)
+		return v.validateNvidiaDriverToolkitAddon()
 	}
 	return nil
 }
@@ -305,7 +305,7 @@ func (v *addonValidator) validateDeschedulerAddon(newAddon *v1beta1.Addon) error
 	return nil
 }
 
-func (v *addonValidator) validatePCIDevicesControllerAddon(newAddon *v1beta1.Addon) error {
+func (v *addonValidator) validatePCIDevicesControllerAddon() error {
 	// Check if any VMs are using HostDevices (PCI devices, USB devices) or GPUs (vGPU devices)
 	vms, err := v.vmCache.List(metav1.NamespaceAll, labels.Everything())
 	if err != nil {
@@ -334,7 +334,7 @@ func (v *addonValidator) validatePCIDevicesControllerAddon(newAddon *v1beta1.Add
 	return nil
 }
 
-func (v *addonValidator) validateNvidiaDriverToolkitAddon(newAddon *v1beta1.Addon) error {
+func (v *addonValidator) validateNvidiaDriverToolkitAddon() error {
 	// Check if any VMs are using GPUs (vGPU devices and SR-IOV GPU devices)
 	vms, err := v.vmCache.List(metav1.NamespaceAll, labels.Everything())
 	if err != nil {

--- a/pkg/webhook/resources/addon/validator_test.go
+++ b/pkg/webhook/resources/addon/validator_test.go
@@ -1922,7 +1922,7 @@ func Test_validatePCIDevicesControllerAddon(t *testing.T) {
 			}
 
 			// Test the validation
-			err := validator.validatePCIDevicesControllerAddon(nil)
+			err := validator.validatePCIDevicesControllerAddon()
 			if tc.expectedError {
 				assert.NotNil(t, err, tc.name)
 			} else {
@@ -2121,7 +2121,7 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 			}
 
 			// Test the validation
-			err := validator.validateNvidiaDriverToolkitAddon(nil)
+			err := validator.validateNvidiaDriverToolkitAddon()
 			if tc.expectedError {
 				assert.NotNil(t, err, tc.name)
 			} else {

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -174,6 +174,7 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 			clients.LoggingFactory.Logging().V1beta1().ClusterOutput().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().UpgradeLog().Cache(),
 			clients.Core.Node().Cache(),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 		),
 		version.NewValidator(),
 		volumesnapshot.NewValidator(


### PR DESCRIPTION
#### Problem:
When disabling pcidevices-controller and  nvidia-driver-toolkit, we don't check whether VMs use it or not. 

#### Solution:
We need to check whether VMs use it or not. For the Intuitive way, we can directly check `vm.spec`.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9531

#### Test plan:

#### case1 - pcidevices-controller

1. Enable pcidevices-controller
2. Start a VM with passthrough pcidevices / usbdevices
3. Disable pcidevices-controller

#### case2 - nvidia-driver-toolkit

1. Enable pcidevices-controller and nvidia-driver-toolkit
2. Enable SR-IOV GPU or MIG GPU
3. Start a VM with passthrough vGPU
4. Disable pcidevices-controller and nvidia-driver-toolkit

Both cases should pop up a rejected response like this:

<img width="547" height="163" alt="image" src="https://github.com/user-attachments/assets/d0e28e1f-770a-4c4b-9562-ecee2e2b6838" />

#### Additional documentation or context
