### PR TITLE
Fix cdi vm image upload failed

### DIFF
--- a/pkg/controller/master/image/vm_image_controller_test.go
+++ b/pkg/controller/master/image/vm_image_controller_test.go
@@ -1,0 +1,210 @@
+package image
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakecore "k8s.io/client-go/kubernetes/fake"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/image/backend"
+	"github.com/harvester/harvester/pkg/image/cdi"
+	"github.com/harvester/harvester/pkg/image/common"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+const (
+	testNamespace = "default"
+	testImageName = "test-image"
+	testSCName    = "longhorn-test"
+)
+
+// TestVMImageHandler_OnChanged_UploadImageInitialization tests that an upload-type
+// VMImage enters the initialized state when the DataVolume is not found.
+func TestVMImageHandler_OnChanged_UploadImageInitialization(t *testing.T) {
+	type args struct {
+		vmImage      *harvesterv1.VirtualMachineImage
+		dataVolume   *cdiv1.DataVolume
+		storageClass *storagev1.StorageClass
+	}
+
+	tests := []struct {
+		name              string
+		args              args
+		wantErr           bool
+		wantInitialized   bool
+		wantConditionTrue bool
+	}{
+		{
+			name: "Upload VMImage without DataVolume should enter initialized state",
+			args: args{
+				vmImage: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testImageName,
+						Namespace: testNamespace,
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						DisplayName:            "Test Upload Image",
+						SourceType:             harvesterv1.VirtualMachineImageSourceTypeUpload,
+						Backend:                harvesterv1.VMIBackendCDI,
+						TargetStorageClassName: testSCName,
+					},
+					Status: harvesterv1.VirtualMachineImageStatus{},
+				},
+				dataVolume: nil, // No DataVolume exists yet
+				storageClass: &storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testSCName,
+					},
+					Provisioner: "driver.longhorn.io",
+				},
+			},
+			wantErr:           false,
+			wantInitialized:   true,
+			wantConditionTrue: true,
+		},
+		{
+			name: "Upload VMImage with existing DataVolume should not re-initialize",
+			args: args{
+				vmImage: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testImageName,
+						Namespace: testNamespace,
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						DisplayName:            "Test Upload Image",
+						SourceType:             harvesterv1.VirtualMachineImageSourceTypeUpload,
+						Backend:                harvesterv1.VMIBackendCDI,
+						TargetStorageClassName: testSCName,
+					},
+					Status: harvesterv1.VirtualMachineImageStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Initialized",
+								Status: "True",
+							},
+						},
+					},
+				},
+				dataVolume: &cdiv1.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testImageName,
+						Namespace: testNamespace,
+					},
+					Status: cdiv1.DataVolumeStatus{
+						Phase: cdiv1.UploadReady,
+					},
+				},
+				storageClass: &storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testSCName,
+					},
+					Provisioner: "driver.longhorn.io",
+				},
+			},
+			wantErr:           false,
+			wantInitialized:   true,
+			wantConditionTrue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup fake clients
+			var coreClientset = fakecore.NewSimpleClientset()
+			var harvFakeClient = fakegenerated.NewSimpleClientset()
+
+			// Add StorageClass
+			if tt.args.storageClass != nil {
+				err := coreClientset.Tracker().Add(tt.args.storageClass)
+				assert.Nil(t, err, "should add StorageClass to tracker")
+			}
+
+			// Add VMImage
+			if tt.args.vmImage != nil {
+				err := harvFakeClient.Tracker().Add(tt.args.vmImage)
+				assert.Nil(t, err, "should add VMImage to tracker")
+			}
+
+			// Add DataVolume if exists
+			if tt.args.dataVolume != nil {
+				err := harvFakeClient.Tracker().Add(tt.args.dataVolume)
+				assert.Nil(t, err, "should add DataVolume to tracker")
+			}
+
+			// Create VMIOperator
+			vmio, err := common.GetVMIOperator(
+				fakeclients.VirtualMachineImageClient(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				fakeclients.VirtualMachineImageCache(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				http.Client{},
+			)
+			assert.Nil(t, err, "should create VMIOperator")
+
+			// Create CDI backend
+			cdiBackend := cdi.GetBackend(
+				context.Background(),
+				fakeclients.DataVolumeClient(harvFakeClient.CdiV1beta1().DataVolumes),
+				fakeclients.StorageClassClient(coreClientset.StorageV1().StorageClasses),
+				fakeclients.PersistentVolumeClaimCache(coreClientset.CoreV1().PersistentVolumeClaims),
+				vmio,
+			)
+
+			// Create backends map
+			backends := map[harvesterv1.VMIBackend]backend.Backend{
+				harvesterv1.VMIBackendCDI: cdiBackend,
+			}
+
+			// Create handler
+			h := &vmImageHandler{
+				vmiClient:     fakeclients.VirtualMachineImageClient(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				vmiController: fakeclients.VirtualMachineImageClient(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				vmio:          vmio,
+				backends:      backends,
+			}
+
+			// Call OnChanged
+			result, err := h.OnChanged("", tt.args.vmImage)
+
+			// Verify error expectation
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnChanged() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Verify result
+			if result == nil {
+				t.Error("OnChanged() returned nil result")
+				return
+			}
+
+			// Check if VMImage was initialized
+			if tt.wantInitialized {
+				// Get the updated VMImage from the tracker
+				gvr := schema.GroupVersionResource{
+					Group:    "harvesterhci.io",
+					Version:  "v1beta1",
+					Resource: "virtualmachineimages",
+				}
+				obj, err := harvFakeClient.Tracker().Get(gvr, tt.args.vmImage.Namespace, tt.args.vmImage.Name)
+				assert.Nil(t, err, "should get VMImage from tracker")
+
+				updatedVMI, ok := obj.(*harvesterv1.VirtualMachineImage)
+				assert.True(t, ok, "should be a VirtualMachineImage")
+
+				// Check if Initialized condition is set and StorageClassName is set
+				if tt.wantConditionTrue {
+					isInitialized := harvesterv1.ImageInitialized.IsTrue(updatedVMI)
+					assert.Equal(t, testSCName, updatedVMI.Status.StorageClassName, "VMImage should have StorageClassName set to %s", testSCName)
+					assert.True(t, isInitialized, "VMImage should have Initialized condition set to True")
+				}
+			}
+		})
+	}
+}

--- a/pkg/image/cdi/upload.go
+++ b/pkg/image/cdi/upload.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -258,7 +257,7 @@ func (cu *Uploader) DoUpload(vmImg *harvesterv1.VirtualMachineImage, req *http.R
 	}
 	defer uploadResp.Body.Close()
 
-	body, err := ioutil.ReadAll(uploadResp.Body)
+	body, err := io.ReadAll(uploadResp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/pkg/image/common/operator.go
+++ b/pkg/image/common/operator.go
@@ -11,8 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
@@ -234,12 +232,11 @@ func (vmio *vmiOperator) UpdateSize(old *harvesterv1.VirtualMachineImage, size i
 }
 
 func (vmio *vmiOperator) UpdateVirtualSizeAndSize(old *harvesterv1.VirtualMachineImage, virtualSize, size int64) (*harvesterv1.VirtualMachineImage, error) {
-	return vmio.updateWithRetry(old, func(vmi *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
-		logrus.Debugf("Updating VMImage %s/%s: virtualSize=%d, size=%d (resourceVersion: %s)", vmi.Namespace, vmi.Name, virtualSize, size, vmi.ResourceVersion)
-		vmi.Status.VirtualSize = virtualSize
-		vmi.Status.Size = size
-		return vmi, nil
-	})
+	logrus.Debugf("Updating VMImage %s/%s: virtualSize=%d, size=%d (resourceVersion: %s)", old.Namespace, old.Name, virtualSize, size, old.ResourceVersion)
+	newVMI := old.DeepCopy()
+	newVMI.Status.VirtualSize = virtualSize
+	newVMI.Status.Size = size
+	return vmio.UpdateVMI(old, newVMI)
 }
 
 func (vmio *vmiOperator) UpdateLastFailedTime(old *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error) {
@@ -377,46 +374,4 @@ func (vmio *vmiOperator) Imported(old *harvesterv1.VirtualMachineImage, msg stri
 
 func (vmio *vmiOperator) BackingImageMissing(old *harvesterv1.VirtualMachineImage, err error) (*harvesterv1.VirtualMachineImage, error) {
 	return vmio.stateTransit(old, VMImageStateBackingImageMissing, fmt.Sprintf("Failed to get backing image: %s", err.Error()), 0, 0, 0)
-}
-
-func (vmio *vmiOperator) updateWithRetry(old *harvesterv1.VirtualMachineImage, updateFunc func(*harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error)) (*harvesterv1.VirtualMachineImage, error) {
-	namespace := old.Namespace
-	name := old.Name
-	var updatedVMI *harvesterv1.VirtualMachineImage
-
-	backoff := wait.Backoff{
-		Steps:    5,
-		Duration: 1 * time.Second,
-		Factor:   2.0,
-		Jitter:   0.1,
-	}
-
-	err := retry.OnError(backoff, func(err error) bool {
-		// Retry on conflict errors or transient API errors
-		return apierrors.IsConflict(err) || apierrors.IsServerTimeout(err) || apierrors.IsTimeout(err) || apierrors.IsServiceUnavailable(err)
-	}, func() error {
-		// Fetch the latest VMImage before each retry attempt to get the current resource version
-		latestVMI, err := vmio.cache.Get(namespace, name)
-		if err != nil {
-			logrus.Warnf("Failed to get latest VMImage %s/%s: %v", namespace, name, err)
-			return err
-		}
-
-		newVMI, err := updateFunc(latestVMI.DeepCopy())
-		if err != nil {
-			return err
-		}
-
-		updatedVMI, err = vmio.UpdateVMI(latestVMI, newVMI)
-		if err != nil {
-			logrus.Warnf("Failed to update VM Image: %v, will retry if retriable.", err)
-		}
-		return err
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to update VM Image after retries: %v", err)
-	}
-
-	return updatedVMI, nil
 }

--- a/pkg/util/fakeclients/datavolume.go
+++ b/pkg/util/fakeclients/datavolume.go
@@ -1,0 +1,80 @@
+package fakeclients
+
+import (
+	"context"
+
+	cditype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/cdi.kubevirt.io/v1beta1"
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+type DataVolumeClient func() cditype.DataVolumeInterface
+
+func (c DataVolumeClient) Create(dataVolume *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	return c().Create(context.TODO(), dataVolume, metav1.CreateOptions{})
+}
+
+func (c DataVolumeClient) Update(dataVolume *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	return c().Update(context.TODO(), dataVolume, metav1.UpdateOptions{})
+}
+
+func (c DataVolumeClient) UpdateStatus(*cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	panic("implement me")
+}
+
+func (c DataVolumeClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return c().Delete(context.TODO(), name, *options)
+}
+
+func (c DataVolumeClient) Get(namespace, name string, options metav1.GetOptions) (*cdiv1.DataVolume, error) {
+	return c().Get(context.TODO(), name, options)
+}
+
+func (c DataVolumeClient) List(namespace string, opts metav1.ListOptions) (*cdiv1.DataVolumeList, error) {
+	return c().List(context.TODO(), opts)
+}
+
+func (c DataVolumeClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	return c().Watch(context.TODO(), opts)
+}
+
+func (c DataVolumeClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *cdiv1.DataVolume, err error) {
+	return c().Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}
+
+func (c DataVolumeClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*cdiv1.DataVolume, *cdiv1.DataVolumeList], error) {
+	panic("implement me")
+}
+
+type DataVolumeCache func(string) cditype.DataVolumeInterface
+
+func (c DataVolumeCache) Get(namespace, name string) (*cdiv1.DataVolume, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c DataVolumeCache) List(namespace string, selector labels.Selector) ([]*cdiv1.DataVolume, error) {
+	list, err := c(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*cdiv1.DataVolume, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, err
+}
+
+func (c DataVolumeCache) AddIndexer(indexName string, indexer generic.Indexer[*cdiv1.DataVolume]) {
+	panic("implement me")
+}
+
+func (c DataVolumeCache) GetByIndex(indexName, key string) ([]*cdiv1.DataVolume, error) {
+	panic("implement me")
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:

We are using the wrong upload api for `multipart/form-data`, instead of using `/v1alpha1/upload` , we need to switch to `/v1beta1/upload-form`.
However, CDI can only handle upload-form api correctly if form data field name is file, see
https://github.com/kubevirt/containerized-data-importer/blob/release-v1.62/pkg/uploadserver/uploadserver.go#L117
So we have to do some changes in the harvester-ui-extension as currently we use chunk as field name in the form data, see
[https://github.com/harvester/harvester-ui-extension/blob/c169853e5a09ad7545075d8c2[…]ec2/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js](https://github.com/harvester/harvester-ui-extension/blob/c169853e5a09ad7545075d8c2ffb4cb3fdc64ec2/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js#L322)

#### Solution:

- if upload http request header content-type is `multipart/form-data`, use endpoint `/v1alpha1/upload-form` instead of `/v1alpha1/upload`.
- fix an issue that uploaded VMImage never entered initialized state which ends up create VM failed.
- move retry mechaism of UpdateVirtualSizeAndSize from cdi.go to upload.go

#### Related Issue(s):

#9843


#### Test plan:

**_This needs to be tested with patch https://github.com/harvester/harvester-ui-extension/pull/684_**

test all VM image upload scenario

##### VM image creation

1. setup a harvester cluster with lhv2 or lvm ... any third-party storage is fine, what we want is testing vm image with cdi backend
1. [Leap-16.0-online-installer-x86_64.install.iso](https://download.opensuse.org/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso) upload this iso file in the VM Image page with the 3-rd party storage class.
    - before this patch, this iso file cannot be successfully uploaded to harvester
1. create VM with the uploaded vm image
1. upload the same iso but this time use harvseter-longhorn storage class and create VM

##### airgapped upgrade iso upload

1. goto Settings > server-version > 3-dots button > Upgrade
3. upload harvester iso file, please use a regular one, e.g.harvester-v1.7.0-amd64.iso

Note: if you encountered the `context cancel` issue which cause upload failed, please run below command to increase proxy-read|send-timeout.

```
kubectl annotate ingress rancher-expose \
  -n cattle-system \
  nginx.ingress.kubernetes.io/proxy-read-timeout="1800" \
  nginx.ingress.kubernetes.io/proxy-send-timeout="1800" \
  --overwrite
```

https://github.com/harvester/harvester/issues/9313#issuecomment-3409815722

#### Additional documentation or context

