### PR TITLE
fix: do not block vmstate-persistence usage

### DIFF
--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -239,8 +239,5 @@ func (v *pvcValidator) isBelongToUpgradeImage(pvc *corev1.PersistentVolumeClaim)
 }
 
 func isUsingReservedSC(pvc *corev1.PersistentVolumeClaim) bool {
-	if pvc.Spec.StorageClassName == nil {
-		return false
-	}
-	return *pvc.Spec.StorageClassName == util.StorageClassLonghornStatic || *pvc.Spec.StorageClassName == util.StorageClassVmstatePersistence
+	return pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName == util.StorageClassLonghornStatic
 }

--- a/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
@@ -241,8 +241,7 @@ func TestCreate(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassVmstatePersistence),
 				},
 			},
-			expectError:   true,
-			errorContains: "reserved storage class",
+			expectError: false,
 		},
 	}
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:

https://kubevirt.io/user-guide/compute/persistent_tpm_and_uefi_state/#tpm-with-persistent-state

if user set TPM with persistent state to the VM, kubevirt will create a pvc with sc `vmstate-persistence`. While we block any PVC with sc `vmstate-persistence` in webhook validtor, see https://github.com/harvester/harvester/pull/9366.

#### Solution:

do not block vmstate-persistence usage, this PR works as a band-aid, if we want to block vmstate-persistence usage, we have to figure out other solution.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9919

#### Test plan:
see issue desc

https://github.com/user-attachments/assets/4400777f-3f94-4b39-9180-1a146924f5e8


#### Additional documentation or context
