### PR TITLE
VMBuilder: Add methods for CPU/memory requests

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"encoding/json"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -13,8 +14,10 @@ const (
 	defaultVMGenerateName = "harv-"
 	defaultVMNamespace    = "default"
 
-	defaultVMCPUCores = 1
-	defaultVMMemory   = "256Mi"
+	defaultVMCPUCores   = 1
+	defaultVMCPUThreads = 1
+	defaultVMCPUSockets = 1
+	defaultVMMemory     = "256Mi"
 
 	HarvesterAPIGroup                                     = "harvesterhci.io"
 	LabelAnnotationPrefixHarvester                        = HarvesterAPIGroup + "/"
@@ -49,7 +52,9 @@ func NewVMBuilder(creator string) *VMBuilder {
 	}
 	runStrategy := kubevirtv1.RunStrategyHalted
 	cpu := &kubevirtv1.CPU{
-		Cores: defaultVMCPUCores,
+		Cores:   defaultVMCPUCores,
+		Sockets: defaultVMCPUSockets,
+		Threads: defaultVMCPUThreads,
 	}
 	resources := kubevirtv1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -168,7 +173,9 @@ func (v *VMBuilder) GuestMemory(amount string) *VMBuilder {
 		return v
 	}
 
-	v.VirtualMachine.Spec.Template.Spec.Domain.Memory.Guest = &quantity
+	v.VirtualMachine.Spec.Template.Spec.Domain.Memory = &kubevirtv1.Memory{
+		Guest: &quantity,
+	}
 	return v
 }
 
@@ -181,6 +188,11 @@ func (v *VMBuilder) Memory(memory string) *VMBuilder {
 }
 
 func (v *VMBuilder) CPUCores(cores int) *VMBuilder {
+	if cores < 1 {
+		v.Error = fmt.Errorf("invalid number of CPU cores: %d", cores)
+		return v
+	}
+
 	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Cores = uint32(cores)   // nolint:gosec
 	sockets := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets) // nolint:gosec
 	threads := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads) // nolint:gosec
@@ -192,6 +204,10 @@ func (v *VMBuilder) CPUCores(cores int) *VMBuilder {
 }
 
 func (v *VMBuilder) CPUSockets(sockets int) *VMBuilder {
+	if sockets < 1 {
+		v.Error = fmt.Errorf("invalid number of CPU sockets: %d", sockets)
+		return v
+	}
 	cores := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Cores)       // nolint:gosec
 	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets = uint32(sockets) // nolint:gosec
 	threads := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads)   // nolint:gosec
@@ -203,6 +219,10 @@ func (v *VMBuilder) CPUSockets(sockets int) *VMBuilder {
 }
 
 func (v *VMBuilder) CPUThreads(threads int) *VMBuilder {
+	if threads < 1 {
+		v.Error = fmt.Errorf("invalid number of CPU threads: %d", threads)
+		return v
+	}
 	cores := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Cores)       // nolint:gosec
 	sockets := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets)   // nolint:gosec
 	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads = uint32(threads) // nolint:gosec
@@ -213,13 +233,9 @@ func (v *VMBuilder) CPUThreads(threads int) *VMBuilder {
 	return v
 }
 
+// This is just an alias for CPUCores to preserve backwards compatibility.
 func (v *VMBuilder) CPU(cores int) *VMBuilder {
-	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Cores = uint32(cores) // nolint:gosec
-	if len(v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits) == 0 {
-		v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits = corev1.ResourceList{}
-	}
-	v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceCPU] = *resource.NewQuantity(int64(cores), resource.DecimalSI)
-	return v
+	return v.CPUCores(cores)
 }
 
 func (v *VMBuilder) EvictionStrategy(liveMigrate bool) *VMBuilder {

--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -161,11 +161,55 @@ func (v *VMBuilder) Annotations(annotations map[string]string) *VMBuilder {
 	return v
 }
 
+func (v *VMBuilder) GuestMemory(amount string) *VMBuilder {
+	quantity, err := resource.ParseQuantity(amount)
+	if err != nil {
+		v.Error = err
+		return v
+	}
+
+	v.VirtualMachine.Spec.Template.Spec.Domain.Memory.Guest = &quantity
+	return v
+}
+
 func (v *VMBuilder) Memory(memory string) *VMBuilder {
 	if len(v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits) == 0 {
 		v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits = corev1.ResourceList{}
 	}
 	v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(memory)
+	return v
+}
+
+func (v *VMBuilder) CPUCores(cores int) *VMBuilder {
+	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Cores = uint32(cores)   // nolint:gosec
+	sockets := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets) // nolint:gosec
+	threads := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads) // nolint:gosec
+	if len(v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits) == 0 {
+		v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits = corev1.ResourceList{}
+	}
+	v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceCPU] = *resource.NewQuantity(int64(cores*sockets*threads), resource.DecimalSI)
+	return v
+}
+
+func (v *VMBuilder) CPUSockets(sockets int) *VMBuilder {
+	cores := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Cores)       // nolint:gosec
+	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets = uint32(sockets) // nolint:gosec
+	threads := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads)   // nolint:gosec
+	if len(v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits) == 0 {
+		v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits = corev1.ResourceList{}
+	}
+	v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceCPU] = *resource.NewQuantity(int64(cores*sockets*threads), resource.DecimalSI)
+	return v
+}
+
+func (v *VMBuilder) CPUThreads(threads int) *VMBuilder {
+	cores := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Cores)       // nolint:gosec
+	sockets := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets)   // nolint:gosec
+	v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads = uint32(threads) // nolint:gosec
+	if len(v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits) == 0 {
+		v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits = corev1.ResourceList{}
+	}
+	v.VirtualMachine.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceCPU] = *resource.NewQuantity(int64(cores*sockets*threads), resource.DecimalSI)
 	return v
 }
 

--- a/pkg/builder/vm_test.go
+++ b/pkg/builder/vm_test.go
@@ -48,19 +48,22 @@ func TestCPUCores(t *testing.T) {
 			continue
 		}
 
-		if !tc.expectError {
-			if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
-				t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
-				continue
-			}
-			if testVM.Spec.Template.Spec.Domain.CPU.Cores < 1 {
-				t.Errorf("test %s: unexpected value for cpu cores", tc.description)
-				continue
-			}
-			if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Cores {
-				t.Errorf("test %s: unexpected cpu cores value", tc.description)
-				continue
-			}
+		if tc.expectError {
+			continue
+		}
+
+		if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
+			t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
+			continue
+		}
+
+		if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Cores {
+			t.Errorf("test %s: unexpected cpu coresvalue: %d, expected: %d",
+				tc.description,
+				testVM.Spec.Template.Spec.Domain.CPU.Cores,
+				tc.expectation,
+			)
+			continue
 		}
 	}
 }
@@ -107,19 +110,22 @@ func TestCPUSockets(t *testing.T) {
 			continue
 		}
 
-		if !tc.expectError {
-			if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
-				t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
-				continue
-			}
-			if testVM.Spec.Template.Spec.Domain.CPU.Sockets < 1 {
-				t.Errorf("test %s: unexpected value for cpu sockets", tc.description)
-				continue
-			}
-			if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Sockets {
-				t.Errorf("test %s: unexpected cpu cores value", tc.description)
-				continue
-			}
+		if tc.expectError {
+			continue
+		}
+
+		if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
+			t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
+			continue
+		}
+
+		if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Sockets {
+			t.Errorf("test %s: unexpected cpu sockets value: %d, expected: %d",
+				tc.description,
+				testVM.Spec.Template.Spec.Domain.CPU.Sockets,
+				tc.expectation,
+			)
+			continue
 		}
 	}
 }
@@ -166,19 +172,22 @@ func TestCPUThreads(t *testing.T) {
 			continue
 		}
 
-		if !tc.expectError {
-			if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
-				t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
-				continue
-			}
-			if testVM.Spec.Template.Spec.Domain.CPU.Threads < 1 {
-				t.Errorf("test %s: unexpected value for cpu cores", tc.description)
-				continue
-			}
-			if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Threads {
-				t.Errorf("test %s: unexpected cpu cores value", tc.description)
-				continue
-			}
+		if tc.expectError {
+			continue
+		}
+
+		if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
+			t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
+			continue
+		}
+
+		if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Threads {
+			t.Errorf("test %s: unexpected cpu threads value: %d, expected: %d",
+				tc.description,
+				testVM.Spec.Template.Spec.Domain.CPU.Threads,
+				tc.expectation,
+			)
+			continue
 		}
 	}
 }

--- a/pkg/builder/vm_test.go
+++ b/pkg/builder/vm_test.go
@@ -2,15 +2,266 @@ package builder
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-type testcase struct {
-	name        string
-	builder     *VMBuilder
-	expectation bool
+func TestCPUCores(t *testing.T) {
+	type testcase struct {
+		description string
+		builder     *VMBuilder
+		expectation uint32
+		expectError bool
+	}
+
+	testcases := []testcase{
+		{
+			description: "default value",
+			builder:     NewVMBuilder("test"),
+			expectation: defaultVMCPUCores,
+			expectError: false,
+		},
+		{
+			description: "set cpu cores",
+			builder:     NewVMBuilder("test").CPUCores(4),
+			expectation: 4,
+			expectError: false,
+		},
+		{
+			description: "invalid value",
+			builder:     NewVMBuilder("test").CPUCores(-2),
+			expectation: 1,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		testVM, err := tc.builder.VM()
+
+		if tc.expectError && err == nil {
+			t.Errorf("test %s: unexpected error", tc.description)
+			continue
+		}
+
+		if !tc.expectError && err != nil {
+			t.Errorf("test %s: expected error", tc.description)
+			continue
+		}
+
+		if !tc.expectError {
+			if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
+				t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
+				continue
+			}
+			if testVM.Spec.Template.Spec.Domain.CPU.Cores < 1 {
+				t.Errorf("test %s: unexpected value for cpu cores", tc.description)
+				continue
+			}
+			if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Cores {
+				t.Errorf("test %s: unexpected cpu cores value", tc.description)
+				continue
+			}
+		}
+	}
+}
+
+func TestCPUSockets(t *testing.T) {
+	type testcase struct {
+		description string
+		builder     *VMBuilder
+		expectation uint32
+		expectError bool
+	}
+
+	testcases := []testcase{
+		{
+			description: "default value",
+			builder:     NewVMBuilder("test"),
+			expectation: defaultVMCPUSockets,
+			expectError: false,
+		},
+		{
+			description: "set cpu cores",
+			builder:     NewVMBuilder("test").CPUSockets(4),
+			expectation: 4,
+			expectError: false,
+		},
+		{
+			description: "invalid value",
+			builder:     NewVMBuilder("test").CPUSockets(-2),
+			expectation: 1,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		testVM, err := tc.builder.VM()
+
+		if tc.expectError && err == nil {
+			t.Errorf("test %s: unexpected error", tc.description)
+			continue
+		}
+
+		if !tc.expectError && err != nil {
+			t.Errorf("test %s: expected error", tc.description)
+			continue
+		}
+
+		if !tc.expectError {
+			if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
+				t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
+				continue
+			}
+			if testVM.Spec.Template.Spec.Domain.CPU.Sockets < 1 {
+				t.Errorf("test %s: unexpected value for cpu sockets", tc.description)
+				continue
+			}
+			if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Sockets {
+				t.Errorf("test %s: unexpected cpu cores value", tc.description)
+				continue
+			}
+		}
+	}
+}
+
+func TestCPUThreads(t *testing.T) {
+	type testcase struct {
+		description string
+		builder     *VMBuilder
+		expectation uint32
+		expectError bool
+	}
+
+	testcases := []testcase{
+		{
+			description: "default value",
+			builder:     NewVMBuilder("test"),
+			expectation: defaultVMCPUThreads,
+			expectError: false,
+		},
+		{
+			description: "set cpu threads",
+			builder:     NewVMBuilder("test").CPUThreads(4),
+			expectation: 4,
+			expectError: false,
+		},
+		{
+			description: "invalid value",
+			builder:     NewVMBuilder("test").CPUThreads(-2),
+			expectation: 1,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		testVM, err := tc.builder.VM()
+
+		if tc.expectError && err == nil {
+			t.Errorf("test %s: unexpected error", tc.description)
+			continue
+		}
+
+		if !tc.expectError && err != nil {
+			t.Errorf("test %s: expected error", tc.description)
+			continue
+		}
+
+		if !tc.expectError {
+			if testVM == nil || testVM.Spec.Template.Spec.Domain.CPU == nil {
+				t.Errorf("test %s: unexpected nil value for domain cpu", tc.description)
+				continue
+			}
+			if testVM.Spec.Template.Spec.Domain.CPU.Threads < 1 {
+				t.Errorf("test %s: unexpected value for cpu cores", tc.description)
+				continue
+			}
+			if tc.expectation != testVM.Spec.Template.Spec.Domain.CPU.Threads {
+				t.Errorf("test %s: unexpected cpu cores value", tc.description)
+				continue
+			}
+		}
+	}
+}
+
+func TestGuestMemory(t *testing.T) {
+	type testcase struct {
+		description string
+		builder     *VMBuilder
+		expectation *resource.Quantity
+		expectError bool
+	}
+
+	qtyPtr := func(qty string) *resource.Quantity {
+		res := resource.MustParse(qty)
+		return &res
+	}
+
+	testcases := []testcase{
+		{
+			description: "default value",
+			builder:     NewVMBuilder("test"),
+			expectation: nil,
+			expectError: false,
+		},
+		{
+			description: "set guest memory",
+			builder:     NewVMBuilder("test").GuestMemory("2Gi"),
+			expectation: qtyPtr("2Gi"),
+			expectError: false,
+		},
+		{
+			description: "invalid value",
+			builder:     NewVMBuilder("test").GuestMemory("foobar"),
+			expectation: nil,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		testVM, err := tc.builder.VM()
+
+		if tc.expectError && err == nil {
+			t.Errorf("test %s: unexpected error", tc.description)
+			continue
+		}
+
+		if !tc.expectError && err != nil {
+			t.Errorf("test %s: expected error", tc.description)
+			continue
+		}
+
+		if tc.expectation == nil {
+			if testVM != nil && testVM.Spec.Template.Spec.Domain.Memory != nil {
+				t.Errorf("test %s: unexpected non-nil value", tc.description)
+				continue
+			}
+		}
+
+		if tc.expectation != nil {
+			if testVM.Spec.Template.Spec.Domain.Memory == nil {
+				t.Errorf("test %s: unexpected nil value for domain memory", tc.description)
+				continue
+			}
+			if testVM.Spec.Template.Spec.Domain.Memory.Guest == nil {
+				t.Errorf("test %s: unexpected nil value for guest memory", tc.description)
+				continue
+			}
+			if !tc.expectation.Equal(*testVM.Spec.Template.Spec.Domain.Memory.Guest) {
+				t.Errorf("test %s: unexpected guest memory value", tc.description)
+				continue
+			}
+		}
+	}
 }
 
 func TestDedicatedCPUPlacement(t *testing.T) {
+
+	type testcase struct {
+		name        string
+		builder     *VMBuilder
+		expectation bool
+	}
+
 	testcases := []testcase{
 		{
 			name:        "default value",
@@ -39,6 +290,13 @@ func TestDedicatedCPUPlacement(t *testing.T) {
 }
 
 func TestIsolateEmulatorThread(t *testing.T) {
+
+	type testcase struct {
+		name        string
+		builder     *VMBuilder
+		expectation bool
+	}
+
 	testcases := []testcase{
 		{
 			name:        "default value",


### PR DESCRIPTION
Add differentiated resources for CPU and memory resource requests to the VMBuilder. These functions allow the caller to make specific arrangements for the CPU topologies and for the memory of the guest VM. This is necessary to facilitate CPU and memory hotplugging with the VMBuilder

related-to: harvester/harvester#9708

#### Problem:

The VMBuilder does not expose sufficiently flexible methods for setting CPU topology and memory attributes to facilitate CPU and memory hotplugging.

#### Solution:

Add more flexible methods for expressing CPU topology and memory attributes to the VMBuilder

#### Related Issue(s):

harvester/harvester#9708

#### Test plan:

#### Additional documentation or context
