### PR TITLE
feat: support virtiofs for secret, configmap and serviceaccount

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -68,7 +68,7 @@ kubevirt:
       ## Specify kubevirt feature gates
       vmStateStorageClass: "vmstate-persistence"
       developerConfiguration:
-        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager", "VMPersistentState", "VMLiveUpdateFeatures", "ExpandDisks"]
+        featureGates: ["LiveMigration", "HotplugVolumes", "HostDevices", "GPU", "CPUManager", "VMPersistentState", "VMLiveUpdateFeatures", "ExpandDisks", EnableVirtioFsConfigVolumes]
 
       vmRolloutStrategy: "LiveUpdate"
 


### PR DESCRIPTION
#### Problem:
Support virtio-fs for Secret, ConfigMap, and ServiceAccount in Harvester VMs

#### Solution:
Support virtio-fs for Secret, ConfigMap, and ServiceAccount in Harvester VMs

#### Related Issue(s):
#9762 

#### Test plan:
* Update the Harvester deployment with this PR.
* Confirm that the KubeVirt feature gate `EnableVirtioFsConfigVolumes` is enabled.

PS: For the script below:
* Please update the configuration to match your environment (e.g., [script config section](https://github.com/WebberHuang1118/harvester-study/blob/master/virtiofs/secret/setup-vm-virtiofs.sh#L6-L12)).
* Use `cleanup` mode to remove all related resources.

##### Virtisfs with secret
[virtio-fs Secret example script](https://github.com/WebberHuang1118/harvester-study/blob/master/virtiofs/secret/setup-vm-virtiofs.sh) shows how to mount a Secret into the VM as a filesystem via virtio-fs.
- Set up all required resources from scratch
  ```
   ./secret/setup-vm-virtiofs.sh setup
  [INFO] Starting full setup...
  [INFO] Enabling virtiofs feature gate...
  kubevirt.kubevirt.io/kubevirt configured
  [INFO] Waiting for KubeVirt to reconcile (10 seconds)...
  [INFO] Creating app secret: app-secret...
  secret/app-secret created
  [INFO] Creating PVC: os-vol-secret...
  persistentvolumeclaim/os-vol-secret created
  [INFO] Waiting for PVC to be bound...
  ....
  
  [INFO] To test virtiofs mount inside VM, run:
    ls -al /mnt/app-secret
    cat /mnt/app-secret/token
    cat /mnt/app-secret/endpoint
  
  [INFO] To rotate secret:
    ./secret/setup-vm-virtiofs.sh rotate-secret
  ```
- In the VM, verify the Secret data based on the script’s output
- Update the secret
  ```
   ./secret/setup-vm-virtiofs.sh rotate-secret
  [INFO] Rotating secret: app-secret...
  [INFO] Current secret values:
    endpoint: https://example.internal
    token: abc-123
  
  [INFO] New secret values:
    endpoint: https://api-1769763971.example.internal
    token: token-6a54411f2284d6a0
  
  ....
  
  Then inside VM:
    cat /mnt/app-secret/endpoint  # Should show: https://api-1769763971.example.internal
    cat /mnt/app-secret/token     # Should show: token-6a54411f2284d6a0
  
  [SUCCESS] Changes should be visible immediately (no VM restart required)!
  ```
- Verify the VM can see the updated data content

##### Virtisfs with configmap
[virtio-fs Configmap example script](https://github.com/WebberHuang1118/harvester-study/blob/master/virtiofs/configmap/setup-vm-virtiofs.sh) shows how to mount a Configmap into the VM as a filesystem via virtio-fs.
- Set up all required resources from scratch
  ```
   ./configmap/setup-vm-virtiofs.sh setup
  [INFO] Starting full setup...
  [INFO] Enabling virtiofs feature gate...
  kubevirt.kubevirt.io/kubevirt configured
  [INFO] Waiting for KubeVirt to reconcile (10 seconds)...
  [INFO] Creating app configmap: app-config...
  configmap/app-config created
  [INFO] Creating PVC: os-vol-configmap...
  persistentvolumeclaim/os-vol-configmap created
  [INFO] Waiting for PVC to be bound...
  persistentvolumeclaim/os-vol-configmap condition met
  [INFO] Creating VM: vm-configmap...
  virtualmachine.kubevirt.io/vm-configmap created
  [INFO] Waiting for VM to be ready (may take a few minutes)...
  virtualmachine.kubevirt.io/vm-configmap condition met
   ...
  
  [INFO] To test virtiofs mount inside VM, run:
    ls -al /mnt/app-config
    cat /mnt/app-config/api.conf
    cat /mnt/app-config/database.conf
    cat /mnt/app-config/features.json
    cat /mnt/app-config/app.properties
  
  [INFO] To update configmap:
    ./configmap/setup-vm-virtiofs.sh update-config
  ```
- In the VM, verify the Configmap data based on the script’s output
- Update the configmap
  ```
  ./configmap/setup-vm-virtiofs.sh update-config
  [INFO] Updating configmap: app-config...
  [INFO] Current configmap data keys:
  [
    "api.conf",
    "app.properties",
    "database.conf",
    "features.json"
  ]
  
  [INFO] Updating configmap with new values...
  configmap/app-config patched
  [SUCCESS] ConfigMap updated successfully!
  
  [INFO] VM is running. Verifying the changes are visible inside VM...
  
  To verify the changes inside VM, run:
    virtctl -n default console vm-configmap
  
  Then inside VM:
    cat /mnt/app-config/api.conf
    cat /mnt/app-config/database.conf
    cat /mnt/app-config/features.json
    cat /mnt/app-config/app.properties
  
  [SUCCESS] Changes should be visible immediately (no VM restart required)!
  ```
- Verify the VM can see the updated data content

##### Virtisfs with serviceaccount
[virtio-fs Serviceaccount example script](https://github.com/WebberHuang1118/harvester-study/blob/master/virtiofs/serviceaccount/setup-vm-virtiofs.sh) shows how to mount a Serviceaccount into the VM as a filesystem via virtio-fs.
- Set up all required resources from scratch
  ```
  ./serviceaccount/setup-vm-virtiofs.sh setup
  [INFO] Starting full setup...
  [INFO] Enabling virtiofs feature gate...
  kubevirt.kubevirt.io/kubevirt configured
  [INFO] Waiting for KubeVirt to reconcile (10 seconds)...
  [INFO] Creating namespace: sa-virtiofs-test...
  namespace/sa-virtiofs-test created
  [SUCCESS] Namespace sa-virtiofs-test created
  [INFO] Creating ServiceAccount and RBAC: vm-sa...
  serviceaccount/vm-sa created
  role.rbac.authorization.k8s.io/vm-sa-read created
  rolebinding.rbac.authorization.k8s.io/vm-sa-read created
  [SUCCESS] ServiceAccount and RBAC created
  [INFO] Creating PVC: os-vol-sa...
  persistentvolumeclaim/os-vol-sa created
  [INFO] Waiting for PVC to be bound...
  persistentvolumeclaim/os-vol-sa condition met
  [INFO] Creating VM: vm-sa...
   ...
  
  [INFO] ServiceAccount mounted at: /mnt/serviceaccount
  
  [SUCCESS] To connect to VM console, run:
    virtctl -n sa-virtiofs-test console vm-sa
  
  [SUCCESS] To verify serviceaccount mount inside VM, run:
    sudo mount | grep virtiofs
    sudo ls -al /mnt/serviceaccount
    sudo cat /mnt/serviceaccount/namespace
    sudo cat /mnt/serviceaccount/token
  
  [SUCCESS] To test Kubernetes API access inside VM:
    TOKEN="$(sudo cat /mnt/serviceaccount/token)"
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/api
  
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/api/v1/namespaces/sa-virtiofs-test/pods
  ```
- In the VM, verify the Serviceaccount data based on the script’s output
- Update the serviceaccount
  ```
  ./serviceaccount/setup-vm-virtiofs.sh update-rbac
  [INFO] Updating RBAC permissions for vm-sa...
  [INFO] Applying extended RBAC permissions:
    Core API resources: pods, services, configmaps, secrets
      Verbs: get, list, watch
    Apps API resources: deployments, statefulsets
      Verbs: get, list, watch
  
  role.rbac.authorization.k8s.io/vm-sa-read configured
  [SUCCESS] RBAC permissions updated with extended permissions
  
  [INFO] Updated Role details:
  Name:         vm-sa-read
  Labels:       <none>
  Annotations:  <none>
  PolicyRule:
    Resources          Non-Resource URLs  Resource Names  Verbs
    ---------          -----------------  --------------  -----
    configmaps         []                 []              [get list watch]
    pods               []                 []              [get list watch]
    secrets            []                 []              [get list watch]
    services           []                 []              [get list watch]
    deployments.apps   []                 []              [get list watch]
    statefulsets.apps  []                 []              [get list watch]
  
  [SUCCESS] To test these permissions inside the VM, run:
    TOKEN="$(sudo cat /mnt/serviceaccount/token)"
  
    # Test access to pods:
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/api/v1/namespaces/sa-virtiofs-test/pods
  
    # Test access to services:
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/api/v1/namespaces/sa-virtiofs-test/services
  
    # Test access to configmaps:
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/api/v1/namespaces/sa-virtiofs-test/configmaps
  
    # Test access to secrets:
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/api/v1/namespaces/sa-virtiofs-test/secrets
  
    # Test access to deployments:
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/apis/apps/v1/namespaces/sa-virtiofs-test/deployments
  
    # Test access to statefulsets:
    sudo curl --cacert /mnt/serviceaccount/ca.crt \
      -H "Authorization: Bearer ${TOKEN}" \
      https://kubernetes.default.svc/apis/apps/v1/namespaces/sa-virtiofs-test/statefulsets
  ```
- Verify the VM can see the updated data content

#### Additional documentation or context
