### PR TITLE
Add longhorn RWX storage network settings

### DIFF
--- a/pkg/apis/harvesterhci.io/v1beta1/settings.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/settings.go
@@ -38,3 +38,12 @@ type SettingStatus struct {
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
 }
+
+// EffectiveValue returns the effective value of the setting.
+// Value takes precedence; if it is empty, Default is returned.
+func (s *Setting) EffectiveValue() string {
+	if s.Value != "" {
+		return s.Value
+	}
+	return s.Default
+}

--- a/pkg/controller/master/storagenetwork/storage_network.go
+++ b/pkg/controller/master/storagenetwork/storage_network.go
@@ -4,19 +4,24 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	lhtypes "github.com/longhorn/longhorn-manager/types"
 	ctlmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
@@ -31,20 +36,8 @@ import (
 )
 
 const (
-	ControllerName = "harvester-storage-network-controller"
-
-	// for compatiability, will be removed on Harvester v1.6.0
-	StorageNetworkAnnotation        = util.StorageNetworkAnnotation
-	ReplicaStorageNetworkAnnotation = util.ReplicaStorageNetworkAnnotation
-	PausedStorageNetworkAnnotation  = util.PausedStorageNetworkAnnotation
-	HashStorageNetworkAnnotation    = util.HashStorageNetworkAnnotation
-	NadStorageNetworkAnnotation     = util.NadStorageNetworkAnnotation
-	OldNadStorageNetworkAnnotation  = util.OldNadStorageNetworkAnnotation
-
-	HashStorageNetworkLabel = util.HashStorageNetworkLabel
-
-	StorageNetworkNetAttachDefPrefix    = util.StorageNetworkNetAttachDefPrefix
-	StorageNetworkNetAttachDefNamespace = util.StorageNetworkNetAttachDefNamespace
+	ControllerName    = "harvester-storage-network-controller"
+	RWXControllerName = "harvester-rwx-network-controller"
 
 	BridgeSuffix = "-br"
 
@@ -59,12 +52,55 @@ const (
 	// error messages
 	msgWaitForVolumes = "waiting for all volumes detached: %s"
 
-	longhornStorageNetworkName = "storage-network"
+	longhornStorageNetworkName          = "storage-network"
+	longhornEndpointNetworkForRWXVolume = "endpoint-network-for-rwx-volume"
 )
+
+type NetworkKeys struct {
+	nadPrefix         string // the prefix of the generated NAD, the full name will be prefix + random string
+	nadNamespace      string // the namespace of the generated NAD
+	settingHashAnno   string // the annotation to save the hash value of the setting, used to check if the value is changed
+	settingNadAnno    string // the annotation to save the current NAD name used by the setting
+	settingOldNadAnno string // the annotation to save the old NAD name used by the setting, used to remove old NAD after new NAD is created successfully
+	nadAnno           string // the annotation to mark if the NAD is created for storage network setting
+	nadHashLabel      string // the label to save the hash value of the NAD used by setting, used to find the NAD by hash value
+}
+
+var ErrNADNotApplied = errors.New("NAD not yet applied to pod")
+var ErrNADHashChanged = errors.New("NAD hash changed")
+
+var (
+	snAnnotationKeys = &NetworkKeys{
+		nadPrefix:         util.StorageNetworkNetAttachDefPrefix,
+		nadNamespace:      util.StorageNetworkNetAttachDefNamespace,
+		settingHashAnno:   util.HashStorageNetworkAnnotation,
+		settingNadAnno:    util.NadStorageNetworkAnnotation,
+		settingOldNadAnno: util.OldNadStorageNetworkAnnotation,
+		nadAnno:           util.StorageNetworkAnnotation,
+		nadHashLabel:      util.HashStorageNetworkLabel,
+	}
+	rwxAnnotationKeys = &NetworkKeys{
+		nadPrefix:         util.RWXNetworkNetAttachDefPrefix,
+		nadNamespace:      util.RWXNetworkNetAttachDefNamespace,
+		settingHashAnno:   util.RWXHashNetworkAnnotation,
+		settingNadAnno:    util.RWXNadNetworkAnnotation,
+		settingOldNadAnno: util.RWXOldNadNetworkAnnotation,
+		nadAnno:           util.RWXNetworkAnnotation,
+		nadHashLabel:      util.RWXHashNetworkLabel,
+	}
+)
+
+func getNetworkKeys(setting *harvesterv1.Setting) *NetworkKeys {
+	if setting.Name == settings.StorageNetworkName {
+		return snAnnotationKeys
+	}
+	return rwxAnnotationKeys
+}
 
 type Handler struct {
 	ctx                               context.Context
 	settings                          ctlharvesterv1.SettingClient
+	settingsCache                     ctlharvesterv1.SettingCache
 	longhornSettings                  ctllhv1.SettingClient
 	longhornSettingCache              ctllhv1.SettingCache
 	longhornVolumeCache               ctllhv1.VolumeCache
@@ -81,6 +117,7 @@ type Handler struct {
 	whereaboutsCNIIPPoolCache         whereaboutscniv1.IPPoolCache
 	settingsController                ctlharvesterv1.SettingController
 	nodeCache                         ctlcorev1.NodeCache
+	podCache                          ctlcorev1.PodCache
 }
 
 // register the setting controller and reconsile longhorn setting when storage network changed
@@ -95,10 +132,12 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	networkAttachmentDefinitions := management.CniFactory.K8s().V1().NetworkAttachmentDefinition()
 	whereaboutsCNI := management.WhereaboutsCNIFactory.Whereabouts().V1alpha1()
 	node := management.CoreFactory.Core().V1().Node()
+	pod := management.CoreFactory.Core().V1().Pod()
 
 	controller := &Handler{
 		ctx:                               ctx,
 		settings:                          settings,
+		settingsCache:                     settings.Cache(),
 		longhornSettings:                  longhornSettings,
 		longhornSettingCache:              longhornSettings.Cache(),
 		longhornVolumeCache:               longhornVolumes.Cache(),
@@ -115,9 +154,11 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		whereaboutsCNIIPPoolCache:         whereaboutsCNI.IPPool().Cache(),
 		settingsController:                settings,
 		nodeCache:                         node.Cache(),
+		podCache:                          pod.Cache(),
 	}
 
 	settings.OnChange(ctx, ControllerName, controller.OnStorageNetworkChange)
+	settings.OnChange(ctx, RWXControllerName, controller.OnRWXNetworkChange)
 	return nil
 }
 
@@ -225,27 +266,65 @@ func (h *Handler) sha1(s string) string {
 	return fmt.Sprintf("%x", sha1sum)
 }
 
-func (h *Handler) checkIsSameHashValue(setting *harvesterv1.Setting) bool {
-	currentHash := h.sha1(setting.Value)
-	savedHash := setting.Annotations[util.HashStorageNetworkAnnotation]
-	return currentHash == savedHash
+func (h *Handler) getValue(setting *harvesterv1.Setting) (string, error) {
+	if setting.Name == settings.RWXNetworkSettingName {
+		return h.getRWXNetworkValue(setting.Value)
+	}
+	return setting.Value, nil
 }
 
-func (h *Handler) setHashAnnotations(setting *harvesterv1.Setting) *harvesterv1.Setting {
-	setting.Annotations[util.HashStorageNetworkAnnotation] = h.sha1(setting.Value)
-	return setting
+func (h *Handler) checkIsSameHashValue(setting *harvesterv1.Setting) (bool, error) {
+	hashInput, err := h.getValue(setting)
+	if err != nil {
+		return false, err
+	}
+	currentHash := h.sha1(hashInput)
+	keys := getNetworkKeys(setting)
+	savedHash := setting.Annotations[keys.settingHashAnno]
+	return currentHash == savedHash, nil
+}
+
+func (h *Handler) setHashAnnotations(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	keys := getNetworkKeys(setting)
+	hashInput, err := h.getValue(setting)
+	if err != nil {
+		return nil, err
+	}
+	setting.Annotations[keys.settingHashAnno] = h.sha1(hashInput)
+	return setting, nil
 }
 
 func (h *Handler) setNadAnnotations(setting *harvesterv1.Setting, newNad string) *harvesterv1.Setting {
-	setting.Annotations[util.OldNadStorageNetworkAnnotation] = setting.Annotations[util.NadStorageNetworkAnnotation]
-	setting.Annotations[util.NadStorageNetworkAnnotation] = newNad
+	keys := getNetworkKeys(setting)
+	setting.Annotations[keys.settingOldNadAnno] = setting.Annotations[keys.settingNadAnno]
+	setting.Annotations[keys.settingNadAnno] = newNad
 	return setting
 }
 
-func (h *Handler) createNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachmentDefinition, error) {
+// getNetworkConfig returns the network.Config to use for NAD creation.
+// For the rwx-network composite setting, it extracts the inner Network field.
+func (h *Handler) getNetworkConfig(setting *harvesterv1.Setting) (network.Config, error) {
+	if setting.Name == settings.RWXNetworkSettingName {
+		var rwxConfig settings.RWXNetworkConfig
+		if err := json.Unmarshal([]byte(setting.Value), &rwxConfig); err != nil {
+			return network.Config{}, fmt.Errorf("parsing rwx-network value: %v", err)
+		}
+		if rwxConfig.Network == nil {
+			return network.Config{}, fmt.Errorf("network config is nil in rwx-network setting value")
+		}
+		return *rwxConfig.Network, nil
+	}
 	var config network.Config
 	if err := json.Unmarshal([]byte(setting.Value), &config); err != nil {
-		return nil, fmt.Errorf("parsing value error %v", err)
+		return network.Config{}, fmt.Errorf("parsing value error %v", err)
+	}
+	return config, nil
+}
+
+func (h *Handler) createNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachmentDefinition, error) {
+	config, err := h.getNetworkConfig(setting)
+	if err != nil {
+		return nil, err
 	}
 	bridgeConfig := network.CreateBridgeConfig(config)
 
@@ -254,17 +333,23 @@ func (h *Handler) createNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachm
 		return nil, fmt.Errorf("output json error %v", err)
 	}
 
+	hashInput, err := h.getValue(setting)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := getNetworkKeys(setting)
 	nad := nadv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: util.StorageNetworkNetAttachDefPrefix,
-			Namespace:    util.StorageNetworkNetAttachDefNamespace,
+			GenerateName: keys.nadPrefix,
+			Namespace:    keys.nadNamespace,
 		},
 	}
 	nad.Annotations = map[string]string{
-		util.StorageNetworkAnnotation: "true",
+		keys.nadAnno: "true",
 	}
 	nad.Labels = map[string]string{
-		util.HashStorageNetworkLabel: h.sha1(setting.Value),
+		keys.nadHashLabel: h.sha1(hashInput),
 	}
 	nad.Spec.Config = string(nadConfig)
 
@@ -278,9 +363,15 @@ func (h *Handler) createNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachm
 }
 
 func (h *Handler) findOrCreateNad(setting *harvesterv1.Setting) (*nadv1.NetworkAttachmentDefinition, error) {
-	nads, err := h.networkAttachmentDefinitions.List(util.StorageNetworkNetAttachDefNamespace, metav1.ListOptions{
+	hashInput, err := h.getValue(setting)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := getNetworkKeys(setting)
+	nads, err := h.networkAttachmentDefinitions.List(keys.nadNamespace, metav1.ListOptions{
 		LabelSelector: labels.Set{
-			util.HashStorageNetworkLabel: h.sha1(setting.Value),
+			keys.nadHashLabel: h.sha1(hashInput),
 		}.String(),
 	})
 	if err != nil {
@@ -293,9 +384,9 @@ func (h *Handler) findOrCreateNad(setting *harvesterv1.Setting) (*nadv1.NetworkA
 
 	if len(nads.Items) > 1 {
 		logrus.WithFields(logrus.Fields{
-			"num_of_nad":          len(nads.Items),
-			"storage_network_nad": nads.Items[0].Name,
-		}).Info("storage network: found more than one match nad")
+			"num_of_nad": len(nads.Items),
+			"nad_name":   nads.Items[0].Name,
+		}).Info("Found more than one match nad")
 	}
 
 	return &nads.Items[0], nil
@@ -306,11 +397,20 @@ func (h *Handler) checkValueIsChanged(setting *harvesterv1.Setting) (*harvesterv
 	var err error
 	nadAnnotation := ""
 
-	if h.checkIsSameHashValue(setting) {
+	hashInput, err := h.getValue(setting)
+	if err != nil {
+		return setting, err
+	}
+
+	same, err := h.checkIsSameHashValue(setting)
+	if err != nil {
+		return setting, err
+	}
+	if same {
 		return setting, nil
 	}
 
-	if setting.Value != "" {
+	if hashInput != "" {
 		nad, err := h.findOrCreateNad(setting)
 		if err != nil {
 			return setting, err
@@ -319,16 +419,19 @@ func (h *Handler) checkValueIsChanged(setting *harvesterv1.Setting) (*harvesterv
 	}
 
 	setting = h.setNadAnnotations(setting, nadAnnotation)
-	setting = h.setHashAnnotations(setting)
+	if setting, err = h.setHashAnnotations(setting); err != nil {
+		return setting, err
+	}
 
 	if updatedSetting, err = h.setConfiguredCondition(setting, false, ReasonInProgress, "create NAD"); err != nil {
 		return setting, fmt.Errorf("create nad update status error %v", err)
 	}
-	return updatedSetting, fmt.Errorf("check hash again")
+	return updatedSetting, fmt.Errorf("check hash again: %w", ErrNADHashChanged)
 }
 
 func (h *Handler) removeOldNad(setting *harvesterv1.Setting) error {
-	oldNad := setting.Annotations[util.OldNadStorageNetworkAnnotation]
+	keys := getNetworkKeys(setting)
+	oldNad := setting.Annotations[keys.settingOldNadAnno]
 	if oldNad == "" {
 		return nil
 	}
@@ -336,7 +439,7 @@ func (h *Handler) removeOldNad(setting *harvesterv1.Setting) error {
 	nadName := strings.Split(oldNad, "/")
 	if len(nadName) != 2 {
 		logrus.Errorf("split nad namespace and name failed %s", oldNad)
-		setting.Annotations[util.OldNadStorageNetworkAnnotation] = ""
+		setting.Annotations[keys.settingOldNadAnno] = ""
 		return nil
 	}
 	namespace := nadName[0]
@@ -344,7 +447,7 @@ func (h *Handler) removeOldNad(setting *harvesterv1.Setting) error {
 
 	if _, err := h.networkAttachmentDefinitionsCache.Get(namespace, name); err != nil {
 		if apierrors.IsNotFound(err) {
-			setting.Annotations[util.OldNadStorageNetworkAnnotation] = ""
+			setting.Annotations[keys.settingOldNadAnno] = ""
 			return nil
 		}
 
@@ -356,7 +459,7 @@ func (h *Handler) removeOldNad(setting *harvesterv1.Setting) error {
 		return fmt.Errorf("remove nad error %v", err)
 	}
 
-	setting.Annotations[util.OldNadStorageNetworkAnnotation] = ""
+	setting.Annotations[keys.settingOldNadAnno] = ""
 	return nil
 }
 
@@ -398,6 +501,16 @@ func (h *Handler) validateIPAddressesAllocations(setting *harvesterv1.Setting) e
 }
 
 func (h *Handler) handleLonghornSettingPostConfig(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	// If rwx-network is in share mode, re-trigger its reconciliation so the
+	// freshly-configured storage-network NAD is propagated to Longhorn.
+	isShareStorageNetwork, err := util.IsShareStorageNetwork(h.settingsCache)
+	if err != nil {
+		return nil, err
+	}
+	if isShareStorageNetwork {
+		h.settingsController.Enqueue(settings.RWXNetworkSettingName)
+	}
+
 	// check if we need to restart monitoring pods
 	if err := h.checkPodStatusAndStart(); err != nil {
 		if _, updateConditionErr := h.setConfiguredCondition(setting, false, ReasonInProgress, MsgRestartPod); updateConditionErr != nil {
@@ -411,7 +524,7 @@ func (h *Handler) handleLonghornSettingPostConfig(setting *harvesterv1.Setting) 
 		return setting, fmt.Errorf("remove old nad error %v", err)
 	}
 
-	err := h.validateIPAddressesAllocations(setting)
+	err = h.validateIPAddressesAllocations(setting)
 	if err != nil {
 		setting, err := h.setConfiguredCondition(setting, false, ReasonInProgress, MsgIPAssignmentFailure)
 		if err != nil {
@@ -812,4 +925,272 @@ func (h *Handler) updateLonghornStorageNetwork(storageNetwork string) error {
 		return err
 	}
 	return nil
+}
+
+// OnRWXNetworkChange handles changes to the rwx-network setting.
+// The setting value is a JSON-encoded RWXNetworkConfig:
+//   - share-storage-network=true  -> propagate the storage-network NAD to Longhorn
+//   - share-storage-network=false -> manage a dedicated RWX NAD and propagate it to Longhorn
+func (h *Handler) OnRWXNetworkChange(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	if setting == nil || setting.DeletionTimestamp != nil || setting.Name != settings.RWXNetworkSettingName {
+		return setting, nil
+	}
+	settingCopy := setting.DeepCopy()
+
+	initialized := settingCopy.Annotations != nil &&
+		settingCopy.Annotations[util.RWXNetworkInitializedAnno] == "true"
+	if settingCopy.Value == "" && !initialized {
+		return h.initRWXNetwork(settingCopy)
+	}
+	if settingCopy.Annotations == nil {
+		settingCopy.Annotations = make(map[string]string)
+	}
+
+	var rwxConfig settings.RWXNetworkConfig
+	if err := json.Unmarshal([]byte(setting.EffectiveValue()), &rwxConfig); err != nil {
+		return setting, fmt.Errorf("parsing rwx-network value: %v", err)
+	}
+
+	if settingCopy.Annotations[util.RWXOldNadNetworkAnnotation] != "" {
+		return h.reconcileRWXNADCleanup(settingCopy, rwxConfig)
+	}
+
+	if rwxConfig.ShareStorageNetwork {
+		return h.reconcileShareStorageNetwork(settingCopy)
+	}
+
+	return h.reconcileDedicatedRWXNetwork(settingCopy)
+}
+
+// reconcileRWXNADCleanup handles the cleanup-pending state.
+// It verifies all CSI plugin pods have adopted the new NAD before deleting
+// the old one, then clears the pending annotation and returns. The next
+// reconcile will confirm the steady state via the share/dedicated path.
+func (h *Handler) reconcileRWXNADCleanup(setting *harvesterv1.Setting, rwxConfig settings.RWXNetworkConfig) (*harvesterv1.Setting, error) {
+	expectedNAD, err := h.getExpectedRWXNAD(setting, rwxConfig)
+	if err != nil {
+		return setting, err
+	}
+
+	if err := h.checkCSIPluginPodsNetworkStatus(expectedNAD); errors.Is(err, ErrNADNotApplied) {
+		logrus.Infof("RWX NAD cleanup pending, will retry: %v", err)
+		h.settingsController.EnqueueAfter(settings.RWXNetworkSettingName, 10*time.Second)
+		return setting, nil
+	} else if err != nil {
+		return setting, err
+	}
+
+	if err := h.removeOldNad(setting); err != nil {
+		return setting, fmt.Errorf("failed to remove old RWX NAD: %v", err)
+	}
+
+	return h.settings.Update(setting)
+}
+
+// reconcileShareStorageNetwork handles the share-storage-network=true steady state.
+// It points Longhorn at the storage-network NAD. If a dedicated NAD was previously
+// in use, it schedules it for cleanup on the next reconcile (cleanup-pending state).
+func (h *Handler) reconcileShareStorageNetwork(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	nad, err := h.getStorageNetworkNAD()
+	if err != nil {
+		return setting, err
+	}
+
+	if err := h.updateLonghornRWXEndpoint(nad); err != nil {
+		return setting, err
+	}
+
+	// If a dedicated NAD is still referenced, dereference it now so the NAD
+	// webhook allows deletion, and mark it for cleanup on the next reconcile.
+	if currentNad := setting.Annotations[util.RWXNadNetworkAnnotation]; currentNad != "" {
+		setting.Annotations[util.RWXOldNadNetworkAnnotation] = currentNad
+		setting.Annotations[util.RWXNadNetworkAnnotation] = ""
+		// Clear hash so switching back to dedicated mode later re-creates the NAD.
+		setting.Annotations[util.RWXHashNetworkAnnotation] = ""
+	}
+
+	harvesterv1.SettingConfigured.True(setting)
+	harvesterv1.SettingConfigured.Reason(setting, ReasonCompleted)
+	return h.settings.Update(setting)
+}
+
+// reconcileDedicatedRWXNetwork handles the share-storage-network=false steady state.
+// It ensures a dedicated NAD exists for the configured network and points Longhorn at it.
+func (h *Handler) reconcileDedicatedRWXNetwork(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	updatedSetting, err := h.checkValueIsChanged(setting)
+	// skip the error that triggers a requeue to wait for the NAD to be applied, but return any other error
+	// otherwise we stuck in the reconcileRWXNADCleanup because the lh rwx endpoint is not updated to the new nad yet.
+	if err != nil && !errors.Is(err, ErrNADHashChanged) {
+		return updatedSetting, err
+	}
+
+	nad := updatedSetting.Annotations[util.RWXNadNetworkAnnotation]
+	if err := h.updateLonghornRWXEndpoint(nad); err != nil {
+		return updatedSetting, err
+	}
+
+	return h.setConfiguredCondition(updatedSetting, true, ReasonCompleted, "")
+}
+
+// getExpectedRWXNAD returns the NAD name that CSI plugin pods should currently
+// be using, based on the current mode.
+func (h *Handler) getExpectedRWXNAD(setting *harvesterv1.Setting, rwxConfig settings.RWXNetworkConfig) (string, error) {
+	if rwxConfig.ShareStorageNetwork {
+		return h.getStorageNetworkNAD()
+	}
+	return setting.Annotations[util.RWXNadNetworkAnnotation], nil
+}
+
+// checkCSIPluginPodsNetworkStatus verifies that all longhorn-csi-plugin pods
+// have the given NAD name in their k8s.v1.cni.cncf.io/network-status annotation.
+// Returns an error (causing a requeue) if any pod is missing the NAD.
+func (h *Handler) checkCSIPluginPodsNetworkStatus(expectedNAD string) error {
+	if expectedNAD == "" {
+		return nil
+	}
+
+	pods, err := h.listLHCSIPluginPods()
+	if err != nil {
+		return fmt.Errorf("failed to list longhorn-csi-plugin pods: %v", err)
+	}
+
+	for _, pod := range pods {
+		if err := checkNADInPodNetworkStatus(pod, expectedNAD); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) listLHCSIPluginPods() ([]*corev1.Pod, error) {
+	requirement, err := labels.NewRequirement(util.LabelAppNameKey, selection.Equals, []string{lhtypes.CSIPluginName})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create label requirement: %v", err)
+	}
+	labelSelector := labels.NewSelector().Add(*requirement)
+	return h.podCache.List(util.LonghornSystemNamespaceName, labelSelector)
+}
+
+// checkNADInPodNetworkStatus checks if the given NAD name is present in the pod's network-status annotation.
+// Returns an error if the annotation is missing, cannot be parsed, or does not contain the expected NAD.
+func checkNADInPodNetworkStatus(pod *corev1.Pod, expectedNAD string) error {
+	statusJSON := pod.Annotations[nadv1.NetworkStatusAnnot]
+	if statusJSON == "" {
+		return fmt.Errorf("pod %s/%s: missing network-status annotation: %w", pod.Namespace, pod.Name, ErrNADNotApplied)
+	}
+
+	var statuses []nadv1.NetworkStatus
+	if err := json.Unmarshal([]byte(statusJSON), &statuses); err != nil {
+		return fmt.Errorf("failed to parse network-status annotation on pod %s/%s: %v", pod.Namespace, pod.Name, err)
+	}
+
+	for _, s := range statuses {
+		if s.Name == expectedNAD {
+			return nil
+		}
+	}
+	return fmt.Errorf("pod %s/%s: NAD %s not found in network-status: %w", pod.Namespace, pod.Name, expectedNAD, ErrNADNotApplied)
+}
+
+// initRWXNetwork handles the upgrade case where rwx-network has no value.
+// If the Longhorn storage-network and endpoint-network-for-rwx-volume settings share the same NAD,
+// the user had both pointing at the same network before this setting existed, so we reflect that
+// by setting share-storage-network=true. Otherwise the setting is skipped (pure initialization).
+func (h *Handler) initRWXNetwork(setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {
+	isShare, err := h.isLHRWXShareStorageNetwork()
+	if err != nil {
+		return setting, err
+	}
+
+	if setting.Annotations == nil {
+		setting.Annotations = make(map[string]string)
+	}
+	setting.Annotations[util.RWXNetworkInitializedAnno] = "true"
+	if !isShare {
+		return h.settings.Update(setting)
+	}
+
+	shareConfig := settings.RWXNetworkConfig{ShareStorageNetwork: true}
+	shareConfigJSON, err := json.Marshal(shareConfig)
+	if err != nil {
+		return setting, fmt.Errorf("failed to marshal rwx-network config: %v", err)
+	}
+	setting.Value = string(shareConfigJSON)
+	newSetting, err := h.settings.Update(setting)
+	if err != nil {
+		logrus.Errorf("failed to update rwx-network setting during init: %v", err)
+		return setting, fmt.Errorf("failed to update rwx-network setting: %v", err)
+	}
+	return newSetting, nil
+}
+
+func (h *Handler) isLHRWXShareStorageNetwork() (bool, error) {
+	// don't use cache here since we want to reflect the latest LH setting values
+	lhStorageNetwork, err := h.longhornSettings.Get(util.LonghornSystemNamespaceName, longhornStorageNetworkName, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to get longhorn %s setting: %v", longhornStorageNetworkName, err)
+	}
+	lhRWXEndpoint, err := h.longhornSettings.Get(util.LonghornSystemNamespaceName, longhornEndpointNetworkForRWXVolume, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to get longhorn %s setting: %v", longhornEndpointNetworkForRWXVolume, err)
+	}
+	return lhStorageNetwork != nil && lhRWXEndpoint != nil &&
+		lhStorageNetwork.Value != "" && lhStorageNetwork.Value == lhRWXEndpoint.Value, nil
+}
+
+// getStorageNetworkNAD returns the NAD name currently in use by the storage-network setting.
+func (h *Handler) getStorageNetworkNAD() (string, error) {
+	storageNetwork, err := h.settings.Get(settings.StorageNetworkName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get %s setting: %v", settings.StorageNetworkName, err)
+	}
+	if storageNetwork.EffectiveValue() == "" {
+		return "", nil
+	}
+	nad, ok := storageNetwork.Annotations[util.NadStorageNetworkAnnotation]
+	if !ok || nad == "" {
+		return "", fmt.Errorf("storage-network annotation %s does not exist or is empty", util.NadStorageNetworkAnnotation)
+	}
+	return nad, nil
+}
+
+// getRWXNetworkValue returns the canonical JSON of the network-only portion of the
+// rwx-network composite value. This ensures the NAD hash is stable across
+// share-storage-network flag changes.
+func (h *Handler) getRWXNetworkValue(settingValue string) (string, error) {
+	if settingValue == "" {
+		return "", nil
+	}
+	var rwxConfig settings.RWXNetworkConfig
+	if err := json.Unmarshal([]byte(settingValue), &rwxConfig); err != nil {
+		return "", fmt.Errorf("failed to unmarshal rwx-network: %v", err)
+	}
+	if rwxConfig.Network == nil {
+		return "", nil
+	}
+	networkJSON, err := json.Marshal(rwxConfig.Network)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal network config: %v", err)
+	}
+	return string(networkJSON), nil
+}
+
+func (h *Handler) updateLonghornRWXEndpoint(storageNetwork string) error {
+	rwxSN, err := h.longhornSettingCache.Get(util.LonghornSystemNamespaceName, longhornEndpointNetworkForRWXVolume)
+	if err != nil {
+		return err
+	}
+
+	if rwxSN.Value == storageNetwork {
+		return nil
+	}
+
+	rwxSNCpy := rwxSN.DeepCopy()
+	rwxSNCpy.Value = storageNetwork
+	_, err = h.longhornSettings.Update(rwxSNCpy)
+	return err
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -50,6 +50,7 @@ var (
 	CSIOnlineExpandValidation              = NewSetting(CSIOnlineExpandValidationSettingName, `{"driver.longhorn.io":true}`)
 	ContainerdRegistry                     = NewSetting(ContainerdRegistrySettingName, "")
 	StorageNetwork                         = NewSetting(StorageNetworkName, "")
+	RWXNetwork                             = NewSetting(RWXNetworkSettingName, `{"share-storage-network":false}`)
 	DefaultVMTerminationGracePeriodSeconds = NewSetting(DefaultVMTerminationGracePeriodSecondsSettingName, "120")
 	AutoRotateRKE2CertsSet                 = NewSetting(AutoRotateRKE2CertsSettingName, InitAutoRotateRKE2Certs())
 	KubeconfigTTL                          = NewSetting(KubeconfigDefaultTokenTTLMinutesSettingName, "0") // "0" is default value to ensure token does not expire
@@ -92,6 +93,7 @@ const (
 	ContainerdRegistrySettingName                     = "containerd-registry"
 	HarvesterCSICCMSettingName                        = "harvester-csi-ccm-versions"
 	StorageNetworkName                                = "storage-network"
+	RWXNetworkSettingName                             = "rwx-network"
 	DefaultVMTerminationGracePeriodSecondsSettingName = "default-vm-termination-grace-period-seconds"
 	SupportBundleExpirationSettingName                = "support-bundle-expiration"
 	NTPServersSettingName                             = "ntp-servers"

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	networkutil "github.com/harvester/harvester/pkg/util/network"
 )
 
 type TargetType string
@@ -395,4 +396,23 @@ func GetClusterRegistrationURLSetting(setting *harvesterv1.Setting) *ClusterRegi
 		reg.InsecureSkipTLSVerify = true
 	}
 	return reg
+
+}
+
+type RWXNetworkConfig struct {
+	ShareStorageNetwork bool                `json:"share-storage-network"`
+	Network             *networkutil.Config `json:"network,omitempty"`
+}
+
+func GetRWXNetworkConfig(setting *harvesterv1.Setting) (*RWXNetworkConfig, error) {
+	if setting == nil {
+		return nil, fmt.Errorf("the setting is empty, can't get the setting")
+	}
+
+	rwxConfig := &RWXNetworkConfig{}
+	value := setting.EffectiveValue()
+	if err := json.Unmarshal([]byte(value), rwxConfig); err != nil {
+		return nil, fmt.Errorf("invalid JSON `%s`: %s", value, err.Error())
+	}
+	return rwxConfig, nil
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -234,9 +234,9 @@ const (
 	LabelCPUManagerUpdatePolicy      = prefix + "/cpu-manager-update-policy"
 	LabelCPUManagerExitCode          = prefix + "/cpu-manager-exit-code"
 
-	VClusterNamespace          = "rancher-vcluster"
-	LablelVClusterAppNameKey   = "app"
-	LablelVClusterAppNameValue = "vcluster"
+	VClusterNamespace         = "rancher-vcluster"
+	LabelAppNameKey           = "app"
+	LabelVClusterAppNameValue = "vcluster"
 
 	StorageClassHarvesterLonghorn  = "harvester-longhorn"  // the initial & default storageclass
 	StorageClassLonghornStatic     = "longhorn-static"     // internal storageclass used for management of existing Longhorn volumes
@@ -265,6 +265,17 @@ const (
 
 	StorageNetworkNetAttachDefPrefix    = "storagenetwork-"
 	StorageNetworkNetAttachDefNamespace = HarvesterSystemNamespaceName
+
+	RWXNetworkAnnotation       = "rwx-network.settings.harvesterhci.io"
+	RWXHashNetworkAnnotation   = RWXNetworkAnnotation + "/hash"
+	RWXNadNetworkAnnotation    = RWXNetworkAnnotation + "/net-attach-def"
+	RWXOldNadNetworkAnnotation = RWXNetworkAnnotation + "/old-net-attach-def"
+	RWXNetworkInitializedAnno  = RWXNetworkAnnotation + "/initialized"
+
+	RWXHashNetworkLabel = RWXHashNetworkAnnotation
+
+	RWXNetworkNetAttachDefPrefix    = "rwx-network-"
+	RWXNetworkNetAttachDefNamespace = HarvesterSystemNamespaceName
 
 	HarvesterCRDManagedChart         = "harvester-crd"
 	HarvesterManagedChart            = "harvester"

--- a/pkg/util/setting.go
+++ b/pkg/util/setting.go
@@ -5,6 +5,7 @@ import (
 
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // get the value of AdditionalGuestMemoryOverheadRatio, if failed, return the default ratio
@@ -81,4 +82,24 @@ func IsRestoreVM(settingCache ctlharvesterv1.SettingCache) (bool, error) {
 		return false, err
 	}
 	return upgradeConfig.RestoreVM, nil
+}
+
+func IsShareStorageNetwork(settingCache ctlharvesterv1.SettingCache) (bool, error) {
+	if settingCache == nil {
+		return false, fmt.Errorf("the settingCache is empty, can't get the setting")
+	}
+	rwxSN, err := settingCache.Get(settings.RWXNetworkSettingName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get %s setting, err: %v", settings.RWXNetworkSettingName, err)
+	}
+
+	rwxConfig, err := settings.DecodeConfig[settings.RWXNetworkConfig](rwxSN.EffectiveValue())
+	if err != nil || rwxConfig == nil {
+		return false, err
+	}
+
+	return rwxConfig.ShareStorageNetwork, nil
 }

--- a/pkg/util/volume.go
+++ b/pkg/util/volume.go
@@ -3,15 +3,19 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/settings"
+	lh "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 )
 
 const (
@@ -19,6 +23,7 @@ const (
 	AnnBetaStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
 	LonghornDataLocality      = "dataLocality"
 	IndexPodByPVC             = "indexPodByPVC"
+	rwxVolumeDisplayMax       = 3
 )
 
 var (
@@ -189,4 +194,39 @@ func IsVolumeSnapshotReady(vs *snapshotv1.VolumeSnapshot) bool {
 		return false
 	}
 	return vs.Status != nil && vs.Status.ReadyToUse != nil && *vs.Status.ReadyToUse
+}
+
+// CheckRWXNonMigratableVolumesDetached returns an error listing attached non-migratable RWX volumes if any exist.
+func CheckRWXNonMigratableVolumesDetached(volumeCache ctllhv1.VolumeCache) error {
+	volumes, err := volumeCache.List(LonghornSystemNamespaceName, labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list longhorn volumes: %v", err)
+	}
+
+	attached := make([]string, 0)
+	for _, volume := range volumes {
+		if volume.Spec.AccessMode != lh.AccessModeReadWriteMany {
+			continue
+		}
+		// Migratable volumes are VM live-migration block devices, not RWX
+		// filesystem volumes; they don't use the RWX network path.
+		if volume.Spec.Migratable {
+			continue
+		}
+		if volume.Status.State != lh.VolumeStateDetached {
+			attached = append(attached, volume.Name)
+		}
+	}
+
+	if len(attached) == 0 {
+		return nil
+	}
+
+	display := attached
+	suffix := ""
+	if len(attached) > rwxVolumeDisplayMax {
+		display = attached[:rwxVolumeDisplayMax]
+		suffix = "..."
+	}
+	return fmt.Errorf("there are RWX volumes not in detached state: %s", strings.Join(display, ", ")+suffix)
 }

--- a/pkg/webhook/resources/networkattachmentdefinition/validator.go
+++ b/pkg/webhook/resources/networkattachmentdefinition/validator.go
@@ -3,7 +3,6 @@ package networkattachmentdefinition
 import (
 	"fmt"
 
-	hncutils "github.com/harvester/harvester-network-controller/pkg/utils"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,33 +46,33 @@ func (v *nadValidator) Delete(_ *types.Request, obj runtime.Object) error {
 		return nil
 	}
 
-	// Skip NADs that are not used for storage network.
-	// A resource is considered as a storage network NAD if it meets all the
-	// following conditions:
-	// 1. The namespace is `harvester-system`
-	// 2. It has the annotation `storage-network.settings.harvesterhci.io: true`
-	// 3. The name has the prefix `storagenetwork-`
-	if !hncutils.IsStorageNetworkNad(nad) {
-		return nil
-	}
-
-	// Get the `storage-network` setting to check if it uses the deleting NAD.
-	setting, err := v.settingCache.Get(settings.StorageNetworkName)
-	if err != nil && apierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return werror.NewInternalError(err.Error())
-	}
-	if setting == nil {
-		return nil
-	}
-
-	nadNamespacedName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
-	current := setting.Annotations[util.NadStorageNetworkAnnotation]
-	if current == nadNamespacedName {
-		return werror.NewBadRequest(fmt.Sprintf("cannot delete NetworkAttachmentDefinition %s which is used by Harvester setting '%s'", nadNamespacedName, settings.StorageNetworkName))
+	for _, settingName := range []string{settings.StorageNetworkName, settings.RWXNetworkSettingName} {
+		usedBySetting, err := v.checkNadUsedBySetting(nad, settingName)
+		if err != nil {
+			return werror.NewInternalError(err.Error())
+		}
+		if usedBySetting {
+			return werror.NewBadRequest(fmt.Sprintf("cannot delete NetworkAttachmentDefinition %s/%s which is used by Harvester setting '%s'", nad.Namespace, nad.Name, settingName))
+		}
 	}
 
 	return nil
+}
+
+func (v *nadValidator) checkNadUsedBySetting(nad *cniv1.NetworkAttachmentDefinition, settingName string) (bool, error) {
+	setting, err := v.settingCache.Get(settingName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	if setting == nil {
+		return false, nil
+	}
+
+	nadAnno := util.NadStorageNetworkAnnotation
+	if settingName == settings.RWXNetworkSettingName {
+		nadAnno = util.RWXNadNetworkAnnotation
+	}
+	nadNamespacedName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
+	current := setting.Annotations[nadAnno]
+	return current == nadNamespacedName, nil
 }

--- a/pkg/webhook/resources/networkattachmentdefinition/validator_test.go
+++ b/pkg/webhook/resources/networkattachmentdefinition/validator_test.go
@@ -39,11 +39,21 @@ func TestDeleteAllowsWhenNotUsed(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "correct namespace and name",
+			name: "storage-network NAD: correct namespace and name, setting not referencing it",
 			nad: &cniv1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: util.HarvesterSystemNamespaceName,
 					Name:      util.StorageNetworkNetAttachDefPrefix + "aaaaa",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "rwx-network NAD: correct namespace and name, setting not referencing it",
+			nad: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: util.RWXNetworkNetAttachDefNamespace,
+					Name:      util.RWXNetworkNetAttachDefPrefix + "aaaaa",
 				},
 			},
 			expectErr: false,
@@ -81,6 +91,36 @@ func TestDeleteBlocksWhenUsed(t *testing.T) {
 			Name:      nadName,
 			Annotations: map[string]string{
 				util.StorageNetworkAnnotation: "true",
+			},
+		},
+	}
+
+	err := validator.Delete(nil, nad)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot delete NetworkAttachmentDefinition")
+}
+
+func TestDeleteBlocksRWXNadWhenUsed(t *testing.T) {
+	nadName := util.RWXNetworkNetAttachDefPrefix + "bbbbb"
+	nadNamespacedName := fmt.Sprintf("%s/%s", util.RWXNetworkNetAttachDefNamespace, nadName)
+
+	clientset := fakegenerated.NewSimpleClientset(&apiv1.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: settings.RWXNetworkSettingName,
+			Annotations: map[string]string{
+				util.RWXNadNetworkAnnotation: nadNamespacedName,
+			},
+		},
+	})
+
+	validator := NewValidator(ctlv1beta1.SettingCache(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings)))
+
+	nad := &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: util.RWXNetworkNetAttachDefNamespace,
+			Name:      nadName,
+			Annotations: map[string]string{
+				util.RWXNetworkAnnotation: "true",
 			},
 		},
 	}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -76,6 +76,7 @@ const (
 	labelAppNameValueImportController = "harvester-vm-import-controller"
 	maxTTLDurationMinutes             = 52560000 //specifies max duration allowed for kubeconfig TTL setting, and corresponds to 100 years
 	mgmtClusterNetwork                = "mgmt"
+	rwxExtraIPs                       = 32 // arbitrary number to allow some RWX workloads to be created
 )
 
 var certs = getSystemCerts()
@@ -113,7 +114,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.LHIMResourcesSettingName:                          validateLHIMResources,
 }
 
-type validateSettingUpdateFunc func(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error
+type validateSettingUpdateFunc func(request *types.Request, oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error
 
 var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
 	settings.VMForceResetPolicySettingName:                     validateUpdateVMForceResetPolicy,
@@ -185,6 +186,10 @@ func NewValidator(
 	validateSettingUpdateFuncs[settings.StorageNetworkName] = validator.validateUpdateStorageNetwork
 	validateSettingDeleteFuncs[settings.StorageNetworkName] = validator.validateDeleteStorageNetwork
 
+	validateSettingFuncs[settings.RWXNetworkSettingName] = validator.validateRWXNetwork
+	validateSettingUpdateFuncs[settings.RWXNetworkSettingName] = validator.validateUpdateRWXNetwork
+	validateSettingDeleteFuncs[settings.RWXNetworkSettingName] = validator.validateDeleteRWXNetwork
+
 	validateSettingFuncs[settings.VMMigrationNetworkSettingName] = validator.validateVMMigrationNetwork
 	validateSettingUpdateFuncs[settings.VMMigrationNetworkSettingName] = validator.validateUpdateVMMigrationNetwork
 	validateSettingDeleteFuncs[settings.VMMigrationNetworkSettingName] = validator.validateDeleteVMMigrationNetwork
@@ -247,19 +252,19 @@ func (v *settingValidator) Resource() types.Resource {
 	}
 }
 
-func (v *settingValidator) Create(_ *types.Request, newObj runtime.Object) error {
-	return validateSetting(newObj)
+func (v *settingValidator) Create(request *types.Request, newObj runtime.Object) error {
+	return validateSetting(request, newObj)
 }
 
-func (v *settingValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
-	return validateUpdateSetting(oldObj, newObj)
+func (v *settingValidator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	return validateUpdateSetting(request, oldObj, newObj)
 }
 
 func (v *settingValidator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	return validateDeleteSetting(oldObj)
 }
 
-func validateSetting(newObj runtime.Object) error {
+func validateSetting(request *types.Request, newObj runtime.Object) error {
 	setting := newObj.(*v1beta1.Setting)
 
 	if validateFunc, ok := validateSettingFuncs[setting.Name]; ok {
@@ -269,12 +274,12 @@ func validateSetting(newObj runtime.Object) error {
 	return nil
 }
 
-func validateUpdateSetting(oldObj runtime.Object, newObj runtime.Object) error {
+func validateUpdateSetting(request *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	oldSetting := oldObj.(*v1beta1.Setting)
 	newSetting := newObj.(*v1beta1.Setting)
 
 	if validateUpdateFunc, ok := validateSettingUpdateFuncs[newSetting.Name]; ok {
-		return validateUpdateFunc(oldSetting, newSetting)
+		return validateUpdateFunc(request, oldSetting, newSetting)
 	}
 
 	return nil
@@ -333,7 +338,7 @@ func (v *settingValidator) validateHTTPProxy(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func (v *settingValidator) validateUpdateHTTPProxy(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateHTTPProxy(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateHTTPProxy(newSetting)
 }
 
@@ -419,7 +424,7 @@ func validateOvercommitConfig(setting *v1beta1.Setting) error {
 	return validateOvercommitConfigHelper(settings.KeywordValue, setting.Value)
 }
 
-func validateUpdateOvercommitConfig(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateOvercommitConfig(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateOvercommitConfig(newSetting)
 }
 
@@ -447,7 +452,7 @@ func validateVMForceResetPolicy(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateVMForceResetPolicy(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateVMForceResetPolicy(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateVMForceResetPolicy(newSetting)
 }
 
@@ -502,7 +507,7 @@ func (v *settingValidator) validateBackupTargetFields(target *settings.BackupTar
 	return nil
 }
 
-func (v *settingValidator) validateUpdateBackupTarget(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateBackupTarget(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateBackupTarget(newSetting)
 }
 
@@ -719,7 +724,7 @@ func validateNTPServer(server string, nameValidator, patternValidator *regexp.Re
 	return true
 }
 
-func validateUpdateNTPServers(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateNTPServers(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateNTPServers(newSetting)
 }
 
@@ -748,7 +753,7 @@ func validateVipPoolsConfig(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateVipPoolsConfig(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateVipPoolsConfig(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateVipPoolsConfig(newSetting)
 }
 
@@ -778,7 +783,7 @@ func validateSupportBundleTimeout(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSupportBundleTimeout(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSupportBundleTimeout(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleTimeout(newSetting)
 }
 
@@ -808,7 +813,7 @@ func validateSupportBundleExpiration(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSupportBundleNodeCollectionTimeout(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSupportBundleNodeCollectionTimeout(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleNodeCollectionTimeout(newSetting)
 }
 
@@ -838,7 +843,7 @@ func validateSupportBundleNodeCollectionTimeout(setting *v1beta1.Setting) error 
 	return nil
 }
 
-func validateUpdateSupportBundle(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSupportBundle(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleExpiration(newSetting)
 }
 
@@ -868,7 +873,7 @@ func validateSupportBundleFileName(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSupportBundleFileName(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSupportBundleFileName(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleFileName(newSetting)
 }
 
@@ -910,7 +915,7 @@ func validateSSLCertificates(setting *v1beta1.Setting) error {
 	return validateSSLCertificatesHelper(settings.KeywordValue, setting.Value)
 }
 
-func validateUpdateSSLCertificates(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSSLCertificates(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSSLCertificates(newSetting)
 }
 
@@ -949,7 +954,7 @@ func validateSSLParameters(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSSLParameters(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSSLParameters(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSSLParameters(newSetting)
 }
 
@@ -1028,7 +1033,7 @@ func validateSupportBundleImage(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateSupportBundleImage(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateSupportBundleImage(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleImage(newSetting)
 }
 
@@ -1048,11 +1053,11 @@ func (v *settingValidator) validateVolumeSnapshotClass(setting *v1beta1.Setting)
 	return nil
 }
 
-func (v *settingValidator) validateUpdateVolumeSnapshotClass(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateVolumeSnapshotClass(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateVolumeSnapshotClass(newSetting)
 }
 
-func (v *settingValidator) validateUpdateLonghornV2DataEngine(oldSetting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateLonghornV2DataEngine(_ *types.Request, oldSetting, newSetting *v1beta1.Setting) error {
 	if oldSetting.Value == newSetting.Value {
 		return nil
 	}
@@ -1096,7 +1101,7 @@ func validateContainerdRegistry(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateContainerdRegistry(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateContainerdRegistry(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateContainerdRegistry(newSetting)
 }
 
@@ -1131,6 +1136,7 @@ func (v *settingValidator) validateNetworkHelper(name, value string) (*networkut
 	networkRangeValidators := map[string]func(*networkutil.Config) error{
 		settings.StorageNetworkName:            v.checkStorageNetworkRangeValid,
 		settings.VMMigrationNetworkSettingName: v.checkVMMigrationNetworkRangeValid,
+		settings.RWXNetworkSettingName:         v.checkRWXNetworkRangeValid,
 	}
 	if validator, ok := networkRangeValidators[name]; ok {
 		if err := validator(&config); err != nil {
@@ -1141,34 +1147,44 @@ func (v *settingValidator) validateNetworkHelper(name, value string) (*networkut
 }
 
 func (v *settingValidator) getNetworkConfig(settingName string) (*networkutil.Config, error) {
-	if settingName != settings.StorageNetworkName && settingName != settings.VMMigrationNetworkSettingName {
+	if settingName != settings.StorageNetworkName &&
+		settingName != settings.VMMigrationNetworkSettingName &&
+		settingName != settings.RWXNetworkSettingName {
 		return nil, nil
 	}
 
 	networkConfigSetting, err := v.settingCache.Get(settingName)
 	if err != nil {
+		// during harvester bootstrap, the setting might not be created yet, return nil in this case
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get %s setting, err: %v", settingName, err)
 	}
 
-	if networkConfigSetting.Value != "" {
-		var config networkutil.Config
-		if err := json.Unmarshal([]byte(networkConfigSetting.Value), &config); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal the %s setting value %v, %w", settingName, networkConfigSetting.Value, err)
-		}
-		return &config, nil
+	effectiveValue := networkConfigSetting.EffectiveValue()
+	if effectiveValue == "" {
+		return nil, nil
 	}
 
-	if networkConfigSetting.Default != "" {
-		var config networkutil.Config
-		if err := json.Unmarshal([]byte(networkConfigSetting.Default), &config); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal the %s setting default value %v, %w", settingName, networkConfigSetting.Default, err)
+	// rwx-network uses a composite JSON format; extract the inner network config.
+	if settingName == settings.RWXNetworkSettingName {
+		var rwxConfig settings.RWXNetworkConfig
+		if err := json.Unmarshal([]byte(effectiveValue), &rwxConfig); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal the %s setting value %v, %w", settingName, effectiveValue, err)
 		}
-		return &config, nil
+		// When sharing the storage-network, the networks are identical — no overlap possible.
+		if rwxConfig.ShareStorageNetwork {
+			return nil, nil
+		}
+		return rwxConfig.Network, nil
 	}
-	return nil, nil
+
+	var config networkutil.Config
+	if err := json.Unmarshal([]byte(effectiveValue), &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the %s setting value %v, %w", settingName, effectiveValue, err)
+	}
+	return &config, nil
 }
 
 func (v *settingValidator) validateStorageNetwork(setting *v1beta1.Setting) error {
@@ -1190,12 +1206,19 @@ func (v *settingValidator) validateStorageNetwork(setting *v1beta1.Setting) erro
 		config = valueConfig
 	}
 
-	vmMigraionNetworkConfig, err := v.getNetworkConfig(settings.VMMigrationNetworkSettingName)
+	vmMigrationNetworkConfig, err := v.getNetworkConfig(settings.VMMigrationNetworkSettingName)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	rwxNetworkConfig, err := v.getNetworkConfig(settings.RWXNetworkSettingName)
 	if err != nil {
 		return werror.NewInternalError(err.Error())
 	}
 
-	if err = checkNetworkOverlap(settings.StorageNetworkName, config, settings.VMMigrationNetworkSettingName, vmMigraionNetworkConfig); err != nil {
+	if err = checkNetworkOverlap(settings.StorageNetworkName, config, map[string]*networkutil.Config{
+		settings.VMMigrationNetworkSettingName: vmMigrationNetworkConfig,
+		settings.RWXNetworkSettingName:         rwxNetworkConfig,
+	}); err != nil {
 		return werror.NewInvalidError(err.Error(), settings.StorageNetworkName)
 	}
 
@@ -1207,7 +1230,7 @@ func (v *settingValidator) validateStorageNetwork(setting *v1beta1.Setting) erro
 	return nil
 }
 
-func (v *settingValidator) validateUpdateStorageNetwork(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateStorageNetwork(_ *types.Request, oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	if newSetting.Name != settings.StorageNetworkName {
 		return nil
 	}
@@ -1248,20 +1271,187 @@ func (v *settingValidator) validateUpdateStorageNetwork(oldSetting *v1beta1.Sett
 		config = valueConfig
 	}
 
-	vmMigraionNetworkConfig, err := v.getNetworkConfig(settings.VMMigrationNetworkSettingName)
+	vmMigrationNetworkConfig, err := v.getNetworkConfig(settings.VMMigrationNetworkSettingName)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	rwxNetworkConfig, err := v.getNetworkConfig(settings.RWXNetworkSettingName)
 	if err != nil {
 		return werror.NewInternalError(err.Error())
 	}
 
-	if err = checkNetworkOverlap(settings.StorageNetworkName, config, settings.VMMigrationNetworkSettingName, vmMigraionNetworkConfig); err != nil {
+	if err = checkNetworkOverlap(settings.StorageNetworkName, config, map[string]*networkutil.Config{
+		settings.VMMigrationNetworkSettingName: vmMigrationNetworkConfig,
+		settings.RWXNetworkSettingName:         rwxNetworkConfig,
+	}); err != nil {
 		return werror.NewInvalidError(err.Error(), settings.StorageNetworkName)
+	}
+
+	if err := v.checkStorageNetworkNotBlockedByRWX(newSetting); err != nil {
+		return err
 	}
 
 	return v.checkStorageNetworkUsage()
 }
 
+// checkStorageNetworkNotBlockedByRWX returns an error if the new setting would clear the storage
+// network while rwx-network is in share mode (share-storage-network=true).
+func (v *settingValidator) checkStorageNetworkNotBlockedByRWX(newSetting *v1beta1.Setting) error {
+	if newSetting.EffectiveValue() != "" {
+		return nil
+	}
+	isShareStorageNetwork, err := util.IsShareStorageNetwork(v.settingCache)
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("failed to determine if %s is in share mode: %v", settings.RWXNetworkSettingName, err))
+	}
+	if isShareStorageNetwork {
+		return werror.NewInvalidError(
+			fmt.Sprintf("%s cannot be disabled while %s has share-storage-network=true",
+				settings.StorageNetworkName, settings.RWXNetworkSettingName),
+			settings.StorageNetworkName,
+		)
+	}
+	return nil
+}
+
 func (v *settingValidator) validateDeleteStorageNetwork(_ *v1beta1.Setting) error {
 	return werror.NewMethodNotAllowed(fmt.Sprintf("Disallow delete setting name %s", settings.StorageNetworkName))
+}
+
+func (v *settingValidator) validateRWXNetwork(setting *v1beta1.Setting) error {
+	return v.validateRWXNetworkHelper(setting)
+}
+
+func (v *settingValidator) validateUpdateRWXNetwork(request *types.Request, oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	if oldSetting.EffectiveValue() == newSetting.EffectiveValue() {
+		return nil
+	}
+
+	// Internal controller writes (e.g. bootstrap/upgrade init) bypass user-facing
+	// validation: volumes may still be attached and the network config may be
+	// intentionally omitted (share-storage-network=true with no Network field).
+	if request.IsFromController() {
+		return nil
+	}
+
+	if err := v.checkRWXNotInProgress(oldSetting, newSetting); err != nil {
+		return err
+	}
+
+	if err := v.validateRWXNetworkHelper(newSetting); err != nil {
+		return err
+	}
+
+	if err := v.validateShareFlagTransition(oldSetting, newSetting); err != nil {
+		return err
+	}
+
+	if err := util.CheckRWXNonMigratableVolumesDetached(v.lhVolumeCache); err != nil {
+		return werror.NewInvalidError(err.Error(), settings.RWXNetworkSettingName)
+	}
+
+	return nil
+}
+
+// checkRWXNotInProgress blocks updates while a previous change is still in
+// progress, unless the update is a reset to the default value.
+func (v *settingValidator) checkRWXNotInProgress(oldSetting, newSetting *v1beta1.Setting) error {
+	sc := v1beta1.SettingConfigured
+	if !sc.IsFalse(oldSetting) || sc.GetReason(oldSetting) != storagenetwork.ReasonInProgress {
+		return nil
+	}
+	isResetToDefault := newSetting.Value == settings.RWXNetwork.Default &&
+		newSetting.Default == settings.RWXNetwork.Default
+	if isResetToDefault {
+		return nil
+	}
+	return werror.NewConflict(fmt.Sprintf(
+		"cannot update the setting %q because it is still being configured (reason: %q, message: %q)",
+		settings.RWXNetworkSettingName,
+		sc.GetReason(oldSetting),
+		sc.GetMessage(oldSetting),
+	))
+}
+
+// validateShareFlagTransition ensures that switching from dedicated to shared
+// mode (false -> true) is only allowed when storage-network is already configured.
+func (v *settingValidator) validateShareFlagTransition(oldSetting, newSetting *v1beta1.Setting) error {
+	var oldConfig, newConfig settings.RWXNetworkConfig
+	if oldSetting.EffectiveValue() != "" {
+		if err := json.Unmarshal([]byte(oldSetting.EffectiveValue()), &oldConfig); err != nil {
+			return werror.NewInvalidError(fmt.Sprintf("failed to parse old %s value: %v", settings.RWXNetworkSettingName, err), settings.KeywordValue)
+		}
+	}
+	if newSetting.EffectiveValue() != "" {
+		if err := json.Unmarshal([]byte(newSetting.EffectiveValue()), &newConfig); err != nil {
+			return werror.NewInvalidError(fmt.Sprintf("failed to parse new %s value: %v", settings.RWXNetworkSettingName, err), settings.KeywordValue)
+		}
+	}
+
+	if oldConfig.ShareStorageNetwork || !newConfig.ShareStorageNetwork {
+		return nil
+	}
+
+	sn, err := v.settingCache.Get(settings.StorageNetworkName)
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("failed to get %s setting, err: %v", settings.StorageNetworkName, err))
+	}
+	if sn.EffectiveValue() == "" {
+		return werror.NewInvalidError(fmt.Sprintf("%s is not set", settings.StorageNetworkName), settings.RWXNetworkSettingName)
+	}
+	return nil
+}
+
+// validateRWXNetworkHelper validates the rwx-network composite config.
+func (v *settingValidator) validateRWXNetworkHelper(setting *v1beta1.Setting) error {
+	if setting == nil || setting.Name != settings.RWXNetworkSettingName {
+		return nil
+	}
+
+	effectiveValue := setting.EffectiveValue()
+
+	var rwxConfig settings.RWXNetworkConfig
+	dec := json.NewDecoder(strings.NewReader(effectiveValue))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&rwxConfig); err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("invalid JSON for %s: %v", settings.RWXNetworkSettingName, err), settings.KeywordValue)
+	}
+
+	if rwxConfig.Network == nil {
+		return nil
+	}
+
+	networkJSON, err := json.Marshal(rwxConfig.Network)
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("failed to marshal network config: %v", err))
+	}
+
+	config, err := v.validateNetworkHelper(settings.RWXNetworkSettingName, string(networkJSON))
+	if err != nil {
+		return werror.NewInvalidError(err.Error(), settings.KeywordValue)
+	}
+
+	storageNetworkConfig, err := v.getNetworkConfig(settings.StorageNetworkName)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	vmMigrationNetworkConfig, err := v.getNetworkConfig(settings.VMMigrationNetworkSettingName)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+
+	if err = checkNetworkOverlap(settings.RWXNetworkSettingName, config, map[string]*networkutil.Config{
+		settings.StorageNetworkName:            storageNetworkConfig,
+		settings.VMMigrationNetworkSettingName: vmMigrationNetworkConfig,
+	}); err != nil {
+		return werror.NewInvalidError(err.Error(), settings.RWXNetworkSettingName)
+	}
+
+	return nil
+}
+
+func (v *settingValidator) validateDeleteRWXNetwork(_ *v1beta1.Setting) error {
+	return werror.NewMethodNotAllowed(fmt.Sprintf("Disallow delete setting name %s", settings.RWXNetworkSettingName))
 }
 
 func (v *settingValidator) validateVMMigrationNetwork(setting *v1beta1.Setting) error {
@@ -1291,19 +1481,26 @@ func (v *settingValidator) validateVMMigrationNetwork(setting *v1beta1.Setting) 
 		config = valueConfig
 	}
 
-	storagetNetworkConfig, err := v.getNetworkConfig(settings.StorageNetworkName)
+	storageNetworkConfig, err := v.getNetworkConfig(settings.StorageNetworkName)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	rwxNetworkConfig, err := v.getNetworkConfig(settings.RWXNetworkSettingName)
 	if err != nil {
 		return werror.NewInternalError(err.Error())
 	}
 
-	if err = checkNetworkOverlap(settings.VMMigrationNetworkSettingName, config, settings.StorageNetworkName, storagetNetworkConfig); err != nil {
+	if err = checkNetworkOverlap(settings.VMMigrationNetworkSettingName, config, map[string]*networkutil.Config{
+		settings.StorageNetworkName:    storageNetworkConfig,
+		settings.RWXNetworkSettingName: rwxNetworkConfig,
+	}); err != nil {
 		return werror.NewInvalidError(err.Error(), settings.VMMigrationNetworkSettingName)
 	}
 
 	return nil
 }
 
-func (v *settingValidator) validateUpdateVMMigrationNetwork(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateVMMigrationNetwork(_ *types.Request, oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	if newSetting.Name != settings.VMMigrationNetworkSettingName {
 		return nil
 	}
@@ -1326,12 +1523,19 @@ func (v *settingValidator) validateUpdateVMMigrationNetwork(oldSetting *v1beta1.
 		config = valueConfig
 	}
 
-	storagetNetworkConfig, err := v.getNetworkConfig(settings.StorageNetworkName)
+	storageNetworkConfig, err := v.getNetworkConfig(settings.StorageNetworkName)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	rwxNetworkConfig, err := v.getNetworkConfig(settings.RWXNetworkSettingName)
 	if err != nil {
 		return werror.NewInternalError(err.Error())
 	}
 
-	if err = checkNetworkOverlap(settings.VMMigrationNetworkSettingName, config, settings.StorageNetworkName, storagetNetworkConfig); err != nil {
+	if err = checkNetworkOverlap(settings.VMMigrationNetworkSettingName, config, map[string]*networkutil.Config{
+		settings.StorageNetworkName:    storageNetworkConfig,
+		settings.RWXNetworkSettingName: rwxNetworkConfig,
+	}); err != nil {
 		return werror.NewInvalidError(err.Error(), settings.VMMigrationNetworkSettingName)
 	}
 
@@ -1407,7 +1611,7 @@ func (v *settingValidator) getSystemVolumes() (map[string]struct{}, error) {
 
 func (v *settingValidator) getVClusterVolumes() (map[string]struct{}, error) {
 	sets := labels.Set{
-		util.LablelVClusterAppNameKey: util.LablelVClusterAppNameValue,
+		util.LabelAppNameKey: util.LabelVClusterAppNameValue,
 	}
 
 	pvcs, err := v.pvcCache.List(util.VClusterNamespace, sets.AsSelector())
@@ -1685,12 +1889,27 @@ func (v *settingValidator) checkStorageNetworkRangeValid(config *networkutil.Con
 		return werror.NewInternalError(err.Error())
 	}
 
-	MinAllocatableIPAddrs := 0
+	minAllocatableIPAddrs := 0
 
 	// Formula - https://docs.harvesterhci.io/v1.4/advanced/storagenetwork/
-	//Number of Images to download/upload is dynamic, so skipped in the formula calculated.
+	// Number of Images to download/upload is dynamic, so skipped in the formula calculated.
 	for _, lhNode := range lhnodes {
-		MinAllocatableIPAddrs = MinAllocatableIPAddrs + 2 + (len(lhNode.Spec.Disks) * 2)
+		minAllocatableIPAddrs += 2 + (len(lhNode.Spec.Disks) * 2)
+	}
+
+	// In shared mode the storage network also carries RWX traffic, so add
+	// 1 IP per non-witness node for the longhorn-csi-plugin DaemonSet.
+	isShared, err := util.IsShareStorageNetwork(v.settingCache)
+	if err != nil {
+		return werror.NewInternalError(err.Error())
+	}
+	if isShared {
+		nonWitnessCount, err := v.countNonWitnessNodes()
+		if err != nil {
+			return err
+		}
+		minAllocatableIPAddrs += nonWitnessCount
+		minAllocatableIPAddrs += rwxExtraIPs // add extra IPs for RWX workloads, as in checkRWXNetworkRangeValid
 	}
 
 	count, err := webhookUtil.GetUsableIPAddressesCount(config.Range, config.Exclude)
@@ -1698,59 +1917,97 @@ func (v *settingValidator) checkStorageNetworkRangeValid(config *networkutil.Con
 		return err
 	}
 
-	if count < MinAllocatableIPAddrs {
-		return fmt.Errorf("allocatable IP address range is < %d,allocate sufficient range", MinAllocatableIPAddrs)
+	if count < minAllocatableIPAddrs {
+		return fmt.Errorf("allocatable IP address range is < %d, allocate sufficient range", minAllocatableIPAddrs)
 	}
 
 	return nil
 }
 
+// checkVMMigrationNetworkRangeValid validates that the usable IP range has at least
+// 1 address per non-witness node. Used for VM migration network (1 IP per virt-handler)
 func (v *settingValidator) checkVMMigrationNetworkRangeValid(config *networkutil.Config) error {
+	nonWitnessCount, err := v.countNonWitnessNodes()
+	if err != nil {
+		return err
+	}
+
+	count, err := webhookUtil.GetUsableIPAddressesCount(config.Range, config.Exclude)
+	if err != nil {
+		return err
+	}
+
+	if count < nonWitnessCount {
+		return fmt.Errorf("allocatable IP address range is < %d, allocate sufficient range", nonWitnessCount)
+	}
+
+	return nil
+}
+
+// checkRWXNetworkRangeValid validates that the usable IP range has at least
+// 1 address per longhorn-csi-plugin pod plus rwxExtraIPs extra IPs for RWX workloads.
+func (v *settingValidator) checkRWXNetworkRangeValid(config *networkutil.Config) error {
+	nonWitnessCount, err := v.countNonWitnessNodes()
+	if err != nil {
+		return err
+	}
+
+	count, err := webhookUtil.GetUsableIPAddressesCount(config.Range, config.Exclude)
+	if err != nil {
+		return err
+	}
+
+	required := nonWitnessCount + rwxExtraIPs
+	if count < required {
+		return fmt.Errorf("allocatable IP address range is < %d (nodes: %d + %d extra), allocate sufficient range", required, nonWitnessCount, rwxExtraIPs)
+	}
+
+	return nil
+}
+
+// countNonWitnessNodes returns the number of nodes that are not witness nodes.
+func (v *settingValidator) countNonWitnessNodes() (int, error) {
 	nodes, err := v.nodeCache.List(labels.Everything())
 	if err != nil {
-		return werror.NewInternalError(err.Error())
+		return 0, werror.NewInternalError(err.Error())
 	}
-	witnessNode := 0
+	witnessNodes := 0
 	for _, node := range nodes {
 		if node.Labels == nil {
 			continue
 		}
 		if _, ok := node.Labels["node-role.harvesterhci.io/witness"]; ok {
-			witnessNode++
+			witnessNodes++
 		}
 	}
-
-	count, err := webhookUtil.GetUsableIPAddressesCount(config.Range, config.Exclude)
-	if err != nil {
-		return err
-	}
-
-	// 1 node has 1 virt-handler which needs 1 IP address.
-	if count < len(nodes)-witnessNode {
-		return fmt.Errorf("allocatable IP address range is < %d,allocate sufficient range", len(nodes))
-	}
-
-	return nil
+	return len(nodes) - witnessNodes, nil
 }
 
-func checkNetworkOverlap(c1Name string, c1 *networkutil.Config, c2Name string, c2 *networkutil.Config) error {
-	if c1 == nil || c2 == nil {
+// checkNetworkOverlap checks that the c1 config does not have overlapping usable IP addresses
+// with any config in the c2 map. Nil configs are skipped, so if a peer setting does not
+// exist yet (e.g. during fresh install), its overlap check is safely bypassed.
+func checkNetworkOverlap(c1Name string, c1 *networkutil.Config, c2 map[string]*networkutil.Config) error {
+	if c1 == nil {
 		return nil
 	}
 
-	c1UsableIPAddresses, err := webhookUtil.GetUsableIPAddresses(c1.Range, c1.Exclude)
+	c1UsableIPs, err := webhookUtil.GetUsableIPAddresses(c1.Range, c1.Exclude)
 	if err != nil {
 		return err
 	}
 
-	c2UsableIPAddresses, err := webhookUtil.GetUsableIPAddresses(c2.Range, c2.Exclude)
-	if err != nil {
-		return err
-	}
-
-	for c1IP := range c1UsableIPAddresses {
-		if _, ok := c2UsableIPAddresses[c1IP]; ok {
-			return fmt.Errorf("%s: the network configuration is overlapped with %s", c1Name, c2Name)
+	for name, config := range c2 {
+		if config == nil {
+			continue
+		}
+		ips, err := webhookUtil.GetUsableIPAddresses(config.Range, config.Exclude)
+		if err != nil {
+			return err
+		}
+		for ip := range c1UsableIPs {
+			if _, ok := ips[ip]; ok {
+				return fmt.Errorf("%s: the network configuration is overlapped with %s", c1Name, name)
+			}
 		}
 	}
 	return nil
@@ -1784,7 +2041,7 @@ func validateDefaultVMTerminationGracePeriodSeconds(setting *v1beta1.Setting) er
 	return nil
 }
 
-func validateUpdateDefaultVMTerminationGracePeriodSeconds(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateDefaultVMTerminationGracePeriodSeconds(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateDefaultVMTerminationGracePeriodSeconds(newSetting)
 }
 
@@ -1821,7 +2078,7 @@ func validateAutoRotateRKE2Certs(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateAutoRotateRKE2Certs(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateAutoRotateRKE2Certs(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateAutoRotateRKE2Certs(newSetting)
 }
 
@@ -1856,7 +2113,7 @@ func validateKubeConfigTTLSetting(newSetting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateKubeConfigTTLSetting(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateKubeConfigTTLSetting(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateKubeConfigTTLSetting(newSetting)
 }
 
@@ -1987,7 +2244,7 @@ func (v *settingValidator) validateUpgradeConfig(setting *v1beta1.Setting) error
 	return v.validateUpgradeConfigFields(setting)
 }
 
-func (v *settingValidator) validateUpdateUpgradeConfig(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateUpgradeConfig(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateUpgradeConfig(newSetting)
 }
 
@@ -2002,7 +2259,7 @@ func validateAdditionalGuestMemoryOverheadRatio(newSetting *v1beta1.Setting) err
 	return nil
 }
 
-func validateUpdateAdditionalGuestMemoryOverheadRatio(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateAdditionalGuestMemoryOverheadRatio(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateAdditionalGuestMemoryOverheadRatio(newSetting)
 }
 
@@ -2014,7 +2271,7 @@ func validateMaxHotplugRatio(setting *v1beta1.Setting) error {
 	return validateMaxHotplugRatioHelper(settings.KeywordValue, setting.Value)
 }
 
-func validateUpdateMaxHotplugRatio(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func validateUpdateMaxHotplugRatio(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateMaxHotplugRatio(newSetting)
 }
 
@@ -2066,7 +2323,7 @@ func validateMaxHotplugRatioHelper(field, value string) error {
 	return nil
 }
 
-func (v *settingValidator) validateUpdateLHIMResources(oldSetting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateLHIMResources(request *types.Request, oldSetting, newSetting *v1beta1.Setting) error {
 	if newSetting.Name != settings.LHIMResourcesSettingName {
 		return nil
 	}
@@ -2166,7 +2423,7 @@ func (v *settingValidator) validateRancherCluster(newSetting *v1beta1.Setting) e
 	return nil
 }
 
-func (v *settingValidator) validateUpdateRancherCluster(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateRancherCluster(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateRancherCluster(newSetting)
 }
 
@@ -2212,7 +2469,7 @@ func (v *settingValidator) validateKubeVirtMigration(newSetting *v1beta1.Setting
 	return nil
 }
 
-func (v *settingValidator) validateUpdateKubeVirtMigration(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+func (v *settingValidator) validateUpdateKubeVirtMigration(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return v.validateKubeVirtMigration(newSetting)
 }
 

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/rancher/wrangler/v3/pkg/webhook"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,8 @@ import (
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
+	networkutil "github.com/harvester/harvester/pkg/util/network"
+	whTypes "github.com/harvester/harvester/pkg/webhook/types"
 )
 
 func Test_validateOvercommitConfig(t *testing.T) {
@@ -1365,6 +1368,45 @@ func Test_validateStorageNetworkConfig(t *testing.T) {
 	}
 }
 
+func Test_checkStorageNetworkNotBlockedByRWX(t *testing.T) {
+	clearSetting := &v1beta1.Setting{
+		ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+		Value:      "",
+	}
+
+	tests := []struct {
+		name        string
+		rwxValue    string
+		expectedErr bool
+	}{
+		{
+			name:        "clear storage-network while share-storage-network=true -> blocked",
+			rwxValue:    `{"share-storage-network":true,"network":{}}`,
+			expectedErr: true,
+		},
+		{
+			name:        "clear storage-network while share-storage-network=false -> allowed",
+			rwxValue:    `{"share-storage-network":false,"network":{}}`,
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(&v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      tt.rwxValue,
+			})
+			v := &settingValidator{
+				settingCache: fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+			}
+
+			err := v.checkStorageNetworkNotBlockedByRWX(clearSetting)
+			assert.Equal(t, tt.expectedErr, err != nil, err)
+		})
+	}
+}
+
 func Test_validateMaxHotplugRatio(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1689,7 +1731,7 @@ func Test_settingValidator_validateUpdateLHIMResources(t *testing.T) {
 		newSetting := oldSetting.DeepCopy()
 		newSetting.Value = `{"cpu":{"v1":"20","v2":"20"}}`
 
-		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		err = v.validateUpdateLHIMResources(nil, oldSetting, newSetting)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "detach all Longhorn volumes"))
 	})
@@ -1718,7 +1760,7 @@ func Test_settingValidator_validateUpdateLHIMResources(t *testing.T) {
 		newSetting := oldSetting.DeepCopy()
 		newSetting.Value = `{"cpu":{"v1":"20","v2":"20"}}`
 
-		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		err = v.validateUpdateLHIMResources(nil, oldSetting, newSetting)
 		assert.NoError(t, err)
 	})
 
@@ -1748,7 +1790,7 @@ func Test_settingValidator_validateUpdateLHIMResources(t *testing.T) {
 		newSetting.Default = `{"cpu":{"v1":"12","v2":"12"}}`
 		newSetting.Value = ""
 
-		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		err = v.validateUpdateLHIMResources(nil, oldSetting, newSetting)
 		assert.NoError(t, err)
 	})
 
@@ -1776,7 +1818,7 @@ func Test_settingValidator_validateUpdateLHIMResources(t *testing.T) {
 		newSetting := oldSetting.DeepCopy()
 		newSetting.Value = ""
 
-		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		err = v.validateUpdateLHIMResources(nil, oldSetting, newSetting)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "detach all Longhorn volumes"))
 	})
@@ -1805,7 +1847,7 @@ func Test_settingValidator_validateUpdateLHIMResources(t *testing.T) {
 		newSetting := oldSetting.DeepCopy()
 		newSetting.Value = `{"cpu":{}}`
 
-		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		err = v.validateUpdateLHIMResources(nil, oldSetting, newSetting)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "detach all Longhorn volumes"))
 	})
@@ -1834,7 +1876,410 @@ func Test_settingValidator_validateUpdateLHIMResources(t *testing.T) {
 		newSetting := oldSetting.DeepCopy()
 		newSetting.Value = `{"cpu":{}}`
 
-		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		err = v.validateUpdateLHIMResources(nil, oldSetting, newSetting)
 		assert.NoError(t, err)
 	})
+}
+
+func Test_validateUpdateRWXNetwork(t *testing.T) {
+	// composite format helpers
+	rwxDedicated := func(vlan int, clusterNetwork, ipRange string) string {
+		return fmt.Sprintf(`{"share-storage-network":false,"network":{"vlan":%d,"clusterNetwork":%q,"range":%q}}`, vlan, clusterNetwork, ipRange)
+	}
+	rwxShare := `{"share-storage-network":true,"network":{}}`
+	storageNetworkValue := `{"vlan":100,"clusterNetwork":"vlan","range":"192.168.0.0/24"}`
+
+	attachedRWXVolume := &lhv1beta2.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rwx-vol-attached",
+			Namespace: "longhorn-system",
+		},
+		Spec: lhv1beta2.VolumeSpec{
+			AccessMode: lhv1beta2.AccessModeReadWriteMany,
+		},
+		Status: lhv1beta2.VolumeStatus{
+			State: lhv1beta2.VolumeStateAttached,
+		},
+	}
+
+	attachedMigratableRWXVolume := &lhv1beta2.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rwx-migratable-vol-attached",
+			Namespace: "longhorn-system",
+		},
+		Spec: lhv1beta2.VolumeSpec{
+			AccessMode: lhv1beta2.AccessModeReadWriteMany,
+			Migratable: true,
+		},
+		Status: lhv1beta2.VolumeStatus{
+			State: lhv1beta2.VolumeStateAttached,
+		},
+	}
+
+	tests := []struct {
+		name             string
+		oldSetting       *v1beta1.Setting
+		newSetting       *v1beta1.Setting
+		existingSettings []*v1beta1.Setting
+		existingVolumes  []*lhv1beta2.Volume
+		expectedErr      bool
+	}{
+		{
+			// Same effective value -> early return, no further checks
+			name: "no change -> ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      "",
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "dedicated->share, storage-network set, volumes attached -> not ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(101, "vlan", "192.168.1.0/24"),
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxShare,
+			},
+			existingSettings: []*v1beta1.Setting{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+					Value:      storageNetworkValue,
+				},
+			},
+			existingVolumes: []*lhv1beta2.Volume{attachedRWXVolume},
+			expectedErr:     true,
+		},
+		{
+			// share=false->false, network changed, no attached volumes -> ok
+			name: "dedicated network changed, volumes detached -> ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(101, "mgmt", "192.168.1.0/24"),
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(102, "mgmt", "192.168.2.0/24"),
+			},
+			expectedErr: false,
+		},
+		{
+			// share=false->false, network changed, volumes attached -> not ok
+			name: "dedicated network changed, volumes attached -> not ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(101, "mgmt", "192.168.1.0/24"),
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(102, "mgmt", "192.168.2.0/24"),
+			},
+			existingVolumes: []*lhv1beta2.Volume{attachedRWXVolume},
+			expectedErr:     true,
+		},
+		{
+			// share=false->true: storage-network not set -> not ok
+			name: "dedicated->share, storage-network not set -> not ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(101, "vlan", "192.168.1.0/24"),
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxShare,
+			},
+			existingSettings: []*v1beta1.Setting{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+					Value:      "",
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			// share=true->false: no attached volumes -> ok
+			name: "share->dedicated, volumes detached -> ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxShare,
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(101, "mgmt", "192.168.1.0/24"),
+			},
+			expectedErr: false,
+		},
+		{
+			// share=true->false: volumes attached -> not ok
+			name: "share->dedicated, volumes attached -> not ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxShare,
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(101, "mgmt", "192.168.1.0/24"),
+			},
+			existingVolumes: []*lhv1beta2.Volume{attachedRWXVolume},
+			expectedErr:     true,
+		},
+		{
+			// empty->valid dedicated JSON (mgmt cluster bypasses VlanStatus/VC checks), no volumes -> ok
+			name: "empty->valid dedicated JSON, no volumes -> ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      "",
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(100, "mgmt", "192.168.0.0/24"),
+			},
+			expectedErr: false,
+		},
+		{
+			// empty->invalid JSON: unmarshal fails -> error
+			name: "empty->invalid JSON -> error",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      "",
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      `{invalid}`,
+			},
+			expectedErr: true,
+		},
+		{
+			// dedicated with VLAN ID > 4094: checkNetworkVlanValid fails -> error
+			name: "dedicated->invalid VLAN ID -> error",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      "",
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      `{"share-storage-network":false,"network":{"vlan":5000,"clusterNetwork":"mgmt","range":"192.168.0.0/24"}}`,
+			},
+			expectedErr: true,
+		},
+		{
+			// attached migratable RWX volume should NOT block the update
+			name: "dedicated network changed, only migratable RWX volumes attached -> ok",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(101, "mgmt", "192.168.1.0/24"),
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      rwxDedicated(102, "mgmt", "192.168.2.0/24"),
+			},
+			existingVolumes: []*lhv1beta2.Volume{attachedMigratableRWXVolume},
+			expectedErr:     false,
+		},
+		{
+			// dedicated with non-CIDR range: checkNetworkRangeValid fails -> error
+			name: "dedicated->invalid range -> error",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      "",
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      `{"share-storage-network":false,"network":{"vlan":100,"clusterNetwork":"mgmt","range":"not-a-cidr"}}`,
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty->network fields at top level instead of nested under 'network' -> error",
+			oldSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      "",
+			},
+			newSetting: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.RWXNetworkSettingName},
+				Value:      `{"share-storage-network":false,"vlan":201,"clusterNetwork":"rwx","range":"192.168.201.0/24","exclude":["192.168.201.1/32"]}`,
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := make([]runtime.Object, 0, len(tt.existingSettings)+len(tt.existingVolumes))
+			for _, s := range tt.existingSettings {
+				objects = append(objects, s)
+			}
+			for _, vol := range tt.existingVolumes {
+				objects = append(objects, vol)
+			}
+
+			clientset := fake.NewSimpleClientset(objects...)
+			v := &settingValidator{
+				settingCache:  fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+				lhVolumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+				nodeCache:     fakeclients.NodeCache(clientset.CoreV1().Nodes),
+			}
+
+			req := &whTypes.Request{Request: &webhook.Request{}}
+			err := v.validateUpdateRWXNetwork(req, tt.oldSetting, tt.newSetting)
+			assert.Equal(t, tt.expectedErr, err != nil, err)
+		})
+	}
+}
+
+func Test_checkNetworkOverlap(t *testing.T) {
+	tests := []struct {
+		name    string
+		c1Name  string
+		c1      *networkutil.Config
+		c2      map[string]*networkutil.Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "c1 is nil, skip check",
+			c1Name:  "storage-network",
+			c1:      nil,
+			c2:      map[string]*networkutil.Config{"vm-migration-network": {Range: "192.168.1.0/24"}},
+			wantErr: false,
+		},
+		{
+			name:    "c2 contains only nil configs, no overlap",
+			c1Name:  "storage-network",
+			c1:      &networkutil.Config{Range: "192.168.1.0/24"},
+			c2:      map[string]*networkutil.Config{"vm-migration-network": nil},
+			wantErr: false,
+		},
+		{
+			name:    "non-overlapping CIDRs, no error",
+			c1Name:  "storage-network",
+			c1:      &networkutil.Config{Range: "192.168.1.0/24"},
+			c2:      map[string]*networkutil.Config{"vm-migration-network": {Range: "192.168.2.0/24"}},
+			wantErr: false,
+		},
+		{
+			name:    "overlapping CIDRs, return error",
+			c1Name:  "storage-network",
+			c1:      &networkutil.Config{Range: "192.168.1.0/24"},
+			c2:      map[string]*networkutil.Config{"vm-migration-network": {Range: "192.168.1.0/24"}},
+			wantErr: true,
+			errMsg:  "storage-network: the network configuration is overlapped with vm-migration-network",
+		},
+		{
+			name:   "c1 exclude removes overlap, no error",
+			c1Name: "storage-network",
+			c1: &networkutil.Config{
+				Range:   "192.168.1.0/30",
+				Exclude: []string{"192.168.1.1/32", "192.168.1.2/32"},
+			},
+			c2:      map[string]*networkutil.Config{"vm-migration-network": {Range: "192.168.1.1/32"}},
+			wantErr: false,
+		},
+		{
+			name:    "invalid CIDR in c1, return error",
+			c1Name:  "storage-network",
+			c1:      &networkutil.Config{Range: "not-a-cidr"},
+			c2:      map[string]*networkutil.Config{"vm-migration-network": {Range: "192.168.1.0/24"}},
+			wantErr: true,
+		},
+		{
+			name:   "multiple c2 configs, one overlaps, return error",
+			c1Name: "storage-network",
+			c1:     &networkutil.Config{Range: "10.0.0.0/24"},
+			c2: map[string]*networkutil.Config{
+				"vm-migration-network": {Range: "192.168.1.0/24"},
+				"rwx-network":          {Range: "10.0.0.0/24"},
+			},
+			wantErr: true,
+			errMsg:  "storage-network: the network configuration is overlapped with rwx-network",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkNetworkOverlap(tt.c1Name, tt.c1, tt.c2)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.EqualError(t, err, tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_checkRWXNetworkRangeValid(t *testing.T) {
+	witnessLabel := map[string]string{"node-role.harvesterhci.io/witness": "true"}
+
+	tests := []struct {
+		name        string
+		nodes       []runtime.Object
+		config      *networkutil.Config
+		expectedErr bool
+	}{
+		{
+			// 3 non-witness nodes, required = 3+32 = 35; /24 gives 254 usable IPs
+			name: "sufficient IPs for 3 nodes -> ok",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-3"}},
+			},
+			config:      &networkutil.Config{Range: "192.168.0.0/24"},
+			expectedErr: false,
+		},
+		{
+			// 3 non-witness nodes, required = 35; /27 gives 30 usable IPs
+			name: "insufficient IPs for 3 nodes -> error",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-3"}},
+			},
+			config:      &networkutil.Config{Range: "192.168.0.0/27"},
+			expectedErr: true,
+		},
+		{
+			// 2 non-witness + 1 witness; required = 2+32 = 34; /27 gives 30 usable IPs
+			name: "witness node not counted, still insufficient -> error",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "witness-1", Labels: witnessLabel}},
+			},
+			config:      &networkutil.Config{Range: "192.168.0.0/27"},
+			expectedErr: true,
+		},
+		{
+			// exclude reduces usable IPs below required
+			name: "exclude range makes IPs insufficient -> error",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-3"}},
+			},
+			// Use tighter: /27=30 IPs, exclude /28=14 IPs -> 16 IPs, required=35 -> error
+			config:      &networkutil.Config{Range: "192.168.0.0/27", Exclude: []string{"192.168.0.0/28"}},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tt.nodes...)
+			v := &settingValidator{
+				nodeCache: fakeclients.NodeCache(clientset.CoreV1().Nodes),
+			}
+			err := v.checkRWXNetworkRangeValid(tt.config)
+			assert.Equal(t, tt.expectedErr, err != nil, err)
+		})
+	}
 }

--- a/pkg/webhook/types/request.go
+++ b/pkg/webhook/types/request.go
@@ -27,6 +27,9 @@ func (r *Request) Username() string {
 }
 
 func (r *Request) IsFromController() bool {
+	if r.options == nil {
+		return false
+	}
 	return r.Username() == r.options.HarvesterControllerUsername
 }
 


### PR DESCRIPTION
#### Problem:
Longhorn supports two separate networks for storage traffic: `storage-network` and `endpoint-network-for-rwx-volume` (used for RWX volume I/O). Previously, Harvester only exposed the storage-network setting, with no way to configure a dedicated network for RWX volumes. This forced RWX and replication traffic to share the same network, or left endpoint-network-for-rwx-volume unconfigured.

#### Solution:

Add new Harvester settings to manage the Longhorn endpoint-network-for-rwx-volume setting:

- `rwx-storage-network`: Configures a dedicated VLAN network for RWX volume traffic, independent of the existing storage-network. This settings is a json encoded string which includes two fields, 
  1. "share-storage-network": set the endpoint-network-for-rwx-volume NAD the same as storage-network
  2. "network": the network field follows the same VLAN/CIDR configuration format as storage-network.
- default: `{"share-storage-network":false}`
- example value: `{"share-storage-network":false, "network": {"vlan":203,"clusterNetwork":"mgmt","range":"192.168.201.0/24"}}`

Note that if `rwx-storage-network` is "" or `share-storage-network` is set to false without `network` specified, longhorn use the default Kubernetes cluster network for rwx volumes. see https://longhorn.io/docs/1.11.0/references/settings/#endpoint-network-for-rwx-volume

Validation rules enforced:
- rwx-storage-network.network cannot be cleared if rwx-storage-network.share-storaget-network is false and RWX volumes not all detached
- rwx-storage-network.network must not overlap in IP range with storage-network or vm-migration-network
- storage-network cannot be cleared while rwx-storage-network.share-storaget-network is true
- Toggling rwx-storage-network.share-storaget-network (in either direction) requires all RWX volumes to be detached first

_**Note: these settings drive Longhorn's endpoint-network-for-rwx-volume in one direction only. Manual changes made directly in Longhorn will not be reflected back to Harvester.**_

#### Related Issue(s):
related to #7218, #6910

#### Test plan:

Background: New setting controlling the network for RWX (ReadWriteMany) Longhorn volumes. Supports two modes:
- Share mode (share-storage-network: true) — reuses the storage-network NAD.
- Dedicated mode (share-storage-network: false + network config) — creates a separate NAD.
- The RWX volumes below means `migratable: false` longhorn volume which does not related to the VM use case. We mainly use it in guest cluster workload.

Prerequisites: Harvester cluster with 2 VLANs available for storage-network, rwx-storage-network.

TC-1: Default state & deletion protection
1. Find rwx-storage-network in Settings — verify default value is {"share-storage-network":false}.
2. Run kubectl delete setting rwx-network — expect MethodNotAllowed error.

TC-2: Share mode — blocking conditions
1. With storage-network active and all RWX volumes detached, set {"share-storage-network": true}.
    - Expect: Accepted. Longhorn's endpoint-network-for-rwx-volume points to the same NAD as storage-network.
2. With at least one RWX volume attached, attempt the same update.
    - Expect: Rejected with a message listing the attached volume(s).
3. Clear storage-network, then attempt to enable share mode.
    - Expect: Rejected with storage-network is not set.
4. With share mode active, attempt to clear storage-network.
    - Expect: Rejected with storage-network cannot be disabled while rwx-network has share-storage-network=true.

TC-3: Dedicated mode — overlap validation
1. With all RWX volumes detached, set a non-overlapping dedicated network (e.g. VLAN 200, 192.168.200.0/24).
    - Expect: Accepted. A NAD prefixed rwx-network- is created in harvester-system. Longhorn's endpoint-network-for-rwx-volume points to it.
2. With at least one RWX volume attached, attempt the same update.
    - Expect: Rejected with a message listing the attached volume(s).
3. Attempt to set a network that overlaps storage-network or vm-migration-network with all rwx volume detached
    - Expect: Rejected with an overlap error naming the conflicting setting.
4. Attempt to update storage-network or vm-migration-network to overlap the active RWX dedicated range with all rwx volume detached.
    - Expect: Rejected with an overlap error referencing rwx-network.

TC-4: Mode transitions & cleanup
1. Switch from share → dedicated (all RWX volumes detached): verify a new dedicated NAD is created and Longhorn is updated.
2. Switch from dedicated → share: verify the dedicated NAD is deleted and Longhorn now references the storage-network NAD.
3. Reset to {"share-storage-network": false} (no network): verify the dedicated NAD is removed and Longhorn's RWX network setting is cleared.
4. Attempt to manually delete the NAD referenced by rwx-network — expect rejection: cannot delete NetworkAttachmentDefinition ... used by setting 'rwx-network'.

TC-5: share-storgae-network is set to true after Upgrade
1. Set up storage network and enable [storage-network-for-rwx-volume-enabled](https://longhorn.io/docs/1.10.2/references/settings/#storage-network-for-rwx-volume-enabled) in harvester v1.7.1
2. Upgrade harvester to a version which have this patch applied
3. after upgrade finished, check rwx-network, the value now is `{"share-storage-network":true}`