### PR TITLE
change to harvester vm builder for vGPU allocation

### DIFF
--- a/pkg/builder/device.go
+++ b/pkg/builder/device.go
@@ -38,21 +38,8 @@ func (v *VMBuilder) HostDevice(name, hostDeviceName, tag string) *VMBuilder {
 	return v
 }
 
-func (v *VMBuilder) GPU(name, hostDeviceName, tag string, virtualGPUOptions *kubevirtv1.VGPUOptions) *VMBuilder {
-	gpus := v.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs
-	gpu := kubevirtv1.GPU{
-		Name:       name,
-		DeviceName: hostDeviceName,
-	}
-	if virtualGPUOptions != nil {
-		gpu.VirtualGPUOptions = virtualGPUOptions
-	}
-	if tag != "" {
-		gpu.Tag = tag
-	}
-	gpus = append(gpus, gpu)
-	v.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs = gpus
-	return v
+func (v *VMBuilder) GPU(name, hostDeviceName, tag string, _ *kubevirtv1.VGPUOptions) *VMBuilder {
+	return v.HostDevice(name, hostDeviceName, tag)
 }
 
 func (v *VMBuilder) TPM() *VMBuilder {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
With Harvester v1.8.x the vGPU devices need to now be added as normal HostDevices.

The PR makes a small change to the vm builder to ensure GPU devices are added as regular HostDevices
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10026

#### Test plan:
<!-- Describe the test plan by steps. -->
To test:
* Install Harvester master build containing this change to a node supporting MIG backed or time sliced vGPUs
* Enable PCIDevices Controller
* Enable NVIDIA driver toolkit and ensure correct driver is installed
* Enable SRIOVGPU device
* Enable MIGConfiguration if needed (for MIG backed GPUs)
* Enable vGPUs
* Import Harvester into a Rancher 2.13.x / 2.14.x setup
* Attempt to create a downstream cluster using vGPUs
* Cluster should provision successfully

#### Additional documentation or context
