### PR TITLE
chore: add go mod tidy in the validate-ci to ensure the lib consistency

### DIFF
--- a/scripts/validate-ci
+++ b/scripts/validate-ci
@@ -7,6 +7,7 @@ cd $(dirname $0)/..
 echo "Running dirty check"
 
 go generate
+go mod tidy
 
 source ./scripts/version
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
- When introducing new lib, dev may not run `go mod tidy`, and CI should catch this error.

#### Solution:
- add go mod tidy in the validate-ci, thanks to @wheatdog

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
