### PR TITLE
feat: introduce a setting to control Longhorn Instance Manager (IM) resources

### DIFF
--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -70,6 +70,7 @@ type Handler struct {
 	ingressCache         networkingv1.IngressCache
 	longhornSettings     ctllhv1.SettingClient
 	longhornSettingCache ctllhv1.SettingCache
+	longhornVolumeCache  ctllhv1.VolumeCache
 	configmaps           ctlcorev1.ConfigMapClient
 	configmapCache       ctlcorev1.ConfigMapCache
 	endpointCache        ctlcorev1.EndpointsCache

--- a/pkg/controller/master/setting/instance_manager_resources.go
+++ b/pkg/controller/master/setting/instance_manager_resources.go
@@ -1,0 +1,125 @@
+package setting
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhtypes "github.com/longhorn/longhorn-manager/types"
+	"k8s.io/apimachinery/pkg/labels"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+const msgWaitForAttachedVolumes = "waiting for all volumes detached: %s"
+
+func (h *Handler) syncLHIMResources(setting *harvesterv1.Setting) error {
+	resources, err := settings.DecodeLHIMResources(setting.Value)
+	if err != nil {
+		return fmt.Errorf("invalid JSON %q for %s: %w", setting.Value, setting.Name, err)
+	}
+	if resources.IsEmpty() {
+		// Ignore the initial default value so Harvester does not overwrite an
+		// existing Longhorn setting until the user has configured this setting
+		// with a meaningful value at least once.
+		if setting.Annotations[util.AnnotationHash] == "" {
+			return nil
+		}
+		return h.syncLHIMResourcesToLonghornDefault()
+	}
+	v1CPU := resources.CPU.V1
+	v2CPU := resources.CPU.V2
+
+	if err := lhtypes.ValidateCPUReservationValues(lhtypes.SettingNameGuaranteedInstanceManagerCPU, v1CPU); err != nil {
+		return fmt.Errorf("invalid CPU value for cpu.v1 %q in %s: %w", v1CPU, setting.Name, err)
+	}
+	if err := lhtypes.ValidateCPUReservationValues(lhtypes.SettingNameGuaranteedInstanceManagerCPU, v2CPU); err != nil {
+		return fmt.Errorf("invalid CPU value for cpu.v2 %q in %s: %w", v2CPU, setting.Name, err)
+	}
+
+	if err := h.checkLonghornVolumeDetached(); err != nil {
+		return err
+	}
+
+	lhSetting, err := h.longhornSettingCache.Get(util.LonghornSystemNamespaceName, string(lhtypes.SettingNameGuaranteedInstanceManagerCPU))
+	if err != nil {
+		return err
+	}
+
+	lhValueBytes, err := json.Marshal(map[string]string{
+		string(lhv1beta2.DataEngineTypeV1): v1CPU,
+		string(lhv1beta2.DataEngineTypeV2): v2CPU,
+	})
+	if err != nil {
+		return err
+	}
+
+	lhValue := string(lhValueBytes)
+	if lhSetting.Value == lhValue {
+		return nil
+	}
+
+	lhSettingCpy := lhSetting.DeepCopy()
+	lhSettingCpy.Value = lhValue
+	_, err = h.longhornSettings.Update(lhSettingCpy)
+	return err
+}
+
+func (h *Handler) syncLHIMResourcesToLonghornDefault() error {
+	lhSetting, err := h.longhornSettingCache.Get(util.LonghornSystemNamespaceName, string(lhtypes.SettingNameGuaranteedInstanceManagerCPU))
+	if err != nil {
+		return err
+	}
+
+	defaultValue, err := defaultLonghornLHIMResourcesValue()
+	if err != nil {
+		return err
+	}
+	if lhSetting.Value == defaultValue {
+		return nil
+	}
+
+	if err := h.checkLonghornVolumeDetached(); err != nil {
+		return err
+	}
+
+	lhSettingCpy := lhSetting.DeepCopy()
+	lhSettingCpy.Value = defaultValue
+	_, err = h.longhornSettings.Update(lhSettingCpy)
+	return err
+}
+
+func defaultLonghornLHIMResourcesValue() (string, error) {
+	valueBytes, err := json.Marshal(map[string]string{
+		string(lhv1beta2.DataEngineTypeV1): lhtypes.SettingDefinitionGuaranteedInstanceManagerCPU.Default,
+		string(lhv1beta2.DataEngineTypeV2): lhtypes.SettingDefinitionGuaranteedInstanceManagerCPU.Default,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return string(valueBytes), nil
+}
+
+func (h *Handler) checkLonghornVolumeDetached() error {
+	volumes, err := h.longhornVolumeCache.List(util.LonghornSystemNamespaceName, labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list longhorn volumes: %w", err)
+	}
+
+	attachedVolumes := make([]string, 0)
+	for _, volume := range volumes {
+		if volume.Status.State != lhv1beta2.VolumeStateDetached {
+			attachedVolumes = append(attachedVolumes, volume.Name)
+		}
+	}
+
+	if len(attachedVolumes) > 0 {
+		return fmt.Errorf(msgWaitForAttachedVolumes, strings.Join(attachedVolumes, ","))
+	}
+
+	return nil
+}

--- a/pkg/controller/master/setting/instance_manager_resources_test.go
+++ b/pkg/controller/master/setting/instance_manager_resources_test.go
@@ -1,0 +1,313 @@
+package setting
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	longhorn "github.com/longhorn/longhorn-manager/types"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestHandler_syncLHIMResources(t *testing.T) {
+	defaultLHIMResources := map[string]string{
+		"v1": longhorn.SettingDefinitionGuaranteedInstanceManagerCPU.Default,
+		"v2": longhorn.SettingDefinitionGuaranteedInstanceManagerCPU.Default,
+	}
+
+	createHandler := func(clientset *fake.Clientset) *Handler {
+		return &Handler{
+			longhornSettings:     fakeclients.LonghornSettingClient(clientset.LonghornV1beta2().Settings),
+			longhornSettingCache: fakeclients.LonghornSettingCache(clientset.LonghornV1beta2().Settings),
+			longhornVolumeCache:  fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+		}
+	}
+
+	t.Run("updates longhorn setting when all volumes are detached", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		handler := createHandler(clientset)
+
+		err := clientset.Tracker().Add(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      string(longhorn.SettingNameGuaranteedInstanceManagerCPU),
+			},
+			Value: `{"v1":"12","v2":"12"}`,
+		})
+		assert.NoError(t, err)
+		err = clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-detached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateDetached,
+			},
+		})
+		assert.NoError(t, err)
+
+		input := &harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{"v1":"15","v2":"20"}}`,
+		}
+
+		err = handler.syncLHIMResources(input)
+		assert.NoError(t, err)
+
+		lhSetting, getErr := handler.longhornSettings.Get(util.LonghornSystemNamespaceName, string(longhorn.SettingNameGuaranteedInstanceManagerCPU), metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		actual := map[string]string{}
+		assert.NoError(t, json.Unmarshal([]byte(lhSetting.Value), &actual))
+		assert.Equal(t, map[string]string{"v1": "15", "v2": "20"}, actual)
+	})
+
+	t.Run("does not reset longhorn setting when value is empty and longhorn is already default", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		handler := createHandler(clientset)
+
+		err := clientset.Tracker().Add(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      string(longhorn.SettingNameGuaranteedInstanceManagerCPU),
+			},
+			Value: `{"v1":"12","v2":"12"}`,
+		})
+		assert.NoError(t, err)
+		err = clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		input := &harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Default:    `{"cpu":{}}`,
+			Value:      "",
+		}
+
+		err = handler.syncLHIMResources(input)
+		assert.NoError(t, err)
+
+		lhSetting, getErr := handler.longhornSettings.Get(util.LonghornSystemNamespaceName, string(longhorn.SettingNameGuaranteedInstanceManagerCPU), metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		actual := map[string]string{}
+		assert.NoError(t, json.Unmarshal([]byte(lhSetting.Value), &actual))
+		assert.Equal(t, defaultLHIMResources, actual)
+	})
+
+	t.Run("does not change longhorn setting when value is cpu empty object on initial default state", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		handler := createHandler(clientset)
+
+		err := clientset.Tracker().Add(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      string(longhorn.SettingNameGuaranteedInstanceManagerCPU),
+			},
+			Value: `{"v1":"20","v2":"20"}`,
+		})
+		assert.NoError(t, err)
+		err = clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-detached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateDetached,
+			},
+		})
+		assert.NoError(t, err)
+
+		input := &harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{}}`,
+		}
+
+		err = handler.syncLHIMResources(input)
+		assert.NoError(t, err)
+
+		lhSetting, getErr := handler.longhornSettings.Get(util.LonghornSystemNamespaceName, string(longhorn.SettingNameGuaranteedInstanceManagerCPU), metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		actual := map[string]string{}
+		assert.NoError(t, json.Unmarshal([]byte(lhSetting.Value), &actual))
+		assert.Equal(t, map[string]string{"v1": "20", "v2": "20"}, actual)
+	})
+
+	t.Run("resets longhorn setting to default when value is cpu empty object after meaningful value was applied", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		handler := createHandler(clientset)
+
+		err := clientset.Tracker().Add(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      string(longhorn.SettingNameGuaranteedInstanceManagerCPU),
+			},
+			Value: `{"v1":"20","v2":"20"}`,
+		})
+		assert.NoError(t, err)
+		err = clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-detached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateDetached,
+			},
+		})
+		assert.NoError(t, err)
+
+		input := &harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        settings.LHIMResourcesSettingName,
+				Annotations: map[string]string{util.AnnotationHash: "previous-meaningful-hash"},
+			},
+			Value: `{"cpu":{}}`,
+		}
+
+		err = handler.syncLHIMResources(input)
+		assert.NoError(t, err)
+
+		lhSetting, getErr := handler.longhornSettings.Get(util.LonghornSystemNamespaceName, string(longhorn.SettingNameGuaranteedInstanceManagerCPU), metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		actual := map[string]string{}
+		assert.NoError(t, json.Unmarshal([]byte(lhSetting.Value), &actual))
+		assert.Equal(t, defaultLHIMResources, actual)
+	})
+
+	t.Run("rejects reset to default when value is empty and there are attached volumes", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		handler := createHandler(clientset)
+
+		err := clientset.Tracker().Add(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      string(longhorn.SettingNameGuaranteedInstanceManagerCPU),
+			},
+			Value: `{"v1":"20","v2":"20"}`,
+		})
+		assert.NoError(t, err)
+		err = clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		input := &harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        settings.LHIMResourcesSettingName,
+				Annotations: map[string]string{util.AnnotationHash: "previous-meaningful-hash"},
+			},
+			Default: `{"cpu":{}}`,
+			Value:   "",
+		}
+
+		err = handler.syncLHIMResources(input)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "waiting for all volumes detached"))
+
+		lhSetting, getErr := handler.longhornSettings.Get(util.LonghornSystemNamespaceName, string(longhorn.SettingNameGuaranteedInstanceManagerCPU), metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		actual := map[string]string{}
+		assert.NoError(t, json.Unmarshal([]byte(lhSetting.Value), &actual))
+		assert.Equal(t, map[string]string{"v1": "20", "v2": "20"}, actual)
+	})
+
+	t.Run("rejects reset to default when value is cpu empty object and there are attached volumes", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		handler := createHandler(clientset)
+
+		err := clientset.Tracker().Add(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      string(longhorn.SettingNameGuaranteedInstanceManagerCPU),
+			},
+			Value: `{"v1":"20","v2":"20"}`,
+		})
+		assert.NoError(t, err)
+		err = clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		input := &harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        settings.LHIMResourcesSettingName,
+				Annotations: map[string]string{util.AnnotationHash: "previous-meaningful-hash"},
+			},
+			Value: `{"cpu":{}}`,
+		}
+
+		err = handler.syncLHIMResources(input)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "waiting for all volumes detached"))
+
+		lhSetting, getErr := handler.longhornSettings.Get(util.LonghornSystemNamespaceName, string(longhorn.SettingNameGuaranteedInstanceManagerCPU), metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		actual := map[string]string{}
+		assert.NoError(t, json.Unmarshal([]byte(lhSetting.Value), &actual))
+		assert.Equal(t, map[string]string{"v1": "20", "v2": "20"}, actual)
+	})
+
+	t.Run("rejects update while there are attached volumes", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		handler := createHandler(clientset)
+
+		err := clientset.Tracker().Add(&lhv1beta2.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      string(longhorn.SettingNameGuaranteedInstanceManagerCPU),
+			},
+			Value: `{"v1":"12","v2":"12"}`,
+		})
+		assert.NoError(t, err)
+		err = clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		input := &harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{"v1":"20","v2":"20"}}`,
+		}
+
+		err = handler.syncLHIMResources(input)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "waiting for all volumes detached"))
+
+		lhSetting, getErr := handler.longhornSettings.Get(util.LonghornSystemNamespaceName, string(longhorn.SettingNameGuaranteedInstanceManagerCPU), metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		actual := map[string]string{}
+		assert.NoError(t, json.Unmarshal([]byte(lhSetting.Value), &actual))
+		assert.Equal(t, defaultLHIMResources, actual)
+	})
+}

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -26,6 +26,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	configmaps := management.CoreFactory.Core().V1().ConfigMap()
 	endpoints := management.CoreFactory.Core().V1().Endpoints()
 	lhs := management.LonghornFactory.Longhorn().V1beta2().Setting()
+	lhVolumes := management.LonghornFactory.Longhorn().V1beta2().Volume()
 	managedCharts := management.RancherManagementFactory.Management().V3().ManagedChart()
 	ingresses := management.NetworkingFactory.Networking().V1().Ingress()
 	helmChartConfigs := management.HelmFactory.Helm().V1().HelmChartConfig()
@@ -53,6 +54,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		ingressCache:         ingresses.Cache(),
 		longhornSettings:     lhs,
 		longhornSettingCache: lhs.Cache(),
+		longhornVolumeCache:  lhVolumes.Cache(),
 		configmaps:           configmaps,
 		configmapCache:       configmaps.Cache(),
 		endpointCache:        endpoints.Cache(),
@@ -96,6 +98,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		harvSettings.ContainerdRegistrySettingName:               controller.syncContainerdRegistry,
 		harvSettings.NTPServersSettingName:                       controller.syncNodeConfig,
 		harvSettings.LonghornV2DataEngineSettingName:             controller.syncNodeConfig,
+		harvSettings.LHIMResourcesSettingName:                    controller.syncLHIMResources,
 		harvSettings.AutoRotateRKE2CertsSettingName:              controller.syncAutoRotateRKE2Certs,
 		harvSettings.KubeconfigDefaultTokenTTLMinutesSettingName: controller.syncKubeconfigTTL,
 		harvSettings.AdditionalGuestMemoryOverheadRatioName:      controller.syncAdditionalGuestMemoryOverheadRatio,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -54,6 +54,7 @@ var (
 	AutoRotateRKE2CertsSet                 = NewSetting(AutoRotateRKE2CertsSettingName, InitAutoRotateRKE2Certs())
 	KubeconfigTTL                          = NewSetting(KubeconfigDefaultTokenTTLMinutesSettingName, "0") // "0" is default value to ensure token does not expire
 	LonghornV2DataEngineEnabled            = NewSetting(LonghornV2DataEngineSettingName, "false")
+	LHIMResources                          = NewSetting(LHIMResourcesSettingName, `{"cpu":{}}`)
 	AdditionalGuestMemoryOverheadRatio     = NewSetting(AdditionalGuestMemoryOverheadRatioName, AdditionalGuestMemoryOverheadRatioDefault)
 	RancherCluster                         = NewSetting(RancherClusterSettingName, "{}")
 	// HarvesterCSICCMVersion this is the chart version from https://github.com/harvester/charts instead of image versions
@@ -100,6 +101,7 @@ const (
 	SupportBundleFileNameSettingName                  = "support-bundle-file-name"
 	UpgradeConfigSettingName                          = "upgrade-config"
 	LonghornV2DataEngineSettingName                   = "longhorn-v2-data-engine-enabled"
+	LHIMResourcesSettingName                          = "instance-manager-resources"
 	LogLevelSettingName                               = "log-level"
 	AdditionalGuestMemoryOverheadRatioName            = "additional-guest-memory-overhead-ratio"
 	ClusterRegistrationURLSettingName                 = "cluster-registration-url"

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/sirupsen/logrus"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -105,6 +106,78 @@ type Overcommit struct {
 	CPU     int `json:"cpu"`
 	Memory  int `json:"memory"`
 	Storage int `json:"storage"`
+}
+
+type LHIMCPUConfig struct {
+	V1 string `json:"v1"`
+	V2 string `json:"v2"`
+}
+
+type LHIMResourcesConfig struct {
+	CPU LHIMCPUConfig `json:"cpu"`
+}
+
+func (c *LHIMResourcesConfig) IsEmpty() bool {
+	return c == nil || (c.CPU.V1 == "" && c.CPU.V2 == "")
+}
+
+func DecodeLHIMResources(value string) (*LHIMResourcesConfig, error) {
+	if value == "" {
+		return &LHIMResourcesConfig{}, nil
+	}
+
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal([]byte(value), &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal failed, error: %w, value: %s", err, value)
+	}
+	cpuRaw, ok := raw["cpu"]
+	if !ok {
+		return nil, fmt.Errorf("cpu is required")
+	}
+
+	cpuMap := map[string]json.RawMessage{}
+	if err := json.Unmarshal(cpuRaw, &cpuMap); err != nil {
+		return nil, fmt.Errorf("cpu must be an object with v1/v2, error: %w", err)
+	}
+	if len(cpuMap) == 0 {
+		return &LHIMResourcesConfig{}, nil
+	}
+
+	v1Raw, ok := cpuMap[string(lhv1beta2.DataEngineTypeV1)]
+	if !ok {
+		return nil, fmt.Errorf("cpu.v1 is required")
+	}
+	v2Raw, ok := cpuMap[string(lhv1beta2.DataEngineTypeV2)]
+	if !ok {
+		return nil, fmt.Errorf("cpu.v2 is required")
+	}
+
+	v1, err := decodeLHIMCPUValue(v1Raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cpu.v1: %w", err)
+	}
+	v2, err := decodeLHIMCPUValue(v2Raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cpu.v2: %w", err)
+	}
+
+	return &LHIMResourcesConfig{
+		CPU: LHIMCPUConfig{
+			V1: v1,
+			V2: v2,
+		},
+	}, nil
+}
+
+func decodeLHIMCPUValue(raw json.RawMessage) (string, error) {
+	var stringValue string
+	if err := json.Unmarshal(raw, &stringValue); err != nil {
+		return "", err
+	}
+	if _, err := strconv.Atoi(stringValue); err != nil {
+		return "", err
+	}
+	return stringValue, nil
 }
 
 type SSLCertificate struct {

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -22,10 +22,13 @@ import (
 	// S3 Ref: https://github.com/longhorn/backupstore/blob/3912081eb7c5708f0027ebbb0da4934537eb9d72/s3/s3.go#L33-L37
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/harvester/go-common/ds"
+	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester-network-controller/pkg/utils"
 	"github.com/longhorn/backupstore"
 	_ "github.com/longhorn/backupstore/nfs" //nolint
 	_ "github.com/longhorn/backupstore/s3"  //nolint
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhtypes "github.com/longhorn/longhorn-manager/types"
 	"github.com/rancher/lasso/pkg/log"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -42,9 +45,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-
-	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester-network-controller/pkg/utils"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/containerd"
@@ -110,6 +110,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.KubeconfigDefaultTokenTTLMinutesSettingName:       validateKubeConfigTTLSetting,
 	settings.AdditionalGuestMemoryOverheadRatioName:            validateAdditionalGuestMemoryOverheadRatio,
 	settings.MaxHotplugRatioSettingName:                        validateMaxHotplugRatio,
+	settings.LHIMResourcesSettingName:                          validateLHIMResources,
 }
 
 type validateSettingUpdateFunc func(oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error
@@ -203,6 +204,9 @@ func NewValidator(
 	validateSettingUpdateFuncs[settings.KubeVirtMigrationSettingName] = validator.validateUpdateKubeVirtMigration
 
 	validateSettingDeleteFuncs[settings.ClusterPodSecurityStandardSettingName] = validator.validateDeleteClusterPodSecurityStandard
+
+	validateSettingUpdateFuncs[settings.LHIMResourcesSettingName] = validator.validateUpdateLHIMResources
+	validateSettingDeleteFuncs[settings.LHIMResourcesSettingName] = validator.validateDeleteLHIMResources
 
 	return validator
 }
@@ -2014,6 +2018,40 @@ func validateUpdateMaxHotplugRatio(_ *v1beta1.Setting, newSetting *v1beta1.Setti
 	return validateMaxHotplugRatio(newSetting)
 }
 
+func validateLHIMResources(setting *v1beta1.Setting) error {
+	// If value is empty, this setting is using default and should be ignored.
+	if setting.Value == "" {
+		return nil
+	}
+
+	return validateLHIMResourcesHelper(settings.KeywordValue, setting.Value)
+}
+
+func validateLHIMResourcesHelper(field, value string) error {
+	if value == "" {
+		return nil
+	}
+
+	resources, err := settings.DecodeLHIMResources(value)
+	if err != nil {
+		return fmt.Errorf("failed to parse %v: %w", field, err)
+	}
+	if resources.IsEmpty() {
+		return nil
+	}
+
+	v1CPU := resources.CPU.V1
+	v2CPU := resources.CPU.V2
+	if err := lhtypes.ValidateCPUReservationValues(lhtypes.SettingNameGuaranteedInstanceManagerCPU, v1CPU); err != nil {
+		return fmt.Errorf("failed to validate %v cpu.v1: %w", field, err)
+	}
+	if err := lhtypes.ValidateCPUReservationValues(lhtypes.SettingNameGuaranteedInstanceManagerCPU, v2CPU); err != nil {
+		return fmt.Errorf("failed to validate %v cpu.v2: %w", field, err)
+	}
+
+	return nil
+}
+
 func validateMaxHotplugRatioHelper(field, value string) error {
 	if value == "" {
 		return nil
@@ -2027,6 +2065,63 @@ func validateMaxHotplugRatioHelper(field, value string) error {
 	}
 	return nil
 }
+
+func (v *settingValidator) validateUpdateLHIMResources(oldSetting, newSetting *v1beta1.Setting) error {
+	if newSetting.Name != settings.LHIMResourcesSettingName {
+		return nil
+	}
+
+	if oldSetting.Default == newSetting.Default && oldSetting.Value == newSetting.Value {
+		return nil
+	}
+
+	oldResources, err := settings.DecodeLHIMResources(oldSetting.Value)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("failed to parse previous %s: %v", settings.KeywordValue, err), settings.KeywordValue)
+	}
+	newResources, err := settings.DecodeLHIMResources(newSetting.Value)
+	if err != nil {
+		return werror.NewInvalidError(fmt.Sprintf("failed to parse %s: %v", settings.KeywordValue, err), settings.KeywordValue)
+	}
+
+	oldMeaningful := oldResources != nil && !oldResources.IsEmpty()
+	newDefault := newResources.IsEmpty()
+
+	// When changing from a meaningful value back to default (empty value or
+	// {"cpu":{}}), require all Longhorn volumes to be detached before allowing
+	// the reset.
+	if oldMeaningful && newDefault {
+		return v.validateLHIMResourcesDetached()
+	}
+	if newDefault {
+		return nil
+	}
+	if err := validateLHIMResources(newSetting); err != nil {
+		return err
+	}
+
+	return v.validateLHIMResourcesDetached()
+}
+
+func (v *settingValidator) validateLHIMResourcesDetached() error {
+	volumes, err := v.lhVolumeCache.List(util.LonghornSystemNamespaceName, labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	for _, volume := range volumes {
+		if volume.Status.State != lhv1beta2.VolumeStateDetached {
+			return werror.NewInvalidError("please detach all Longhorn volumes before configuring instance-manager-resources", settings.KeywordValue)
+		}
+	}
+
+	return nil
+}
+
+func (v *settingValidator) validateDeleteLHIMResources(_ *v1beta1.Setting) error {
+	return werror.NewMethodNotAllowed(fmt.Sprintf("Disallow delete setting name %s", settings.LHIMResourcesSettingName))
+}
+
 func (v *settingValidator) validateRancherCluster(newSetting *v1beta1.Setting) error {
 	var (
 		rancherClusterConfig *settings.RancherClusterConfig

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,7 @@ import (
 	"github.com/harvester/harvester/pkg/controller/master/storagenetwork"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
 
@@ -1563,6 +1565,276 @@ func Test_validateStorageNetwork_Update_InProgress(t *testing.T) {
 		newSetting.Value = settings.StorageNetwork.Default
 
 		err := v.Update(nil, oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
+}
+
+func Test_validateLHIMResources(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   *v1beta1.Setting
+		errMsg string
+	}{
+		{
+			name: "ok to create instance-manager-resources with none values",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			},
+			errMsg: "",
+		},
+		{
+			name: "ok to create instance-manager-resources with default only",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Default:    `{"cpu":{}}`,
+				Value:      "",
+			},
+			errMsg: "",
+		},
+		{
+			name: "ok to create instance-manager-resources with value cpu empty object",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Value:      `{"cpu":{}}`,
+			},
+			errMsg: "",
+		},
+		{
+			name: "ok to create instance-manager-resources with valid value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Default:    `{"cpu":{"v1":"12","v2":"12"}}`,
+				Value:      `{"cpu":{"v1":"20","v2":"30"}}`,
+			},
+			errMsg: "",
+		},
+		{
+			name: "fail to create instance-manager-resources with invalid value",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Value:      `{"cpu":{"v1":"41","v2":"12"}}`,
+			},
+			errMsg: "failed to validate value",
+		},
+		{
+			name: "fail to create instance-manager-resources with invalid json",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Value:      `{"memory":1024}`,
+			},
+			errMsg: "failed to parse value",
+		},
+		{
+			name: "fail to create instance-manager-resources with float cpu.v1",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Value:      `{"cpu":{"v1":41.8,"v2":12}}`,
+			},
+			errMsg: "failed to parse value",
+		},
+		{
+			name: "fail to create instance-manager-resources with non-numeric cpu.v1 string",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Value:      `{"cpu":{"v1":"abc","v2":12}}`,
+			},
+			errMsg: "failed to parse value",
+		},
+		{
+			name: "fail to create instance-manager-resources with empty cpu.v1 string",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+				Value:      `{"cpu":{"v1":"","v2":12}}`,
+			},
+			errMsg: "failed to parse value",
+		},
+	}
+
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Create(nil, tt.args)
+			if tt.errMsg != "" {
+				assert.True(t, strings.Contains(err.Error(), tt.errMsg))
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_settingValidator_validateUpdateLHIMResources(t *testing.T) {
+	t.Run("rejects update when there are attached volumes", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		v := &settingValidator{
+			lhVolumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+		}
+
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{"v1":"12","v2":"12"}}`,
+		}
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = `{"cpu":{"v1":"20","v2":"20"}}`
+
+		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "detach all Longhorn volumes"))
+	})
+
+	t.Run("allows update when all volumes are detached", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-detached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateDetached,
+			},
+		})
+		assert.NoError(t, err)
+
+		v := &settingValidator{
+			lhVolumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+		}
+
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{"v1":"12","v2":"12"}}`,
+		}
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = `{"cpu":{"v1":"20","v2":"20"}}`
+
+		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows update when value is empty and setting stays on default", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		v := &settingValidator{
+			lhVolumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+		}
+
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Default:    `{"cpu":{}}`,
+			Value:      "",
+		}
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Default = `{"cpu":{"v1":"12","v2":"12"}}`
+		newSetting.Value = ""
+
+		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects update when changing from meaningful value to empty value and there are attached volumes", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		v := &settingValidator{
+			lhVolumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+		}
+
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{"v1":"12","v2":"12"}}`,
+		}
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = ""
+
+		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "detach all Longhorn volumes"))
+	})
+
+	t.Run("rejects update when changing from meaningful value to cpu empty object and there are attached volumes", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-attached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateAttached,
+			},
+		})
+		assert.NoError(t, err)
+
+		v := &settingValidator{
+			lhVolumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+		}
+
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{"v1":"12","v2":"12"}}`,
+		}
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = `{"cpu":{}}`
+
+		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "detach all Longhorn volumes"))
+	})
+
+	t.Run("allows update when changing from meaningful value to cpu empty object and all volumes are detached", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(&lhv1beta2.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: util.LonghornSystemNamespaceName,
+				Name:      "vol-detached",
+			},
+			Status: lhv1beta2.VolumeStatus{
+				State: lhv1beta2.VolumeStateDetached,
+			},
+		})
+		assert.NoError(t, err)
+
+		v := &settingValidator{
+			lhVolumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+		}
+
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.LHIMResourcesSettingName},
+			Value:      `{"cpu":{"v1":"12","v2":"12"}}`,
+		}
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = `{"cpu":{}}`
+
+		err = v.validateUpdateLHIMResources(oldSetting, newSetting)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION

#### Problem:
Let Harvester users configure Longhorn Instance Manager (IM) CPU usage from Harvester (via either the UI or CLI).

#### Solution:
Introduce a new Harvester setting, `instance-manager-resources`, e.g.,
```
apiVersion: harvesterhci.io/v1beta1
default: '{"cpu":{"v1":"12","v2":"12"}}'
kind: Setting
metadata:
  annotations:
    harvesterhci.io/hash: f70e0094431c520294b322a918d9dc0cc11a005d12a43dd45b758293
  creationTimestamp: "2026-03-03T07:52:31Z"
  generation: 7
  name: instance-manager-resources
  resourceVersion: "23115941"
  uid: b32cc7f2-a0fd-4042-bd11-5f34221b4e52
status:
  conditions:
  - lastUpdateTime: "2026-03-03T08:26:02Z"
    status: "True"
    type: configured
value: '{"cpu":{"v1":"20","v2":"20"}}'
```

This will sync to the Longhorn `guaranteed-instance-manager-cpu` setting for v1 and v2 IM CPU usage. 

Since Longhorn may extend IM resource controls in the future [longhorn#6351](https://github.com/longhorn/longhorn/issues/6351), this Harvester setting gives us flexibility for future needs—for example, if memory becomes configurable, we could extend this setting to include that as well.
```
apiVersion: harvesterhci.io/v1beta1
default: '{"cpu":{"v1":"12","v2":"12"}, "memory":{"v1":"1G","v2":"2G"}}'
kind: Setting
metadata:
  annotations:
    harvesterhci.io/hash: f70e0094431c520294b322a918d9dc0cc11a005d12a43dd45b758293
  creationTimestamp: "2026-03-03T07:52:31Z"
  generation: 7
  name: instance-manager-resources
  resourceVersion: "23115941"
  uid: b32cc7f2-a0fd-4042-bd11-5f34221b4e52
status:
  conditions:
  - lastUpdateTime: "2026-03-03T08:26:02Z"
    status: "True"
    type: configured
value: '{"cpu":{"v1":"20","v2":"20"}, "memory":{"v1":"5G","v2":"5G"}}'
```

#### Related Issue(s):
#7867 

#### Test plan:
* Build Harvester v1.7.1 and update the Longhorn setting **Guaranteed Instance Manager CPU** ([docs](https://longhorn.io/docs/1.11.1/references/settings/#guaranteed-instance-manager-cpu)) to a specific value, e.g., `{"v1":"10","v2":"10"}`.
- Update the Harvester with ISO from this PR
- Longhorn setting **Guaranteed Instance Manager CPU** is not changed
- Create a running VM and try to update the setting—it should be rejected, e.g.,
  ```
  $ kubectl patch setting.harvesterhci.io instance-manager-resources   --type=merge   -p '{"value":"{\"cpu\":{\"v1\":\"20\",\"v2\":\"20\"}}"}'` 
  The request is invalid: value: please detach all Longhorn volumes before configuring instance-manager-resources
  ```
- Make sure there are no running VMs or attached Longhorn volumes.
- Update the setting again—it should succeed this time
  ```
  $ kubectl patch setting.harvesterhci.io instance-manager-resources   --type=merge   -p '{"value":"{\"cpu\":{\"v1\":\"20\",\"v2\":\"20\"}}"}'
  setting.harvesterhci.io/instance-manager-resources patched
  ```
- * Reset `setting.harvesterhci.io/instance-manager-resources` to the default value. The Longhorn **Guaranteed Instance Manager CPU** setting ([docs](https://longhorn.io/docs/1.11.1/references/settings/#guaranteed-instance-manager-cpu)) will then be set back to the default: `{"v1":"12","v2":"12"}`.

#### Additional documentation or context
