### PR TITLE
UI Server: Fix API Paths

### DIFF
--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -94,7 +94,6 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	vueUI := ui.Vue
 	m.Handle("/dashboard/", vueUI.IndexFile())
 	m.PathPrefix("/dashboard/").Handler(vueUI.IndexFileOnNotFound())
-	m.PathPrefix("/api-ui").Handler(vueUI.ServeAsset("api-ui"))
 
 	if r.options.RancherURL != "" {
 		host, scheme, err := parseRancherServerURL(r.options.RancherURL)

--- a/pkg/server/ui/api.go
+++ b/pkg/server/ui/api.go
@@ -1,10 +1,16 @@
 package ui
 
 import (
+	"fmt"
+
 	apiserver "github.com/rancher/apiserver/pkg/server"
 	"github.com/rancher/apiserver/pkg/writer"
 
 	"github.com/harvester/harvester/pkg/settings"
+)
+
+const (
+	UIAssetPathPrefix = "/dashboard/api-ui"
 )
 
 func ConfigureAPIUI(server *apiserver.Server) {
@@ -21,31 +27,21 @@ func ConfigureAPIUI(server *apiserver.Server) {
 	if !ok {
 		return
 	}
-	w.CSSURL = CSSURL
-	w.JSURL = JSURL
+	w.CSSURL = URL("ui.min.css")
+	w.JSURL = URL("ui.min.js")
 	w.APIUIVersion = settings.APIUIVersion.Get
 }
 
-func JSURL() string {
-	switch settings.UISource.Get() {
-	case "auto":
-		if !settings.IsRelease() {
+func URL(filename string) func() string {
+	return func() string {
+		switch settings.UISource.Get() {
+		case "auto":
+			if !settings.IsRelease() {
+				return ""
+			}
+		case "external":
 			return ""
 		}
-	case "external":
-		return ""
+		return fmt.Sprintf("%s/%s", UIAssetPathPrefix, filename)
 	}
-	return "/api-ui/ui.min.js"
-}
-
-func CSSURL() string {
-	switch settings.UISource.Get() {
-	case "auto":
-		if !settings.IsRelease() {
-			return ""
-		}
-	case "external":
-		return ""
-	}
-	return "/api-ui/ui.min.css"
 }

--- a/pkg/server/ui/ui.go
+++ b/pkg/server/ui/ui.go
@@ -42,6 +42,7 @@ func newHandler(
 		middleware: responsewriter.Chain{
 			responsewriter.Gzip,
 			responsewriter.FrameOptions,
+			responsewriter.ContentType,
 			responsewriter.CacheMiddleware("json", "js", "css"),
 		}.Handler,
 		indexMiddleware: responsewriter.Chain{
@@ -92,9 +93,9 @@ func (u *handler) path() (path string, isURL bool) {
 	}
 }
 
-func (u *handler) ServeAsset(subFolder string) http.Handler {
+func (u *handler) ServeAsset() http.Handler {
 	return u.middleware(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		http.FileServer(http.Dir(filepath.Join(u.pathSetting(), subFolder))).ServeHTTP(rw, req)
+		http.FileServer(http.Dir(u.pathSetting())).ServeHTTP(rw, req)
 	}))
 }
 
@@ -102,7 +103,7 @@ func (u *handler) IndexFileOnNotFound() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/dashboard")
 		if _, err := os.Stat(filepath.Join(u.pathSetting(), req.URL.Path)); err == nil {
-			u.ServeAsset("").ServeHTTP(rw, req)
+			u.ServeAsset().ServeHTTP(rw, req)
 		} else {
 			u.IndexFile().ServeHTTP(rw, req)
 		}


### PR DESCRIPTION
#### Problem:

The "View in API" function relies on a index.html page generated by Rancher APIServer. This page refers to a Javascript and a CSS document hosted under the `/api-ui` path, however that path isn't routed correctly in Harvester. The actual path where these two documents are available is underneath `/dashboard/api-ui`.

#### Solution:

To fix this, inject the correct path into the index page used for the "View in API" function.
Remove the disfunct implementation stub for the `/api-ui` route as it's no longer needed, since all other web UI paths are served from underneath the `/dashboard` path as well.

#### Related Issue(s):

related-to: harvester/harvester#9614

#### Test plan:

1) Install Harvester
2) Go to Settings --> UI
3) Set `ui-source` to `Bundled`
4) Go to Preferences
5) Enable "View in API"
6) Navigate to any resource in the cluster, click on the menu --> "View in API"

Expected outcome:

There should be a HTML page similar to this screenshot, showing the JSON representation of the selected resource:
<img width="3835" height="1867" alt="Screenshot at 2026-02-02 16-59-55" src="https://github.com/user-attachments/assets/10b49356-9540-48c8-8c44-cde241a26c53" />

#### Additional documentation or context

