### PR TITLE
feat: add timeout to connect backup target

### DIFF
--- a/pkg/util/backup/backup.go
+++ b/pkg/util/backup/backup.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	VMImageMetadataFolderPath = "harvester/vmimages/"
+	// The webhook timeout is 10 seconds, so we can't set too long timeout here.
+	ConnectBackupStoreTimeout = 8 * time.Second
 )
 
 func ConstructEndpoint(target *settings.BackupTarget) string {
@@ -46,11 +48,10 @@ func GetBackupStoreDriver(secretCache ctlcorev1.SecretCache, target *settings.Ba
 
 	endpoint := ConstructEndpoint(target)
 
-	// Add 5 second timeout for backup store driver initialization.
 	// There might be a goroutine leak if the driver doesn't end properly,
 	// Although we can pass ctx, but the underlying driver implementation doesn't support it.
 	// So we should be careful when using GetBackupStoreDriver function.
-	bsDriver, err := util.RunWithTimeoutAndResult(5*time.Second, func(_ context.Context) (backupstore.BackupStoreDriver, error) {
+	bsDriver, err := util.RunWithTimeoutAndResult(ConnectBackupStoreTimeout, func(_ context.Context) (backupstore.BackupStoreDriver, error) {
 		return backupstore.GetBackupStoreDriver(endpoint)
 	})
 	if err != nil {

--- a/pkg/util/timeout.go
+++ b/pkg/util/timeout.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type result[T any] struct {
+	value T
+	err   error
+}
+
+// RunWithTimeoutAndResult executes a function with a timeout and returns both a result and an error.
+// It returns the result and error from the function, or a nil result with timeout error if timeout occurs.
+// Also, we can pass a context to the function for cancellation support.
+func RunWithTimeoutAndResult[T any](timeout time.Duration, fn func(ctx context.Context) (T, error)) (T, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	done := make(chan result[T], 1)
+	go func() {
+		value, err := fn(ctx)
+		done <- result[T]{value: value, err: err}
+	}()
+
+	select {
+	case res := <-done:
+		return res.value, res.err
+	case <-ctx.Done():
+		var zero T
+		return zero, fmt.Errorf("timeout after %v", timeout)
+	}
+}

--- a/pkg/util/timeout.go
+++ b/pkg/util/timeout.go
@@ -11,10 +11,13 @@ type result[T any] struct {
 	err   error
 }
 
+// callbackWithContext is a function type that accepts a context and returns a result with an error.
+type callbackWithContext[T any] func(ctx context.Context) (T, error)
+
 // RunWithTimeoutAndResult executes a function with a timeout and returns both a result and an error.
 // It returns the result and error from the function, or a nil result with timeout error if timeout occurs.
 // Also, we can pass a context to the function for cancellation support.
-func RunWithTimeoutAndResult[T any](timeout time.Duration, fn func(ctx context.Context) (T, error)) (T, error) {
+func RunWithTimeoutAndResult[T any](timeout time.Duration, fn callbackWithContext[T]) (T, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -578,11 +578,10 @@ func (v *settingValidator) validateBackupTarget(setting *v1beta1.Setting) error 
 	// NFS: https://github.com/longhorn/backupstore/blob/56ddc538b85950b02c37432e4854e74f2647ca61/nfs/nfs.go#L46-L81
 	endpoint := backuputil.ConstructEndpoint(target)
 
-	// Add 5 second timeout for backup store driver initialization.
 	// There might be a goroutine leak if the driver doesn't end properly,
 	// Although we can pass ctx, but the underlying driver implementation doesn't support it.
 	// So we should be careful when using GetBackupStoreDriver function.
-	_, err = util.RunWithTimeoutAndResult(5*time.Second, func(_ context.Context) (backupstore.BackupStoreDriver, error) {
+	_, err = util.RunWithTimeoutAndResult(backuputil.ConnectBackupStoreTimeout, func(_ context.Context) (backupstore.BackupStoreDriver, error) {
 		return backupstore.GetBackupStoreDriver(endpoint)
 	})
 	if err != nil {


### PR DESCRIPTION
#### Problem:
The webhook timeout is 10 second, but longhorn timeout is 300 second. If endpoint is not reachable, we return the context canceled.

#### Solution:
We should have our own timeout when calling this function.

<img width="1698" height="229" alt="image" src="https://github.com/user-attachments/assets/cdb64189-3af7-4194-a523-f10f62995ced" />

<img width="1700" height="202" alt="image" src="https://github.com/user-attachments/assets/5cc962f6-e418-4324-a411-16e632d74256" />


#### Related Issue(s):
https://github.com/harvester/harvester/issues/6903

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
