### PR TITLE
Storage-network NAD can be deleted from kubectl directly

### DIFF
--- a/pkg/webhook/resources/networkattachmentdefinition/validator.go
+++ b/pkg/webhook/resources/networkattachmentdefinition/validator.go
@@ -1,0 +1,79 @@
+package networkattachmentdefinition
+
+import (
+	"fmt"
+
+	hncutils "github.com/harvester/harvester-network-controller/pkg/utils"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(settingCache ctlharvesterv1.SettingCache) types.Validator {
+	return &nadValidator{
+		settingCache: settingCache,
+	}
+}
+
+type nadValidator struct {
+	types.DefaultValidator
+	settingCache ctlharvesterv1.SettingCache
+}
+
+func (v *nadValidator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{"network-attachment-definitions"},
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   cniv1.SchemeGroupVersion.Group,
+		APIVersion: cniv1.SchemeGroupVersion.Version,
+		ObjectType: &cniv1.NetworkAttachmentDefinition{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Delete,
+		},
+	}
+}
+
+func (v *nadValidator) Delete(_ *types.Request, obj runtime.Object) error {
+	nad := obj.(*cniv1.NetworkAttachmentDefinition)
+	if nad == nil {
+		return nil
+	}
+
+	// Skip NADs that are not used for storage network.
+	// A resource is considered as a storage network NAD if it meets all the
+	// following conditions:
+	// 1. The namespace is `harvester-system`
+	// 2. It has the annotation `storage-network.settings.harvesterhci.io: true`
+	// 3. The name has the prefix `storagenetwork-`
+	if !hncutils.IsStorageNetworkNad(nad) {
+		return nil
+	}
+
+	// Get the `storage-network` setting to check if it uses the deleting NAD.
+	setting, err := v.settingCache.Get(settings.StorageNetworkName)
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	if setting == nil {
+		return nil
+	}
+
+	nadNamespacedName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
+	current := setting.Annotations[util.NadStorageNetworkAnnotation]
+	if current == nadNamespacedName {
+		return werror.NewBadRequest(fmt.Sprintf("cannot delete NetworkAttachmentDefinition %s which is used by Harvester setting '%s'", nadNamespacedName, settings.StorageNetworkName))
+	}
+
+	return nil
+}

--- a/pkg/webhook/resources/networkattachmentdefinition/validator_test.go
+++ b/pkg/webhook/resources/networkattachmentdefinition/validator_test.go
@@ -1,0 +1,110 @@
+package networkattachmentdefinition
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	apiv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	ctlv1beta1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestDeleteAllowsWhenNotUsed(t *testing.T) {
+	clientset := fakegenerated.NewSimpleClientset()
+	validator := NewValidator(ctlv1beta1.SettingCache(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings)))
+
+	testCases := []struct {
+		name      string
+		nad       *cniv1.NetworkAttachmentDefinition
+		expectErr bool
+	}{
+		{
+			name: "incorrect namespace and name",
+			nad: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "nad1",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "correct namespace and name",
+			nad: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: util.HarvesterSystemNamespaceName,
+					Name:      util.StorageNetworkNetAttachDefPrefix + "aaaaa",
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validator.Delete(nil, tc.nad)
+		if tc.expectErr {
+			assert.Error(t, err, tc.name)
+		} else {
+			assert.NoError(t, err, tc.name)
+		}
+	}
+}
+
+func TestDeleteBlocksWhenUsed(t *testing.T) {
+	nadName := util.StorageNetworkNetAttachDefPrefix + "bbbbb"
+	nadNamespacedName := fmt.Sprintf("%s/%s", util.HarvesterSystemNamespaceName, nadName)
+
+	clientset := fakegenerated.NewSimpleClientset(&apiv1.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: settings.StorageNetworkName,
+			Annotations: map[string]string{
+				util.NadStorageNetworkAnnotation: nadNamespacedName,
+			},
+		},
+	})
+
+	validator := NewValidator(ctlv1beta1.SettingCache(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings)))
+
+	nad := &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: util.HarvesterSystemNamespaceName,
+			Name:      nadName,
+			Annotations: map[string]string{
+				util.StorageNetworkAnnotation: "true",
+			},
+		},
+	}
+
+	err := validator.Delete(nil, nad)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot delete NetworkAttachmentDefinition")
+}
+
+func TestDeleteFailsWhenSettingCacheFails(t *testing.T) {
+	clientset := fakegenerated.NewSimpleClientset()
+	clientset.PrependReactor("get", "settings", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("simulated cache error")
+	})
+
+	validator := NewValidator(ctlv1beta1.SettingCache(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings)))
+
+	nad := &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: util.HarvesterSystemNamespaceName,
+			Name:      util.StorageNetworkNetAttachDefPrefix + "ccccc",
+		},
+	}
+
+	err := validator.Delete(nil, nad)
+	assert.Error(t, err)
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/resources/keypair"
 	"github.com/harvester/harvester/pkg/webhook/resources/managedchart"
 	"github.com/harvester/harvester/pkg/webhook/resources/namespace"
+	"github.com/harvester/harvester/pkg/webhook/resources/networkattachmentdefinition"
 	"github.com/harvester/harvester/pkg/webhook/resources/node"
 	"github.com/harvester/harvester/pkg/webhook/resources/persistentvolumeclaim"
 	"github.com/harvester/harvester/pkg/webhook/resources/resourcequota"
@@ -202,6 +203,9 @@ func Validation(clients *clients.Clients, options *config.Options) (http.Handler
 		deployment.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),
 			clients.AppsFactory.Apps().V1().Deployment().Cache(),
+		),
+		networkattachmentdefinition.NewValidator(
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache(),
 		),
 	}
 


### PR DESCRIPTION
#### Problem:
Storage-network NAD can be deleted from kubectl directly

#### Solution:
Add a validation webhook that checks if the NetworkAttachmentDefinition (NAD) resource to be deleted is used for the "storage-network" Harvester setting.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9623

#### Test plan:
***Case 1***
- Go to the Harvester settings page and edit `storage-network`. You may use the following settings:
```
Enabled: Yes
Type: L2VLanNetwork
VLAN ID: 100
Cluster Network: mgmt
IP Range: 192.168.0.0/24
Exclude IPs: 192.168.0.100/32
```
Note, all VMs need to be stopped to apply the settings.
- List existing NAD. In our case there is only the new created storage-network NAD.
```
$ k get network-attachment-definitions.k8s.cni.cncf.io -n harvester-system                           
NAME                   AGE
storagenetwork-c6bss   21s

$ k get network-attachment-definitions.k8s.cni.cncf.io -n harvester-system -oyaml storagenetwork-c6bss
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  annotations:
    storage-network.settings.harvesterhci.io: "true"
  creationTimestamp: "2026-02-12T09:12:06Z"
  finalizers:
  - wrangler.cattle.io/harvester-network-manager-nad-controller
  generateName: storagenetwork-
  generation: 1
  labels:
    network.harvesterhci.io/clusternetwork: mgmt
    network.harvesterhci.io/ready: "true"
    network.harvesterhci.io/type: L2VlanNetwork
    network.harvesterhci.io/vlan-id: "100"
    storage-network.settings.harvesterhci.io/hash: dce1f180919270dd1456f56679727f0d8a015031
  name: storagenetwork-c6bss
  namespace: harvester-system
  resourceVersion: "1096273"
  uid: 259751e6-75a7-4ebb-9019-bc1b24fa1f20
spec:
  config: '{"cniVersion":"0.3.1","type":"bridge","bridge":"mgmt-br","promiscMode":true,"vlan":100,"ipam":{"type":"whereabouts","range":"192.168.0.0/24","exclude":["192.168.0.100/32"]}}'
```
- Try to delete the NAD:
```
$ k delete network-attachment-definitions.k8s.cni.cncf.io -n harvester-system storagenetwork-c6bss
Error from server (BadRequest): admission webhook "validator.harvesterhci.io" denied the request: cannot delete NetworkAttachmentDefinition harvester-system/storagenetwork-c6bss which is used by Harvester setting 'storage-network'
```
The resource is not allowed to be deleted.

***Case 2***
- Make sure a storage network is configured (see case 1).
- Go to the Harvester settings page and edit `storage-network`.
- Click the `Use the default value` button. The `Disabled` checkbox is selected. Click `Save`.
- Try to delete the NAD:
```
$ k delete network-attachment-definitions.k8s.cni.cncf.io -n harvester-system storagenetwork-c6bss
Error from server (NotFound): network-attachment-definitions.k8s.cni.cncf.io "storagenetwork-c6bss" not found
```
The NAD does not exist anymore at this moment because it has been automatically removed by Harvester.