### PR TITLE
fix: skip patching VM-less VMI in mutator

### DIFF
--- a/pkg/webhook/resources/virtualmachineinstance/mutator.go
+++ b/pkg/webhook/resources/virtualmachineinstance/mutator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -47,6 +48,9 @@ func (m *vmiMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patc
 
 	vm, err := m.vm.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/webhook/resources/virtualmachineinstance/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachineinstance/mutator_test.go
@@ -228,3 +228,25 @@ func TestPatchMacAddress(t *testing.T) {
 		assert.Equal(t, tc.patches, patchOps, tc.name)
 	}
 }
+
+func TestCreateWithoutVM(t *testing.T) {
+	vmi := &kubevirtv1.VirtualMachineInstance{
+		Spec: kubevirtv1.VirtualMachineInstanceSpec{
+			Domain: kubevirtv1.DomainSpec{
+				Devices: kubevirtv1.Devices{
+					Interfaces: []kubevirtv1.Interface{
+						{
+							Name: "default",
+						},
+					},
+				},
+			},
+		},
+	}
+	req := &types.Request{}
+	clientSet := fake.NewSimpleClientset()
+	mutator := NewMutator(fakeclients.VirtualMachineCache(clientSet.KubevirtV1().VirtualMachines))
+	patchOps, err := mutator.Create(req, vmi)
+	assert.Nil(t, err)
+	assert.Nil(t, patchOps)
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Couldn't create a VMI directly since the VMI mutator currently expect the existence of the wrapping VM CR.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Skip patching VM-less VMI in mutator.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#9172 

#### Test plan:
<!-- Describe the test plan by steps. -->

- Create a VMI directly via kubectl

#### Additional documentation or context

N/A
