### PR TITLE
feat: support adding support_bundle_file_name to customize bundle name

### DIFF
--- a/pkg/controller/master/supportbundle/manager.go
+++ b/pkg/controller/master/supportbundle/manager.go
@@ -102,6 +102,10 @@ func (m *Manager) Create(sb *harvesterv1.SupportBundle, image string, pullPolicy
 									Value: sb.Name,
 								},
 								{
+									Name:  "SUPPORT_BUNDLE_FILE_NAME",
+									Value: settings.SupportBundleFileName.Get(),
+								},
+								{
 									Name:  "SUPPORT_BUNDLE_DESCRIPTION",
 									Value: sb.Spec.Description,
 								},

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -39,6 +39,7 @@ var (
 	SupportBundleTimeout                   = NewSetting(SupportBundleTimeoutSettingName, supportBundleUtil.SupportBundleTimeoutDefaultStr)                      // Unit is minute. 0 means disable timeout.
 	SupportBundleExpiration                = NewSetting(SupportBundleExpirationSettingName, supportBundleUtil.SupportBundleExpirationDefaultStr)                // Unit is minute.
 	SupportBundleNodeCollectionTimeout     = NewSetting(SupportBundleNodeCollectionTimeoutName, supportBundleUtil.SupportBundleNodeCollectionTimeoutDefaultStr) // Unit is minute.
+	SupportBundleFileName                  = NewSetting(SupportBundleFileNameSettingName, "")                                                                   // Custom file name for support bundle files, must follow RFC 1123 Label Names
 	DefaultStorageClass                    = NewSetting(DefaultStorageClassSettingName, "longhorn")
 	HTTPProxy                              = NewSetting(HTTPProxySettingName, "{}")
 	VMForceResetPolicySet                  = NewSetting(VMForceResetPolicySettingName, InitVMForceResetPolicy())
@@ -96,6 +97,7 @@ const (
 	AutoRotateRKE2CertsSettingName                    = "auto-rotate-rke2-certs"
 	KubeconfigDefaultTokenTTLMinutesSettingName       = "kubeconfig-default-token-ttl-minutes"
 	SupportBundleNodeCollectionTimeoutName            = "support-bundle-node-collection-timeout"
+	SupportBundleFileNameSettingName                  = "support-bundle-file-name"
 	UpgradeConfigSettingName                          = "upgrade-config"
 	LonghornV2DataEngineSettingName                   = "longhorn-v2-data-engine-enabled"
 	LogLevelSettingName                               = "log-level"

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -96,6 +97,7 @@ var validateSettingFuncs = map[string]validateSettingFunc{
 	settings.SupportBundleTimeoutSettingName:                   validateSupportBundleTimeout,
 	settings.SupportBundleExpirationSettingName:                validateSupportBundleExpiration,
 	settings.SupportBundleNodeCollectionTimeoutName:            validateSupportBundleNodeCollectionTimeout,
+	settings.SupportBundleFileNameSettingName:                  validateSupportBundleFileName,
 	settings.OvercommitConfigSettingName:                       validateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateSSLCertificates,
@@ -117,6 +119,7 @@ var validateSettingUpdateFuncs = map[string]validateSettingUpdateFunc{
 	settings.SupportBundleTimeoutSettingName:                   validateUpdateSupportBundleTimeout,
 	settings.SupportBundleExpirationSettingName:                validateUpdateSupportBundle,
 	settings.SupportBundleNodeCollectionTimeoutName:            validateUpdateSupportBundleNodeCollectionTimeout,
+	settings.SupportBundleFileNameSettingName:                  validateUpdateSupportBundleFileName,
 	settings.OvercommitConfigSettingName:                       validateUpdateOvercommitConfig,
 	settings.VipPoolsConfigSettingName:                         validateUpdateVipPoolsConfig,
 	settings.SSLCertificatesSettingName:                        validateUpdateSSLCertificates,
@@ -832,6 +835,36 @@ func validateSupportBundleNodeCollectionTimeout(setting *v1beta1.Setting) error 
 
 func validateUpdateSupportBundle(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateSupportBundleExpiration(newSetting)
+}
+
+// validateSupportBundleFileNameHelper validates that the file name follows RFC 1123 Label Names
+// using Kubernetes built-in validation.
+func validateSupportBundleFileNameHelper(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	errs := validation.IsDNS1123Label(value)
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid file name: %s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+func validateSupportBundleFileName(setting *v1beta1.Setting) error {
+	if err := validateSupportBundleFileNameHelper(setting.Default); err != nil {
+		return werror.NewInvalidError(err.Error(), settings.KeywordDefault)
+	}
+
+	if err := validateSupportBundleFileNameHelper(setting.Value); err != nil {
+		return werror.NewInvalidError(err.Error(), settings.KeywordValue)
+	}
+	return nil
+}
+
+func validateUpdateSupportBundleFileName(_ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	return validateSupportBundleFileName(newSetting)
 }
 
 func validateSSLCertificatesHelper(field, value string) error {

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -309,6 +309,98 @@ func Test_validateSupportBundleNodeCollectionTimeout(t *testing.T) {
 	}
 }
 
+func Test_validateSupportBundleFileName(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *v1beta1.Setting
+		expectedErr bool
+	}{
+		{
+			name: "empty default",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Default:    "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid name with hyphens",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "my-cluster-01",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid name starting with hyphen",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "-invalid",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid name ending with hyphen",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "invalid-",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid name with uppercase letters",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "Invalid",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid name with underscore",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "test_name",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid name with special characters",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "test@name",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid name exceeding max length (64 chars)",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "a1234567890123456789012345678901234567890123456789012345678901234",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid name with spaces",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.SupportBundleFileNameSettingName},
+				Value:      "my cluster",
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSupportBundleFileName(tt.args)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
 func Test_validateSSLProtocols(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
#### Problem:

Since the customer wants a global name for support bundle, we can provide a support bundle file name setting. It's not directly related to the cluster name. 

NOTE: Although the customer can rename the file after downloading, the custom still wants a pre-defined name for that.

#### Solution:
Provide a support bundle file name setting.

- If it's empty, format will be `supportbundle_c2eb6186-525f-411e-91ee-e88ed090d66d_2025-09-17T03-39-17Z`.
- If not, format will be `supportbundle_{support-bundle-file-name}_2025-09-17T03-39-17Z`.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9257

#### Test plan:

After configuring the setting, remember to generate support bundle.

case 1: empty support bundle file name
case 2: non-empty support bundle file name
case 3: the format only supports [RFC 1123 Label Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names), you can try with other invalid strings

#### Additional documentation or context
