### PR TITLE
fix: stop image download retries after max attempts

### DIFF
--- a/pkg/image/backingimage/backing_image_controller.go
+++ b/pkg/image/backingimage/backing_image_controller.go
@@ -53,7 +53,7 @@ func (h *backingImageHandler) OnChanged(_ string, bi *lhv1beta2.BackingImage) (*
 		return nil, err
 	}
 
-	if harvesterv1.ImageRetryLimitExceeded.IsTrue(vmi) {
+	if h.vmio.IsRetryLimitExceeded(vmi) {
 		return bi, nil
 	}
 

--- a/pkg/image/backingimage/backing_image_controller.go
+++ b/pkg/image/backingimage/backing_image_controller.go
@@ -52,6 +52,11 @@ func (h *backingImageHandler) OnChanged(_ string, bi *lhv1beta2.BackingImage) (*
 	} else if err != nil {
 		return nil, err
 	}
+
+	if harvesterv1.ImageRetryLimitExceeded.IsTrue(vmi) {
+		return bi, nil
+	}
+
 	// There are two states that we care about here:
 	// - ImageInitialized
 	// - ImageImported

--- a/pkg/image/backingimage/backing_image_controller_test.go
+++ b/pkg/image/backingimage/backing_image_controller_test.go
@@ -1,0 +1,178 @@
+package backingimage
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/image/common"
+	"github.com/harvester/harvester/pkg/ref"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+const (
+	testNamespace = "default"
+	testImageName = "test-image"
+	testSCName    = "longhorn-test"
+	testRetry     = 3
+)
+
+// TestBackingImageHandler_OnChanged tests that a BackingImage is reconciled when a VirtualMachineImage is changed
+// VMImage enters the initialized state when the DataVolume is not found.
+func TestBackingImageHandler_OnChanged_RetryLimitExceeded(t *testing.T) {
+	tests := []struct {
+		name           string
+		vmImage        *harvesterv1.VirtualMachineImage
+		backingImage   *lhv1beta2.BackingImage
+		result         *lhv1beta2.BackingImage
+		expectedFailed int
+		err            error
+	}{
+		{
+			name: "BackingImage should be reconciled when a VirtualMachineImage is changed",
+			vmImage: &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testImageName,
+					Namespace: testNamespace,
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					DisplayName:            "Test Upload Image",
+					SourceType:             harvesterv1.VirtualMachineImageSourceTypeUpload,
+					Backend:                harvesterv1.VMIBackendBackingImage,
+					TargetStorageClassName: testSCName,
+					Retry:                  testRetry,
+				},
+				Status: harvesterv1.VirtualMachineImageStatus{
+					Failed: testRetry - 1,
+					Conditions: []harvesterv1.Condition{
+						{
+							Type:   harvesterv1.ImageInitialized,
+							Status: "True",
+						},
+					},
+				},
+			},
+			backingImage: &lhv1beta2.BackingImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testImageName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						util.AnnotationImageID: ref.Construct(testNamespace, testImageName),
+					},
+				},
+				Status: lhv1beta2.BackingImageStatus{
+					DiskFileStatusMap: map[string]*lhv1beta2.BackingImageDiskFileStatus{
+						"test-disk": {
+							State:   lhv1beta2.BackingImageStateFailed,
+							Message: "test error",
+						},
+					},
+				},
+			},
+			result:         nil,
+			expectedFailed: testRetry,
+			err:            nil,
+		},
+		{
+			name: "BackingImage should not be reconciled when retry limit is exceeded",
+			vmImage: &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testImageName,
+					Namespace: testNamespace,
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					DisplayName:            "Test Upload Image",
+					SourceType:             harvesterv1.VirtualMachineImageSourceTypeUpload,
+					Backend:                harvesterv1.VMIBackendBackingImage,
+					TargetStorageClassName: testSCName,
+					Retry:                  testRetry,
+				},
+				Status: harvesterv1.VirtualMachineImageStatus{
+					Failed: testRetry,
+					Conditions: []harvesterv1.Condition{
+						{
+							Type:   harvesterv1.ImageRetryLimitExceeded,
+							Status: "True",
+						},
+					},
+				},
+			},
+			backingImage: &lhv1beta2.BackingImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testImageName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						util.AnnotationImageID: ref.Construct(testNamespace, testImageName),
+					},
+				},
+				Status: lhv1beta2.BackingImageStatus{
+					DiskFileStatusMap: map[string]*lhv1beta2.BackingImageDiskFileStatus{
+						"test-disk": {
+							State:   lhv1beta2.BackingImageStateFailed,
+							Message: "test error",
+						},
+					},
+				},
+			},
+			result: &lhv1beta2.BackingImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testImageName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						util.AnnotationImageID: ref.Construct(testNamespace, testImageName),
+					},
+				},
+				Status: lhv1beta2.BackingImageStatus{
+					DiskFileStatusMap: map[string]*lhv1beta2.BackingImageDiskFileStatus{
+						"test-disk": {
+							State:   lhv1beta2.BackingImageStateFailed,
+							Message: "test error",
+						},
+					},
+				},
+			},
+			expectedFailed: testRetry,
+			err:            nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup fake clients
+			var harvFakeClient = fakegenerated.NewSimpleClientset()
+			require.NoError(t, harvFakeClient.Tracker().Add(tt.vmImage))
+
+			// Create VMIOperator
+			vmio, err := common.GetVMIOperator(
+				fakeclients.VirtualMachineImageClient(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				fakeclients.VirtualMachineImageCache(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				http.Client{},
+			)
+			require.Nil(t, err, "should create VMIOperator")
+
+			// Create handler
+			h := &backingImageHandler{
+				vmiCache: fakeclients.VirtualMachineImageCache(harvFakeClient.HarvesterhciV1beta1().VirtualMachineImages),
+				vmio:     vmio,
+			}
+
+			// Call OnChanged
+			result, err := h.OnChanged("", tt.backingImage)
+			require.Equal(t, tt.result, result)
+			require.Equal(t, tt.err, err)
+
+			updated, err := harvFakeClient.HarvesterhciV1beta1().
+				VirtualMachineImages(testNamespace).
+				Get(context.Background(), testImageName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedFailed, updated.Status.Failed)
+		})
+	}
+}

--- a/pkg/image/common/operator.go
+++ b/pkg/image/common/operator.go
@@ -69,6 +69,7 @@ type VMIOperator interface {
 	IsImported(vmi *harvesterv1.VirtualMachineImage) bool
 	IsDecryptOperation(vmi *harvesterv1.VirtualMachineImage) bool
 	IsEncryptOperation(vmi *harvesterv1.VirtualMachineImage) bool
+	IsRetryLimitExceeded(vmi *harvesterv1.VirtualMachineImage) bool
 
 	CheckURLAndUpdate(old *harvesterv1.VirtualMachineImage) (*harvesterv1.VirtualMachineImage, error)
 	UpdateVirtualSize(old *harvesterv1.VirtualMachineImage, virtualSize int64) (*harvesterv1.VirtualMachineImage, error)
@@ -185,6 +186,10 @@ func (vmio *vmiOperator) IsImported(vmi *harvesterv1.VirtualMachineImage) bool {
 
 func (vmio *vmiOperator) IsDecryptOperation(vmi *harvesterv1.VirtualMachineImage) bool {
 	return vmi.Spec.SecurityParameters.CryptoOperation == harvesterv1.VirtualMachineImageCryptoOperationTypeDecrypt
+}
+
+func (vmio *vmiOperator) IsRetryLimitExceeded(vmi *harvesterv1.VirtualMachineImage) bool {
+	return harvesterv1.ImageRetryLimitExceeded.IsTrue(vmi)
 }
 
 func (vmio *vmiOperator) IsEncryptOperation(vmi *harvesterv1.VirtualMachineImage) bool {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
- ISO Image download will exceed the retry limit, root cause is the backingImage controller does not check retry when reconciling.

#### Solution:
- Early return in backing operator when read retry limit

#### Related Issue(s):
#9813

#### Test plan:
1. create a iso image with fake checksum
  - url : https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
  - checksum: a0f50d914d522368827119cdcf7225f9b31f32f8774ec2b255bfc167b410ba531dde73a609faa263c1b536d0c0ad510cd3e682c707a504d5c5972de1ece63f16
2. ensure it retry failed with no exceed retry max

[Expected result]
<img width="1922" height="96" alt="Screenshot 2026-01-28 at 4 58 24 PM" src="https://github.com/user-attachments/assets/816e3cf1-085c-4b8d-b770-af79bddf3a2c" />


#### Additional documentation or context
