### PR TITLE
API Server: Remove Noop Extension APIServer

### DIFF
--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -195,31 +195,6 @@ func (s *HarvesterServer) Scaled() *config.Scaled {
 	return config.ScaledWithContext(s.Context)
 }
 
-// noopExtensionAPIServer is a no-op implementation of ExtensionAPIServer
-type noopExtensionAPIServer struct {
-	registered chan struct{}
-}
-
-func newNoopExtensionAPIServer() *noopExtensionAPIServer {
-	ch := make(chan struct{})
-	close(ch) // immediately close the channel to indicate "registered"
-	return &noopExtensionAPIServer{
-		registered: ch,
-	}
-}
-
-func (n *noopExtensionAPIServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	http.NotFoundHandler().ServeHTTP(rw, req)
-}
-
-func (n *noopExtensionAPIServer) Run(ctx context.Context) error {
-	return nil // no-op
-}
-
-func (n *noopExtensionAPIServer) Registered() <-chan struct{} {
-	return n.registered
-}
-
 func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 	factory, err := controller.NewSharedControllerFactoryFromConfig(s.RESTConfig, Scheme)
 	if err != nil {
@@ -264,10 +239,6 @@ func (s *HarvesterServer) generateSteveServer(options config.Options) error {
 		AuthMiddleware:  steveauth.ExistingContext,
 		Router:          router.Routes,
 		AccessSetLookup: s.ASL,
-
-		// FIXME: Steve requires an ExtensionAPIServer, otherwise it panics.
-		// We can remove this line after bumping rancher/steve to v0.6.20.
-		ExtensionAPIServer: newNoopExtensionAPIServer(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Remove noop extension API server. This is no longer needed since the Steve server dependency has been bumped to >= v0.6.20 The Steve server no longer requires an extension API server. Therefore we no longer need to implement a noop extension API server to be able to instantiate a Steve server.

#### Problem:

Fixme item: workaround for bug in external library.

#### Solution:

Library was fixed. Remove workaround.

#### Related Issue(s):

N/A. Not tracked in issue tracker.

#### Test plan:

N/A. No new features or behaviors.

#### Additional documentation or context


This fixme was introduced in https://github.com/harvester/harvester/commit/71726ee3a782d412700d9226934710ce06e64e38 to work around a bug in Steve, which has since been fixed.
The Steve version was bumped in https://github.com/harvester/harvester/commit/e605979c85b87886e1579aaedc54cd81a9f0c0cb to a version containing the fix.