### PR TITLE
Refine pvc validator to restrict vmstate-persistence SC while allowing KubeVirt system usage

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -29,6 +29,7 @@ const (
 	LabelVMCreator                      = prefix + "/creator"
 	LabelVMimported                     = "migration.harvesterhci.io/imported"
 	LabelNodeNameKey                    = "kubevirt.io/nodeName"
+	LabelKubeVirtPersistentState        = "persistent-state-for" // KubeVirt-managed label for persistent state PVCs
 	LabelHarvesterUpgrade               = prefix + "/upgrade"
 	LabelHarvesterUpgradeState          = prefix + "/upgradeState"
 	LabelHarvesterUpgradeComponent      = prefix + "/upgradeComponent"

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -190,20 +190,31 @@ func (v *pvcValidator) checkGoldenImageAnno(pvc *corev1.PersistentVolumeClaim) e
 }
 
 func (v *pvcValidator) validateInternalUsage(pvc *corev1.PersistentVolumeClaim) error {
-	if !isUsingReservedSC(pvc) {
+	if pvc.Spec.StorageClassName == nil {
 		return nil
 	}
 
-	isBelongToUpgradeImage, err := v.isBelongToUpgradeImage(pvc)
-	if err != nil {
-		return werror.NewInternalError(fmt.Sprintf("failed to check if pvc %s/%s is for internal usage: %v", pvc.Namespace, pvc.Name, err))
+	scName := *pvc.Spec.StorageClassName
+	switch scName {
+	case util.StorageClassLonghornStatic:
+		isBelongToUpgradeImage, err := v.isBelongToUpgradeImage(pvc)
+		if err != nil {
+			return werror.NewInternalError(fmt.Sprintf("failed to check if pvc %s/%s is for internal usage: %v", pvc.Namespace, pvc.Name, err))
+		}
+		if !isBelongToUpgradeImage {
+			message := fmt.Sprintf("can not create volume with the reserved storage class %s", scName)
+			return werror.NewInvalidError(message, "spec.storageClassName")
+		}
+		return nil
+	case util.StorageClassVmstatePersistence:
+		if !isManagedByKubeVirt(pvc) {
+			message := fmt.Sprintf("can not create volume with the reserved storage class %s", scName)
+			return werror.NewInvalidError(message, "spec.storageClassName")
+		}
+		return nil
+	default:
+		return nil
 	}
-	if !isBelongToUpgradeImage {
-		message := fmt.Sprintf("can not create volume with the reserved storage class %s", *pvc.Spec.StorageClassName)
-		return werror.NewInvalidError(message, "spec.storageClassName")
-	}
-
-	return nil
 }
 
 func (v *pvcValidator) isBelongToUpgradeImage(pvc *corev1.PersistentVolumeClaim) (bool, error) {
@@ -238,6 +249,34 @@ func (v *pvcValidator) isBelongToUpgradeImage(pvc *corev1.PersistentVolumeClaim)
 	return false, nil
 }
 
-func isUsingReservedSC(pvc *corev1.PersistentVolumeClaim) bool {
-	return pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName == util.StorageClassLonghornStatic
+// isManagedByKubeVirt checks if a PVC creation request is legitimately from KubeVirt.
+// It validates multiple criteria to prevent users from bypassing the restriction:
+// 1. Must have the persistent-state-for label with a non-empty value
+// 2. Must have owner reference to a VM or VMI
+// 3. The label value must match the owner's name (VM/VMI name)
+func isManagedByKubeVirt(pvc *corev1.PersistentVolumeClaim) bool {
+	if pvc.Labels == nil {
+		return false
+	}
+
+	// Check if the label exists and has a non-empty value
+	vmName, exists := pvc.Labels[util.LabelKubeVirtPersistentState]
+	if !exists || vmName == "" {
+		return false
+	}
+
+	// Verify that the PVC has an owner reference to a VM or VMI
+	hasValidOwner := false
+	for _, owner := range pvc.OwnerReferences {
+		if owner.Kind == kubevirtv1.VirtualMachineGroupVersionKind.Kind ||
+			owner.Kind == kubevirtv1.VirtualMachineInstanceGroupVersionKind.Kind {
+			// The owner name should match the label value
+			if owner.Name == vmName {
+				hasValidOwner = true
+				break
+			}
+		}
+	}
+
+	return hasValidOwner
 }

--- a/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
@@ -241,7 +241,74 @@ func TestCreate(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassVmstatePersistence),
 				},
 			},
+			expectError:   true,
+			errorContains: "reserved storage class",
+		},
+		{
+			name: "create PVC with reserved vmstate-persistence storage class managed by KubeVirt",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "persistent-state-for-vm1",
+					Namespace: "default",
+					Labels: map[string]string{
+						util.LabelKubeVirtPersistentState: "vm1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "kubevirt.io/v1",
+							Kind:       "VirtualMachine",
+							Name:       "vm1",
+							UID:        "test-uid",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassVmstatePersistence),
+				},
+			},
 			expectError: false,
+		},
+		{
+			name: "create PVC with reserved vmstate-persistence storage class with label but no owner reference",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "persistent-state-for-vm1",
+					Namespace: "default",
+					Labels: map[string]string{
+						util.LabelKubeVirtPersistentState: "vm1",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassVmstatePersistence),
+				},
+			},
+			expectError:   true,
+			errorContains: "reserved storage class",
+		},
+		{
+			name: "create PVC with reserved vmstate-persistence storage class with mismatched label and owner",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "persistent-state-for-vm1",
+					Namespace: "default",
+					Labels: map[string]string{
+						util.LabelKubeVirtPersistentState: "vm1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "kubevirt.io/v1",
+							Kind:       "VirtualMachine",
+							Name:       "vm2", // mismatched name
+							UID:        "test-uid",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassVmstatePersistence),
+				},
+			},
+			expectError:   true,
+			errorContains: "reserved storage class",
 		},
 	}
 


### PR DESCRIPTION
#### Problem:
Users can create PVCs with reserved storage classes `vmstate-persistence` which is reserved for KubeVirt VM backend storage (TPM, persistent EFI)

This can cause conflicts and potential security/operational issues.

#### Solution:
Add validation in the PVC webhook to:
1. Block user-created PVCs using reserved storage classes
2. Allow KubeVirt-managed PVCs (identified by the `persistent-state-for` label) to use `vmstate-persistence`

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9927

#### Test plan:

**Positive Test: VM with TPM Enabled**
1. Create a VM with TPM enabled via UI (see [docs](https://docs.harvesterhci.io/v1.7/vm/index/#tpm-device))
2. Verify backend storage PVC is created automatically:
   ```bash
   kubectl get pvc -n default -l persistent-state-for=<vm-name>
   ```
3. Confirm it uses `vmstate-persistence` storage class
4. VM should start successfully

Expected: VM works, PVC created automatically by KubeVirt

**Negative Test: User Creates PVC with Reserved Storage Class**
1. Apply this YAML:
   ```yaml
   apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: user-created-pvc
     namespace: default
   spec:
     accessModes:
       - ReadWriteOnce
     resources:
       requests:
         storage: 10Mi
     storageClassName: vmstate-persistence
   ```

Expected: Rejected with error:
```
Error from server: admission webhook "validator.harvesterhci.io" denied the request: can not create volume with the reserved storage class vmstate-persistence
```

#### Additional documentation or context
- KubeVirt backend storage reference: [backend-storage.go](https://github.com/kubevirt/kubevirt/blob/main/pkg/storage/backend-storage/backend-storage.go)
