### PR TITLE
Add v171 to upgrade matix to get image list

### DIFF
--- a/package/upgrade-matrix.yaml
+++ b/package/upgrade-matrix.yaml
@@ -1,4 +1,6 @@
 versions:
+- name: v1.7.1
+  minUpgradableVersion: v1.6.0
 - name: v1.7.0
   minUpgradableVersion: v1.6.0
 - name: v1.6.1


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

On https://github.com/harvester/harvester/issues/10094, we notice below error

```
time="2026-02-24T12:07:08Z" level=info msg="Trying to get v1.7.1 image list"
time="2026-02-24T12:07:18Z" level=info msg="Trying to get v1.7.1 image list"
time="2026-02-24T12:07:29Z" level=info msg="Trying to get v1.7.1 image list"
time="2026-02-24T12:07:29Z" level=warning msg="Failed to cleanup images: unexpected status: 404 Not Found"
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Update matrix to get image list

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10094

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
