### PR TITLE
chore: fix deprecated api

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,8 +47,7 @@ linters:
         text: "QF1012:" # Use fmt.Fprint(...) instead of Write([]byte(fmt.Sprint(...)))
 formatters:
   enable:
-    - goimports # checks if the code and import statements are formatted according to the 'goimports' command
-    - golines # checks if code is formatted, and fixes long lines
+    - gofmt
 run:
   timeout: 5m
   tests: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,9 +47,6 @@ linters:
         text: "QF1008:" # could remove embedded field from selector (staticcheck)
       - linters:
           - staticcheck
-        text: "SA1019:" # function is deprecated (staticcheck)
-      - linters:
-          - staticcheck
         text: "QF1012:" # Use fmt.Fprint(...) instead of Write([]byte(fmt.Sprint(...)))
 run:
   timeout: 5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
-version: 2
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - govet
@@ -10,9 +10,6 @@ linters:
     - unused
     - misspell
     - prealloc
-  formatters:
-    enable:
-      - gofmt
   settings:
     gosec:
       # https://github.com/securego/gosec#available-rules
@@ -23,13 +20,13 @@ linters:
         - G402 # TLS InsecureSkipVerify set true
         - G505 # Blocklisted import crypto/md5: weak cryptographic primitive
       config:
-        G306: "0644" # Poor file permissions used when writing to a new file 
-  exclude-files:
-    - /zz_generated_
-    - _generated
-  exclude-dirs:
-    - generated
+        G306: "0644" # Poor file permissions used when writing to a new file
   exclusions:
+    paths:
+      - vendor
+      - pkg/generated
+      - .*zz_generated.*
+      - .*_generated.*
     presets:
       - comments
       - common-false-positives
@@ -48,6 +45,10 @@ linters:
       - linters:
           - staticcheck
         text: "QF1012:" # Use fmt.Fprint(...) instead of Write([]byte(fmt.Sprint(...)))
+formatters:
+  enable:
+    - goimports # checks if the code and import statements are formatted according to the 'goimports' command
+    - golines # checks if code is formatted, and fixes long lines
 run:
   timeout: 5m
   tests: true

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
 FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 AS grub2-mbr
 FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 AS grub2-efi
 
-FROM golang:1.25-bookworm
+FROM golang:1.25.6-bookworm
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH
@@ -45,7 +45,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     docker-ce=5:20.10.* \
     && rm -rf /var/lib/apt/lists/*
 ## install golangci
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
 
 ## install controller-gen
 RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester
 
-go 1.25.6
+go 1.25
 
 replace (
 	// k8s.io/code-generator still remains v0.31.5 due to kubevirt v1.6.0.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester
 
-go 1.25
+go 1.25.6
 
 replace (
 	// k8s.io/code-generator still remains v0.31.5 due to kubevirt v1.6.0.

--- a/pkg/api/supportbundle/download_handler.go
+++ b/pkg/api/supportbundle/download_handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -87,7 +86,7 @@ func (h *DownloadHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.Response
 
 	if resp.StatusCode != http.StatusOK {
 		msg := fmt.Sprintf("Unexpected status code %d from manager.", resp.StatusCode)
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err == nil {
 			var errResp harvesterv1.ErrorResponse
 			if e := json.Unmarshal(body, &errResp); e == nil {

--- a/pkg/controller/admission/wait.go
+++ b/pkg/controller/admission/wait.go
@@ -20,7 +20,7 @@ const (
 
 // Wait waits for the admission webhook server to register ValidatingWebhookConfiguration and MutatingWebhookConfiguration resources.
 func Wait(ctx context.Context, clientSet *kubernetes.Clientset) error {
-	return wait.PollImmediate(PollingInterval, PollingTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, PollingInterval, PollingTimeout, true, func(ctx context.Context) (bool, error) {
 		logrus.Infof("Waiting for ValidatingWebhookConfiguration %s...", webhook.ValidatingWebhookName)
 		_, err := clientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, webhook.ValidatingWebhookName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -30,7 +30,7 @@ import (
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -376,7 +376,7 @@ func (h *Handler) getVolumeBackups(backup *harvesterv1.VirtualMachineBackup, vm 
 				},
 				Spec: pvc.Spec,
 			},
-			ReadyToUse: pointer.BoolPtr(false),
+			ReadyToUse: ptr.To(false),
 			VolumeSize: volumeSize,
 		}
 
@@ -502,7 +502,7 @@ func (h *Handler) initBackup(backup *harvesterv1.VirtualMachineBackup, vm *kubev
 	var err error
 	backupCpy := backup.DeepCopy()
 	backupCpy.Status = harvesterv1.VirtualMachineBackupStatus{
-		ReadyToUse: pointer.BoolPtr(false),
+		ReadyToUse: ptr.To(false),
 		SourceUID:  &vm.UID,
 		SourceSpec: &harvesterv1.VirtualMachineSourceSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -687,14 +687,14 @@ func (h *Handler) createVolumeSnapshot(vmBackup *harvesterv1.VirtualMachineBacku
 					Kind:       vmBackupKind.Kind,
 					Name:       vmBackup.Name,
 					UID:        vmBackup.UID,
-					Controller: pointer.BoolPtr(true),
+					Controller: ptr.To(true),
 				},
 			},
 			Annotations: map[string]string{},
 		},
 		Spec: snapshotv1.VolumeSnapshotSpec{
 			Source:                  volumeSnapshotSource,
-			VolumeSnapshotClassName: pointer.StringPtr(volumeSnapshotClass.Name),
+			VolumeSnapshotClassName: ptr.To(volumeSnapshotClass.Name),
 		},
 	}
 
@@ -768,7 +768,7 @@ func (h *Handler) createVolumeSnapshotContent(
 					Kind:       vmBackupKind.Kind,
 					Name:       vmBackup.Name,
 					UID:        vmBackup.UID,
-					Controller: pointer.BoolPtr(true),
+					Controller: ptr.To(true),
 				},
 			},
 		},
@@ -776,9 +776,9 @@ func (h *Handler) createVolumeSnapshotContent(
 			Driver:         "driver.longhorn.io",
 			DeletionPolicy: snapshotv1.VolumeSnapshotContentDelete,
 			Source: snapshotv1.VolumeSnapshotContentSource{
-				SnapshotHandle: pointer.StringPtr(snapshotHandle),
+				SnapshotHandle: ptr.To(snapshotHandle),
 			},
-			VolumeSnapshotClassName: pointer.StringPtr(snapshotClass.Name),
+			VolumeSnapshotClassName: ptr.To(snapshotClass.Name),
 			VolumeSnapshotRef: corev1.ObjectReference{
 				Name:      *volumeBackup.Name,
 				Namespace: vmBackup.Namespace,
@@ -794,7 +794,7 @@ func (h *Handler) setStatusError(vmBackup *harvesterv1.VirtualMachineBackup, err
 
 	vmBackupCpy.Status.Error = &harvesterv1.Error{
 		Time:    currentTime(),
-		Message: pointer.StringPtr(err.Error()),
+		Message: ptr.To(err.Error()),
 	}
 
 	if _, updateErr := h.vmBackups.Update(vmBackupCpy); updateErr != nil {

--- a/pkg/controller/master/backup/backup_metadata.go
+++ b/pkg/controller/master/backup/backup_metadata.go
@@ -23,7 +23,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -439,7 +438,7 @@ func (h *MetadataHandler) createVMBackupIfNotExist(backupMetadata VirtualMachine
 		},
 		Spec: backupMetadata.BackupSpec,
 		Status: harvesterv1.VirtualMachineBackupStatus{
-			ReadyToUse: pointer.BoolPtr(false),
+			ReadyToUse: ptr.To(false),
 			BackupTarget: &harvesterv1.BackupTarget{
 				Endpoint:     target.Endpoint,
 				BucketName:   target.BucketName,

--- a/pkg/controller/master/backup/backup_status.go
+++ b/pkg/controller/master/backup/backup_status.go
@@ -9,7 +9,7 @@ import (
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/util"
@@ -84,13 +84,13 @@ func (h *Handler) updateConditions(vmBackup *harvesterv1.VirtualMachineBackup) e
 	if errorMessage != "" && (vmBackupCpy.Status.Error == nil || vmBackupCpy.Status.Error.Message == nil || *vmBackupCpy.Status.Error.Message != errorMessage) {
 		vmBackupCpy.Status.Error = &harvesterv1.Error{
 			Time:    currentTime(),
-			Message: pointer.StringPtr(errorMessage),
+			Message: ptr.To(errorMessage),
 		}
 		setCondition(vmBackupCpy, harvesterv1.BackupConditionProgressing, false, "Error", errorMessage)
 		setCondition(vmBackupCpy, harvesterv1.BackupConditionReady, false, "", "Not Ready")
 	}
 
-	vmBackupCpy.Status.ReadyToUse = pointer.BoolPtr(ready)
+	vmBackupCpy.Status.ReadyToUse = ptr.To(ready)
 
 	if !reflect.DeepEqual(vmBackup.Status, vmBackupCpy.Status) {
 		if _, err := h.vmBackups.Update(vmBackupCpy); err != nil {
@@ -168,7 +168,7 @@ func (h *Handler) OnLHBackupChanged(_ string, lhBackup *lhv1beta2.Backup) (*lhv1
 		vmBackupCpy := vmBackup.DeepCopy()
 		for i, volumeBackup := range vmBackupCpy.Status.VolumeBackups {
 			if *volumeBackup.Name == snapshot.Name {
-				vmBackupCpy.Status.VolumeBackups[i].LonghornBackupName = pointer.StringPtr(lhBackup.Name)
+				vmBackupCpy.Status.VolumeBackups[i].LonghornBackupName = ptr.To(lhBackup.Name)
 			}
 		}
 

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -29,7 +29,6 @@ import (
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
@@ -373,7 +372,7 @@ func (h *RestoreHandler) LHEngineOnChange(_ string, lhEngine *lhv1beta2.Engine) 
 			continue
 		}
 
-		vmRestoreCpy.Status.VolumeRestores[i].LonghornEngineName = pointer.String(lhEngine.Name)
+		vmRestoreCpy.Status.VolumeRestores[i].LonghornEngineName = ptr.To(lhEngine.Name)
 		vmRestoreCpy.Status.VolumeRestores[i].VolumeSize = volume.Spec.Size
 		break
 	}
@@ -966,15 +965,15 @@ func (h *RestoreHandler) createRestoredPVC(
 					Kind:               vmRestoreKindName,
 					Name:               vmRestore.Name,
 					UID:                vmRestore.UID,
-					Controller:         pointer.BoolPtr(true),
-					BlockOwnerDeletion: pointer.BoolPtr(true),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
 				},
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: volumeBackup.PersistentVolumeClaim.Spec.AccessModes,
 			DataSource: &corev1.TypedLocalObjectReference{
-				APIGroup: pointer.StringPtr(snapshotv1.SchemeGroupVersion.Group),
+				APIGroup: ptr.To(snapshotv1.SchemeGroupVersion.Group),
 				Kind:     volumeSnapshotKindName,
 				Name:     dataSourceName,
 			},
@@ -1033,9 +1032,9 @@ func (h *RestoreHandler) getOrCreateVolumeSnapshotContent(
 			// Use Retain policy to prevent LH Backup from being removed when users delete a VM.
 			DeletionPolicy: snapshotv1.VolumeSnapshotContentRetain,
 			Source: snapshotv1.VolumeSnapshotContentSource{
-				SnapshotHandle: pointer.StringPtr(snapshotHandle),
+				SnapshotHandle: ptr.To(snapshotHandle),
 			},
-			VolumeSnapshotClassName: pointer.StringPtr(settings.VolumeSnapshotClass.Get()),
+			VolumeSnapshotClassName: ptr.To(settings.VolumeSnapshotClass.Get()),
 			VolumeSnapshotRef: corev1.ObjectReference{
 				Name:      h.constructVolumeSnapshotName(vmRestore.Name, *volumeBackup.Name),
 				Namespace: vmRestore.Namespace,
@@ -1073,15 +1072,15 @@ func (h *RestoreHandler) getOrCreateVolumeSnapshot(
 					Kind:               vmRestoreKindName,
 					Name:               vmRestore.Name,
 					UID:                vmRestore.UID,
-					BlockOwnerDeletion: pointer.BoolPtr(true),
+					BlockOwnerDeletion: ptr.To(true),
 				},
 			},
 		},
 		Spec: snapshotv1.VolumeSnapshotSpec{
 			Source: snapshotv1.VolumeSnapshotSource{
-				VolumeSnapshotContentName: pointer.StringPtr(volumeSnapshotContent.Name),
+				VolumeSnapshotContentName: ptr.To(volumeSnapshotContent.Name),
 			},
-			VolumeSnapshotClassName: pointer.StringPtr(settings.VolumeSnapshotClass.Get()),
+			VolumeSnapshotClassName: ptr.To(settings.VolumeSnapshotClass.Get()),
 		},
 	})
 }

--- a/pkg/controller/master/backup/util.go
+++ b/pkg/controller/master/backup/util.go
@@ -16,7 +16,6 @@ import (
 	wranglername "github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
@@ -143,8 +142,8 @@ func configVMOwner(vm *kubevirtv1.VirtualMachine) []metav1.OwnerReference {
 			Kind:               kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 			Name:               vm.Name,
 			UID:                vm.UID,
-			Controller:         pointer.BoolPtr(true),
-			BlockOwnerDeletion: pointer.BoolPtr(true),
+			Controller:         ptr.To(true),
+			BlockOwnerDeletion: ptr.To(true),
 		},
 	}
 }

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -3,8 +3,10 @@ package node
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/rancher/wrangler/v3/pkg/condition"
 	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
@@ -58,6 +60,8 @@ var (
 
 	ConditionJobComplete = condition.Cond(batchv1.JobComplete)
 	ConditionJobFailed   = condition.Cond(batchv1.JobFailed)
+
+	promoteEventTitle = cases.Title(language.English)
 )
 
 // PromoteHandler
@@ -222,7 +226,7 @@ func (h *PromoteHandler) logPromoteEvent(node *corev1.Node, status string) {
 		Kind: "Node",
 	}
 	h.recorder.Event(nodeReference, eventType,
-		fmt.Sprintf("NodePromote%s", strings.Title(status)),
+		fmt.Sprintf("NodePromote%s", promoteEventTitle.String(status)),
 		fmt.Sprintf("Node %s promote status change: %s => %s", node.Name, preStatus, status))
 }
 

--- a/pkg/controller/master/schedulevmbackup/common_test.go
+++ b/pkg/controller/master/schedulevmbackup/common_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -58,14 +58,14 @@ var (
 		Status: harvesterv1.VirtualMachineBackupStatus{
 			SourceSpec:    &harvesterv1.VirtualMachineSourceSpec{},
 			VolumeBackups: []harvesterv1.VolumeBackup{},
-			ReadyToUse:    pointer.Bool(true),
+			ReadyToUse:    ptr.To(true),
 			Error:         nil,
 		},
 	}
 
 	vmbackup1Info = &harvesterv1.VMBackupInfo{
 		Name:       vmbackup1.Name,
-		ReadyToUse: pointer.Bool(true),
+		ReadyToUse: ptr.To(true),
 		Error:      nil,
 	}
 
@@ -82,7 +82,7 @@ var (
 			},
 		},
 		Status: harvesterv1.VirtualMachineBackupStatus{
-			ReadyToUse: pointer.Bool(true),
+			ReadyToUse: ptr.To(true),
 			Error:      nil,
 		},
 	}
@@ -100,7 +100,7 @@ var (
 			},
 		},
 		Status: harvesterv1.VirtualMachineBackupStatus{
-			ReadyToUse: pointer.Bool(true),
+			ReadyToUse: ptr.To(true),
 			Error:      nil,
 		},
 	}
@@ -118,7 +118,7 @@ var (
 			},
 		},
 		Status: harvesterv1.VirtualMachineBackupStatus{
-			ReadyToUse: pointer.Bool(false),
+			ReadyToUse: ptr.To(false),
 			Error:      &harvesterv1.Error{},
 		},
 	}

--- a/pkg/controller/master/schedulevmbackup/lhbackup.go
+++ b/pkg/controller/master/schedulevmbackup/lhbackup.go
@@ -7,7 +7,7 @@ import (
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 )
@@ -63,7 +63,7 @@ func (h *svmbackupHandler) OnLHBackupChanged(_ string, lhBackup *lhv1beta2.Backu
 	vmBackupCpy := vmBackup.DeepCopy()
 	for i, volumeBackup := range vmBackupCpy.Status.VolumeBackups {
 		if *volumeBackup.Name == snapshot.Name {
-			vmBackupCpy.Status.VolumeBackups[i].LonghornBackupName = pointer.StringPtr(lhBackup.Name)
+			vmBackupCpy.Status.VolumeBackups[i].LonghornBackupName = ptr.To(lhBackup.Name)
 		}
 	}
 

--- a/pkg/controller/master/setting/cluster_registration_url.go
+++ b/pkg/controller/master/setting/cluster_registration_url.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/rancher/wrangler/v3/pkg/objectset"
@@ -31,7 +30,7 @@ func (h *Handler) registerCluster(setting *harvesterv1.Setting) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/master/upgrade/version_syncer.go
+++ b/pkg/controller/master/upgrade/version_syncer.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"runtime"
@@ -230,7 +230,7 @@ func (s *versionSyncer) getNewVersion(v Version) (*harvesterv1.Version, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/master/virtualmachine/vmi_network_controller.go
+++ b/pkg/controller/master/virtualmachine/vmi_network_controller.go
@@ -122,7 +122,7 @@ func (h *VMNetworkController) updateVMMacAddressFromAnnotation(vmi *kubevirtv1.V
 
 	vmCopy := vm.DeepCopy()
 	vmInterfaces := vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces
-	for i := range(vmInterfaces) {
+	for i := range vmInterfaces {
 		iface := vmInterfaces[i]
 		macAddress, observed := vmiInterfaces[iface.Name]
 		if iface.MacAddress != "" {

--- a/pkg/util/crd/init.go
+++ b/pkg/util/crd/init.go
@@ -194,7 +194,7 @@ func (f *Factory) waitCRD(ctx context.Context, crdName string, gvk schema.GroupV
 	defer logrus.Infof("Done waiting for CRD %s to become available", crdName)
 
 	first := true
-	return wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 		if !first {
 			logrus.Infof("Waiting for CRD %s to become available", crdName)
 		}

--- a/pkg/util/nad.go
+++ b/pkg/util/nad.go
@@ -8,7 +8,6 @@ import (
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
-
 type NetConf struct {
 	cnitypes.PluginConf
 }

--- a/pkg/util/virtualmachineinstance/virtualmachineinstance_test.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance_test.go
@@ -632,83 +632,83 @@ func Test_ListByNode(t *testing.T) {
 
 func Test_ValidateVMMigratable(t *testing.T) {
 	var testCases = []struct {
-		name   string
-		vmi    *kubevirtv1.VirtualMachineInstance
-		err    error
+		name string
+		vmi  *kubevirtv1.VirtualMachineInstance
+		err  error
 	}{
-			{
-				name: "should return err when status condition LiveMigratable is False",
-				vmi: &kubevirtv1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "vm1",
-					},
-					Status: kubevirtv1.VirtualMachineInstanceStatus{
-						Phase: kubevirtv1.Running,
-						Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
-							{
-								Type: kubevirtv1.VirtualMachineInstanceIsMigratable,
-								Status: corev1.ConditionFalse,
-								Reason: "InterfaceNotLiveMigratable",
-							},
+		{
+			name: "should return err when status condition LiveMigratable is False",
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "vm1",
+				},
+				Status: kubevirtv1.VirtualMachineInstanceStatus{
+					Phase: kubevirtv1.Running,
+					Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
+						{
+							Type:   kubevirtv1.VirtualMachineInstanceIsMigratable,
+							Status: corev1.ConditionFalse,
+							Reason: "InterfaceNotLiveMigratable",
 						},
 					},
 				},
-				err: fmt.Errorf("VM default/vm1 is not live migratable as the condition reported with reason: InterfaceNotLiveMigratable"),
 			},
-			{
-				name: "should return nil when status condition LiveMigratable is True",
-				vmi: &kubevirtv1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "vm1",
-					},
-					Status: kubevirtv1.VirtualMachineInstanceStatus{
-						Phase: kubevirtv1.Running,
-						Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
-							{
-								Type: kubevirtv1.VirtualMachineInstanceIsMigratable,
-								Status: corev1.ConditionTrue,
-							},
+			err: fmt.Errorf("VM default/vm1 is not live migratable as the condition reported with reason: InterfaceNotLiveMigratable"),
+		},
+		{
+			name: "should return nil when status condition LiveMigratable is True",
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "vm1",
+				},
+				Status: kubevirtv1.VirtualMachineInstanceStatus{
+					Phase: kubevirtv1.Running,
+					Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
+						{
+							Type:   kubevirtv1.VirtualMachineInstanceIsMigratable,
+							Status: corev1.ConditionTrue,
 						},
 					},
 				},
-				err: nil,
 			},
-			{
-				name: "should return nil when status condition LiveMigratable is Unknown",
-				vmi: &kubevirtv1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "vm1",
-					},
-					Status: kubevirtv1.VirtualMachineInstanceStatus{
-						Phase: kubevirtv1.Running,
-						Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
-							{
-								Type: kubevirtv1.VirtualMachineInstanceIsMigratable,
-								Status: corev1.ConditionUnknown,
-							},
+			err: nil,
+		},
+		{
+			name: "should return nil when status condition LiveMigratable is Unknown",
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "vm1",
+				},
+				Status: kubevirtv1.VirtualMachineInstanceStatus{
+					Phase: kubevirtv1.Running,
+					Conditions: []kubevirtv1.VirtualMachineInstanceCondition{
+						{
+							Type:   kubevirtv1.VirtualMachineInstanceIsMigratable,
+							Status: corev1.ConditionUnknown,
 						},
 					},
 				},
-				err: nil,
 			},
-			{
-				name: "should return nil when status condition LiveMigratable is not found",
-				vmi: &kubevirtv1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "vm1",
-					},
-					Status: kubevirtv1.VirtualMachineInstanceStatus{
-						Phase: kubevirtv1.Running,
-						Conditions: []kubevirtv1.VirtualMachineInstanceCondition{},
-					},
+			err: nil,
+		},
+		{
+			name: "should return nil when status condition LiveMigratable is not found",
+			vmi: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "vm1",
 				},
-				err: nil,
+				Status: kubevirtv1.VirtualMachineInstanceStatus{
+					Phase:      kubevirtv1.Running,
+					Conditions: []kubevirtv1.VirtualMachineInstanceCondition{},
+				},
 			},
-		}
+			err: nil,
+		},
+	}
 
 	for _, tc := range testCases {
 		err := ValidateVMMigratable(tc.vmi)

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/webhook"
@@ -39,7 +39,7 @@ import (
 )
 
 func Validation(clients *clients.Clients, options *config.Options) (http.Handler, []types.Resource, error) {
-	bearToken, err := ioutil.ReadFile(clients.RESTConfig.BearerTokenFile)
+	bearToken, err := os.ReadFile(clients.RESTConfig.BearerTokenFile)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/webhook/util/http_client.go
+++ b/pkg/webhook/util/http_client.go
@@ -3,8 +3,8 @@ package util
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -13,7 +13,7 @@ import (
 
 func GetHTTPTransportWithCertificates(config *rest.Config) (*http.Transport, error) {
 	logrus.Debugf("config: %+v", config)
-	caCert, err := ioutil.ReadFile(config.TLSClientConfig.CAFile)
+	caCert, err := os.ReadFile(config.TLSClientConfig.CAFile)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/fuzz/file.go
+++ b/tests/framework/fuzz/file.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -21,7 +20,7 @@ const (
 
 // File tries to create a file with given size and returns the path and the SHA256 checksum or error.
 func File(size FileByteSize) (path string, checksum string, berr error) {
-	tempFile, err := ioutil.TempFile("", "rand-")
+	tempFile, err := os.CreateTemp("", "rand-")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/tests/framework/ready/ready.go
+++ b/tests/framework/ready/ready.go
@@ -28,7 +28,7 @@ type Condition struct {
 }
 
 func (c *Condition) Wait(ctx context.Context) error {
-	return wait.PollImmediate(c.interval, c.timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, c.interval, c.timeout, true, func(ctx context.Context) (bool, error) {
 		select {
 		case <-ctx.Done():
 			return true, nil


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->
#### Problem:

- The current `.golangci.yaml` excludes Staticcheck [SA1019](https://staticcheck.dev/docs/checks#SA1019) (deprecated API usage), so CI won’t flag deprecated API calls, and we may keep using APIs after they are deprecated.

#### Solution:

- Remove the exclusion for SA1019 in .golangci.yaml.

#### Expected result:
- CI will fail when code uses deprecated APIs, ensuring we catch and remove deprecated API calls during development.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
#9982

#### Test plan:
- make validation, ensure no deprecate api comes up.
- manually run the vm restore / replace, ensure it works as it is. 

#### Additional documentation or context
- Found our current golangci-linter is not correct for v2, so I make some changes to adapt the current v2
