### PR TITLE
settings: decrease some overcommit ratios

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -13,6 +13,44 @@ pre_upgrade_manifest() {
   fi
 }
 
+# Preserve the current overcommit-config value before upgrade.
+# The new version lowers the default storage overcommit from 200% to 100%.
+# For users who never customized the setting (value is empty), we pin the
+# current default so their effective configuration is not silently changed.
+preserve_overcommit_config() {
+  if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.7\.[0-9]$ ]]; then
+    echo "Skip migrate overcommit config if you are not upgrade from v1.7.x, current version: $UPGRADE_PREVIOUS_VERSION"
+    return
+  fi
+  local setting_name="overcommit-config"
+  local setting_json
+  setting_json=$(kubectl get settings.harvesterhci.io "$setting_name" -o json 2>/dev/null) || {
+    echo "Warning: failed to get $setting_name setting, skipping preservation"
+    return 0
+  }
+
+  local current_value
+  current_value=$(echo "$setting_json" | jq -r '.value // empty')
+
+  if [ -n "$current_value" ]; then
+    echo "overcommit-config already has a customized value, skipping preservation"
+    return 0
+  fi
+
+  local default_value
+  default_value=$(echo "$setting_json" | jq -r '.default // empty')
+
+  if [ -z "$default_value" ]; then
+    echo "Warning: overcommit-config has no default value, skipping preservation"
+    return 0
+  fi
+
+  echo "Preserving current overcommit-config default as explicit value: $default_value"
+  local patch_json
+  patch_json=$(jq -n --arg v "$default_value" '{"value": $v}')
+  kubectl patch settings.harvesterhci.io "$setting_name" --type merge -p "$patch_json"
+}
+
 wait_managed_chart() {
   namespace=$1
   name=$2
@@ -1376,6 +1414,7 @@ wait_repo
 detect_repo
 detect_upgrade
 pre_upgrade_manifest
+preserve_overcommit_config
 pause_all_charts
 skip_restart_rancher_system_agent
 upgrade_rancher

--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -36,8 +36,8 @@ var (
 	bootstrapSettings = []string{
 		settings.SSLCertificatesSettingName,
 		settings.KubeconfigDefaultTokenTTLMinutesSettingName,
-		// The Longhorn storage over-provisioning percentage is set to 100, whereas Harvester uses 200.
-		// This needs to be synchronized when Harvester starts.
+		// We need to sync overcommit config on bootstrap
+		// Now, storage overcommit was aligned with Longhorn setting,
 		settings.OvercommitConfigSettingName,
 		// always run this when Harvester POD starts
 		settings.AdditionalGuestMemoryOverheadRatioName,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -43,7 +43,7 @@ var (
 	DefaultStorageClass                    = NewSetting(DefaultStorageClassSettingName, "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
-	OvercommitConfig                       = NewSetting(OvercommitConfigSettingName, `{"cpu":1600,"memory":150,"storage":200}`)
+	OvercommitConfig                       = NewSetting(OvercommitConfigSettingName, `{"cpu":1000,"memory":150,"storage":100}`)
 	VipPools                               = NewSetting(VipPoolsConfigSettingName, "")
 	AutoDiskProvisionPaths                 = NewSetting(AutoDiskProvisionPathsSettingName, "")
 	CSIDriverConfig                        = NewSetting(CSIDriverConfigSettingName, `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"}}`)


### PR DESCRIPTION
        - decrease CPU to 1000%, storage to 100%
        - To align with default configuration of Longhorn, Kubevirt
        - add the upgrade part, we will keep the current running
          configuration (no matter default/new applied)

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
We should align the storage overcommit with Longhorn's default settings

#### Solution:
Align the storage overcommit

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9954
https://github.com/harvester/harvester/issues/10087

#### Test plan:
1. Create Harvester cluster
2. Ensure the default storage overcommit was 100%
3. Ensure the default CPU overcommit was 1000%
4. Ensure the old settings `{"cpu":1600,"memory":150,"storage":200}` was applied as value

#### Additional documentation or context
