### PR TITLE
fix(restore): preserve CPU topology during VM restore

### DIFF
--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -723,21 +723,9 @@ func (h *RestoreHandler) createNewVM(restore *harvesterv1.VirtualMachineRestore,
 	vmName := restore.Spec.Target.Name
 	logrus.Infof("restore target does not exist, creating a new vm %s", vmName)
 
-	restoreID := getRestoreID(restore)
 	vmCpy := backup.Status.SourceSpec.DeepCopy()
 
-	newVMAnnotations := map[string]string{
-		lastRestoreAnnotation: restoreID,
-		restoreNameAnnotation: restore.Name,
-	}
-	if reservedMem, ok := vmCpy.ObjectMeta.Annotations[util.AnnotationReservedMemory]; ok {
-		newVMAnnotations[util.AnnotationReservedMemory] = reservedMem
-	}
-
-	// without this, the mutating webhook will treat the VM as non-hotplug and overwrite maxSockets to 1, causing validation failure
-	if enableHotplug, ok := vmCpy.ObjectMeta.Annotations[util.AnnotationEnableCPUAndMemoryHotplug]; ok {
-		newVMAnnotations[util.AnnotationEnableCPUAndMemoryHotplug] = enableHotplug
-	}
+	newVMAnnotations := getNewVMAnnotations(restore, vmCpy.ObjectMeta.Annotations)
 
 	newVMSpecAnnotations, err := sanitizeVirtualMachineAnnotationsForRestore(restore, vmCpy.Spec.Template.ObjectMeta.Annotations)
 	if err != nil {
@@ -789,6 +777,29 @@ func (h *RestoreHandler) createNewVM(restore *harvesterv1.VirtualMachineRestore,
 	}
 
 	return newVM, nil
+}
+
+// getNewVMAnnotations creates annotations map for a new VM with restore metadata and preserved annotations
+func getNewVMAnnotations(restore *harvesterv1.VirtualMachineRestore, sourceAnnotations map[string]string) map[string]string {
+	restoreID := getRestoreID(restore)
+	newVMAnnotations := map[string]string{
+		lastRestoreAnnotation: restoreID,
+		restoreNameAnnotation: restore.Name,
+	}
+
+	// Preserve specific annotations from source VM
+	preservedAnnotations := []string{
+		util.AnnotationReservedMemory,
+		util.AnnotationEnableCPUAndMemoryHotplug,
+	}
+
+	for _, annotation := range preservedAnnotations {
+		if value, ok := sourceAnnotations[annotation]; ok {
+			newVMAnnotations[annotation] = value
+		}
+	}
+
+	return newVMAnnotations
 }
 
 func (h *RestoreHandler) updateOwnerRefAndTargetUID(vmRestore *harvesterv1.VirtualMachineRestore, vm *kubevirtv1.VirtualMachine) error {

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -734,6 +734,11 @@ func (h *RestoreHandler) createNewVM(restore *harvesterv1.VirtualMachineRestore,
 		newVMAnnotations[util.AnnotationReservedMemory] = reservedMem
 	}
 
+	// without this, the mutating webhook will treat the VM as non-hotplug and overwrite maxSockets to 1, causing validation failure
+	if enableHotplug, ok := vmCpy.ObjectMeta.Annotations[util.AnnotationEnableCPUAndMemoryHotplug]; ok {
+		newVMAnnotations[util.AnnotationEnableCPUAndMemoryHotplug] = enableHotplug
+	}
+
 	newVMSpecAnnotations, err := sanitizeVirtualMachineAnnotationsForRestore(restore, vmCpy.Spec.Template.ObjectMeta.Annotations)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
VM restore may fail when the original VM uses CPU hotplug and explicitly sets maxSockets.

During the restore flow in `createNewVM()`, the VM spec from the backup is passed through `reconcileVM()`. This function may drop or alter CPU hotplug-related fields, specifically `.CPU.MaxSockets`. As a result, the restored VM can contain an invalid CPU topology where sockets > maxSockets

kubeVirt correctly rejects this configuration via admission webhook with:
`Number of sockets in CPU topology is greater than the maximum sockets allowed
`
Restore should be spec-preserving, but CPU topology is currently being mutated during sanitization.

#### Solution:
After calling `reconcileVM()`, explicitly restore the full CPU struct from the backup to ensure all CPU fields (sockets, cores, threads, maxSockets, model, etc.) are preserved.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10051

#### Test plan:

1. Create a VM with CPU hotplug enabled and explicit topology:
```
sockets: 2
cores: 1
threads: 1
maxSockets: 2
```
2. Verify the VM starts successfully.
3. Create a VM backup.
4. Delete the VM.
5. Restore the VM from backup.
6. Verify:
- The restored VM is created successfully.
- No admission webhook error occurs.
- The restored CPU spec matches the original backup exactly.
- The VM starts successfully.
7. Regression test:
- Restore a VM without CPU hotplug configuration.
- Confirm behavior remains unchanged.