### PR TITLE
fix: remove GA featureGates

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -68,7 +68,12 @@ kubevirt:
       ## Specify kubevirt feature gates
       vmStateStorageClass: "vmstate-persistence"
       developerConfiguration:
-        featureGates: ["LiveMigration", "HostDevices", "GPU", "CPUManager", "VMPersistentState", "VMLiveUpdateFeatures", "ExpandDisks", "EnableVirtioFsConfigVolumes", "DeclarativeHotplugVolumes"]
+        featureGates:
+          - CPUManager
+          - DeclarativeHotplugVolumes
+          - ExpandDisks
+          - EnableVirtioFsConfigVolumes
+          - HostDevices
 
       vmRolloutStrategy: "LiveUpdate"
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Following feature gates have been deprecated as the functionality is now GA.
- LiveMigration
- GPU
- VMPersistentState
- VMLiveUpdateFeatures

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Remove them

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#9683

#### Test plan:
<!-- Describe the test plan by steps. -->

Basic function of these feature gates when they were introduced. 
- LiveMigration: https://github.com/harvester/harvester/commit/930f40822075bf9100e2b6bc7db4ef0b0d9fbd6a -> VM live migration
- GPU: https://github.com/harvester/harvester/commit/4898e2050f123e1ee9e1a87988c6328c1cb9b9c1 -> vGPU attached VM
- VMPersistentState: https://github.com/harvester/harvester/commit/91e6dfbbf1d03dae19d2a173b870bfcc7b72f08a -> TPM/UEFI persistence
- VMLiveUpdateFeatures: https://github.com/harvester/harvester/commit/b0a59f5b6531bec2d70702f2b813f1056139814a -> CPU/Memory Hotplug

Ideally, the removal of these GA feature gates should be safe, as it should already be QA by KubeVirt team.

#### Additional documentation or context
