### PR TITLE
additional changes to pod mutator to allow support for forklift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	kubevirt.io/kubevirt v1.7.0
 	sigs.k8s.io/cluster-api v1.9.5
 	sigs.k8s.io/controller-runtime v0.21.0
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
 	sigs.k8s.io/kind v0.30.0
 	sigs.k8s.io/kustomize/kyaml v0.19.0
 	sigs.k8s.io/yaml v1.6.0
@@ -351,7 +352,6 @@ require (
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.32.1 // indirect
 	sigs.k8s.io/cli-utils v0.37.2 // indirect
-	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect

--- a/pkg/webhook/resources/pod/mutator_test.go
+++ b/pkg/webhook/resources/pod/mutator_test.go
@@ -1,9 +1,15 @@
 package pod
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"sigs.k8s.io/json"
+
+	"github.com/rancher/wrangler/v3/pkg/patch"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -271,4 +277,283 @@ func Test_shouldPatch(t *testing.T) {
 		result := shouldPatch(&testCase.input.pod)
 		assert.Equal(t, testCase.output, result, "case %q", testCase.name)
 	}
+}
+
+const (
+	podJSON = `{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "annotations": {
+            "cni.projectcalico.org/containerID": "1e516216321c29a5672c435447d77c95880b184e0005e7fe04f2507d46b92d33",
+            "cni.projectcalico.org/podIP": "",
+            "cni.projectcalico.org/podIPs": "",
+            "k8s.v1.cni.cncf.io/network-status": "[{\n    \"name\": \"k8s-pod-network\",\n    \"ips\": [\n        \"10.52.1.181\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]"
+        },
+        "creationTimestamp": "2026-02-01T23:37:56Z",
+        "generateName": "vmware-gm-ubuntu-test-migration-vm-13007-",
+        "generation": 1,
+        "labels": {
+            "forklift.app": "virt-v2v",
+            "migration": "3abfbc07-fb99-46db-bd30-b69242686b7d",
+            "plan": "e3f762d7-4a72-47c2-a333-0651c9614bcc",
+            "vmID": "vm-13007"
+        },
+        "name": "vmware-gm-ubuntu-test-migration-vm-13007-p7r8g",
+        "namespace": "default",
+        "resourceVersion": "19875589",
+        "uid": "7f9eba5e-0564-4b5f-8526-b44331eea8a1"
+    },
+    "spec": {
+        "affinity": {
+            "podAntiAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "podAffinityTerm": {
+                            "labelSelector": {
+                                "matchExpressions": [
+                                    {
+                                        "key": "forklift.app",
+                                        "operator": "In",
+                                        "values": [
+                                            "virt-v2v"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "namespaceSelector": {},
+                            "topologyKey": "kubernetes.io/hostname"
+                        },
+                        "weight": 100
+                    }
+                ]
+            }
+        },
+        "containers": [
+            {
+                "env": [
+                    {
+                        "name": "V2V_HOSTNAME",
+                        "value": "ubuntu"
+                    },
+                    {
+                        "name": "V2V_vmName",
+                        "value": "gm-ubuntu-test"
+                    },
+                    {
+                        "name": "V2V_libvirtURL",
+                        "value": "vpx://fakeendpoint"
+                    },
+                    {
+                        "name": "V2V_source",
+                        "value": "vSphere"
+                    },
+                    {
+                        "name": "V2V_fingerprint",
+                        "value": "fake-v2v-fingerprint"
+                    },
+                    {
+                        "name": "V2V_extra_args",
+                        "value": "[]"
+                    },
+                    {
+                        "name": "LOCAL_MIGRATION",
+                        "value": "true"
+                    }
+                ],
+                "envFrom": [
+                    {
+                        "prefix": "V2V_",
+                        "secretRef": {
+                            "name": "vmware-gm-ubuntu-test-migration-vm-13007-drhh2"
+                        }
+                    }
+                ],
+                "image": "gmehta3/harvester-forklift-virt-v2v:main-head",
+                "imagePullPolicy": "Always",
+                "name": "virt-v2v",
+                "ports": [
+                    {
+                        "containerPort": 2112,
+                        "name": "metrics",
+                        "protocol": "TCP"
+                    }
+                ],
+                "resources": {
+                    "limits": {
+                        "cpu": "4",
+                        "devices.kubevirt.io/kvm": "1",
+                        "memory": "8Gi"
+                    },
+                    "requests": {
+                        "cpu": "1",
+                        "devices.kubevirt.io/kvm": "1",
+                        "memory": "1Gi"
+                    }
+                },
+                "securityContext": {
+                    "allowPrivilegeEscalation": false,
+                    "capabilities": {
+                        "drop": [
+                            "ALL"
+                        ]
+                    }
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeDevices": [
+                    {
+                        "devicePath": "/dev/block0",
+                        "name": "vmware-gm-ubuntu-test-migration-vm-13007-ndzrv"
+                    }
+                ],
+                "volumeMounts": [
+                    {
+                        "mountPath": "/mnt/v2v",
+                        "name": "libvirt-domain-xml"
+                    },
+                    {
+                        "mountPath": "/opt",
+                        "name": "vddk-vol-mount"
+                    },
+                    {
+                        "mountPath": "/etc/secret",
+                        "name": "secret-volume",
+                        "readOnly": true
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "kube-api-access-7bhl8",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "enableServiceLinks": true,
+        "nodeName": "dell-140-tink-system",
+        "nodeSelector": {
+            "kubevirt.io/schedulable": "true"
+        },
+        "preemptionPolicy": "PreemptLowerPriority",
+        "priority": 0,
+        "restartPolicy": "Never",
+        "schedulerName": "default-scheduler",
+        "securityContext": {
+            "fsGroup": 107,
+            "runAsNonRoot": true,
+            "runAsUser": 107,
+            "seccompProfile": {
+                "type": "RuntimeDefault"
+            }
+        },
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/not-ready",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            },
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/unreachable",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            }
+        ],
+        "volumes": [
+            {
+                "name": "vmware-gm-ubuntu-test-migration-vm-13007-ndzrv",
+                "persistentVolumeClaim": {
+                    "claimName": "vmware-gm-ubuntu-test-migration-vm-13007-ndzrv"
+                }
+            },
+            {
+                "configMap": {
+                    "defaultMode": 420,
+                    "name": "vmware-gm-ubuntu-test-migration-vm-13007-clsv4"
+                },
+                "name": "libvirt-domain-xml"
+            },
+            {
+                "emptyDir": {},
+                "name": "vddk-vol-mount"
+            },
+            {
+                "name": "secret-volume",
+                "secret": {
+                    "defaultMode": 420,
+                    "secretName": "vmware-gm-ubuntu-test-migration-vm-13007-drhh2"
+                }
+            },
+            {
+                "name": "kube-api-access-7bhl8",
+                "projected": {
+                    "defaultMode": 420,
+                    "sources": [
+                        {
+                            "serviceAccountToken": {
+                                "expirationSeconds": 3607,
+                                "path": "token"
+                            }
+                        },
+                        {
+                            "configMap": {
+                                "items": [
+                                    {
+                                        "key": "ca.crt",
+                                        "path": "ca.crt"
+                                    }
+                                ],
+                                "name": "kube-root-ca.crt"
+                            }
+                        },
+                        {
+                            "downwardAPI": {
+                                "items": [
+                                    {
+                                        "fieldRef": {
+                                            "apiVersion": "v1",
+                                            "fieldPath": "metadata.namespace"
+                                        },
+                                        "path": "namespace"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}`
+)
+
+func Test_generateForkliftV2VPatch(t *testing.T) {
+	assert := require.New(t)
+	sourcePod, err := generatePod([]byte(podJSON))
+	assert.NoError(err, "expected no error during generation of source pod")
+	patchOps, err := generateForkliftV2VPatch(sourcePod)
+	assert.NotEmpty(patchOps, "expected to find patchops for forklift v2v pod")
+	assert.NoError(err, "expected no error during generation of patch")
+	patchData := fmt.Sprintf("[%s]", strings.Join(patchOps, ","))
+	patchedPodBytes, err := patch.Apply([]byte(podJSON), []byte(patchData))
+	assert.NoError(err, "expected no error during application of patch to source pod")
+	targetPod, err := generatePod(patchedPodBytes)
+	assert.NoError(err, "expected no error during generation of target pod")
+	assert.Equal(corev1.SeccompProfileTypeUnconfined, targetPod.Spec.SecurityContext.SeccompProfile.Type, "expected pod seccomp profile to be unconfined")
+	for i := range targetPod.Spec.Containers {
+		assert.Equal(true, *targetPod.Spec.Containers[i].SecurityContext.Privileged, "expected to find privileged container security context")
+		assert.Equal(corev1.PullIfNotPresent, targetPod.Spec.Containers[i].ImagePullPolicy, "expected to find imagePullPolicy IfNotPresent")
+	}
+
+}
+
+func generatePod(content []byte) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	err := json.UnmarshalCaseSensitivePreserveInts(content, pod)
+	return pod, err
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
When using forklift with harvester, the disk conversion by the virt-v2v fails with the cryptic error

```
No interfaces with usable IPv6 routes
UNIX domain socket bound at /tmp/libguestfs4z8aH8/passt.sock
Couldn't create user namespace: Operation not permitted
libguestfs: trace: v2v: launch = -1 (error)
virt-v2v: error: libguestfs error: passt exited with status 1
rm -rf -- '/tmp/v2vnbdkit.HVbzom'
```

This seems to stem from the securityContext and secCompProfile applied to the virt-v2v pod when running on non openshift clusters.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR adds a minor change to harvester webhook to mutate virt-v2v pods to have privileged permissions to allow successful conversion of disks.

In addition the converter pod container use the ImagePullPolicy of `Always`. The mutator also mutates this to `IfNotPresent`

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/suse-virtualization-mgmt/issues/18

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
