### PR TITLE
fix: add ifname=name:mac to kernel args on upgrade

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -635,6 +635,7 @@ set_nic_names_by_mac_address() {
   # get current third_party_kernel_args
   local args=$(chroot $HOST_DIR grub2-editenv /oem/grubenv list |grep third_party_kernel_args | awk -F"third_party_kernel_args=" '{print $2}')
 
+  local update_args=0
   # append ifname=name:mac for all existing en* interfaces
   for i in $HOST_DIR/sys/class/net/en* ; do
     [ -e "$i" ] || continue
@@ -644,10 +645,13 @@ set_nic_names_by_mac_address() {
     # don't add duplicates if there's already an ifname= for this mac address
     [[ "$args" =~ ifname=[^[:space:]]+:$mac ]] && continue
     args="$args ifname=$name:$mac"
+    update_args=1
   done
 
-  # save updated third_party_kernel_args
-  chroot $HOST_DIR grub2-editenv /oem/grubenv set third_party_kernel_args="${args}"
+  if [ $update_args -eq 1 ]; then
+    # save updated third_party_kernel_args
+    chroot $HOST_DIR grub2-editenv /oem/grubenv set third_party_kernel_args="${args}"
+  fi
 }
 
 upgrade_os() {

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -638,6 +638,7 @@ set_nic_names_by_mac_address() {
   # append ifname=name:mac for all existing en* interfaces
   for i in $HOST_DIR/sys/class/net/en* ; do
     [ -e "$i" ] || continue
+    [ -e "$i/address" ] || continue
     local name=$(basename $i)
     local mac=$(cat "$i/address")
     # don't add duplicates if there's already an ifname= for this mac address


### PR DESCRIPTION
#### Problem:
It's possible for updated NIC drivers to result in persistent network interface names changing after upgrade, e.g. to add port numbers, so `enp6s0f0` becomes `enp6s0f0np0`. This in turn breaks network configuration which is of course based on the original (pre-upgrade) interface names.

#### Solution:
On upgrade, if we add kernel command line arguments for each existing NIC with their current names and MAC addresses, it means that when we boot into a new OS, we are guaranteed to keep the existing interface names.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9815
https://github.com/harvester/harvester/issues/9802

#### Test plan:
To verify the implementation is correct:
- Install Harvester.
- Run `ip link` to get a list of network interfaces. We're interested here in actual ethernet adapaters, so anything that starts with `en`, for example:
  ```
  # ip link | grep -A1 ': en'
  2: enp1s0: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master mgmt-bo state UP mode DEFAULT group default qlen 1000
      link/ether 52:54:00:a6:2d:da brd ff:ff:ff:ff:ff:ff
  3: enp7s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
      link/ether 52:54:00:e3:19:34 brd ff:ff:ff:ff:ff:ff
  ```
- Upgrade to a version with this fix. After upgrade, you should see `ifname=` lines matching the above interface names and MAC addresses in the grub config, and thus in the kernel command line:
  ```
  # grub2-editenv /oem/grubenv list | grep kernel
  third_party_kernel_args= multipath=off ifname=enp1s0:52:54:00:a6:2d:da enp7s0:52:54:00:e3:19:34
  
  # cat /proc/cmdline
  BOOT_IMAGE=(loop0)/boot/vmlinuz [...] ifname=enp1s0:52:54:00:a6:2d:da enp7s0:52:54:00:e3:19:34 [...] 
  ```

To simulate the fix solving the problem in a libvirt environment:

1. Install Harvester without this fix in a VM.
2. Upgrade to a newer version of Harvester that does _not_ include this fix. When the VM reboots after upgrading the OS, shut down the VM, and edit the NIC config with virt-manager or virsh to put the NIC on a different PCI bus. For example, in my testing, I originally had `bus="0x01"`, which gave me a NIC named `enp1s0`. Then I changed it to `bus="0x08"`, which gives `enp8s0`.
3. Start the VM again (being sure to select the correct grub boot option - it may have landed on "fallback" by default depending on how quick you were with the power off)
4. Verify networking is broken because the NIC name has changed. This simulates the problem.
5. Begin again at step 1, with your virtual NIC back on `bus="0x01"`, then upgrade to a version of Harvester that _does_ include this fix. Again, switch the NIC to a different bus after the OS upgrade.
6. Verify the NIC now has the same pre-upgrade name, even though it's on a different bus, and that networking works correctly. `ip link` will show something like the following, if `enp8s0` was successfully renamed back to `enp1so`:
  ```
     3: enp1s0: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master mgmt-bo state UP mode DEFAULT group default qlen 1000
      link/ether 52:54:00:a6:2d:da brd ff:ff:ff:ff:ff:ff
      altname enp8s0
  ```

To verify this actually fixes the problem with Intel X710 NICs:

- Install Harvester v1.6.x on a host with those NICs. Verify the NIC names don't have port numbers (e.g. `eno1`)
- Upgrade to v1.7.1 with this fix applied. Verify those NIC names _still_ don't have port numbers, but check the `ip link` output. You'll see something like the following, with `altname` appended, which includes the port number. That's the name the interface _would_ have come up with if we hadn't renamed it:
  ```
  # ip link | grep -A2 ': en'
  2: eno1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq master mgmt-bo state UP mode DEFAULT group default qlen 1000
      link/ether d4:c9:ef:ce:30:68 brd ff:ff:ff:ff:ff:ff
      altname eno1np0
  --
  3: eno2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000
      link/ether d4:c9:ef:ce:30:69 brd ff:ff:ff:ff:ff:ff
      altname eno2np1
  ```

#### Additional documentation or context
This potentially adds an extra step necessary if a user ever has to replace a NIC in future. Consider:
- Before upgrade NIC names are whatever they are based on their device properties per https://www.freedesktop.org/software/systemd/man/latest/systemd.net-naming-scheme.html
- After upgrade, NIC names are explicitly set by MAC address, to the names used on the host before upgrade.
- Assume the management NIC fails. User replaces it in the same slot, with the exact same model NIC. One of two things will happen now:
  1. The NIC is _not_ one of the Intel X710s that has the problem with port names being appended due to updated drivers. Because it's in the same slot, it should come up with the same name as the old NIC. This works regardless of the `ifname=....` kernel command line argument for this interface name, because the new NIC has a different _MAC_ address, so that argument has no effect.
  2. The NIC _is_ one of the Intel X710s that has the problem with port names being appended. It will come up with `np0` (or whatever) on the end of the name, and networking won't work properly. In this case, the user has to tweak the kernel command line arguments to map the MAC address of the new NIC to the desired name. This will need to be documented.