### PR TITLE
NAD leaking is seen when you configure the storage-network quickly

### DIFF
--- a/pkg/util/fakeclients/longhornnode.go
+++ b/pkg/util/fakeclients/longhornnode.go
@@ -1,0 +1,79 @@
+package fakeclients
+
+import (
+	"context"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	longhornv1beta2 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/longhorn.io/v1beta2"
+)
+
+// LonghornNodeClient adapts a namespaced Longhorn Node client factory to a simple callable
+type LonghornNodeClient func(string) longhornv1beta2.NodeInterface
+
+func (c LonghornNodeClient) Create(node *lhv1beta2.Node) (*lhv1beta2.Node, error) {
+	return c(node.Namespace).Create(context.TODO(), node, metav1.CreateOptions{})
+}
+
+func (c LonghornNodeClient) Update(node *lhv1beta2.Node) (*lhv1beta2.Node, error) {
+	return c(node.Namespace).Update(context.TODO(), node, metav1.UpdateOptions{})
+}
+
+func (c LonghornNodeClient) UpdateStatus(_ *lhv1beta2.Node) (*lhv1beta2.Node, error) {
+	panic("implement me")
+}
+
+func (c LonghornNodeClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	return c(namespace).Delete(context.TODO(), name, *options)
+}
+
+func (c LonghornNodeClient) Get(namespace, name string, options metav1.GetOptions) (*lhv1beta2.Node, error) {
+	return c(namespace).Get(context.TODO(), name, options)
+}
+
+func (c LonghornNodeClient) List(namespace string, opts metav1.ListOptions) (*lhv1beta2.NodeList, error) {
+	return c(namespace).List(context.TODO(), opts)
+}
+
+func (c LonghornNodeClient) Watch(namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+	return c(namespace).Watch(context.TODO(), opts)
+}
+
+func (c LonghornNodeClient) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (result *lhv1beta2.Node, err error) {
+	return c(namespace).Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}
+
+// LonghornNodeCache adapts a namespaced Node client to a cache-like interface used in tests
+type LonghornNodeCache func(string) longhornv1beta2.NodeInterface
+
+func (c LonghornNodeCache) Get(namespace, name string) (*lhv1beta2.Node, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c LonghornNodeCache) List(namespace string, selector labels.Selector) ([]*lhv1beta2.Node, error) {
+	nodeList, err := c(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	returnNodes := make([]*lhv1beta2.Node, 0, len(nodeList.Items))
+	for i := range nodeList.Items {
+		returnNodes = append(returnNodes, &nodeList.Items[i])
+	}
+
+	return returnNodes, nil
+}
+
+func (c LonghornNodeCache) AddIndexer(_ string, _ generic.Indexer[*lhv1beta2.Node]) {
+	panic("implement me")
+}
+
+func (c LonghornNodeCache) GetByIndex(_, _ string) ([]*lhv1beta2.Node, error) {
+	panic("implement me")
+}

--- a/pkg/util/fakeclients/pvc.go
+++ b/pkg/util/fakeclients/pvc.go
@@ -3,7 +3,6 @@ package fakeclients
 import (
 	"context"
 
-	corev1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
+
+	corev1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/v1"
 )
 
 type PersistentVolumeClaimClient func(string) corev1type.PersistentVolumeClaimInterface
@@ -57,8 +58,18 @@ func (c PersistentVolumeClaimCache) Get(namespace, name string) (*corev1.Persist
 	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c PersistentVolumeClaimCache) List(_ string, _ labels.Selector) ([]*corev1.PersistentVolumeClaim, error) {
-	panic("implement me")
+func (c PersistentVolumeClaimCache) List(namespace string, selector labels.Selector) ([]*corev1.PersistentVolumeClaim, error) {
+	list, err := c(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*corev1.PersistentVolumeClaim, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, err
 }
 
 func (c PersistentVolumeClaimCache) AddIndexer(_ string, _ generic.Indexer[*corev1.PersistentVolumeClaim]) {

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -48,6 +48,7 @@ import (
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/containerd"
 	settingctl "github.com/harvester/harvester/pkg/controller/master/setting"
+	"github.com/harvester/harvester/pkg/controller/master/storagenetwork"
 	ctlv1beta1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllhv1b2 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
@@ -1174,8 +1175,26 @@ func (v *settingValidator) validateUpdateStorageNetwork(oldSetting *v1beta1.Sett
 		return nil
 	}
 
+	// Skip if the `Default` and `Value` fields are not changed. This is the
+	// case when the status is updated.
 	if oldSetting.Default == newSetting.Default && oldSetting.Value == newSetting.Value {
 		return nil
+	}
+
+	// Block updates if a previous `storage-network` change is still in
+	// progress; except for status updates and resetting the setting to its
+	// default value.
+	sc := v1beta1.SettingConfigured
+	isInProgress := sc.IsFalse(oldSetting) && sc.GetReason(oldSetting) == storagenetwork.ReasonInProgress
+	isResetToDefault := newSetting.Value == settings.StorageNetwork.Default &&
+		newSetting.Default == settings.StorageNetwork.Default
+	if isInProgress && !isResetToDefault {
+		return werror.NewConflict(fmt.Sprintf(
+			"cannot update the setting %q because it is still being configured (reason: %q, message: %q)",
+			settings.StorageNetworkName,
+			sc.GetReason(oldSetting),
+			sc.GetMessage(oldSetting),
+		))
 	}
 
 	var (

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/controller/master/storagenetwork"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
@@ -1349,4 +1350,127 @@ func Test_validateMaxHotplugRatio(t *testing.T) {
 		})
 
 	}
+}
+
+func Test_validateStorageNetwork_Update_InProgress(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	v := NewValidator(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings), nil, nil, nil, nil, fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines), nil, nil, nil, fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes), fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims), nil, nil, nil, fakeclients.LonghornNodeCache(clientset.LonghornV1beta2().Nodes), nil)
+
+	t.Run("reject update when 'In Progress'", func(t *testing.T) {
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			Default:    settings.StorageNetwork.Default,
+			Value:      `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":["192.168.50.1/32","192.168.50.2/32"]}`,
+		}
+		v1beta1.SettingConfigured.False(oldSetting)
+		v1beta1.SettingConfigured.Reason(oldSetting, storagenetwork.ReasonInProgress)
+		v1beta1.SettingConfigured.Message(oldSetting, "waiting for all volumes detached: pvc-12375075-487e-4add-9dfb-4e9c3881370d,pvc-736e8599-daf4-458e-8af2-3bbb038b0d46,pvc-d29243f2-e8e8-408a-98cc-e441dc83085d")
+
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":["192.168.50.1/32"]}`
+
+		err := v.Update(nil, oldSetting, newSetting)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "cannot update the setting \"storage-network\" because it is still being configured")
+	})
+
+	t.Run("do not reject update when 'In Progress'", func(t *testing.T) {
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			Default:    settings.StorageNetwork.Default,
+			Value:      `{"vlan":1, "clusterNetwork":"mgmt", "range":"10.0.0.0/24"}`,
+		}
+		v1beta1.SettingConfigured.False(oldSetting)
+		v1beta1.SettingConfigured.Reason(oldSetting, storagenetwork.ReasonInProgress)
+		v1beta1.SettingConfigured.Message(oldSetting, "waiting for all volumes detached: pvc-12375075-487e-4add-9dfb-4e9c3881370d,pvc-736e8599-daf4-458e-8af2-3bbb038b0d46,pvc-d29243f2-e8e8-408a-98cc-e441dc83085d")
+
+		newSetting := oldSetting.DeepCopy()
+		v1beta1.SettingConfigured.True(newSetting)
+		v1beta1.SettingConfigured.Reason(newSetting, storagenetwork.ReasonCompleted)
+
+		err := v.Update(nil, oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
+
+	t.Run("allow update when 'Completed'", func(t *testing.T) {
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			Default:    settings.StorageNetwork.Default,
+			Value:      `{"vlan":1, "clusterNetwork":"mgmt", "range":"10.0.0.0/24"}`,
+		}
+		v1beta1.SettingConfigured.True(oldSetting)
+		v1beta1.SettingConfigured.Reason(oldSetting, storagenetwork.ReasonCompleted)
+
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = `{"vlan":2, "clusterNetwork":"mgmt", "range":"10.0.0.0/24"}`
+
+		err := v.Update(nil, oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
+
+	t.Run("reject update default when 'In Progress'", func(t *testing.T) {
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			Default:    settings.StorageNetwork.Default,
+			Value:      `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":["192.168.50.1/32","192.168.50.2/32"]}`,
+		}
+		v1beta1.SettingConfigured.False(oldSetting)
+		v1beta1.SettingConfigured.Reason(oldSetting, storagenetwork.ReasonInProgress)
+		v1beta1.SettingConfigured.Message(oldSetting, "waiting for all volumes detached: ...")
+
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Default = `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":[]}`
+
+		err := v.Update(nil, oldSetting, newSetting)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "cannot update the setting")
+	})
+
+	t.Run("allow update default when 'Completed'", func(t *testing.T) {
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			Default:    settings.StorageNetwork.Default,
+		}
+		v1beta1.SettingConfigured.True(oldSetting)
+		v1beta1.SettingConfigured.Reason(oldSetting, storagenetwork.ReasonCompleted)
+
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Default = `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":[]}`
+
+		err := v.Update(nil, oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
+
+	t.Run("allow update to default when 'In Progress'", func(t *testing.T) {
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			Default:    settings.StorageNetwork.Default,
+			Value:      `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":["192.168.50.1/32","192.168.50.2/32"]}`,
+		}
+		v1beta1.SettingConfigured.False(oldSetting)
+		v1beta1.SettingConfigured.Reason(oldSetting, storagenetwork.ReasonInProgress)
+		v1beta1.SettingConfigured.Message(oldSetting, "waiting for all volumes detached: ...")
+
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = settings.StorageNetwork.Default
+
+		err := v.Update(nil, oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
+
+	t.Run("allow update to default when 'Completed'", func(t *testing.T) {
+		oldSetting := &v1beta1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+			Default:    settings.StorageNetwork.Default,
+			Value:      `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":["192.168.50.1/32","192.168.50.2/32"]}`,
+		}
+		v1beta1.SettingConfigured.True(oldSetting)
+		v1beta1.SettingConfigured.Reason(oldSetting, storagenetwork.ReasonCompleted)
+
+		newSetting := oldSetting.DeepCopy()
+		newSetting.Value = settings.StorageNetwork.Default
+
+		err := v.Update(nil, oldSetting, newSetting)
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
#### Problem:
Harvester storage-network has status control to ensure the storage-network is applied step-by-step; but the webhook does not check the on-going storage-network change. The controller also does not handle such case.

If you change the the storage-network quickly when the previous operation is not finished yet, it can cause the NAD leaking.

#### Solution:
The webhook takes care to abort a request when the status condition is `In Progress`.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9621

#### Test plan:
***Case 1***
- Run `kubectl edit settings.harvesterhci storage-network` and apply `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":[]}` to the `value` field.
- Run `kubectl get settings.harvesterhci storage-network -oyaml`. The output should look like 
```
apiVersion: harvesterhci.io/v1beta1
kind: Setting
metadata:
  ...
  name: storage-network
  ...
status:
  conditions:
  - lastUpdateTime: "2026-03-03T14:10:56Z"
    message: 'waiting for all volumes detached: pvc-736e8599-daf4-458e-8af2-3bbb038b0d46,pvc-d29243f2-e8e8-408a-98cc-e441dc83085d,pvc-12375075-487e-4add-9dfb-4e9c3881370d'
    reason: In Progress
    status: "False"
    type: configured
...
```
- Be quick and execute `kubectl edit settings.harvesterhci storage-network` again to apply some changes to the `value` field. After saving the following error message should appear:
```
error: settings.harvesterhci.io "storage-network" could not be patched: admission webhook "validator.harvesterhci.io" denied the request: cannot update the Harvester setting "storage-network" because it is still being configured (reason: "In Progress", message: "waiting for all volumes detached: pvc-12375075-487e-4add-9dfb-4e9c3881370d,pvc-736e8599-daf4-458e-8af2-3bbb038b0d46,pvc-d29243f2-e8e8-408a-98cc-e441dc83085d")
```

***Case 2***
Use the Harvester UI to apply changes to the `storage-network` setting.
<img width="1079" height="197" alt="grafik" src="https://github.com/user-attachments/assets/8a4c0673-5d64-4e41-bc33-61b5b9014213" />
When the setting is `In Progress`, the UI should display a warning.
<img width="989" height="628" alt="Bildschirmfoto vom 2026-03-03 15-11-02" src="https://github.com/user-attachments/assets/061804bc-0c27-4863-8d61-702f11f427ec" />

***Case 3***
- Run `kubectl edit settings.harvesterhci storage-network` and apply `{"vlan":50,"clusterNetwork":"mgmt","range":"192.168.50.0/24","exclude":[]}` to the `value` field.
- Run `kubectl get settings.harvesterhci storage-network -oyaml`. The output should look like 
```
apiVersion: harvesterhci.io/v1beta1
kind: Setting
metadata:
  ...
  name: storage-network
  ...
status:
  conditions:
  - lastUpdateTime: "2026-03-03T14:10:56Z"
    message: 'waiting for all volumes detached: pvc-736e8599-daf4-458e-8af2-3bbb038b0d46,pvc-d29243f2-e8e8-408a-98cc-e441dc83085d,pvc-12375075-487e-4add-9dfb-4e9c3881370d'
    reason: In Progress
    status: "False"
    type: configured
...
```
- Be quick and execute `kubectl edit settings.harvesterhci storage-network` again to apply `value: ""`. The command should not print out any error and should finish successful.