### PR TITLE
Builder: Add Disk Cache Mode, Errors and Tests

### DIFF
--- a/pkg/builder/disk.go
+++ b/pkg/builder/disk.go
@@ -91,6 +91,23 @@ func (v *VMBuilder) Disk(diskName, diskBus string, isCDRom bool, bootOrder uint)
 	return v
 }
 
+func (v *VMBuilder) DiskCacheMode(name string, mode kubevirtv1.DriverCache) *VMBuilder {
+	diskFound := false
+
+	for i, disk := range v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Disks {
+		if disk.Name == name {
+			v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Disks[i].Cache = mode
+			diskFound = true
+		}
+	}
+
+	if !diskFound {
+		v.Error = fmt.Errorf("disk %s does not exist in VM %s", name, v.VirtualMachine.Name)
+	}
+
+	return v
+}
+
 func (v *VMBuilder) Volume(diskName string, volume kubevirtv1.Volume) *VMBuilder {
 	var (
 		exist   bool

--- a/pkg/builder/disk.go
+++ b/pkg/builder/disk.go
@@ -92,19 +92,14 @@ func (v *VMBuilder) Disk(diskName, diskBus string, isCDRom bool, bootOrder uint)
 }
 
 func (v *VMBuilder) DiskCacheMode(name string, mode kubevirtv1.DriverCache) *VMBuilder {
-	diskFound := false
-
 	for i, disk := range v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Disks {
 		if disk.Name == name {
 			v.VirtualMachine.Spec.Template.Spec.Domain.Devices.Disks[i].Cache = mode
-			diskFound = true
+			return v
 		}
 	}
 
-	if !diskFound {
-		v.Error = fmt.Errorf("disk %s does not exist in VM %s", name, v.VirtualMachine.Name)
-	}
-
+	v.Error = fmt.Errorf("disk %s does not exist in VM %s", name, v.VirtualMachine.Name)
 	return v
 }
 

--- a/pkg/builder/disk_test.go
+++ b/pkg/builder/disk_test.go
@@ -1,0 +1,83 @@
+package builder
+
+import (
+	"testing"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+func TestDiskCacheMode(t *testing.T) {
+	type testcase struct {
+		description string
+		builder     *VMBuilder
+		expectError bool
+		expectation kubevirtv1.DriverCache
+	}
+	testcases := []testcase{
+		{
+			description: "cache mode `none`",
+			builder: NewVMBuilder("test").
+				Disk("vda", "virtio", false, 1).
+				DiskCacheMode("vda", kubevirtv1.CacheNone),
+			expectError: false,
+			expectation: kubevirtv1.CacheNone,
+		},
+		{
+			description: "cache mode `writethrough`",
+			builder: NewVMBuilder("test").
+				Disk("vda", "virtio", false, 1).
+				DiskCacheMode("vda", kubevirtv1.CacheWriteThrough),
+			expectError: false,
+			expectation: kubevirtv1.CacheWriteThrough,
+		},
+		{
+			description: "cache mode `writeback`",
+			builder: NewVMBuilder("test").
+				Disk("vda", "virtio", false, 1).
+				DiskCacheMode("vda", kubevirtv1.CacheWriteBack),
+			expectError: false,
+			expectation: kubevirtv1.CacheWriteBack,
+		},
+		{
+			description: "multiple disks",
+			builder: NewVMBuilder("test").
+				Disk("vda", "virtio", false, 1).
+				DiskCacheMode("vda", kubevirtv1.CacheWriteBack).
+				Disk("vdb", "virtio", false, 2).
+				DiskCacheMode("vdb", kubevirtv1.CacheWriteBack),
+			expectError: false,
+			expectation: kubevirtv1.CacheWriteBack,
+		},
+		{
+			description: "no disks",
+			builder: NewVMBuilder("test").
+				DiskCacheMode("vda", kubevirtv1.CacheWriteBack),
+			expectError: true,
+			expectation: kubevirtv1.CacheWriteBack,
+		},
+		{
+			description: "wrong disk",
+			builder: NewVMBuilder("test").
+				Disk("vda", "virtio", false, 1).
+				DiskCacheMode("vdb", kubevirtv1.CacheWriteBack),
+			expectError: true,
+			expectation: kubevirtv1.CacheWriteBack,
+		},
+	}
+
+	for _, tc := range testcases {
+		testVM, err := tc.builder.VM()
+
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("failed test %s: generating VM should have failed with error", tc.description)
+			}
+		} else {
+			for _, disk := range testVM.Spec.Template.Spec.Domain.Devices.Disks {
+				if disk.Cache != tc.expectation {
+					t.Errorf("failed test %s: cache mode %s did not match expectation %s for disk %s", tc.description, disk.Cache, tc.expectation, disk.Name)
+				}
+			}
+		}
+	}
+}

--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -32,6 +32,7 @@ const (
 
 type VMBuilder struct {
 	VirtualMachine             *kubevirtv1.VirtualMachine
+	Error                      error
 	SSHNames                   []string
 	WaitForLeaseInterfaceNames []string
 }
@@ -84,6 +85,7 @@ func NewVMBuilder(creator string) *VMBuilder {
 	}
 	return &VMBuilder{
 		VirtualMachine:             vm,
+		Error:                      nil,
 		SSHNames:                   []string{},
 		WaitForLeaseInterfaceNames: []string{},
 	}
@@ -251,6 +253,10 @@ func (v *VMBuilder) IsolateEmulatorThread(isolated bool) *VMBuilder {
 }
 
 func (v *VMBuilder) VM() (*kubevirtv1.VirtualMachine, error) {
+	if v.Error != nil {
+		return nil, v.Error
+	}
+
 	if v.VirtualMachine.Spec.Template.ObjectMeta.Annotations == nil {
 		v.VirtualMachine.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 	}


### PR DESCRIPTION
1) Add errors to the VMBuilder

Add error facility to the VMBuilder. This allows the builder to collect errors e.g. when volume information is inconsistent with disks or when parameters reference devices that don't exist in the domain spec.

2) Add disk cache mode

Add a method for setting the cache mode of a VM disk device.

3) Add tests for VMBuilder disk cache mode setting method

related-to: harvester/harvester#9383

#### Problem:

To facilitate setting the disk cache mode, e.g. for the Terraform provider, it must be exposed in the VM Builder. So far nothing there allows setting the cache mode for disks, meaning that the default values will always be used.

#### Solution:

Add a new method to the VMBuilder, which allows setting the caching mode of a disk device.

Implementing this function as a new method, rather than modifying the existing `Disk(...)` method, allows keeping backwards compatibility and leaves the interface simpler in case default settings suffice.

The downside is that there is the possibility that the caller can try to set the disk cache mode for a disk that doesn't (yet) exist in the domain spec. To handle this situation, the VMBuilder has been expanded to allow collecting errors during the definition of the VM.
These errors are then exposed when applying the build in the function call to `VM()` - much like other existing error cases during the builder application.

#### Related Issue(s):

- harvester/harvester#9383

#### Test plan:

Unit tests included.

#### Additional documentation or context
