### PR TITLE
fix: build: always pull harvester-installer image

### DIFF
--- a/scripts/package-upgrade
+++ b/scripts/package-upgrade
@@ -27,7 +27,10 @@ cp ../../bin/upgrade-helper .
 
 BUILD_ARGS="--build-arg ARCH=${ARCH}"
 if [ -n "${HARVESTER_INSTALLER_REF}" ]; then
+    docker pull rancher/harvester-installer:${HARVESTER_INSTALLER_REF}
     BUILD_ARGS="${BUILD_ARGS} --build-arg HARVESTER_INSTALLER_REF=${HARVESTER_INSTALLER_REF}"
+else
+    docker pull rancher/harvester-installer:master-head
 fi
 docker build -f ${DOCKERFILE} ${BUILD_ARGS} -t ${IMAGE} .
 echo Built ${IMAGE}


### PR DESCRIPTION
#### Problem:
When building Harvester locally, it's possible for your docker cache to have an older version of the harvester-installer image, which means the upgrade container of your local build will use a potentially stale harvester-installer binary. 

#### Solution:
We can solve this by pulling the container on every build.  This should have no real effect on our CI or release builds which run in a clean environment each time.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9909

#### Test plan:
N/A

#### Additional documentation or context