### PR TITLE
add extra permissions to harvester-authenticated role to allow users …

### DIFF
--- a/pkg/data/public.go
+++ b/pkg/data/public.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	publicNamespace = "harvester-public"
+	publicNamespace  = "harvester-public"
+	systemNamespaces = "system-namespaces"
 )
 
 func addPublicNamespace(apply apply.Apply) error {

--- a/pkg/data/rbac.go
+++ b/pkg/data/rbac.go
@@ -53,6 +53,12 @@ func addAuthenticatedRoles(apply apply.Apply) error {
 						Resources:     []string{"namespaces"},
 						ResourceNames: []string{publicNamespace},
 					},
+					{
+						Verbs:         []string{"get", "watch"},
+						APIGroups:     []string{"management.cattle.io"},
+						Resources:     []string{"settings"},
+						ResourceNames: []string{systemNamespaces},
+					},
 				},
 			},
 			&rbacv1.ClusterRoleBinding{


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
standard rancher users while trying to provision downstream clusters on harvester see the following error on the cluster provisioning form

<img width="1342" height="532" alt="image" src="https://github.com/user-attachments/assets/6fa5c83d-0d5e-494d-a570-35a239fabe1e" />

Based on feedback from @a110605  the issue is being caused because standard users do not have permissions to list `system-namespaces` management.cattle.io setting from the underlying harvester cluster

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
A simple fix introduced in the PR is to update `harvester-authenticated` cluster role to include the extra permissions to `read` and `watch` the `system-namespaces` setting.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9336

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
