### PR TITLE
task: add option to registration url setting

### DIFF
--- a/pkg/controller/master/setting/cluster_registration_url.go
+++ b/pkg/controller/master/setting/cluster_registration_url.go
@@ -3,9 +3,12 @@ package setting
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/objectset"
 	"github.com/sirupsen/logrus"
@@ -16,17 +19,40 @@ import (
 	"sigs.k8s.io/yaml"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harvsettings "github.com/harvester/harvester/pkg/settings"
 )
 
 const defaultResponseMaxSize = 1 * 1024 * 1024 // 1MB
 
 // registerCluster imports Harvester to Rancher by applying manifests from the registration URL.
 func (h *Handler) registerCluster(setting *harvesterv1.Setting) error {
-	url := setting.Value
+	logrus.Info("syncing cluster registration URL setting")
+	s := harvsettings.GetClusterRegistrationURLSetting(setting)
+	url := s.URL
 	if url == "" {
+		logrus.Info("resetting cluster registration URL, cleaning up cluster agent if exists")
 		return h.cleanupClusterAgent()
 	}
-	resp, err := h.httpClient.Get(url)
+
+	httpClient := h.httpClient
+	if !s.InsecureSkipTLSVerify {
+		logrus.Info("using system CA certificates to verify the cluster registration URL")
+		caCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			return err
+		}
+		httpClient = http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					RootCAs: caCertPool,
+				},
+			},
+		}
+	}
+
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return err
 	}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -19,7 +19,7 @@ var (
 
 	AdditionalCA                           = NewSetting(AdditionalCASettingName, "")
 	APIUIVersion                           = NewSetting(APIUIVersionSettingName, "1.1.9") // Please update the HARVESTER_API_UI_VERSION in package/Dockerfile when updating the version here.
-	ClusterRegistrationURL                 = NewSetting(ClusterRegistrationURLSettingName, "")
+	ClusterRegistrationURL                 = NewSetting(ClusterRegistrationURLSettingName, `{"url":"","insecureSkipTLSVerify":false}`)
 	ServerVersion                          = NewSetting(ServerVersionSettingName, "dev")
 	UIIndex                                = NewSetting(UIIndexSettingName, DefaultDashboardUIURL)
 	UIPath                                 = NewSetting(UIPathSettingName, "/usr/share/harvester/harvester")

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -303,3 +303,23 @@ func GetPodSecuritySetting(setting *harvesterv1.Setting) (*PodSecuritySetting, e
 	}
 	return pssSetting, nil
 }
+
+type ClusterRegistrationURLSetting struct {
+	URL                   string `json:"url"`
+	InsecureSkipTLSVerify bool   `json:"insecureSkipTLSVerify"`
+}
+
+func GetClusterRegistrationURLSetting(setting *harvesterv1.Setting) *ClusterRegistrationURLSetting {
+	reg := &ClusterRegistrationURLSetting{}
+	value := setting.Default
+	if setting.Value != "" {
+		value = setting.Value
+	}
+
+	if err := json.Unmarshal([]byte(value), reg); err != nil {
+		logrus.Warnf("%s. treating the registration URL value directly for backward compatibility", err.Error())
+		reg.URL = value
+		reg.InsecureSkipTLSVerify = true
+	}
+	return reg
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:

Provide option to configure the client of the `cluster-registration-url` setting handler.

#### Related Issue(s):

https://github.com/harvester/suse-virtualization-mgmt/issues/5

#### Test plan:

see https://github.com/harvester/suse-virtualization-mgmt/issues/5

#### Additional documentation or context