### PR TITLE
chore: replace pointer to ptr as pointer is deprecate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	github.com/urfave/cli v1.22.16
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.40.0
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
 	golang.org/x/net v0.42.0
 	golang.org/x/sync v0.16.0
 	golang.org/x/text v0.27.0
@@ -331,7 +332,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/util"
@@ -538,7 +538,7 @@ func buildPromoteJob(namespace string, node *corev1.Node, promoteImage string) *
 			},
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: pointer.Bool(true),
+				Privileged: ptr.To(true),
 			},
 			Env: []corev1.EnvVar{
 				{

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -10,7 +10,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/controller/master/upgrade/repoinfo"
@@ -378,7 +378,7 @@ func applyNodeJob(upgrade *harvesterv1.Upgrade, repoInfo *repoinfo.RepoInfo, nod
 			},
 		},
 		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: pointer.Int32Ptr(defaultTTLSecondsAfterFinished),
+			TTLSecondsAfterFinished: ptr.To(int32(defaultTTLSecondsAfterFinished)),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -481,7 +481,7 @@ func applyRestoreVMJob(upgrade *harvesterv1.Upgrade, repoInfo *repoinfo.RepoInfo
 			},
 		},
 		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: pointer.Int32Ptr(defaultTTLSecondsAfterFinished),
+			TTLSecondsAfterFinished: ptr.To(int32(defaultTTLSecondsAfterFinished)),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -542,7 +542,7 @@ func applyManifestsJob(upgrade *harvesterv1.Upgrade, repoInfo *repoinfo.RepoInfo
 			},
 		},
 		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: pointer.Int32Ptr(defaultTTLSecondsAfterFinished),
+			TTLSecondsAfterFinished: ptr.To(int32(defaultTTLSecondsAfterFinished)),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/image/backingimage/backingimage.go
+++ b/pkg/image/backingimage/backingimage.go
@@ -16,7 +16,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
@@ -192,7 +192,7 @@ func (bib *Backend) createStorageClass(vmi *harvesterv1.VirtualMachineImage) err
 		},
 		Provisioner:          longhorntypes.LonghornDriverName,
 		ReclaimPolicy:        &reclaimPolicy,
-		AllowVolumeExpansion: pointer.BoolPtr(true),
+		AllowVolumeExpansion: ptr.To(true),
 		VolumeBindingMode:    &volumeBindingMode,
 		Parameters:           params,
 	}

--- a/pkg/webhook/resources/pod/mutator.go
+++ b/pkg/webhook/resources/pod/mutator.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	harvSettings "github.com/harvester/harvester/pkg/settings"
@@ -17,7 +17,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
-var matchingLabelsForNamespace = map[string][]labels.Set {
+var matchingLabelsForNamespace = map[string][]labels.Set{
 	util.LonghornSystemNamespaceName: {
 		{
 			"longhorn.io/component": "backing-image-data-source",
@@ -168,7 +168,7 @@ func (m *podMutator) additionalCAPatches(pod *corev1.Pod) (types.PatchOps, error
 			Name: "additional-ca-volume",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: pointer.Int32(400),
+					DefaultMode: ptr.To(int32(400)),
 					SecretName:  util.AdditionalCASecretName,
 				},
 			},

--- a/pkg/webhook/resources/pod/mutator_test.go
+++ b/pkg/webhook/resources/pod/mutator_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -115,7 +115,7 @@ func Test_volumePatch(t *testing.T) {
 					Name: "additional-ca-volume",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32(400),
+							DefaultMode: ptr.To(int32(400)),
 							SecretName:  util.AdditionalCASecretName,
 						},
 					},
@@ -131,7 +131,7 @@ func Test_volumePatch(t *testing.T) {
 					Name: "additional-ca-volume",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32(400),
+							DefaultMode: ptr.To(int32(400)),
 							SecretName:  util.AdditionalCASecretName,
 						},
 					},
@@ -202,7 +202,7 @@ func Test_volumeMountPatch(t *testing.T) {
 
 func Test_shouldPatch(t *testing.T) {
 	type input struct {
-		pod	corev1.Pod
+		pod corev1.Pod
 	}
 	var testCases = []struct {
 		name   string


### PR DESCRIPTION
#### Problem:
k8s pointer pkg is deprecate now, replace with ptr.To, see https://pkg.go.dev/k8s.io/utils/pointer#pkg-overview

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
