### PR TITLE
Harvester should use the mirrored kube-vip image

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -564,7 +564,7 @@ harvester-load-balancer:
 kube-vip:
   enabled: false
   image:
-    repository: ghcr.io/kube-vip/kube-vip-iptables
+    repository: rancher/mirrored-kube-vip-kube-vip-iptables
     tag: v0.9.2
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"


### PR DESCRIPTION
#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
Make use of the Rancher mirrored kube-vip image.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9641

#### Test plan:
Build the ISO:
```
$ cd ~/git/harvester
$ make
$ export USE_LOCAL_IMAGES=<git_branch_name>-head
$ make build-iso
./.dapper build-iso
...
[ImageCache] docker.io/rancher/kubectl:v1.34.0 exists.
[ImageCache] docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2: pulling...
v0.9.2: Pulling from rancher/mirrored-kube-vip-kube-vip-iptables
fe07684b16b8: Pull complete 
9a8d429f3dff: Pull complete 
83a5ecb0cf8b: Pull complete 
Digest: sha256:ac836ebc3b4f99a4e7cf46e584b41b9708fdda3f71b490726b4098725eca48cd
Status: Downloaded newer image for rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
[ImageCache] docker.io/rancher/support-bundle-kit:master-head has "-head" suffix.
[ImageCache] docker.io/rancher/support-bundle-kit:master-head: pulling...
master-head: Pulling from rancher/support-bundle-kit
...
DRONE_BUILD_EVENT:
docker.io/kubeovn/kube-ovn:v1.14.10
docker.io/longhornio/backing-image-manager:v1.11.0
...
docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
...
docker.io/rancher/mirrored-pause:3.6
...
Added to ISO image: directory '/'='/tmp/tmp.Q28QikBwiP/iso'
xorriso : UPDATE : Writing:      34192s    5.7%   fifo  97%  buf  50%
xorriso : UPDATE : Writing:     178448s   29.8%   fifo  99%  buf  50%  532.8xD 
xorriso : UPDATE : Writing:     530112s   88.4%   fifo  99%  buf  50%  519.5xD 
ISO image produced: 599417 sectors
Written to medium : 599440 sectors at LBA 48
Writing to '/go/src/github.com/harvester/harvester-installer/dist/artifacts/harvester-master-amd64-net-install.iso' completed successfully.

image-lists/
image-lists/rke2-images.linux-amd64-v1.35.1-rke2r1.txt
image-lists/rancherd-bootstrap-images-master.txt
image-lists/rancher-images-v2.14.0-alpha5.txt
image-lists/harvester-extra-master.txt
image-lists/rke2-images-multus.linux-amd64-v1.35.1-rke2r1.txt
image-lists/harvester-images-master.txt
image-lists/harvester-repo-images-master.txt
```
Check if the `mirrored-kube-vip-kube-vip-iptables` image is pulled.

After the ISO is build, run:
```
$ cat dist/artifacts/harvester-images-list-amd64.txt | grep mirrored-kube-vip-kube-vip-iptables
docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
```
Install Harvester using the new created ISO image. After the installation, log into the system via SSH and run:
```
# docker images
...
rancher/mirrored-kube-vip-kube-vip-iptables    v0.9.2    72daf041fc15    2 hours ago      linux/amd64    0.0 B    68.7 MiB
...

# docker ps | grep kube-vip
a648f7937fcc    docker.io/rancher/mirrored-pause:3.6                                                         "/pause"                  7 minutes ago     Up                 k8s://harvester-system/kube-vip-4w97g
e9ac144273ac    docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2                                 "/kube-vip manager"       7 minutes ago     Up                 k8s://harvester-system/kube-vip-4w97g/kube-vip
...
```
Run `k9s`:
<img width="1237" height="713" alt="grafik" src="https://github.com/user-attachments/assets/1b68c23d-d4db-40f2-9671-6d5ef5e9cc08" />
<img width="1237" height="213" alt="grafik" src="https://github.com/user-attachments/assets/8bdb3d8c-5cf0-4998-8062-4cf3ff2b16e5" />
<img width="1237" height="707" alt="grafik" src="https://github.com/user-attachments/assets/fca45389-00c3-48e0-806c-4351f262286a" />

The UI should be accessible via the VIP.

#### Additional documentation or context
