### PR TITLE
upgrade: perform rollback on stuck helm release revision

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -45,6 +45,9 @@ wait_managed_chart() {
   done
 }
 
+# wait for helm release to be deployed to a specified version and status
+# if the most-recent revision of the release is in a pending state and is
+# older than 5 minutes, perform a rollback to the last-known deployed
 wait_helm_release() {
   # Wait for helm release to be deployed to a specified version
   namespace=$1
@@ -59,13 +62,31 @@ wait_helm_release() {
     current_chart=$(echo "$last_history" | yq e '.chart' -)
     current_app_version=$(echo "$last_history" | yq e '.app_version' -)
     current_status=$(echo "$last_history" | yq e '.status' -)
+    current_revision=$(echo "$last_history" | yq e '.revision' -)
+    last_updated_time=$(echo "$last_history" | yq e '.updated' -)
 
-    if [ "$current_chart" != "$chart" ]; then
-      sleep 5
-      continue
-    fi
+    pending_prefix="pending-"
+    deadline_minutes=5
+    if [ "$current_chart" != "$chart" ] || [ "$current_app_version" != "$app_version" ]; then
+      # if the most-recent revision of the release is in a pending state and is
+      # older than 5 minutes, perform a rollback to the last-known deployed
+      # revision to unstuck it. fleet will retry upgrading the revision.
+      if [[ "$current_status" == "$pending_prefix"* ]]; then
+        minutes_passed=$((($(date +%s) - $(date -d"$last_updated_time" +%s)) / 60))
+        echo "$current_chart:$current_app_version in $current_status state for $minutes_passed minutes"
 
-    if [ "$current_app_version" != "$app_version" ]; then
+        if [ "$minutes_passed" -gt "$deadline_minutes" ]; then
+          last_deployed_revision=$(helm -n $namespace history $release_name -oyaml | yq '[.[] | select(.status == "deployed")] | sort_by(.revision) | reverse | .[0].revision')
+          echo "deadline exceeded. rolling back $current_chart:$current_app_version from revision $current_revision to revision $last_deployed_revision"
+
+          helm -n "$namespace" rollback "$release_name" "$last_deployed_revision" --wait
+          rollback_status=$?
+          if [ $rollback_status -ne 0 ]; then
+            echo "failed to rollback $current_chart:$current_app_version to revision $last_deployed_revision, resume wait..."
+          fi
+        fi
+      fi
+
       sleep 5
       continue
     fi
@@ -77,6 +98,7 @@ wait_helm_release() {
 
     break
   done
+  echo "completed helm release $namespace $release_name $chart $app_version $status"
 }
 
 wait_rollout() {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

During upgrade, if the most-recent revision of a component's (e.g., Fleet) Helm release is stuck in the pending state, Fleet will not rollout the new chart version that comes with the upgrade. The workaround to unstuck the rollout is to revert the most-recent release back to the last-known deployed revision.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR updates the upgrade script to perform the automatic rollback to the last-known deployed revision if the most-recent stuck revision is older than 5 minutes. Rancher will resume the chart rollout to the target upgrade version.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#9738. 

#### Test plan:

Goal: The goal is to inject broken Helm release revisions before upgrade and let the upgrade script perform an automatic rollback to the most-recent deployed release revision.

Although this test suite uses the Fleet Helm chart as the test target, the change applies to all components' Helm charts.

1. Install Harvester 1.6.1 (it can be any version of Harvester with Fleet chart <= fleet-107.0.2+up0.13.2)
2. Confirm the Fleet chart is at version `fleet-107.0.2+up0.13.2`:

```sh
$ helm -n cattle-fleet-system list
NAME            NAMESPACE               REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
fleet           cattle-fleet-system     2               2026-01-22 18:00:13.489020411 +0000 UTC deployed        fleet-107.0.2+up0.13.2          0.13.2     
fleet-crd       cattle-fleet-system     1               2026-01-22 17:57:34.301015326 +0000 UTC deployed        fleet-crd-107.0.2+up0.13.2      0.13.2    

$ helm -n cattle-fleet-system history fleet
REVISION        UPDATED                         STATUS          CHART                   APP VERSION     DESCRIPTION     
1               Thu Jan 22 17:57:19 2026        superseded      fleet-107.0.2+up0.13.2  0.13.2          Install complete
2               Thu Jan 22 18:00:13 2026        deployed        fleet-107.0.2+up0.13.2  0.13.2          Upgrade complete
```

3. Inject a broken release revision to the Fleet Helm release by:

     * overriding the Helm release to use a non-existing image tag
     * set the Helm upgrade timer to expire after 1 minute

```sh
helm repo add fleet https://rancher.github.io/fleet-helm-charts/

helm pull fleet/fleet --version 0.13.2

# override the chart to use a non-existing image tag
# the upgrade is set to time out after 1 minute
helm -n cattle-fleet-system upgrade --install --set image.tag=nonexistent --timeout=1m fleet ./fleet-0.13.2.tgz
```

4. Confirm that the upgrade revision is stuck in the `pending-upgrade` state:

```sh
$ helm -n cattle-fleet-system history fleet     
REVISION        UPDATED                         STATUS          CHART                   APP VERSION     DESCRIPTION      
1               Thu Jan 22 17:57:19 2026        superseded      fleet-107.0.2+up0.13.2  0.13.2          Install complete 
2               Thu Jan 22 18:00:13 2026        deployed        fleet-107.0.2+up0.13.2  0.13.2          Upgrade complete 
3               Thu Jan 22 10:12:34 2026        pending-upgrade fleet-0.13.2            0.13.2          Preparing upgrade
```

5. After 1 minute, confirm that the upgrade revision enters a the `failed` state:

```sh
$ helm -n cattle-fleet-system history fleet
REVISION        UPDATED                         STATUS          CHART                   APP VERSION     DESCRIPTION                                                         
1               Thu Jan 22 17:57:19 2026        superseded      fleet-107.0.2+up0.13.2  0.13.2          Install complete                                                    
2               Thu Jan 22 18:00:13 2026        deployed        fleet-107.0.2+up0.13.2  0.13.2          Upgrade complete                                                    
3               Thu Jan 22 10:12:34 2026        failed          fleet-0.13.2            0.13.2          Upgrade "fleet" failed: post-upgrade hooks failed: 1 error occurr...
```

6. Perform a second upgrade attempts, with the timeout set to 1 hour:

```sh
# do not exit this command
helm -n cattle-fleet-system upgrade --install --set image.tag=nonexistent --timeout=60m fleet ./fleet-0.13.2.tgz
```

7. Confirm that a new upgrade revision is created and remain stuck:

```sh
helm -n cattle-fleet-system history fleet 
REVISION        UPDATED                         STATUS          CHART                   APP VERSION     DESCRIPTION                                                         
1               Thu Jan 22 17:57:19 2026        superseded      fleet-107.0.2+up0.13.2  0.13.2          Install complete                                                    
2               Thu Jan 22 18:00:13 2026        deployed        fleet-107.0.2+up0.13.2  0.13.2          Upgrade complete                                                    
3               Thu Jan 22 10:12:34 2026        failed          fleet-0.13.2            0.13.2          Upgrade "fleet" failed: post-upgrade hooks failed: 1 error occurr...
4               Thu Jan 22 10:16:10 2026        pending-upgrade fleet-0.13.2            0.13.2          Preparing upgrade              
```

8. Upgrade the Harvester cluster to an ISO version that includes changes in this PR.

9. Wait till the upgrade `apply-manifest` pod is running:

```sh
watch k -n harvester-system get pod -lharvesterhci.io/upgradeComponent=manifest
```

10. Tail the `apply-manifest` pod logs:

```sh
kubectl -n harvester-system logs -f -lharvesterhci.io/upgradeComponent=manifest
```

11. From the logs, expect the upgrade script to:

      * detect the stuck revision
      * perform a rollback to the last-known deployed revision
      * rollout the latest version of Fleet

```sh
wait helm release cattle-fleet-system fleet fleet-108.0.0+up0.14.0 0.14.0 deployed
fleet-0.13.2:0.13.2 in pending-upgrade state for 35 minutes
deadline exceeded. rolling back fleet-0.13.2:0.13.2 from revision 4 to revision 2
Rollback was a success! Happy Helming!
completed helm release cattle-fleet-system fleet fleet-108.0.0+up0.14.0 0.14.0 deployed
wait helm release cattle-fleet-system fleet-crd fleet-crd-108.0.0+up0.14.0 0.14.0 deployed
completed helm release cattle-fleet-system fleet-crd fleet-crd-108.0.0+up0.14.0 0.14.0 deployed
wait helm release cattle-system rancher-webhook rancher-webhook-108.0.1+up0.9.1 0.9.1 deployed
```

12. Expect the stuck Fleet Helm release to be:

     * rolled back to revision 2, which was the last-known deployed revision, 
     * and eventually, successfully upgraded to fleet-108.0.0+up0.14.0 :

```sh
$ helm -n cattle-fleet-system history fleet 
REVISION        UPDATED                         STATUS          CHART                   APP VERSION     DESCRIPTION                                                         
2               Thu Jan 22 18:00:13 2026        superseded      fleet-107.0.2+up0.13.2  0.13.2          Upgrade complete                                                    
3               Thu Jan 22 10:12:34 2026        failed          fleet-0.13.2            0.13.2          Upgrade "fleet" failed: post-upgrade hooks failed: 1 error occurr...
4               Thu Jan 22 10:16:10 2026        deployed        fleet-0.13.2            0.13.2          Upgrade complete                                                    
5               Thu Jan 22 18:51:11 2026        superseded      fleet-107.0.2+up0.13.2  0.13.2          Rollback to 2                                                       
6               Thu Jan 22 18:52:16 2026        deployed        fleet-108.0.0+up0.14.0  0.14.0          Upgrade complete   
```

13. Confirm that the Fleet controllers are successfully upgraded:

```sh
$ kubectl -n cattle-fleet-system get po -ocustom-columns="NAME:.metadata.name,STATUS:.status.phase,IMAGE:.spec.containers[0].image"
NAME                                STATUS    IMAGE
fleet-controller-5d59dbbfdf-hc9lf   Running   rancher/fleet:v0.14.0
gitjob-fb5cbbbd7-ddc5p              Running   rancher/fleet:v0.14.0
helmops-7b589b8f55-6kkq4            Running   rancher/fleet:v0.14.0
```

14. Confirm that the Fleet agent is successfully upgraded:

```sh
$ kubectl -n cattle-fleet-local-system get po -ocustom-columns="NAME:.metadata.name,STATUS:.status.phase,IMAGE:.spec.containers[0].image"
NAME                          STATUS    IMAGE
fleet-agent-f564564d6-rs2pq   Running   rancher/fleet-agent:v0.14.0
```

#### Additional documentation or context
