### PR TITLE
feat: Support vTPM / EFI state cloning

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -14,12 +16,14 @@ import (
 	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	"github.com/pkg/errors"
 	"github.com/rancher/apiserver/pkg/apierror"
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	wranglername "github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 	"github.com/rancher/wrangler/v3/pkg/slice"
 	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/kubernetes"
@@ -37,6 +42,7 @@ import (
 	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kubevirtmultus "kubevirt.io/kubevirt/pkg/network/multus"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	kubevirtutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 
 	apiutil "github.com/harvester/harvester/pkg/api/util"
@@ -57,9 +63,12 @@ import (
 )
 
 const (
-	vmResource    = "virtualmachines"
-	vmiResource   = "virtualmachineinstances"
-	sshAnnotation = "harvesterhci.io/sshNames"
+	vmResource               = "virtualmachines"
+	vmiResource              = "virtualmachineinstances"
+	sshAnnotation            = "harvesterhci.io/sshNames"
+	efiRenameJobImage        = "busybox:1.37.0"
+	efiRenameJobTTL          = 300
+	efiRenameJobBackoffLimit = 3
 )
 
 var (
@@ -87,6 +96,7 @@ type vmActionHandler struct {
 	vmTemplateVersionClient ctlharvesterv1.VirtualMachineTemplateVersionClient
 	vmiClient               ctlkubevirtv1.VirtualMachineInstanceClient
 	vmimClient              ctlkubevirtv1.VirtualMachineInstanceMigrationClient
+	jobClient               ctlbatchv1.JobClient
 
 	backupCache       ctlharvesterv1.VirtualMachineBackupCache
 	kubevirtCache     ctlkubevirtv1.KubeVirtCache
@@ -102,6 +112,7 @@ type vmActionHandler struct {
 	vmImageCache      ctlharvesterv1.VirtualMachineImageCache
 	vmiCache          ctlkubevirtv1.VirtualMachineInstanceCache
 	vmimCache         ctlkubevirtv1.VirtualMachineInstanceMigrationCache
+	jobCache          ctlbatchv1.JobCache
 }
 
 func (h *vmActionHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
@@ -1229,6 +1240,8 @@ func (h *vmActionHandler) findHotunpluggableNics(rw http.ResponseWriter, namespa
 }
 
 // cloneVM creates a VM which uses volume cloning from the source VM.
+// AnnotationBackendStorageCloneStatus signals the clone progress to the UI.
+// "cloning" = in progress, "cloned" = done.
 func (h *vmActionHandler) cloneVM(name string, namespace string, input CloneInput) error {
 	vm, err := h.vmCache.Get(namespace, name)
 	if err != nil {
@@ -1246,12 +1259,23 @@ func (h *vmActionHandler) cloneVM(name string, namespace string, input CloneInpu
 	}
 	newPVCsString, err := util.MarshalVolumeClaimTemplates(newEntries)
 	if err != nil {
-		return fmt.Errorf("cannot marshal value %+v, err: %w", newEntries, err)
+		return fmt.Errorf("cannot marshal value %+v, err: %w", newPVCs, err)
 	}
 
-	newVM.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = newPVCsString
+	desiredRunStrategy := newVM.Spec.RunStrategy
+	if backendstorage.IsBackendStorageNeeded(newVM) {
+		always := kubevirtv1.RunStrategyAlways
+		newVM.Spec.RunStrategy = &always
+		newVM.Annotations[util.AnnotationBackendStorageCloneStatus] = "cloning"
+	}
+
+	newVM.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = string(newPVCsString)
 	if newVM, err = h.vmClient.Create(newVM); err != nil {
 		return fmt.Errorf("cannot create new VM %s/%s, err: %w", newVM.Namespace, newVM.Name, err)
+	}
+
+	if backendstorage.IsBackendStorageNeeded(newVM) {
+		go h.cloneBackendStorage(vm, newVM, desiredRunStrategy)
 	}
 
 	for oldSecretName, newSecretName := range secretNameMap {
@@ -1345,6 +1369,187 @@ func (h *vmActionHandler) cloneVolumes(newVM *kubevirtv1.VirtualMachine) ([]core
 		newVM.Spec.Template.Spec.Volumes[i] = volume
 	}
 	return newPVCs, secretNameMap, nil
+}
+
+// cloneBackendStorage clones the backend storage (EFI/TPM) of the source VM to the target VM.
+//
+// KubeVirt only creates the backend storage PVC when a VM starts up. The flow is:
+//  1. Force target VM to RunStrategyAlways so KubeVirt creates its backend storage PVC
+//  2. Wait for the target PVC to be created, then copy EFI content from source to target
+//  3. Restore the target VM to the desired RunStrategy
+//
+// This ensures EFI and TPM are independent per-VM (not shared).
+//
+// AnnotationBackendStorageCloneStatus signals the clone progress to the UI.
+// "cloning" = in progress, "cloned" = done.
+func (h *vmActionHandler) cloneBackendStorage(sourceVM, targetVM *kubevirtv1.VirtualMachine, desiredRunStrategy *kubevirtv1.VirtualMachineRunStrategy) {
+	if err := h.copyEFIPersistent(sourceVM, targetVM); err != nil {
+		logrus.Errorf("clone backend storage failed: %v", err)
+		return
+	}
+
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latestVM, err := h.vmClient.Get(targetVM.Namespace, targetVM.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		vmCopy := latestVM.DeepCopy()
+		vmCopy.Spec.RunStrategy = desiredRunStrategy
+		vmCopy.Annotations[util.AnnotationBackendStorageCloneStatus] = "cloned"
+		_, err = h.vmClient.Update(vmCopy)
+		return err
+	}); err != nil {
+		logrus.Errorf("cannot update run strategy for new VM %s/%s, err: %v", targetVM.Namespace, targetVM.Name, err)
+	}
+}
+
+func (h *vmActionHandler) copyEFIPersistent(sourceVM, targetVM *kubevirtv1.VirtualMachine) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sourcePVC, err := h.waitForPVCBound(ctx, sourceVM)
+	if err != nil {
+		return fmt.Errorf("cannot wait for source persistent state PVC for VM %s/%s: %w", sourceVM.Namespace, sourceVM.Name, err)
+	}
+	targetPVC, err := h.waitForPVCBound(ctx, targetVM)
+	if err != nil {
+		return fmt.Errorf("cannot wait for target persistent state PVC for VM %s/%s: %w", targetVM.Namespace, targetVM.Name, err)
+	}
+
+	return h.copyEFIFile(ctx, sourceVM, targetVM, sourcePVC, targetPVC)
+}
+
+func (h *vmActionHandler) waitForPVCBound(ctx context.Context, vm *kubevirtv1.VirtualMachine) (*corev1.PersistentVolumeClaim, error) {
+	pvcs, err := h.pvcCache.List(vm.Namespace, labels.SelectorFromSet(map[string]string{
+		backendstorage.PVCPrefix: vm.Name,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("cannot list source persistent state PVC for VM %s/%s, err: %w", vm.Namespace, vm.Name, err)
+	}
+	if len(pvcs) == 0 {
+		return nil, nil
+	}
+	if len(pvcs) != 1 {
+		return nil, fmt.Errorf("expect 1 source persistent state PVC for VM %s/%s, got %d", vm.Namespace, vm.Name, len(pvcs))
+	}
+	pvc := pvcs[0]
+
+	return pvc, wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		pvc, err := h.pvcCache.Get(vm.Namespace, pvc.Name)
+		if err != nil {
+			return false, err
+		}
+		return pvc.Status.Phase == corev1.ClaimBound, nil
+	})
+}
+
+func (h *vmActionHandler) copyEFIFile(ctx context.Context, sourceVM, targetVM *kubevirtv1.VirtualMachine, sourcePVC, targetPVC *corev1.PersistentVolumeClaim) error {
+	srcFile := fmt.Sprintf("%s_VARS.fd", sourceVM.Name)
+	dstFile := fmt.Sprintf("%s_VARS.fd", targetVM.Name)
+	qemuUserID := strconv.Itoa(107)
+
+	logrus.Infof("Copying EFI file %s from PVC %s to %s in PVC %s", srcFile, sourcePVC.Name, dstFile, targetPVC.Name)
+
+	efiCopyScriptTemplate := `set -e
+src="/src/nvram/{{.Src}}"
+dst="/dst/nvram/{{.Dst}}"
+[ -f "$src" ] && cp "$src" "$dst"
+[ -f "$dst" ] && chown {{.UID}}:{{.UID}} "$dst"
+[ -f "$dst" ] && chmod 600 "$dst"`
+
+	script := strings.NewReplacer(
+		"{{.Src}}", srcFile,
+		"{{.Dst}}", dstFile,
+		"{{.UID}}", qemuUserID,
+	).Replace(efiCopyScriptTemplate)
+
+	copyJob := h.buildEFICopyJob(targetVM, sourcePVC, targetPVC, script)
+	job, err := h.jobClient.Create(copyJob)
+	if err != nil {
+		return fmt.Errorf("create job: %w", err)
+	}
+
+	return h.waitForJobComplete(ctx, job.Namespace, job.Name)
+}
+
+func (h *vmActionHandler) buildEFICopyJob(targetVM *kubevirtv1.VirtualMachine, sourcePVC, targetPVC *corev1.PersistentVolumeClaim, script string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.SimpleNameGenerator.GenerateName(fmt.Sprintf("efi-copy-%s-", targetVM.Name)),
+			Namespace: targetPVC.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: targetVM.APIVersion,
+				Kind:       targetVM.Kind,
+				Name:       targetVM.Name,
+				UID:        targetVM.UID,
+			}},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            ptr.To(int32(efiRenameJobBackoffLimit)),
+			TTLSecondsAfterFinished: ptr.To(int32(efiRenameJobTTL)),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  ptr.To(int64(0)),
+						RunAsGroup: ptr.To(int64(0)),
+					},
+					Containers: []corev1.Container{{
+						Name:    "efi-copy",
+						Image:   efiRenameJobImage,
+						Command: []string{"sh", "-c", script},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "src-pvc",
+								MountPath: "/src",
+							},
+							{
+								Name:      "dst-pvc",
+								MountPath: "/dst",
+							},
+						},
+					}},
+					Volumes: []corev1.Volume{
+						{
+							Name: "src-pvc",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: sourcePVC.Name,
+								},
+							},
+						},
+						{
+							Name: "dst-pvc",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: targetPVC.Name,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (h *vmActionHandler) waitForJobComplete(ctx context.Context, namespace, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		job, err := h.jobClient.Get(namespace, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if job.Status.Succeeded > 0 {
+			return true, nil
+		}
+
+		if job.Status.Failed > 0 && job.Spec.BackoffLimit != nil && job.Status.Failed >= *job.Spec.BackoffLimit {
+			return false, fmt.Errorf("job failed after %d attempts", job.Status.Failed)
+		}
+
+		return false, nil
+	})
 }
 
 func cloneSecretVolume(volume *kubevirtv1.Volume, secretNameMap map[string]string) {

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -14,6 +15,7 @@ import (
 	longhorntypes "github.com/longhorn/longhorn-manager/types"
 	"github.com/pkg/errors"
 	"github.com/rancher/apiserver/pkg/apierror"
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	wranglername "github.com/rancher/wrangler/v3/pkg/name"
@@ -37,6 +39,8 @@ import (
 	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kubevirtmultus "kubevirt.io/kubevirt/pkg/network/multus"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+	"kubevirt.io/kubevirt/pkg/tpm"
 	kubevirtutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 
 	apiutil "github.com/harvester/harvester/pkg/api/util"
@@ -77,6 +81,7 @@ type vmActionHandler struct {
 	vmio                      vmicommon.VMIOperator
 
 	backupClient            ctlharvesterv1.VirtualMachineBackupClient
+	jobClient               ctlbatchv1.JobClient
 	pvcClient               ctlcorev1.PersistentVolumeClaimClient
 	resourceQuotaClient     ctlharvesterv1.ResourceQuotaClient
 	restoreClient           ctlharvesterv1.VirtualMachineRestoreClient
@@ -89,6 +94,7 @@ type vmActionHandler struct {
 	vmimClient              ctlkubevirtv1.VirtualMachineInstanceMigrationClient
 
 	backupCache       ctlharvesterv1.VirtualMachineBackupCache
+	jobCache          ctlbatchv1.JobCache
 	kubevirtCache     ctlkubevirtv1.KubeVirtCache
 	nadCache          ctlcniv1.NetworkAttachmentDefinitionCache
 	nodeCache         ctlcorev1.NodeCache
@@ -1244,6 +1250,8 @@ func (h *vmActionHandler) findHotunpluggableNics(rw http.ResponseWriter, namespa
 }
 
 // cloneVM creates a VM which uses volume cloning from the source VM.
+// AnnotationBSCloneStatus signals the clone progress to the UI.
+// "cloning" = in progress, "cloned" = done.
 func (h *vmActionHandler) cloneVM(name string, namespace string, input CloneInput) error {
 	vm, err := h.vmCache.Get(namespace, name)
 	if err != nil {
@@ -1262,6 +1270,12 @@ func (h *vmActionHandler) cloneVM(name string, namespace string, input CloneInpu
 	newPVCsString, err := util.MarshalVolumeClaimTemplates(newEntries)
 	if err != nil {
 		return fmt.Errorf("cannot marshal value %+v, err: %w", newEntries, err)
+	}
+
+	if backendstorage.IsBackendStorageNeeded(newVM) {
+		if err := h.prepareBackendStorageClone(newVM, vm); err != nil {
+			return fmt.Errorf("prepare backend storage clone error for new vm %s/%s, err %w", newVM.Namespace, newVM.Name, err)
+		}
 	}
 
 	newVM.ObjectMeta.Annotations[util.AnnotationVolumeClaimTemplates] = newPVCsString
@@ -1367,6 +1381,75 @@ func cloneSecretVolume(volume *kubevirtv1.Volume, secretNameMap map[string]strin
 		secretNameMap[volume.Secret.SecretName] = names.SimpleNameGenerator.GenerateName("clone-")
 	}
 	volume.Secret.SecretName = secretNameMap[volume.Secret.SecretName]
+}
+
+func (h *vmActionHandler) prepareBackendStorageClone(newVM, sourceVM *kubevirtv1.VirtualMachine) error {
+	runStrategy, err := newVM.RunStrategy()
+	if err != nil {
+		return err
+	}
+
+	// Backend storage PVCs are KubeVirt-managed and not tracked in
+	// vm.Spec.Template.Spec.Volumes. If the source VM has no current backend
+	// storage PVC yet, there is no state to clone and we should fall back to a
+	// normal VM clone.
+	sourcePVCs, err := h.pvcCache.List(sourceVM.Namespace, labels.SelectorFromSet(labels.Set{
+		backendstorage.PVCPrefix: sourceVM.Name,
+	}))
+	if err != nil {
+		return fmt.Errorf("failed to list backend storage PVCs for source VM %s/%s: %w", sourceVM.Namespace, sourceVM.Name, err)
+	}
+
+	switch len(sourcePVCs) {
+	case 0:
+		return nil
+	case 1:
+		// continue the clone process.
+	default:
+		return fmt.Errorf("expected exactly 1 backend storage PVC for source VM %s/%s (label %s=%s), got %d", sourceVM.Namespace, sourceVM.Name, backendstorage.PVCPrefix, sourceVM.Name, len(sourcePVCs))
+	}
+
+	newVM.Annotations[util.AnnotationBSCloneRunStrategy] = string(runStrategy)
+	newVM.Annotations[util.AnnotationBSCloneSourceVM] = sourceVM.Name
+	if cloneAction := h.determineCloneAction(newVM); cloneAction != "" {
+		newVM.Annotations[util.AnnotationBSCloneActions] = cloneAction
+	}
+	newVM.Annotations[util.AnnotationBSCloneStartTime] = time.Now().Format(time.RFC3339)
+
+	halted := kubevirtv1.RunStrategyHalted
+	newVM.Spec.RunStrategy = &halted
+	newVM.Annotations[util.AnnotationBSCloneStatus] = util.CloneInProgress
+	return nil
+}
+
+// determineCloneAction determines what post-clone action is needed based on the
+// clone VM's desired backend storage configuration (EFI/TPM).
+// The backend storage PVC is always cloned entirely from the source, but the clone VM
+// spec may differ (e.g., user disables EFI or TPM in the clone), requiring cleanup.
+//
+// [Cases]
+// Clone both: needs to rename EFI NVRAM file from source VM.
+// Clone TPM only: needs to delete EFI files from cloned PVC.
+// Clone EFI only: needs to delete TPM state from cloned PVC.
+// Clone CBT only (or no EFI/TPM): no post-clone Job is needed.
+func (h *vmActionHandler) determineCloneAction(cloneVM *kubevirtv1.VirtualMachine) string {
+	if cloneVM == nil || cloneVM.Spec.Template == nil {
+		return ""
+	}
+
+	cloneHasEFI := backendstorage.HasPersistentEFI(&cloneVM.Spec.Template.Spec)
+	cloneHasTPM := tpm.HasPersistentDevice(&cloneVM.Spec.Template.Spec)
+
+	switch {
+	case cloneHasEFI && cloneHasTPM:
+		return util.CloneActionRenameEFI
+	case cloneHasEFI:
+		return util.CloneActionDeleteTPMRenameEFI
+	case cloneHasTPM:
+		return util.CloneActionDeleteEFI
+	default:
+		return ""
+	}
 }
 
 func (h *vmActionHandler) dismissInsufficientResourceQuota(name, namespace string) error {

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -8,12 +8,16 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	kubevirtutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -1586,4 +1590,318 @@ func TestEjectCdRomVolumeAction(t *testing.T) {
 
 	_, err = pvcCache.Get(pvcNamespace, pvcName)
 	assert.True(t, apierrors.IsNotFound(err), "Should delete pvc")
+}
+
+func TestBuildEFICopyJob(t *testing.T) {
+	h := &vmActionHandler{}
+	targetVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "target-vm",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "persistent-state-for-source-vm-abc123",
+			Namespace: "default",
+		},
+	}
+	targetPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "persistent-state-for-target-vm-def456",
+			Namespace: "default",
+		},
+	}
+	script := "test-script"
+
+	job := h.buildEFICopyJob(targetVM, sourcePVC, targetPVC, script)
+
+	assert.Contains(t, job.Name, "efi-copy-target-vm-")
+	assert.Equal(t, "default", job.Namespace)
+	assert.Len(t, job.OwnerReferences, 1)
+	assert.Equal(t, "target-vm", job.OwnerReferences[0].Name)
+	assert.Equal(t, types.UID("test-uid"), job.OwnerReferences[0].UID)
+	assert.Equal(t, int32(efiRenameJobBackoffLimit), *job.Spec.BackoffLimit)
+	assert.Equal(t, int32(efiRenameJobTTL), *job.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, corev1.RestartPolicyNever, job.Spec.Template.Spec.RestartPolicy)
+	assert.Equal(t, int64(0), *job.Spec.Template.Spec.SecurityContext.RunAsUser)
+	assert.Equal(t, int64(0), *job.Spec.Template.Spec.SecurityContext.RunAsGroup)
+
+	assert.Len(t, job.Spec.Template.Spec.Containers, 1)
+	c := job.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, "efi-copy", c.Name)
+	assert.Equal(t, efiRenameJobImage, c.Image)
+	assert.Equal(t, []string{"sh", "-c", script}, c.Command)
+	assert.Len(t, c.VolumeMounts, 2)
+	assert.Equal(t, "src-pvc", c.VolumeMounts[0].Name)
+	assert.Equal(t, "/src", c.VolumeMounts[0].MountPath)
+	assert.Equal(t, "dst-pvc", c.VolumeMounts[1].Name)
+	assert.Equal(t, "/dst", c.VolumeMounts[1].MountPath)
+
+	assert.Len(t, job.Spec.Template.Spec.Volumes, 2)
+	assert.Equal(t, sourcePVC.Name, job.Spec.Template.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName)
+	assert.Equal(t, targetPVC.Name, job.Spec.Template.Spec.Volumes[1].VolumeSource.PersistentVolumeClaim.ClaimName)
+}
+
+func TestCopyEFIFile(t *testing.T) {
+	sourceVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-vm", Namespace: "default"},
+	}
+	targetVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "target-vm", Namespace: "default", UID: "uid-1"},
+	}
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "persistent-state-for-source-vm-xyz", Namespace: "default"},
+	}
+	targetPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "persistent-state-for-target-vm-xyz", Namespace: "default"},
+	}
+
+	t.Run("create job fails", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		clientset.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("mock create job error")
+		})
+
+		h := &vmActionHandler{
+			jobClient: fakeclients.JobClient(clientset.BatchV1().Jobs),
+		}
+
+		err := h.copyEFIFile(context.Background(), sourceVM, targetVM, sourcePVC, targetPVC)
+		assert.EqualError(t, err, "create job: mock create job error")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		clientset.PrependReactor("get", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			ga := action.(k8stesting.GetAction)
+			return true, &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ga.GetName(),
+					Namespace: ga.GetNamespace(),
+				},
+				Status: batchv1.JobStatus{Succeeded: 1},
+			}, nil
+		})
+
+		h := &vmActionHandler{
+			jobClient: fakeclients.JobClient(clientset.BatchV1().Jobs),
+		}
+
+		err := h.copyEFIFile(context.Background(), sourceVM, targetVM, sourcePVC, targetPVC)
+		assert.NoError(t, err)
+
+		jobList, err := clientset.BatchV1().Jobs("default").List(context.Background(), metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Len(t, jobList.Items, 1)
+
+		createdJob := jobList.Items[0]
+		assert.Contains(t, createdJob.Name, "efi-copy-target-vm-")
+		assert.Equal(t, []string{"sh", "-c", `set -e
+src="/src/nvram/source-vm_VARS.fd"
+dst="/dst/nvram/target-vm_VARS.fd"
+[ -f "$src" ] && cp "$src" "$dst"
+[ -f "$dst" ] && chown 107:107 "$dst"
+[ -f "$dst" ] && chmod 600 "$dst"`}, createdJob.Spec.Template.Spec.Containers[0].Command)
+		assert.Len(t, createdJob.Spec.Template.Spec.Volumes, 2)
+		assert.Equal(t, sourcePVC.Name, createdJob.Spec.Template.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName)
+		assert.Equal(t, targetPVC.Name, createdJob.Spec.Template.Spec.Volumes[1].VolumeSource.PersistentVolumeClaim.ClaimName)
+	})
+}
+
+func TestWaitForPVCBound(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-vm", Namespace: "default"},
+	}
+	boundPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "persistent-state-for-source-vm-abc",
+			Namespace: "default",
+			Labels:    map[string]string{backendstorage.PVCPrefix: "source-vm"},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+	secondPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "persistent-state-for-source-vm-def",
+			Namespace: "default",
+			Labels:    map[string]string{backendstorage.PVCPrefix: "source-vm"},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		objects          []runtime.Object
+		setupReactors    func(*fake.Clientset)
+		expectedPVCName  string
+		expectedErrorMsg string
+	}{
+		{
+			name:            "no pvc returns nil",
+			expectedPVCName: "",
+		},
+		{
+			name:             "list fails",
+			expectedErrorMsg: "cannot list source persistent state PVC for VM default/source-vm, err: mock list error",
+			setupReactors: func(clientset *fake.Clientset) {
+				clientset.PrependReactor("list", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("mock list error")
+				})
+			},
+		},
+		{
+			name:             "multiple pvcs fail",
+			objects:          []runtime.Object{boundPVC, secondPVC},
+			expectedErrorMsg: "expect 1 source persistent state PVC for VM default/source-vm, got 2",
+		},
+		{
+			name:            "bound pvc succeeds",
+			objects:         []runtime.Object{boundPVC},
+			expectedPVCName: boundPVC.Name,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tc.objects...)
+			if tc.setupReactors != nil {
+				tc.setupReactors(clientset)
+			}
+
+			h := &vmActionHandler{
+				pvcCache: fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+			}
+
+			pvc, err := h.waitForPVCBound(context.Background(), vm)
+			if tc.expectedErrorMsg != "" {
+				assert.EqualError(t, err, tc.expectedErrorMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+			if tc.expectedPVCName == "" {
+				assert.Nil(t, pvc)
+				return
+			}
+
+			assert.NotNil(t, pvc)
+			assert.Equal(t, tc.expectedPVCName, pvc.Name)
+		})
+	}
+}
+
+func TestCopyEFIPersistent(t *testing.T) {
+	sourceVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-vm", Namespace: "default"},
+	}
+	targetVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "target-vm", Namespace: "default", UID: "uid-1"},
+	}
+	sourcePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "persistent-state-for-source-vm-abc",
+			Namespace: "default",
+			Labels:    map[string]string{backendstorage.PVCPrefix: "source-vm"},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+	targetPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "persistent-state-for-target-vm-xyz",
+			Namespace: "default",
+			Labels:    map[string]string{backendstorage.PVCPrefix: "target-vm"},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+
+	tests := []struct {
+		name             string
+		objects          []runtime.Object
+		setupReactors    func(*fake.Clientset)
+		expectedErrorMsg string
+	}{
+		{
+			name:             "source pvc list fails",
+			objects:          nil,
+			expectedErrorMsg: "cannot wait for source persistent state PVC for VM default/source-vm: cannot list source persistent state PVC for VM default/source-vm, err: mock source list error",
+			setupReactors: func(clientset *fake.Clientset) {
+				clientset.PrependReactor("list", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					listAction := action.(k8stesting.ListAction)
+					if listAction.GetListRestrictions().Labels.String() == labels.SelectorFromSet(map[string]string{backendstorage.PVCPrefix: "source-vm"}).String() {
+						return true, nil, errors.New("mock source list error")
+					}
+					return false, nil, nil
+				})
+			},
+		},
+		{
+			name:             "target pvc list fails",
+			objects:          []runtime.Object{sourcePVC},
+			expectedErrorMsg: "cannot wait for target persistent state PVC for VM default/target-vm: cannot list source persistent state PVC for VM default/target-vm, err: mock target list error",
+			setupReactors: func(clientset *fake.Clientset) {
+				clientset.PrependReactor("list", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					listAction := action.(k8stesting.ListAction)
+					if listAction.GetListRestrictions().Labels.String() == labels.SelectorFromSet(map[string]string{backendstorage.PVCPrefix: "target-vm"}).String() {
+						return true, nil, errors.New("mock target list error")
+					}
+					return false, nil, nil
+				})
+			},
+		},
+		{
+			name:             "copy job creation fails",
+			objects:          []runtime.Object{sourcePVC, targetPVC},
+			expectedErrorMsg: "create job: mock create job error",
+			setupReactors: func(clientset *fake.Clientset) {
+				clientset.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("mock create job error")
+				})
+			},
+		},
+		{
+			name:    "success",
+			objects: []runtime.Object{sourcePVC, targetPVC},
+			setupReactors: func(clientset *fake.Clientset) {
+				clientset.PrependReactor("get", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					ga := action.(k8stesting.GetAction)
+					return true, &batchv1.Job{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      ga.GetName(),
+							Namespace: ga.GetNamespace(),
+						},
+						Status: batchv1.JobStatus{Succeeded: 1},
+					}, nil
+				})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tc.objects...)
+			if tc.setupReactors != nil {
+				tc.setupReactors(clientset)
+			}
+
+			h := &vmActionHandler{
+				pvcCache:  fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+				jobClient: fakeclients.JobClient(clientset.BatchV1().Jobs),
+			}
+
+			err := h.copyEFIPersistent(sourceVM, targetVM)
+			if tc.expectedErrorMsg != "" {
+				assert.EqualError(t, err, tc.expectedErrorMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			jobList, err := clientset.BatchV1().Jobs("default").List(context.Background(), metav1.ListOptions{})
+			assert.NoError(t, err)
+			assert.Len(t, jobList.Items, 1)
+			assert.Equal(t, sourcePVC.Name, jobList.Items[0].Spec.Template.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName)
+			assert.Equal(t, targetPVC.Name, jobList.Items[0].Spec.Template.Spec.Volumes[1].VolumeSource.PersistentVolumeClaim.ClaimName)
+		})
+	}
 }

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kubevirtutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 
@@ -1629,6 +1630,132 @@ func TestBuildVirtualMachineRestore(t *testing.T) {
 			assert.Equal(t, tt.input.BackupName, got.Spec.VirtualMachineBackupName)
 			assert.Equal(t, tt.input.KeepMacAddress, got.Spec.KeepMacAddress)
 			assert.Equal(t, tt.input.HaltAfterRestore, got.Spec.HaltAfterRestore)
+		})
+	}
+}
+
+func TestDetermineCloneAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		cloneVM  *kubevirtv1.VirtualMachine
+		expected string
+	}{
+		{
+			name: "clone has both EFI and TPM - should rename EFI",
+			cloneVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clone-with-efi-and-tpm",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Firmware: &kubevirtv1.Firmware{
+									Bootloader: &kubevirtv1.Bootloader{
+										EFI: &kubevirtv1.EFI{
+											Persistent: ptr.To(true),
+										},
+									},
+								},
+								Devices: kubevirtv1.Devices{
+									TPM: &kubevirtv1.TPMDevice{
+										Persistent: ptr.To(true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: util.CloneActionRenameEFI,
+		},
+		{
+			name: "clone has EFI only (no TPM) - should delete TPM from cloned PVC",
+			cloneVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clone-with-efi-only",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Firmware: &kubevirtv1.Firmware{
+									Bootloader: &kubevirtv1.Bootloader{
+										EFI: &kubevirtv1.EFI{
+											Persistent: ptr.To(true),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: util.CloneActionDeleteTPMRenameEFI,
+		},
+		{
+			name: "clone has TPM only (no EFI) - should delete EFI from cloned PVC",
+			cloneVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clone-with-tpm-only",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Devices: kubevirtv1.Devices{
+									TPM: &kubevirtv1.TPMDevice{
+										Persistent: ptr.To(true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: util.CloneActionDeleteEFI,
+		},
+		{
+			name: "clone has neither EFI nor TPM - should not create post-clone job",
+			cloneVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clone-without-efi-and-tpm",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "clone has CBT only - should not create post-clone job",
+			cloneVM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clone-with-cbt-only",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{},
+				},
+				Status: kubevirtv1.VirtualMachineStatus{
+					ChangedBlockTracking: &kubevirtv1.ChangedBlockTrackingStatus{
+						State: kubevirtv1.ChangedBlockTrackingEnabled,
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &vmActionHandler{}
+			got := handler.determineCloneAction(tt.cloneVM)
+			assert.Equal(t, tt.expected, got, "case %q", tt.name)
 		})
 	}
 }

--- a/pkg/api/vm/schema.go
+++ b/pkg/api/vm/schema.go
@@ -62,6 +62,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 	storageClasses := scaled.StorageFactory.Storage().V1().StorageClass()
 	nads := scaled.CniFactory.K8s().V1().NetworkAttachmentDefinition()
 	resourceQuotas := scaled.Management.HarvesterFactory.Harvesterhci().V1beta1().ResourceQuota()
+	jobs := scaled.Management.BatchFactory.Batch().V1().Job()
 
 	vmiOperator, err := common.GetVMIOperator(vmImages, vmImages.Cache(), storageClasses.Cache(), http.Client{})
 	if err != nil {
@@ -98,6 +99,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		vmTemplateVersionClient: vmtv,
 		vmiClient:               vmis,
 		vmimClient:              vmims,
+		jobClient:               jobs,
 
 		backupCache:       backups.Cache(),
 		kubevirtCache:     kubevirtCache,
@@ -113,6 +115,7 @@ func RegisterSchema(scaled *config.Scaled, server *server.Server, options config
 		vmImageCache:      vmImages.Cache(),
 		vmiCache:          vmis.Cache(),
 		vmimCache:         vmims.Cache(),
+		jobCache:          jobs.Cache(),
 	})
 
 	vmformatter := vmformatter{

--- a/pkg/controller/master/virtualmachine/register.go
+++ b/pkg/controller/master/virtualmachine/register.go
@@ -21,8 +21,9 @@ const (
 	vmControllerCleanupTargetVolumeAnnotationControllerName      = "VMController.CleanupTargetVolumeAnnotation"
 	vmiControllerRemoveDeprecatedFinalizerControllerName         = "VMIController.RemoveDeprecatedFinalizer"
 	vmiControllerSetHaltIfOccurExceededQuotaControllerName       = "VMIController.StopVMIfExceededQuota"
+	vmControllerReconcileBSCloneControllerName                   = "VMController.ReconcileBackendStorageClone"
+	vmControllerCleanupPVCAndSnapshotFinalizerName               = "VMController.CleanupPVCAndSnapshot"
 
-	vmControllerCleanupPVCAndSnapshotFinalizerName = "VMController.CleanupPVCAndSnapshot"
 	// this finalizer is special one which was added by our controller, not wrangler.
 	// https://github.com/harvester/harvester/blob/78b0f20abb118b5d0fba564e18867b90a1d3c0ee/pkg/controller/master/virtualmachine/vm_controller.go#L97-L101
 	deprecatedHarvesterUnsetOwnerOfPVCsFinalizer = "harvesterhci.io/VMController.UnsetOwnerOfPVCs"
@@ -52,6 +53,8 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		snapshotClient   = management.SnapshotFactory.Snapshot().V1().VolumeSnapshot()
 		vmimCache        = management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache()
 		snapshotCache    = snapshotClient.Cache()
+		jobClient        = management.BatchFactory.Batch().V1().Job()
+		jobCache         = jobClient.Cache()
 		scClient         = management.StorageFactory.Storage().V1().StorageClass()
 		scCache          = scClient.Cache()
 		settingCache     = management.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()
@@ -59,8 +62,10 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	)
 
 	// registers the vm controller
-	var vmCtrl = &VMController{
+	vmCtrl := &VMController{
 		dataVolumeClient: dataVolumeClient,
+		jobClient:        jobClient,
+		jobCache:         jobCache,
 		podClient:        podClient,
 		pvcClient:        pvcClient,
 		pvcCache:         pvcCache,
@@ -76,27 +81,29 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 		snapshotCache:    snapshotCache,
 		scClient:         scClient,
 		scCache:          scCache,
+		clientset:        management.ClientSet,
 		settingCache:     settingCache,
 		recorder:         recorder,
 
 		vmrCalculator: resourcequota.NewCalculator(nsCache, podCache, rqCache, vmimCache, settingCache),
 	}
-	var virtualMachineClient = management.VirtFactory.Kubevirt().V1().VirtualMachine()
-	virtualMachineClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)
-	virtualMachineClient.OnChange(ctx, vmControllerStoreRunStrategyControllerName, vmCtrl.StoreRunStrategy)
-	virtualMachineClient.OnChange(ctx, vmControllerSyncLabelsToVmi, vmCtrl.SyncLabelsToVmi)
-	virtualMachineClient.OnChange(ctx, vmControllerSetHaltIfInsufficientResourceQuotaControllerName, vmCtrl.SetHaltIfInsufficientResourceQuota)
-	virtualMachineClient.OnChange(ctx, vmControllerRemoveDeprecatedFinalizerControllerName, vmCtrl.removeDeprecatedFinalizer)
-	virtualMachineClient.OnChange(ctx, vmControllerSetTargetVolumeStrategyControllerName, vmCtrl.SetTargetVolumeStrategy)
-	virtualMachineClient.OnChange(ctx, vmControllerCleanupTargetVolumeAnnotationControllerName, vmCtrl.CleanupTargetVolumeAnnotation)
-	virtualMachineClient.OnRemove(ctx, vmControllerCleanupPVCAndSnapshotFinalizerName, vmCtrl.cleanupPVCAndSnapshot)
+	vmClient.OnChange(ctx, vmControllerCreatePVCsFromAnnotationControllerName, vmCtrl.createPVCsFromAnnotation)
+	vmClient.OnChange(ctx, vmControllerStoreRunStrategyControllerName, vmCtrl.StoreRunStrategy)
+	vmClient.OnChange(ctx, vmControllerSyncLabelsToVmi, vmCtrl.SyncLabelsToVmi)
+	vmClient.OnChange(ctx, vmControllerSetHaltIfInsufficientResourceQuotaControllerName, vmCtrl.SetHaltIfInsufficientResourceQuota)
+	vmClient.OnChange(ctx, vmControllerRemoveDeprecatedFinalizerControllerName, vmCtrl.removeDeprecatedFinalizer)
+	vmClient.OnChange(ctx, vmControllerSetTargetVolumeStrategyControllerName, vmCtrl.SetTargetVolumeStrategy)
+	vmClient.OnChange(ctx, vmControllerCleanupTargetVolumeAnnotationControllerName, vmCtrl.CleanupTargetVolumeAnnotation)
+	vmClient.OnRemove(ctx, vmControllerCleanupPVCAndSnapshotFinalizerName, vmCtrl.cleanupPVCAndSnapshot)
+
+	vmClient.OnChange(ctx, vmControllerReconcileBSCloneControllerName, vmCtrl.ReconcileBackendStorageClone)
+	vmClient.OnRemove(ctx, vmControllerReconcileBSCloneControllerName, vmCtrl.CleanUpBackendStorageClone)
 
 	// registers the vmi controller
-	var virtualMachineCache = virtualMachineClient.Cache()
-	var virtualMachineInstanceClient = management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
-	var vmiCtrl = &VMIController{
+	virtualMachineInstanceClient := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
+	vmiCtrl := &VMIController{
 		vmClient:            vmClient,
-		virtualMachineCache: virtualMachineCache,
+		virtualMachineCache: vmCache,
 		vmiClient:           virtualMachineInstanceClient,
 		nodeCache:           nodeCache,
 		pvcClient:           pvcClient,
@@ -107,7 +114,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	virtualMachineInstanceClient.OnChange(ctx, vmiControllerRemoveDeprecatedFinalizerControllerName, vmiCtrl.removeDeprecatedFinalizer)
 
 	// register the vm network controller upon the VMI changes
-	var vmNetworkCtl = &VMNetworkController{
+	vmNetworkCtl := &VMNetworkController{
 		vmClient:  vmClient,
 		vmCache:   vmCache,
 		vmiClient: virtualMachineInstanceClient,
@@ -115,7 +122,7 @@ func Register(ctx context.Context, management *config.Management, _ config.Optio
 	virtualMachineInstanceClient.OnChange(ctx, vmControllerSetDefaultManagementNetworkMac, vmNetworkCtl.SetDefaultNetworkMacAddress)
 	virtualMachineInstanceClient.OnRemove(ctx, vmControllerBackfillObservedNetworkMac, vmNetworkCtl.BackfillObservedNetworkMacAddress)
 
-	var vmiDeschedulerCtrl = &VMIDeschedulerController{
+	vmiDeschedulerCtrl := &VMIDeschedulerController{
 		vmClient: vmClient,
 		vmCache:  vmCache,
 	}

--- a/pkg/controller/master/virtualmachine/vm_controller.go
+++ b/pkg/controller/master/virtualmachine/vm_controller.go
@@ -3,21 +3,29 @@ package virtualmachine
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
+	wranglername "github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	kubevirt "kubevirt.io/api/core"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+	kubevirtutil "kubevirt.io/kubevirt/pkg/util"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlcdiv1 "github.com/harvester/harvester/pkg/generated/controllers/cdi.kubevirt.io/v1beta1"
@@ -27,8 +35,20 @@ import (
 	"github.com/harvester/harvester/pkg/image/cdi"
 	"github.com/harvester/harvester/pkg/indexeres"
 	"github.com/harvester/harvester/pkg/util"
+	utilHelm "github.com/harvester/harvester/pkg/util/helm"
 	rqutils "github.com/harvester/harvester/pkg/util/resourcequota"
 )
+
+const (
+	backendStorageJobTTL            = 300
+	backendStorageJobBackoffLimit   = 3
+	backendStorageJobLabelKey       = "harvesterhci.io/efi-rename-vm"
+	maxBackendStorageCloneRetries   = 5
+	backendStorageCloneTimeout      = 30 * time.Minute
+	backendStorageCloneRequeueDelay = 5 * time.Second
+)
+
+var fetchImageFromHelmValues = utilHelm.FetchImageFromHelmValues
 
 // A list of labels that are always automatically synchronized with the
 // VMI in addition to the instance labels.
@@ -36,6 +56,8 @@ var syncLabelsToVmi = []string{util.LabelMaintainModeStrategy}
 
 type VMController struct {
 	dataVolumeClient ctlcdiv1.DataVolumeClient
+	jobClient        ctlbatchv1.JobClient
+	jobCache         ctlbatchv1.JobCache
 	podClient        v1.PodClient
 	pvcClient        v1.PersistentVolumeClaimClient
 	pvcCache         v1.PersistentVolumeClaimCache
@@ -51,6 +73,7 @@ type VMController struct {
 	scCache          ctlstoragev1.StorageClassCache
 	snapshotClient   ctlsnapshotv1.VolumeSnapshotClient
 	snapshotCache    ctlsnapshotv1.VolumeSnapshotCache
+	clientset        kubernetes.Interface
 	settingCache     ctlharvesterv1.SettingCache
 	recorder         record.EventRecorder
 
@@ -343,7 +366,7 @@ func (h *VMController) SetHaltIfInsufficientResourceQuota(_ string, vm *kubevirt
 			// Since VMI would wait for Pod to run status,
 			// cause the VM is still in Starting,
 			// that recalculates the VM resource quota each time until the VM is non-Starting.
-			h.vmController.EnqueueAfter(vm.Namespace, vm.Name, 5*time.Second)
+			h.requeueVM(vm)
 			return vm, nil
 		}
 		return vm, h.cleanUpInsufficientResourceAnnotation(vm)
@@ -578,7 +601,7 @@ func (h *VMController) clearMigrationWait(vm *kubevirtv1.VirtualMachine) (*kubev
 		return vm, nil
 	}
 	// Not yet migrating, keep waiting
-	h.vmController.EnqueueAfter(vm.Namespace, vm.Name, 5*time.Second)
+	h.requeueVM(vm)
 	return vm, nil
 }
 
@@ -718,10 +741,676 @@ func (h *VMController) getPVCStorageClass(pvc *corev1.PersistentVolumeClaim) (*s
 				return &sc, nil
 			}
 		}
+		return nil, fmt.Errorf("failed to find default StorageClass for PVC %s/%s", pvc.Namespace, pvc.Name)
 	}
 	sc, err := h.scCache.Get(*pvc.Spec.StorageClassName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get StorageClass %s: %w", *pvc.Spec.StorageClassName, err)
 	}
 	return sc, nil
+}
+
+// isWaitForFirstConsumerPVC checks if the PVC uses WaitForFirstConsumer binding mode
+func (h *VMController) isWaitForFirstConsumerPVC(pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	sc, err := h.getPVCStorageClass(pvc)
+	if err != nil {
+		return false, err
+	}
+	if sc.VolumeBindingMode == nil {
+		// Default is Immediate if not specified
+		return false, nil
+	}
+	return *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer, nil
+}
+
+// CleanUpBackendStorageClone actively deletes backend storage jobs when a VM is being removed.
+func (h *VMController) CleanUpBackendStorageClone(_ string, vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+	if vm == nil {
+		return vm, nil
+	}
+
+	// Only clean up if the VM has a clone in progress
+	if vm.Annotations[util.AnnotationBSCloneStatus] != util.CloneInProgress {
+		return vm, nil
+	}
+
+	if err := h.deleteBackendStorageCloneJobs(vm); err != nil {
+		logrus.Warn(err.Error())
+		return vm, err
+	}
+
+	logrus.Infof("Deleted backend storage jobs for VM %s/%s as VM is being removed", vm.Namespace, vm.Name)
+	return vm, nil
+}
+
+// ReconcileBackendStorageClone drives the backend storage (EFI/TPM) clone as an
+// idempotent state machine. Each reconcile advances one step:
+//
+//  1. Find or create the cloned PVC (via DataSource from the source VM's backend storage PVC, clone EFI/TPM content.)
+//  2. Wait for the cloned PVC to become Bound
+//  3. Create the EFI rename Job (rename NVRAM file from source VM name to target VM name)
+//  4. Wait for the Job to succeed
+//  5. Mark clone complete: set annotation to "cloned" and restore the desired RunStrategy
+//
+// Clone operations built-in protections:
+//   - Timeout: 30 minutes from start
+//   - Retry limit: 5 job failures before giving up
+//   - Cleanup: VM deletion automatically cleans up PVCs, jobs, and secrets via OwnerReferences
+//   - OnRemove: CleanUpBackendStorageClone actively deletes jobs for faster cleanup
+func (h *VMController) ReconcileBackendStorageClone(_ string, vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+	if !needsBackendStorageCloneReconcile(vm) {
+		return vm, nil
+	}
+
+	if vm.Annotations[util.AnnotationBSCloneStage] == util.CloneStagePreCompleted {
+		return h.finalizeBackendStorageClone(vm)
+	}
+
+	expired, err := isBackendStorageCloneExpired(vm)
+	if err != nil {
+		return nil, err
+	}
+	if expired {
+		return h.failBackendStorageClone(vm, fmt.Sprintf("Clone operation exceeded timeout of %v", backendStorageCloneTimeout))
+	}
+
+	// Check the clone action annotation to determine what post-clone processing is needed
+	cloneAction := vm.Annotations[util.AnnotationBSCloneActions]
+	if cloneAction == "" {
+		return h.completeBackendStorageClone(vm)
+	}
+
+	sourceVMName := vm.Annotations[util.AnnotationBSCloneSourceVM]
+	clonedPVC, ready, err := h.awaitClonedBackendStoragePVC(vm, sourceVMName)
+	if err != nil || !ready {
+		return vm, err
+	}
+
+	// clonePVC == nil in this condition represent skip clone.
+	if clonedPVC == nil {
+		return h.failBackendStorageClone(vm, fmt.Sprintf("Source VM %s has no backend storage PVC", sourceVMName))
+	}
+
+	job, waitForDeletion, err := h.reconcileBackendStorageJob(vm, sourceVMName, clonedPVC, cloneAction)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile backend storage job for VM %s/%s: %w", vm.Namespace, vm.Name, err)
+	}
+	if waitForDeletion {
+		h.requeueVM(vm)
+		return vm, nil
+	}
+
+	finish, failed := getBackendStorageJobStatus(job)
+	if !finish {
+		h.requeueVM(vm)
+		return vm, nil
+	}
+	if failed {
+		return h.handleBackendStorageCloneJobFailure(vm, job)
+	}
+	return h.handleBackendStorageCloneJobSuccess(vm, job)
+}
+
+func needsBackendStorageCloneReconcile(vm *kubevirtv1.VirtualMachine) bool {
+	if vm == nil || vm.DeletionTimestamp != nil || vm.Spec.Template == nil {
+		return false
+	}
+	if vm.Annotations[util.AnnotationBSCloneStatus] != util.CloneInProgress {
+		return false
+	}
+	if vm.Annotations[util.AnnotationBSCloneSourceVM] == "" {
+		return false
+	}
+	if vm.Annotations[util.AnnotationBSCloneStartTime] == "" {
+		return false
+	}
+	return true
+}
+
+func isBackendStorageCloneExpired(vm *kubevirtv1.VirtualMachine) (bool, error) {
+	startTime, err := time.Parse(time.RFC3339, vm.Annotations[util.AnnotationBSCloneStartTime])
+	if err != nil {
+		return false, fmt.Errorf("failed to parse clone start time for VM %s/%s: %w", vm.Namespace, vm.Name, err)
+	}
+	return time.Since(startTime) > backendStorageCloneTimeout, nil
+}
+
+func (h *VMController) awaitClonedBackendStoragePVC(vm *kubevirtv1.VirtualMachine, sourceVMName string) (*corev1.PersistentVolumeClaim, bool, error) {
+	clonedPVC, skipClone, err := h.reconcileClonedBackendStoragePVC(vm, sourceVMName)
+	if err != nil {
+		return nil, false, fmt.Errorf("reconcile cloned backend storage PVC for VM %s/%s: %w", vm.Namespace, vm.Name, err)
+	}
+	if skipClone {
+		return nil, true, nil
+	}
+	if clonedPVC == nil {
+		h.recorder.Eventf(vm, corev1.EventTypeWarning, "ClonePVCNotFound",
+			"Source VM %s has no backend storage PVC, will retry", sourceVMName)
+		h.requeueVM(vm)
+		return nil, false, nil
+	}
+
+	isWaitForFirstConsumer, err := h.isWaitForFirstConsumerPVC(clonedPVC)
+	if err != nil {
+		return nil, false, fmt.Errorf("check storage class binding mode for PVC %s/%s: %w", clonedPVC.Namespace, clonedPVC.Name, err)
+	}
+
+	if clonedPVC.Status.Phase != corev1.ClaimBound {
+		if clonedPVC.Status.Phase == corev1.ClaimPending {
+			if isWaitForFirstConsumer {
+				logrus.Infof("PVC %s/%s uses WaitForFirstConsumer binding mode, proceeding to create Job", clonedPVC.Namespace, clonedPVC.Name)
+				return clonedPVC, true, nil
+			}
+			// For Immediate binding mode, wait for PVC to be bound
+			h.recorder.Eventf(vm, corev1.EventTypeWarning, "ClonePVCPending",
+				"Cloned backend storage PVC %s is pending, waiting for it to be bound", clonedPVC.Name)
+		}
+		h.requeueVM(vm)
+		return nil, false, nil
+	}
+	return clonedPVC, true, nil
+}
+
+func (h *VMController) handleBackendStorageCloneJobFailure(vm *kubevirtv1.VirtualMachine, job *batchv1.Job) (*kubevirtv1.VirtualMachine, error) {
+	retries := 0
+	if retriesStr, ok := vm.Annotations[util.AnnotationBSCloneRetries]; ok {
+		if r, err := strconv.Atoi(retriesStr); err == nil {
+			retries = r
+		}
+	}
+	if retries >= maxBackendStorageCloneRetries {
+		return h.failBackendStorageClone(vm, fmt.Sprintf("Clone job failed after %d retries", retries))
+	}
+
+	logrus.Warnf("Backend storage job %s/%s failed, deleting to retry (attempt %d/%d)", job.Namespace, job.Name, retries+1, maxBackendStorageCloneRetries)
+	if err := h.jobClient.Delete(job.Namespace, job.Name, foregroundDeleteOptions()); err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("delete failed backend storage job %s/%s: %w", job.Namespace, job.Name, err)
+	}
+
+	vmCopy := vm.DeepCopy()
+	vmCopy.Annotations[util.AnnotationBSCloneRetries] = strconv.Itoa(retries + 1)
+	if _, err := h.vmClient.Update(vmCopy); err != nil {
+		return nil, fmt.Errorf("update retry count for VM %s/%s: %w", vm.Namespace, vm.Name, err)
+	}
+
+	h.requeueVM(vm)
+	return vm, nil
+}
+
+func (h *VMController) handleBackendStorageCloneJobSuccess(vm *kubevirtv1.VirtualMachine, job *batchv1.Job) (*kubevirtv1.VirtualMachine, error) {
+	vm, err := h.markBackendStorageClonePreCompleted(vm)
+	if err != nil {
+		return nil, fmt.Errorf("mark backend storage clone pre-completed for VM %s/%s: %w", vm.Namespace, vm.Name, err)
+	}
+
+	logrus.Infof("Backend storage job %s/%s succeeded, deleting job", job.Namespace, job.Name)
+	if err := h.jobClient.Delete(job.Namespace, job.Name, foregroundDeleteOptions()); err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("delete succeeded backend storage job %s/%s: %w", job.Namespace, job.Name, err)
+	}
+
+	h.requeueVM(vm)
+	return vm, nil
+}
+
+func (h *VMController) requeueVM(vm *kubevirtv1.VirtualMachine) {
+	h.vmController.EnqueueAfter(vm.Namespace, vm.Name, backendStorageCloneRequeueDelay)
+}
+
+func (h *VMController) reconcileClonedBackendStoragePVC(vm *kubevirtv1.VirtualMachine, sourceVMName string) (*corev1.PersistentVolumeClaim, bool, error) {
+	pvc, err := h.getCurrentClonedBackendStoragePVC(vm)
+	if err != nil {
+		return nil, false, err
+	}
+	if pvc != nil {
+		return pvc, false, nil
+	}
+
+	sourcePVC, skipClone, err := h.findSourceBackendStoragePVC(vm.Namespace, sourceVMName)
+	if err != nil || skipClone {
+		return nil, skipClone, err
+	}
+
+	clonedPVC := buildClonedBackendStoragePVC(vm, sourcePVC)
+
+	existingPVC, err := h.pvcClient.Create(clonedPVC)
+	if err == nil {
+		return existingPVC, false, nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return nil, false, err
+	}
+	// Defensive fallback in case a concurrent reconcile created the PVC first.
+	existingPVC, err = h.getCurrentClonedBackendStoragePVC(vm)
+	return existingPVC, false, err
+}
+
+func (h *VMController) reconcileBackendStorageJob(vm *kubevirtv1.VirtualMachine, sourceVMName string, clonedPVC *corev1.PersistentVolumeClaim, cloneAction string) (*batchv1.Job, bool, error) {
+	job, waitForDeletion, err := h.getCurrentBackendStorageJob(vm)
+	if err != nil {
+		return nil, false, err
+	}
+	if waitForDeletion {
+		return nil, true, nil
+	}
+	if job != nil {
+		return job, false, nil
+	}
+
+	job, err = h.buildBackendStorageJob(vm, sourceVMName, clonedPVC, cloneAction)
+	if err != nil {
+		return nil, false, err
+	}
+	created, err := h.jobClient.Create(job)
+	if err == nil {
+		return created, false, nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return nil, false, err
+	}
+	job, waitForDeletion, err = h.getCurrentBackendStorageJob(vm)
+	if err != nil {
+		return nil, false, err
+	}
+	if waitForDeletion {
+		return nil, true, nil
+	}
+	return job, false, nil
+}
+
+func (h *VMController) getCurrentClonedBackendStoragePVC(vm *kubevirtv1.VirtualMachine) (*corev1.PersistentVolumeClaim, error) {
+	pvcs, err := h.pvcClient.List(vm.Namespace, metav1.ListOptions{
+		LabelSelector: labels.Set{
+			backendstorage.PVCPrefix: vm.Name,
+			util.LabelGeneratedBy:    util.ValueGeneratedByHarvester,
+		}.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var matched []*corev1.PersistentVolumeClaim
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if isOwnedByVM(vm, pvc.OwnerReferences) {
+			matched = append(matched, pvc)
+		}
+	}
+
+	switch len(matched) {
+	case 0:
+		return nil, nil
+	case 1:
+		return matched[0], nil
+	default:
+		return nil, fmt.Errorf("expect at most 1 cloned backend storage PVC for VM %s/%s, got %d", vm.Namespace, vm.Name, len(matched))
+	}
+}
+
+func (h *VMController) findSourceBackendStoragePVC(namespace, sourceVMName string) (*corev1.PersistentVolumeClaim, bool, error) {
+	sourcePVCs, err := h.pvcClient.List(namespace, metav1.ListOptions{
+		LabelSelector: labels.Set{
+			backendstorage.PVCPrefix: sourceVMName,
+		}.String()})
+	if err != nil {
+		return nil, false, err
+	}
+	if len(sourcePVCs.Items) == 0 {
+		logrus.Warnf("no backend storage PVC found for source VM %s/%s, skipping clone", namespace, sourceVMName)
+		return nil, true, nil
+	}
+	if len(sourcePVCs.Items) != 1 {
+		return nil, false, fmt.Errorf("expect 1 backend storage PVC for source VM %s/%s, got %d", namespace, sourceVMName, len(sourcePVCs.Items))
+	}
+	return &sourcePVCs.Items[0], false, nil
+}
+
+func buildClonedBackendStoragePVC(vm *kubevirtv1.VirtualMachine, sourcePVC *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: backendStorageClonePVCGenerateName(vm.Name),
+			Namespace:    vm.Namespace,
+			Labels: map[string]string{
+				backendstorage.PVCPrefix: vm.Name,
+				util.LabelGeneratedBy:    util.ValueGeneratedByHarvester,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(vm, kubevirtv1.VirtualMachineGroupVersionKind),
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: sourcePVC.Spec.AccessModes,
+			DataSource: &corev1.TypedLocalObjectReference{
+				Kind: "PersistentVolumeClaim",
+				Name: sourcePVC.Name,
+			},
+			Resources:        sourcePVC.Spec.Resources,
+			StorageClassName: sourcePVC.Spec.StorageClassName,
+			VolumeMode:       sourcePVC.Spec.VolumeMode,
+		},
+	}
+}
+
+func (h *VMController) buildBackendStorageJob(vm *kubevirtv1.VirtualMachine, sourceVMName string, clonedPVC *corev1.PersistentVolumeClaim, cloneAction string) (*batchv1.Job, error) {
+	script := h.buildBackendStorageScript(sourceVMName, vm.Name, cloneAction)
+	image, err := fetchImageFromHelmValues(
+		h.clientset,
+		util.FleetLocalNamespaceName,
+		util.HarvesterChartReleaseName,
+		[]string{"generalJob", "image"},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get generalJob image for backend storage job in VM %s/%s: %w", vm.Namespace, vm.Name, err)
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: backendStorageCloneJobGenerateName(vm.Name),
+			Namespace:    vm.Namespace,
+			Annotations: map[string]string{
+				util.AnnotationBSCloneStartTime: vm.Annotations[util.AnnotationBSCloneStartTime],
+			},
+			Labels: map[string]string{
+				backendStorageJobLabelKey: vm.Name,
+				util.LabelGeneratedBy:     util.ValueGeneratedByHarvester,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(vm, kubevirtv1.VirtualMachineGroupVersionKind),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            ptr.To(int32(backendStorageJobBackoffLimit)),
+			TTLSecondsAfterFinished: ptr.To(int32(backendStorageJobTTL)),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:    ptr.To(int64(kubevirtutil.NonRootUID)),
+						RunAsGroup:   ptr.To(int64(kubevirtutil.NonRootUID)),
+						RunAsNonRoot: ptr.To(true),
+						FSGroup:      ptr.To(int64(kubevirtutil.NonRootUID)),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Containers: []corev1.Container{{
+						Name:            "backend-storage",
+						Image:           image.ImageName(),
+						ImagePullPolicy: image.GetImagePullPolicy(),
+						Command:         []string{"sh", "-c", script},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.To(true),
+							AllowPrivilegeEscalation: ptr.To(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "pvc",
+							MountPath: "/pvc",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "pvc",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: clonedPVC.Name,
+							},
+						},
+					}},
+				},
+			},
+		},
+	}, nil
+}
+
+func backendStorageClonePVCGenerateName(vmName string) string {
+	return wranglername.SafeConcatName(backendstorage.PVCPrefix, vmName) + "-"
+}
+
+func backendStorageCloneJobGenerateName(vmName string) string {
+	return wranglername.SafeConcatName(util.BackendStorageJobPrefix, vmName) + "-"
+}
+
+// buildBackendStorageScript generates the shell script for post-clone processing.
+func (h *VMController) buildBackendStorageScript(sourceVMName, targetVMName, cloneAction string) string {
+	switch cloneAction {
+	case util.CloneActionDeleteEFI:
+		// Delete EFI NVRAM files (target VM doesn't need EFI)
+		srcFile := fmt.Sprintf("%s_VARS.fd", sourceVMName)
+		return strings.NewReplacer(
+			"{{.Src}}", srcFile,
+		).Replace(`set -e
+src="/pvc/nvram/{{.Src}}"
+[ -f "$src" ] && rm -f "$src"
+echo "Deleted EFI NVRAM file: $src"`)
+
+	case util.CloneActionDeleteTPMRenameEFI:
+		// Delete TPM state directory and rename EFI NVRAM file
+		srcFile := fmt.Sprintf("%s_VARS.fd", sourceVMName)
+		dstFile := fmt.Sprintf("%s_VARS.fd", targetVMName)
+		return strings.NewReplacer(
+			"{{.Src}}", srcFile,
+			"{{.Dst}}", dstFile,
+		).Replace(`set -e
+# Delete TPM state directories
+tpm_dir="/pvc/swtpm"
+tpm_localca_dir="/pvc/swtpm-localca"
+if [ -d "$tpm_dir" ]; then
+  rm -rf "$tpm_dir"
+  echo "Deleted TPM state directory: $tpm_dir"
+fi
+if [ -d "$tpm_localca_dir" ]; then
+  rm -rf "$tpm_localca_dir"
+  echo "Deleted TPM local CA directory: $tpm_localca_dir"
+fi
+
+# Rename EFI NVRAM file from source VM name to target VM name
+src="/pvc/nvram/{{.Src}}"
+dst="/pvc/nvram/{{.Dst}}"
+if [ -f "$src" ]; then
+  mv "$src" "$dst"
+  chmod 600 "$dst"
+  echo "Renamed EFI NVRAM file: $src -> $dst"
+fi`)
+
+	case util.CloneActionRenameEFI:
+		// Rename EFI NVRAM file from source VM name to target VM name
+		srcFile := fmt.Sprintf("%s_VARS.fd", sourceVMName)
+		dstFile := fmt.Sprintf("%s_VARS.fd", targetVMName)
+		return strings.NewReplacer(
+			"{{.Src}}", srcFile,
+			"{{.Dst}}", dstFile,
+		).Replace(`set -e
+src="/pvc/nvram/{{.Src}}"
+dst="/pvc/nvram/{{.Dst}}"
+[ -f "$src" ] && mv "$src" "$dst"
+[ -f "$dst" ] && chmod 600 "$dst"`)
+
+	default:
+		return "exit 0"
+	}
+}
+
+func (h *VMController) completeBackendStorageClone(vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+	vmCopy := vm.DeepCopy()
+
+	if rs, ok := vmCopy.Annotations[util.AnnotationBSCloneRunStrategy]; ok {
+		runStrategy := kubevirtv1.VirtualMachineRunStrategy(rs)
+		vmCopy.Spec.RunStrategy = &runStrategy
+	}
+
+	cleanUpBSCloneAnnotations(vmCopy)
+	vmCopy.Annotations[util.AnnotationBSCloneStatus] = util.CloneComplete
+
+	return h.vmClient.Update(vmCopy)
+}
+
+func (h *VMController) failBackendStorageClone(vm *kubevirtv1.VirtualMachine, reason string) (*kubevirtv1.VirtualMachine, error) {
+	vmCopy := vm.DeepCopy()
+
+	if err := h.deleteBackendStorageCloneJobs(vm); err != nil {
+		logrus.WithError(err).Warnf("Failed to delete backend storage jobs for VM %s/%s during clone failure", vm.Namespace, vm.Name)
+		return nil, fmt.Errorf("delete backend storage jobs for VM %s/%s during clone failure: %w", vm.Namespace, vm.Name, err)
+	}
+
+	cleanUpBSCloneAnnotations(vmCopy)
+	vmCopy.Annotations[util.AnnotationBSCloneStatus] = util.CloneFailed
+
+	h.recorder.Eventf(vm, corev1.EventTypeWarning, "CloneFailed", "Clone operation failed: %s", reason)
+	logrus.Warnf("Clone failed for VM %s/%s: %s", vm.Namespace, vm.Name, reason)
+
+	return h.vmClient.Update(vmCopy)
+}
+
+func cleanUpBSCloneAnnotations(vm *kubevirtv1.VirtualMachine) {
+	for _, key := range []string{
+		util.AnnotationBSCloneStatus,
+		util.AnnotationBSCloneRunStrategy,
+		util.AnnotationBSCloneSourceVM,
+		util.AnnotationBSCloneActions,
+		util.AnnotationBSCloneRetries,
+		util.AnnotationBSCloneStartTime,
+		util.AnnotationBSCloneStage,
+	} {
+		delete(vm.Annotations, key)
+	}
+}
+
+func (h *VMController) markBackendStorageClonePreCompleted(vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+	vmCopy := vm.DeepCopy()
+	if vmCopy.Annotations == nil {
+		vmCopy.Annotations = map[string]string{}
+	}
+	vmCopy.Annotations[util.AnnotationBSCloneStage] = util.CloneStagePreCompleted
+	return h.vmClient.Update(vmCopy)
+}
+
+func (h *VMController) finalizeBackendStorageClone(vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
+	// getCurrentBackendStorageJob returns one of three states:
+	//   (job!=nil, wait=false) - a live job exists
+	//   (job==nil, wait=true)  - no live job, but stale/deleting jobs still present
+	//   (job==nil, wait=false) - no jobs at all, safe to complete
+	job, waitForDeletion, err := h.getCurrentBackendStorageJob(vm)
+	if err != nil {
+		return nil, fmt.Errorf("get backend storage jobs for VM %s/%s while finalizing clone: %w", vm.Namespace, vm.Name, err)
+	}
+	if job == nil && !waitForDeletion {
+		return h.completeBackendStorageClone(vm)
+	}
+	if job != nil && job.DeletionTimestamp == nil {
+		if err := h.jobClient.Delete(job.Namespace, job.Name, foregroundDeleteOptions()); err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("delete backend storage job %s/%s while finalizing clone: %w", job.Namespace, job.Name, err)
+		}
+	}
+
+	h.requeueVM(vm)
+	return vm, nil
+}
+
+// getCurrentBackendStorageJob returns the current backend storage job if it exists and is valid for the current clone operation.
+// Use AnnotationBSCloneStartTime as the unique identifier for the clone operation to determine whether an existing job is stale.
+func (h *VMController) getCurrentBackendStorageJob(vm *kubevirtv1.VirtualMachine) (*batchv1.Job, bool, error) {
+	jobs, err := h.jobClient.List(vm.Namespace, metav1.ListOptions{
+		LabelSelector: labels.Set{
+			backendStorageJobLabelKey: vm.Name,
+			util.LabelGeneratedBy:     util.ValueGeneratedByHarvester,
+		}.String(),
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	var currentJob *batchv1.Job
+	waitForDeletion := false
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		if !isOwnedByVM(vm, job.OwnerReferences) {
+			continue
+		}
+		if job.Annotations[util.AnnotationBSCloneStartTime] != vm.Annotations[util.AnnotationBSCloneStartTime] {
+			if job.DeletionTimestamp == nil {
+				if err := h.jobClient.Delete(job.Namespace, job.Name, foregroundDeleteOptions()); err != nil && !apierrors.IsNotFound(err) {
+					return nil, false, fmt.Errorf("delete stale backend storage job %s/%s: %w", job.Namespace, job.Name, err)
+				}
+			}
+			waitForDeletion = true
+			continue
+		}
+		if job.DeletionTimestamp != nil {
+			waitForDeletion = true
+			continue
+		}
+		if currentJob != nil {
+			return nil, false, fmt.Errorf("expect at most 1 current backend storage job for VM %s/%s, got multiple", vm.Namespace, vm.Name)
+		}
+		currentJob = job
+	}
+
+	// Wait for all terminating jobs to be fully deleted before returning any current job
+	if waitForDeletion {
+		return nil, true, nil
+	}
+
+	if currentJob != nil {
+		return currentJob, false, nil
+	}
+
+	return nil, false, nil
+}
+
+func (h *VMController) deleteBackendStorageCloneJobs(vm *kubevirtv1.VirtualMachine) error {
+	jobs, err := h.jobClient.List(vm.Namespace, metav1.ListOptions{
+		LabelSelector: labels.Set{
+			backendStorageJobLabelKey: vm.Name,
+			util.LabelGeneratedBy:     util.ValueGeneratedByHarvester,
+		}.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("list backend storage jobs for VM %s/%s: %w", vm.Namespace, vm.Name, err)
+	}
+
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		if !isOwnedByVM(vm, job.OwnerReferences) {
+			continue
+		}
+		if err := h.jobClient.Delete(job.Namespace, job.Name, foregroundDeleteOptions()); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete backend storage job %s/%s: %w", job.Namespace, job.Name, err)
+		}
+	}
+	return nil
+}
+
+func isOwnedByVM(vm *kubevirtv1.VirtualMachine, ownerRefs []metav1.OwnerReference) bool {
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.UID == vm.UID {
+			return true
+		}
+	}
+	return false
+}
+
+func foregroundDeleteOptions() *metav1.DeleteOptions {
+	propagationPolicy := metav1.DeletePropagationForeground
+	return &metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+}
+
+// getBackendStorageJobStatus returns whether the Job has reached a terminal state
+// and whether it failed terminally (backoffLimit exhausted).
+func getBackendStorageJobStatus(job *batchv1.Job) (finish bool, failed bool) {
+	for _, c := range job.Status.Conditions {
+		switch c.Type {
+		case batchv1.JobComplete:
+			if c.Status == corev1.ConditionTrue {
+				return true, false
+			}
+		case batchv1.JobFailed:
+			if c.Status == corev1.ConditionTrue {
+				return true, true
+			}
+		}
+	}
+	return false, false
 }

--- a/pkg/controller/master/virtualmachine/vm_controller_test.go
+++ b/pkg/controller/master/virtualmachine/vm_controller_test.go
@@ -2,125 +2,27 @@ package virtualmachine
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
-	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 )
-
-// fakeDataVolumeClient implements ctlcdiv1.DataVolumeClient for testing.
-type fakeDataVolumeClient struct {
-	dvs map[string]*cdiv1.DataVolume // "namespace/name" -> DataVolume
-}
-
-func newFakeDataVolumeClient(dvs ...*cdiv1.DataVolume) *fakeDataVolumeClient {
-	m := make(map[string]*cdiv1.DataVolume)
-	for _, dv := range dvs {
-		m[dv.Namespace+"/"+dv.Name] = dv
-	}
-	return &fakeDataVolumeClient{dvs: m}
-}
-
-func (c *fakeDataVolumeClient) Get(namespace, name string, _ metav1.GetOptions) (*cdiv1.DataVolume, error) {
-	if dv, ok := c.dvs[namespace+"/"+name]; ok {
-		return dv, nil
-	}
-	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "cdi.kubevirt.io", Resource: "datavolumes"}, name)
-}
-
-func (c *fakeDataVolumeClient) Create(_ *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
-	panic("not implemented")
-}
-
-func (c *fakeDataVolumeClient) Update(_ *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
-	panic("not implemented")
-}
-
-func (c *fakeDataVolumeClient) UpdateStatus(_ *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
-	panic("not implemented")
-}
-
-func (c *fakeDataVolumeClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
-	panic("not implemented")
-}
-
-func (c *fakeDataVolumeClient) List(_ string, _ metav1.ListOptions) (*cdiv1.DataVolumeList, error) {
-	panic("not implemented")
-}
-
-func (c *fakeDataVolumeClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
-	panic("not implemented")
-}
-
-func (c *fakeDataVolumeClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (*cdiv1.DataVolume, error) {
-	panic("not implemented")
-}
-
-func (c *fakeDataVolumeClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*cdiv1.DataVolume, *cdiv1.DataVolumeList], error) {
-	panic("not implemented")
-}
-
-// fakePVCCache implements v1.PersistentVolumeClaimCache for testing.
-type fakePVCCache struct {
-	pvcs map[string]*corev1.PersistentVolumeClaim // "namespace/name" -> PVC
-}
-
-func newFakePVCCache(pvcs ...*corev1.PersistentVolumeClaim) *fakePVCCache {
-	m := make(map[string]*corev1.PersistentVolumeClaim)
-	for _, pvc := range pvcs {
-		m[pvc.Namespace+"/"+pvc.Name] = pvc
-	}
-	return &fakePVCCache{pvcs: m}
-}
-
-func (c *fakePVCCache) Get(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
-	if pvc, ok := c.pvcs[namespace+"/"+name]; ok {
-		return pvc, nil
-	}
-	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}, name)
-}
-
-func (c *fakePVCCache) List(_ string, _ labels.Selector) ([]*corev1.PersistentVolumeClaim, error) {
-	panic("not implemented")
-}
-
-func (c *fakePVCCache) AddIndexer(_ string, _ generic.Indexer[*corev1.PersistentVolumeClaim]) {
-	panic("not implemented")
-}
-
-func (c *fakePVCCache) GetByIndex(_, _ string) ([]*corev1.PersistentVolumeClaim, error) {
-	panic("not implemented")
-}
-
-// mustMarshalEntries is a test helper that marshals VolumeClaimTemplateEntry slice to JSON string.
-func mustMarshalEntries(entries []util.VolumeClaimTemplateEntry) string {
-	data, err := json.Marshal(entries)
-	if err != nil {
-		panic(err)
-	}
-	return string(data)
-}
-
-// newFakeVMClient creates a fakeVMClient from a fake clientset.
-// Reuses the fakeVMClient type defined in vmi_network_controller_test.go.
-func newFakeVMClient(clientset *fake.Clientset) fakeVMClient {
-	return fakeVMClient(clientset.KubevirtV1().VirtualMachines)
-}
 
 func TestSetTargetVolumeStrategy(t *testing.T) {
 	type input struct {
@@ -1149,4 +1051,428 @@ func TestCleanupTargetVolumeAnnotation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileBackendStorageClone(t *testing.T) {
+	targetVMName := "target-vm"
+	sourceVMName := "source-vm"
+	namespace := "default"
+	storageClassName := "longhorn"
+	volumeMode := corev1.PersistentVolumeFilesystem
+	origFetchImageFromHelmValues := fetchImageFromHelmValues
+	fetchImageFromHelmValues = func(_ kubernetes.Interface, _, _ string, _ []string) (settings.Image, error) {
+		return settings.Image{
+			Repository:      "rancher/shell",
+			Tag:             "v0.7.0",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+		}, nil
+	}
+	t.Cleanup(func() {
+		fetchImageFromHelmValues = origFetchImageFromHelmValues
+	})
+
+	type input struct {
+		key  string
+		vm   *kubevirtv1.VirtualMachine
+		pvcs []*corev1.PersistentVolumeClaim
+		jobs []*batchv1.Job
+	}
+
+	type output struct {
+		err         bool
+		cloneStatus string
+		cloneStage  string
+		runStrategy *kubevirtv1.VirtualMachineRunStrategy
+		createdPVC  bool
+		createdJob  bool
+		deletedJob  bool
+		enqueue     bool
+		pvc         *corev1.PersistentVolumeClaim
+		job         *batchv1.Job
+	}
+
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "ignore nil VM",
+			given: input{
+				key: "",
+				vm:  nil,
+			},
+			expected: output{},
+		},
+		{
+			name: "ignore VM without clone annotations",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVM(namespace, targetVMName, map[string]string{util.AnnotationBSCloneSourceVM: sourceVMName, util.AnnotationBSCloneRunStrategy: string(kubevirtv1.RunStrategyRerunOnFailure)}),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestSourcePVC(namespace, sourceVMName, storageClassName, volumeMode), newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+			},
+			expected: output{
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+			},
+		},
+		{
+			name: "source PVC exists but cloned PVC does not - create PVC and enqueue retry",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVM(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestSourcePVC(namespace, sourceVMName, storageClassName, volumeMode)},
+			},
+			expected: output{
+				cloneStatus: util.CloneInProgress,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+				createdPVC:  true,
+				enqueue:     true,
+				pvc: buildClonedBackendStoragePVC(
+					newTestVM(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+					newTestSourcePVC(namespace, sourceVMName, storageClassName, volumeMode),
+				),
+			},
+		},
+		{
+			name: "bound cloned PVC exists and stale job start time mismatch - delete stale job and enqueue retry",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+				jobs: []*batchv1.Job{
+					newTestBackendStorageJob(
+						mustBuildBackendStorageJob(t, &VMController{
+							clientset: k8sfake.NewSimpleClientset(),
+						},
+							newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+							sourceVMName,
+							newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound),
+							util.CloneActionRenameEFI,
+						),
+						func(job *batchv1.Job) {
+							job.Annotations[util.AnnotationBSCloneStartTime] = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+						},
+					),
+				},
+			},
+			expected: output{
+				cloneStatus: util.CloneInProgress,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+				deletedJob:  true,
+				enqueue:     true,
+			},
+		},
+		{
+			name: "bound cloned PVC exists but rename job does not - create job and enqueue retry",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+			},
+			expected: output{
+				cloneStatus: util.CloneInProgress,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+				createdJob:  true,
+				enqueue:     true,
+				job: mustBuildBackendStorageJob(t, &VMController{
+					clientset: k8sfake.NewSimpleClientset(),
+				},
+					newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+					sourceVMName,
+					newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound),
+					util.CloneActionRenameEFI,
+				),
+			},
+		},
+		{
+			name: "bound cloned PVC exists and VM has persistent TPM only - mark clone complete without backend storage job",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVMWithPersistentTPM(namespace, targetVMName, newTestCloneInProgressAnnotationsWithAction(sourceVMName, "")),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+			},
+			expected: output{
+				cloneStatus: util.CloneComplete,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyRerunOnFailure),
+			},
+		},
+		{
+			name: "clone exceeded timeout - mark clone failed and keep VM halted",
+			given: input{
+				key: namespace + "/" + targetVMName,
+				vm: func() *kubevirtv1.VirtualMachine {
+					annotations := newTestCloneInProgressAnnotations(sourceVMName)
+					annotations[util.AnnotationBSCloneStartTime] = time.Now().Add(-backendStorageCloneTimeout - time.Minute).UTC().Format(time.RFC3339)
+					return newTestVMWithPersistentEFI(namespace, targetVMName, annotations)
+				}(),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+			},
+			expected: output{
+				cloneStatus: util.CloneFailed,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+			},
+		},
+		{
+			name: "bound cloned PVC and running rename job exist - no create and enqueue retry",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+				jobs: []*batchv1.Job{
+					newTestBackendStorageJob(
+						mustBuildBackendStorageJob(t, &VMController{
+							clientset: k8sfake.NewSimpleClientset(),
+						},
+							newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+							sourceVMName,
+							newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound),
+							util.CloneActionRenameEFI,
+						),
+						func(job *batchv1.Job) {
+							job.Status = batchv1.JobStatus{
+								Active: 1,
+							}
+						},
+					),
+				},
+			},
+			expected: output{
+				cloneStatus: util.CloneInProgress,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+				enqueue:     true,
+			},
+		},
+		{
+			name: "bound cloned PVC and deleting rename job exist - wait for deletion and enqueue retry",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+				jobs: []*batchv1.Job{
+					newTestBackendStorageJob(
+						mustBuildBackendStorageJob(t, &VMController{
+							clientset: k8sfake.NewSimpleClientset(),
+						},
+							newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+							sourceVMName,
+							newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound),
+							util.CloneActionRenameEFI,
+						),
+						func(job *batchv1.Job) {
+							now := metav1.NewTime(time.Now().UTC())
+							job.DeletionTimestamp = &now
+						},
+					),
+				},
+			},
+			expected: output{
+				cloneStatus: util.CloneInProgress,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+				enqueue:     true,
+			},
+		},
+		{
+			name: "job failed with max retries reached - mark clone failed and keep VM halted",
+			given: input{
+				key: namespace + "/" + targetVMName,
+				vm: func() *kubevirtv1.VirtualMachine {
+					annotations := newTestCloneInProgressAnnotations(sourceVMName)
+					annotations[util.AnnotationBSCloneRetries] = strconv.Itoa(maxBackendStorageCloneRetries)
+					return newTestVMWithPersistentEFI(namespace, targetVMName, annotations)
+				}(),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+				jobs: []*batchv1.Job{
+					newTestBackendStorageJob(
+						mustBuildBackendStorageJob(t, &VMController{
+							clientset: k8sfake.NewSimpleClientset(),
+						},
+							newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+							sourceVMName,
+							newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound),
+							util.CloneActionRenameEFI,
+						),
+						func(job *batchv1.Job) {
+							job.Status = batchv1.JobStatus{
+								Failed: 1,
+								Conditions: []batchv1.JobCondition{{
+									Type:   batchv1.JobFailed,
+									Status: corev1.ConditionTrue,
+								}},
+							}
+						},
+					),
+				},
+			},
+			expected: output{
+				cloneStatus: util.CloneFailed,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+				deletedJob:  true,
+			},
+		},
+		{
+			name: "job completed - mark clone pre-completed and enqueue retry",
+			given: input{
+				key:  namespace + "/" + targetVMName,
+				vm:   newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestSourcePVC(namespace, sourceVMName, storageClassName, volumeMode), newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+				jobs: []*batchv1.Job{
+					newTestBackendStorageJob(
+						mustBuildBackendStorageJob(t, &VMController{
+							clientset: k8sfake.NewSimpleClientset(),
+						},
+							newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+							sourceVMName,
+							newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound),
+							util.CloneActionRenameEFI,
+						),
+						func(job *batchv1.Job) {
+							job.Status = batchv1.JobStatus{
+								Succeeded: 1,
+								Conditions: []batchv1.JobCondition{{
+									Type:   batchv1.JobComplete,
+									Status: corev1.ConditionTrue,
+								}},
+							}
+						},
+					),
+				},
+			},
+			expected: output{
+				cloneStatus: util.CloneInProgress,
+				cloneStage:  util.CloneStagePreCompleted,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+				deletedJob:  true,
+				enqueue:     true,
+			},
+		},
+		{
+			name: "pre-completed clone without job - mark clone complete and restore RunStrategy",
+			given: input{
+				key: namespace + "/" + targetVMName,
+				vm: func() *kubevirtv1.VirtualMachine {
+					annotations := newTestCloneInProgressAnnotations(sourceVMName)
+					annotations[util.AnnotationBSCloneStage] = util.CloneStagePreCompleted
+					return newTestVMWithPersistentEFI(namespace, targetVMName, annotations)
+				}(),
+				pvcs: []*corev1.PersistentVolumeClaim{newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound)},
+			},
+			expected: output{
+				cloneStatus: util.CloneComplete,
+				runStrategy: ptrRunStrategy(kubevirtv1.RunStrategyRerunOnFailure),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			if tc.given.vm != nil {
+				err := clientset.Tracker().Add(tc.given.vm)
+				require.NoError(t, err, "mock VM should add into fake tracker")
+			}
+
+			defaultBindingMode := storagev1.VolumeBindingImmediate
+			storageClass := newTestStorageClass(storageClassName, true)
+			storageClass.VolumeBindingMode = &defaultBindingMode
+			k8sClientset := k8sfake.NewSimpleClientset(storageClass)
+			recorder := record.NewFakeRecorder(10)
+			pvcClient := newFakePVCClient(tc.given.pvcs...)
+			jobClient := newFakeJobClient(tc.given.jobs...)
+			scClient := newFakeStorageClassClient(storageClass)
+			scCache := newFakeStorageClassCache(storageClass)
+			vmController := &fakeRequeueVMController{
+				fakeVMClient: newFakeVMClient(clientset),
+			}
+
+			ctrl := &VMController{
+				vmClient:     newFakeVMClient(clientset),
+				vmController: vmController,
+				recorder:     recorder,
+				pvcClient:    pvcClient,
+				jobClient:    jobClient,
+				pvcCache:     newFakePVCCache(tc.given.pvcs...),
+				jobCache:     newFakeJobCache(tc.given.jobs...),
+				scClient:     scClient,
+				scCache:      scCache,
+				clientset:    k8sClientset,
+			}
+
+			result, err := ctrl.ReconcileBackendStorageClone(tc.given.key, tc.given.vm)
+			if tc.expected.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if result != nil {
+				assert.Equal(t, tc.expected.cloneStatus, result.Annotations[util.AnnotationBSCloneStatus])
+				assert.Equal(t, tc.expected.cloneStage, result.Annotations[util.AnnotationBSCloneStage])
+				if tc.expected.runStrategy == nil {
+					assert.Nil(t, result.Spec.RunStrategy)
+				} else {
+					require.NotNil(t, result.Spec.RunStrategy)
+					assert.Equal(t, *tc.expected.runStrategy, *result.Spec.RunStrategy)
+				}
+			}
+
+			if tc.expected.createdPVC {
+				require.Len(t, pvcClient.created, 1)
+				assertCreatedTestPVC(t, tc.expected.pvc, pvcClient.created[0])
+			} else {
+				assert.Empty(t, pvcClient.created)
+			}
+
+			if tc.expected.createdJob {
+				require.Len(t, jobClient.created, 1)
+				assertCreatedTestJob(t, tc.expected.job, jobClient.created[0])
+			} else {
+				assert.Empty(t, jobClient.created)
+			}
+
+			if tc.expected.deletedJob {
+				require.Len(t, jobClient.deleted, 1)
+				assert.Equal(t, namespace, jobClient.deleted[0].Namespace)
+				assert.True(t, strings.HasPrefix(jobClient.deleted[0].Name, backendStorageCloneJobGenerateName(targetVMName)))
+			} else {
+				assert.Empty(t, jobClient.deleted)
+			}
+
+			if tc.expected.enqueue {
+				require.Len(t, vmController.enqueues, 1)
+				assert.Equal(t, namespace, vmController.enqueues[0].namespace)
+				assert.Equal(t, targetVMName, vmController.enqueues[0].name)
+				assert.Equal(t, 5*time.Second, vmController.enqueues[0].after)
+			} else {
+				assert.Empty(t, vmController.enqueues)
+			}
+		})
+	}
+}
+
+func TestBuildBackendStorageJobRequiresConfiguredImage(t *testing.T) {
+	namespace := "default"
+	sourceVMName := "source-vm"
+	targetVMName := "target-vm"
+	origFetchImageFromHelmValues := fetchImageFromHelmValues
+	fetchImageFromHelmValues = func(_ kubernetes.Interface, _, _ string, _ []string) (settings.Image, error) {
+		return settings.Image{}, assert.AnError
+	}
+	t.Cleanup(func() {
+		fetchImageFromHelmValues = origFetchImageFromHelmValues
+	})
+
+	ctrl := &VMController{
+		clientset: k8sfake.NewSimpleClientset(),
+	}
+
+	job, err := ctrl.buildBackendStorageJob(
+		newTestVMWithPersistentEFI(namespace, targetVMName, newTestCloneInProgressAnnotations(sourceVMName)),
+		sourceVMName,
+		newTestClonedPVC(namespace, targetVMName, corev1.ClaimBound),
+		util.CloneActionRenameEFI,
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, job)
 }

--- a/pkg/controller/master/virtualmachine/vm_controller_utils_test.go
+++ b/pkg/controller/master/virtualmachine/vm_controller_utils_test.go
@@ -1,0 +1,669 @@
+package virtualmachine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+)
+
+// fakeDataVolumeClient implements ctlcdiv1.DataVolumeClient for testing.
+type fakeDataVolumeClient struct {
+	dvs map[string]*cdiv1.DataVolume // "namespace/name" -> DataVolume
+}
+
+func newFakeDataVolumeClient(dvs ...*cdiv1.DataVolume) *fakeDataVolumeClient {
+	m := make(map[string]*cdiv1.DataVolume)
+	for _, dv := range dvs {
+		m[dv.Namespace+"/"+dv.Name] = dv
+	}
+	return &fakeDataVolumeClient{dvs: m}
+}
+
+func (c *fakeDataVolumeClient) Get(namespace, name string, _ metav1.GetOptions) (*cdiv1.DataVolume, error) {
+	if dv, ok := c.dvs[namespace+"/"+name]; ok {
+		return dv, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "cdi.kubevirt.io", Resource: "datavolumes"}, name)
+}
+
+func (c *fakeDataVolumeClient) Create(_ *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	panic("not implemented")
+}
+
+func (c *fakeDataVolumeClient) Update(_ *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	panic("not implemented")
+}
+
+func (c *fakeDataVolumeClient) UpdateStatus(_ *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+	panic("not implemented")
+}
+
+func (c *fakeDataVolumeClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	panic("not implemented")
+}
+
+func (c *fakeDataVolumeClient) List(_ string, _ metav1.ListOptions) (*cdiv1.DataVolumeList, error) {
+	panic("not implemented")
+}
+
+func (c *fakeDataVolumeClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (c *fakeDataVolumeClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (*cdiv1.DataVolume, error) {
+	panic("not implemented")
+}
+
+func (c *fakeDataVolumeClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*cdiv1.DataVolume, *cdiv1.DataVolumeList], error) {
+	panic("not implemented")
+}
+
+// fakePVCCache implements v1.PersistentVolumeClaimCache for testing.
+type fakePVCCache struct {
+	pvcs map[string]*corev1.PersistentVolumeClaim // "namespace/name" -> PVC
+}
+
+func newFakePVCCache(pvcs ...*corev1.PersistentVolumeClaim) *fakePVCCache {
+	m := make(map[string]*corev1.PersistentVolumeClaim)
+	for _, pvc := range pvcs {
+		m[pvc.Namespace+"/"+pvc.Name] = pvc
+	}
+	return &fakePVCCache{pvcs: m}
+}
+
+func (c *fakePVCCache) Get(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
+	if pvc, ok := c.pvcs[namespace+"/"+name]; ok {
+		return pvc, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}, name)
+}
+
+func (c *fakePVCCache) List(_ string, _ labels.Selector) ([]*corev1.PersistentVolumeClaim, error) {
+	panic("not implemented")
+}
+
+func (c *fakePVCCache) AddIndexer(_ string, _ generic.Indexer[*corev1.PersistentVolumeClaim]) {
+	panic("not implemented")
+}
+
+func (c *fakePVCCache) GetByIndex(_, _ string) ([]*corev1.PersistentVolumeClaim, error) {
+	panic("not implemented")
+}
+
+type fakeStorageClassClient struct {
+	scs map[string]*storagev1.StorageClass
+}
+
+func newFakeStorageClassClient(scs ...*storagev1.StorageClass) *fakeStorageClassClient {
+	m := make(map[string]*storagev1.StorageClass)
+	for _, sc := range scs {
+		if sc == nil {
+			continue
+		}
+		m[sc.Name] = sc
+	}
+	return &fakeStorageClassClient{scs: m}
+}
+
+func (c *fakeStorageClassClient) Get(name string, _ metav1.GetOptions) (*storagev1.StorageClass, error) {
+	if sc, ok := c.scs[name]; ok {
+		return sc, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "storage.k8s.io", Resource: "storageclasses"}, name)
+}
+
+func (c *fakeStorageClassClient) Create(_ *storagev1.StorageClass) (*storagev1.StorageClass, error) {
+	panic("not implemented")
+}
+
+func (c *fakeStorageClassClient) Update(_ *storagev1.StorageClass) (*storagev1.StorageClass, error) {
+	panic("not implemented")
+}
+
+func (c *fakeStorageClassClient) UpdateStatus(_ *storagev1.StorageClass) (*storagev1.StorageClass, error) {
+	panic("not implemented")
+}
+
+func (c *fakeStorageClassClient) Delete(_ string, _ *metav1.DeleteOptions) error {
+	panic("not implemented")
+}
+
+func (c *fakeStorageClassClient) List(opts metav1.ListOptions) (*storagev1.StorageClassList, error) {
+	var items []storagev1.StorageClass
+	selector, err := labels.Parse(opts.LabelSelector)
+	if err != nil {
+		return nil, err
+	}
+	for _, sc := range c.scs {
+		if sc == nil {
+			continue
+		}
+		if selector.Matches(labels.Set(sc.Labels)) {
+			items = append(items, *sc)
+		}
+	}
+	return &storagev1.StorageClassList{Items: items}, nil
+}
+
+func (c *fakeStorageClassClient) Watch(_ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (c *fakeStorageClassClient) Patch(_ string, _ types.PatchType, _ []byte, _ ...string) (*storagev1.StorageClass, error) {
+	panic("not implemented")
+}
+
+func (c *fakeStorageClassClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.NonNamespacedClientInterface[*storagev1.StorageClass, *storagev1.StorageClassList], error) {
+	panic("not implemented")
+}
+
+type fakeStorageClassCache struct {
+	scs map[string]*storagev1.StorageClass
+}
+
+func newFakeStorageClassCache(scs ...*storagev1.StorageClass) *fakeStorageClassCache {
+	m := make(map[string]*storagev1.StorageClass)
+	for _, sc := range scs {
+		if sc == nil {
+			continue
+		}
+		m[sc.Name] = sc
+	}
+	return &fakeStorageClassCache{scs: m}
+}
+
+func (c *fakeStorageClassCache) Get(name string) (*storagev1.StorageClass, error) {
+	if sc, ok := c.scs[name]; ok {
+		return sc, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "storage.k8s.io", Resource: "storageclasses"}, name)
+}
+
+func (c *fakeStorageClassCache) List(selector labels.Selector) ([]*storagev1.StorageClass, error) {
+	var result []*storagev1.StorageClass
+	for _, sc := range c.scs {
+		if sc == nil {
+			continue
+		}
+		if selector.Matches(labels.Set(sc.Labels)) {
+			result = append(result, sc)
+		}
+	}
+	return result, nil
+}
+
+func (c *fakeStorageClassCache) AddIndexer(_ string, _ generic.Indexer[*storagev1.StorageClass]) {
+	panic("not implemented")
+}
+
+func (c *fakeStorageClassCache) GetByIndex(_, _ string) ([]*storagev1.StorageClass, error) {
+	panic("not implemented")
+}
+
+// mustMarshalEntries is a test helper that marshals VolumeClaimTemplateEntry slice to JSON string.
+func mustMarshalEntries(entries []util.VolumeClaimTemplateEntry) string {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+// newFakeVMClient creates a fakeVMClient from a fake clientset.
+// Reuses the fakeVMClient type defined in vmi_network_controller_test.go.
+func newFakeVMClient(clientset *fake.Clientset) fakeVMClient {
+	return fakeVMClient(clientset.KubevirtV1().VirtualMachines)
+}
+
+type enqueueCall struct {
+	namespace string
+	name      string
+	after     time.Duration
+}
+
+type fakeRequeueVMController struct {
+	fakeVMClient
+	enqueues []enqueueCall
+}
+
+func (c *fakeRequeueVMController) Informer() cache.SharedIndexInformer {
+	return nil
+}
+
+func (c *fakeRequeueVMController) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{}
+}
+
+func (c *fakeRequeueVMController) AddGenericHandler(context.Context, string, generic.Handler) {}
+
+func (c *fakeRequeueVMController) AddGenericRemoveHandler(context.Context, string, generic.Handler) {}
+
+func (c *fakeRequeueVMController) Updater() generic.Updater {
+	return nil
+}
+
+func (c *fakeRequeueVMController) OnChange(context.Context, string, generic.ObjectHandler[*kubevirtv1.VirtualMachine]) {
+}
+
+func (c *fakeRequeueVMController) OnRemove(context.Context, string, generic.ObjectHandler[*kubevirtv1.VirtualMachine]) {
+}
+
+func (c *fakeRequeueVMController) Enqueue(string, string) {}
+
+func (c *fakeRequeueVMController) EnqueueAfter(namespace, name string, after time.Duration) {
+	c.enqueues = append(c.enqueues, enqueueCall{
+		namespace: namespace,
+		name:      name,
+		after:     after,
+	})
+}
+
+func (c *fakeRequeueVMController) Cache() generic.CacheInterface[*kubevirtv1.VirtualMachine] {
+	return nil
+}
+
+// fakePVCClient implements v1.PersistentVolumeClaimClient for testing.
+type fakePVCClient struct {
+	pvcs    map[string]*corev1.PersistentVolumeClaim // "namespace/name" -> PVC
+	created []*corev1.PersistentVolumeClaim
+	counter int
+}
+
+func newFakePVCClient(pvcs ...*corev1.PersistentVolumeClaim) *fakePVCClient {
+	m := make(map[string]*corev1.PersistentVolumeClaim)
+	for _, pvc := range pvcs {
+		if pvc == nil {
+			continue
+		}
+		m[pvc.Namespace+"/"+pvc.Name] = pvc
+	}
+	return &fakePVCClient{pvcs: m, created: []*corev1.PersistentVolumeClaim{}}
+}
+
+func (c *fakePVCClient) Get(namespace, name string, _ metav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
+	if pvc, ok := c.pvcs[namespace+"/"+name]; ok {
+		return pvc, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}, name)
+}
+
+func (c *fakePVCClient) Create(pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	if pvc.Name == "" && pvc.GenerateName != "" {
+		c.counter++
+		pvc = pvc.DeepCopy()
+		pvc.Name = fmt.Sprintf("%s%d", pvc.GenerateName, c.counter)
+	}
+	key := pvc.Namespace + "/" + pvc.Name
+	if _, ok := c.pvcs[key]; ok {
+		return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}, pvc.Name)
+	}
+	c.pvcs[key] = pvc
+	c.created = append(c.created, pvc)
+	return pvc, nil
+}
+
+func (c *fakePVCClient) List(namespace string, opts metav1.ListOptions) (*corev1.PersistentVolumeClaimList, error) {
+	var items []corev1.PersistentVolumeClaim
+	selector, err := labels.Parse(opts.LabelSelector)
+	if err != nil {
+		return nil, err
+	}
+	for _, pvc := range c.pvcs {
+		if pvc == nil {
+			continue
+		}
+		if namespace != "" && pvc.Namespace != namespace {
+			continue
+		}
+		if selector.Matches(labels.Set(pvc.Labels)) {
+			items = append(items, *pvc)
+		}
+	}
+	return &corev1.PersistentVolumeClaimList{Items: items}, nil
+}
+
+func (c *fakePVCClient) Update(_ *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	panic("not implemented")
+}
+
+func (c *fakePVCClient) UpdateStatus(_ *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	panic("not implemented")
+}
+
+func (c *fakePVCClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	panic("not implemented")
+}
+
+func (c *fakePVCClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (c *fakePVCClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (*corev1.PersistentVolumeClaim, error) {
+	panic("not implemented")
+}
+
+func (c *fakePVCClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*corev1.PersistentVolumeClaim, *corev1.PersistentVolumeClaimList], error) {
+	panic("not implemented")
+}
+
+func (c *fakePVCClient) Cache() generic.CacheInterface[*corev1.PersistentVolumeClaim] {
+	panic("not implemented")
+}
+
+// fakeJobClient implements ctlbatchv1.JobClient for testing.
+type fakeJobClient struct {
+	jobs    map[string]*batchv1.Job // "namespace/name" -> Job
+	created []*batchv1.Job
+	deleted []*batchv1.Job
+	counter int
+}
+
+func newFakeJobClient(jobs ...*batchv1.Job) *fakeJobClient {
+	m := make(map[string]*batchv1.Job)
+	for _, job := range jobs {
+		if job == nil {
+			continue
+		}
+		m[job.Namespace+"/"+job.Name] = job
+	}
+	return &fakeJobClient{jobs: m, created: []*batchv1.Job{}, deleted: []*batchv1.Job{}}
+}
+
+func (c *fakeJobClient) Get(namespace, name string, _ metav1.GetOptions) (*batchv1.Job, error) {
+	if job, ok := c.jobs[namespace+"/"+name]; ok {
+		return job, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, name)
+}
+
+func (c *fakeJobClient) Create(job *batchv1.Job) (*batchv1.Job, error) {
+	if job.Name == "" && job.GenerateName != "" {
+		c.counter++
+		job = job.DeepCopy()
+		job.Name = fmt.Sprintf("%s%d", job.GenerateName, c.counter)
+	}
+	key := job.Namespace + "/" + job.Name
+	if _, ok := c.jobs[key]; ok {
+		return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "batch", Resource: "jobs"}, job.Name)
+	}
+	c.jobs[key] = job
+	c.created = append(c.created, job)
+	return job, nil
+}
+
+func (c *fakeJobClient) List(namespace string, opts metav1.ListOptions) (*batchv1.JobList, error) {
+	var items []batchv1.Job
+	selector, err := labels.Parse(opts.LabelSelector)
+	if err != nil {
+		return nil, err
+	}
+	for _, job := range c.jobs {
+		if job == nil {
+			continue
+		}
+		if namespace != "" && job.Namespace != namespace {
+			continue
+		}
+		if selector.Matches(labels.Set(job.Labels)) {
+			items = append(items, *job)
+		}
+	}
+	return &batchv1.JobList{Items: items}, nil
+}
+
+func (c *fakeJobClient) Update(_ *batchv1.Job) (*batchv1.Job, error) {
+	panic("not implemented")
+}
+
+func (c *fakeJobClient) UpdateStatus(_ *batchv1.Job) (*batchv1.Job, error) {
+	panic("not implemented")
+}
+
+func (c *fakeJobClient) Delete(namespace, name string, _ *metav1.DeleteOptions) error {
+	if job, ok := c.jobs[namespace+"/"+name]; ok {
+		c.deleted = append(c.deleted, job)
+	}
+	delete(c.jobs, namespace+"/"+name)
+	return nil
+}
+
+func (c *fakeJobClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}
+
+func (c *fakeJobClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (*batchv1.Job, error) {
+	panic("not implemented")
+}
+
+func (c *fakeJobClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*batchv1.Job, *batchv1.JobList], error) {
+	panic("not implemented")
+}
+
+func (c *fakeJobClient) Cache() generic.CacheInterface[*batchv1.Job] {
+	panic("not implemented")
+}
+
+// fakeJobCache implements ctlbatchv1.JobCache for testing.
+type fakeJobCache struct {
+	jobs map[string]*batchv1.Job // "namespace/name" -> Job
+}
+
+func newFakeJobCache(jobs ...*batchv1.Job) *fakeJobCache {
+	m := make(map[string]*batchv1.Job)
+	for _, job := range jobs {
+		if job == nil {
+			continue
+		}
+		m[job.Namespace+"/"+job.Name] = job
+	}
+	return &fakeJobCache{jobs: m}
+}
+
+func (c *fakeJobCache) Get(namespace, name string) (*batchv1.Job, error) {
+	if job, ok := c.jobs[namespace+"/"+name]; ok {
+		return job, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, name)
+}
+
+func (c *fakeJobCache) List(_ string, _ labels.Selector) ([]*batchv1.Job, error) {
+	panic("not implemented")
+}
+
+func (c *fakeJobCache) AddIndexer(_ string, _ generic.Indexer[*batchv1.Job]) {
+	panic("not implemented")
+}
+
+func (c *fakeJobCache) GetByIndex(_, _ string) ([]*batchv1.Job, error) {
+	panic("not implemented")
+}
+
+func ptrRunStrategy(s kubevirtv1.VirtualMachineRunStrategy) *kubevirtv1.VirtualMachineRunStrategy {
+	return &s
+}
+
+func newTestVM(namespace, name string, annotations map[string]string) *kubevirtv1.VirtualMachine {
+	return &kubevirtv1.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: kubevirtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+			Kind:       "VirtualMachine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			UID:         "target-vm-uid",
+			Annotations: annotations,
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			RunStrategy: ptrRunStrategy(kubevirtv1.RunStrategyHalted),
+			Template:    &kubevirtv1.VirtualMachineInstanceTemplateSpec{},
+		},
+	}
+}
+
+func newTestVMWithPersistentEFI(namespace, name string, annotations map[string]string) *kubevirtv1.VirtualMachine {
+	vm := newTestVM(namespace, name, annotations)
+	persistent := true
+	vm.Spec.Template.Spec.Domain.Firmware = &kubevirtv1.Firmware{
+		Bootloader: &kubevirtv1.Bootloader{
+			EFI: &kubevirtv1.EFI{
+				Persistent: &persistent,
+			},
+		},
+	}
+	return vm
+}
+
+func newTestVMWithPersistentTPM(namespace, name string, annotations map[string]string) *kubevirtv1.VirtualMachine {
+	vm := newTestVM(namespace, name, annotations)
+	persistent := true
+	vm.Spec.Template.Spec.Domain.Devices.TPM = &kubevirtv1.TPMDevice{
+		Persistent: &persistent,
+	}
+	return vm
+}
+
+func newTestSourcePVC(namespace, sourceVMName, storageClassName string, volumeMode corev1.PersistentVolumeMode) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      backendstorage.PVCPrefix + "-" + sourceVMName,
+			Labels: map[string]string{
+				backendstorage.PVCPrefix: sourceVMName,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &storageClassName,
+			VolumeMode:       &volumeMode,
+		},
+	}
+}
+
+func newTestClonedPVC(namespace, targetVMName string, phase corev1.PersistentVolumeClaimPhase) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      backendStorageClonePVCGenerateName(targetVMName) + "existing",
+			Labels: map[string]string{
+				util.LabelKubeVirtPersistentState: targetVMName,
+				util.LabelGeneratedBy:             util.ValueGeneratedByHarvester,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kubevirtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+				Kind:       kubevirtv1.VirtualMachineGroupVersionKind.Kind,
+				UID:        "target-vm-uid",
+				Name:       targetVMName,
+			}},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func newTestStorageClass(name string, defaultClass bool) *storagev1.StorageClass {
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if defaultClass {
+		sc.Annotations = map[string]string{
+			util.AnnotationIsDefaultStorageClassName: "true",
+		}
+	}
+	return sc
+}
+
+func mustBuildBackendStorageJob(t *testing.T, ctrl *VMController, vm *kubevirtv1.VirtualMachine, sourceVMName string, clonedPVC *corev1.PersistentVolumeClaim, cloneAction string) *batchv1.Job {
+	t.Helper()
+	job, err := ctrl.buildBackendStorageJob(vm, sourceVMName, clonedPVC, cloneAction)
+	require.NoError(t, err)
+	return job
+}
+
+func newTestBackendStorageJob(job *batchv1.Job, mutate func(*batchv1.Job)) *batchv1.Job {
+	if job == nil {
+		return nil
+	}
+
+	jobCopy := job.DeepCopy()
+	if jobCopy.Name == "" && jobCopy.GenerateName != "" {
+		jobCopy.Name = jobCopy.GenerateName + "existing"
+	}
+	if mutate != nil {
+		mutate(jobCopy)
+	}
+	return jobCopy
+}
+
+func newTestCloneInProgressAnnotations(sourceVMName string) map[string]string {
+	return newTestCloneInProgressAnnotationsWithAction(sourceVMName, util.CloneActionRenameEFI)
+}
+
+func newTestCloneInProgressAnnotationsWithAction(sourceVMName, cloneAction string) map[string]string {
+	return map[string]string{
+		util.AnnotationBSCloneStatus:      util.CloneInProgress,
+		util.AnnotationBSCloneSourceVM:    sourceVMName,
+		util.AnnotationBSCloneRunStrategy: string(kubevirtv1.RunStrategyRerunOnFailure),
+		util.AnnotationBSCloneActions:     cloneAction,
+		util.AnnotationBSCloneStartTime:   time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+func assertCreatedTestPVC(t *testing.T, expected, actual *corev1.PersistentVolumeClaim) {
+	t.Helper()
+	require.NotNil(t, expected)
+	require.NotNil(t, actual)
+	assert.Equal(t, expected.GenerateName, actual.GenerateName)
+	if expected.Name != "" {
+		assert.Equal(t, expected.Name, actual.Name)
+	} else {
+		assert.True(t, strings.HasPrefix(actual.Name, expected.GenerateName))
+	}
+	assert.Equal(t, expected.Namespace, actual.Namespace)
+	assert.Equal(t, expected.Labels, actual.Labels)
+	assert.Equal(t, expected.OwnerReferences, actual.OwnerReferences)
+	assert.Equal(t, expected.Spec, actual.Spec)
+}
+
+func assertCreatedTestJob(t *testing.T, expected, actual *batchv1.Job) {
+	t.Helper()
+	require.NotNil(t, expected)
+	require.NotNil(t, actual)
+	assert.Equal(t, expected.GenerateName, actual.GenerateName)
+	if expected.Name != "" {
+		assert.Equal(t, expected.Name, actual.Name)
+	} else {
+		assert.True(t, strings.HasPrefix(actual.Name, expected.GenerateName))
+	}
+	assert.Equal(t, expected.Namespace, actual.Namespace)
+	assert.Equal(t, expected.Labels, actual.Labels)
+	assert.Equal(t, expected.OwnerReferences, actual.OwnerReferences)
+	assert.Equal(t, expected.Spec, actual.Spec)
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -16,6 +16,7 @@ const (
 	AnnotationReservedMemory            = prefix + "/reservedMemory"
 	AnnotationHash                      = prefix + "/hash"
 	AnnotationRunStrategy               = prefix + "/vmRunStrategy"
+	AnnotationBackendStorageCloneStatus = prefix + "/clone-backend-storage-status"
 	AnnotationSnapshotFreezeFS          = prefix + "/snapshotFreezeFS"
 	AnnotationSnapshotRevise            = prefix + "/snapRevise"
 	AnnotationSVMBackupID               = prefix + "/svmbackupId"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -90,6 +90,25 @@ const (
 	NodePause                     = "pause"
 	NodeUnpause                   = "unpause"
 
+	// Annotation for backend storage clone.
+	AnnotationBSCloneStatus       = prefix + "/clone-backend-storage-status"
+	AnnotationBSCloneSourceVM     = prefix + "/clone-backend-storage-source-vm"
+	AnnotationBSCloneRunStrategy  = prefix + "/clone-backend-storage-run-strategy"
+	AnnotationBSCloneActions      = prefix + "/clone-backend-storage-actions"
+	AnnotationBSCloneRetries      = prefix + "/clone-backend-storage-retries"
+	AnnotationBSCloneStartTime    = prefix + "/clone-backend-storage-start-time"
+	AnnotationBSCloneStage        = prefix + "/clone-backend-storage-stage"
+	LabelGeneratedBy              = prefix + "/generated-by"
+	ValueGeneratedByHarvester     = "harvester"
+	BackendStorageJobPrefix       = "backend-storage"
+	CloneInProgress               = "cloning"
+	CloneComplete                 = "cloned"
+	CloneFailed                   = "failed"
+	CloneStagePreCompleted        = "pre-completed"
+	CloneActionRenameEFI          = "rename-efi"
+	CloneActionDeleteEFI          = "delete-efi"
+	CloneActionDeleteTPMRenameEFI = "delete-tpm-and-rename-efi"
+
 	HarvesterManagedNodeLabelKey = prefix + "/managed"
 
 	HarvesterPromoteNodeLabelKey        = prefix + "/promote-node"

--- a/pkg/util/fakeclients/job.go
+++ b/pkg/util/fakeclients/job.go
@@ -47,8 +47,8 @@ type JobClient func(string) batchv1type.JobInterface
 func (c JobClient) Update(job *batchv1.Job) (*batchv1.Job, error) {
 	return c(job.Namespace).Update(context.TODO(), job, metav1.UpdateOptions{})
 }
-func (c JobClient) Get(_, _ string, _ metav1.GetOptions) (*batchv1.Job, error) {
-	panic("implement me")
+func (c JobClient) Get(namespace, name string, options metav1.GetOptions) (*batchv1.Job, error) {
+	return c(namespace).Get(context.TODO(), name, options)
 }
 func (c JobClient) Create(job *batchv1.Job) (*batchv1.Job, error) {
 	return c(job.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->
#### Problem:
When cloning a VM with EFI/vTPM persistence enabled, the cloned VM does not inherit the source VM's persisted EFI/vTPM state correctly.

#### Solution:

This PR adds EFI/vTPM persistent-state handling to the VM clone flow by:

- **Cloning the backend storage PVC** using Kubernetes PVC cloning (`spec.dataSource`) to copy all EFI/vTPM state from the source VM's backend-storage PVC to the cloned VM
- **Running a post-processing Job** after the cloned PVC is bound to handle differences between source and target VM configuration:
  - If the target VM has both EFI and vTPM: rename the EFI NVRAM file from `<source-vm>_VARS.fd` to `<target-vm>_VARS.fd`
  - If the target VM has EFI only: delete the cloned vTPM state directories (`swtpm/`, `swtpm-localca/`)
  - If the target VM has vTPM only: delete the cloned EFI NVRAM file
  - If the target VM has neither: skip the job entirely
- **Introducing clone status annotations** so the UI can show the clone as `Pending` while the backend storage clone is in progress

**Security:**
- The post-processing Job runs as non-root (UID 107, qemu user) with a hardened security context to comply with Pod Security Admission restricted policies

With this approach, the cloned VM preserves the expected EFI/vTPM persistent state while allowing users to customize which features to enable in the clone, and the UI can reflect the intermediate clone state more accurately.

Related UI PR: 
- https://github.com/harvester/harvester-ui-extension/pull/730
- https://github.com/harvester/harvester-ui-extension/pull/928


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
#9182

---

## Test Plan: VM Clone with EFI and vTPM

### Prerequisites
- Harvester single-node cluster
- Ubuntu Desktop image (for TPM test)
- TinyCore image (for EFI test)

---

### Test 1 & 2: vTPM Verification (Ubuntu Desktop)


#### Test 1: Clone with EFI only (enable vTPM)
#### Source VM Setup

1. Create Ubuntu Server VM with **vTPM enabled + TPM persistence**

```bash
# Setup SSH
sudo apt install openssh-server -y
sudo systemctl enable --now ssh
sudo passwd ubuntu  # set password: ubuntu

# Install TPM tools
sudo add-apt-repository universe
sudo apt update
sudo apt install tpm2-tools -y
```

3. Seal a secret into TPM:

```bash
# Create primary key
sudo tpm2_createprimary -C e -c primary.ctx

# Seal secret
echo "my-secret" | sudo tpm2_create \
  -C primary.ctx \
  -i - \
  -u sealed.pub \
  -r sealed.priv \
  -p "myauth"

# Load
sudo tpm2_load -C primary.ctx \
  -u sealed.pub \
  -r sealed.priv \
  -c sealed.ctx

# Persist into TPM NV (survives reboot)
sudo tpm2_evictcontrol -C o -c sealed.ctx 0x81000001

# Verify on source VM
sudo tpm2_unseal -c 0x81000001 -p "myauth"
# Expected output: my-secret
```

#### Clone VM Setup

1. Clone source VM, with RerunOnFailure
3. Verify TPM state is  inherited

```bash
sudo tpm2_unseal -c 0x81000001 -p "myauth"
# Expected: my-secret
```
<img width="533" height="352" alt="Screenshot 2026-05-13 at 5 05 11 PM" src="https://github.com/user-attachments/assets/7090c5ce-eb83-40d5-a9b7-cabd853125da" />

4. Verify backend-storage Job / its Pod cleaned up TPM directories:

```bash
kubectl get job -n default
# Expected: No resources found
```

---

#### Test 2: Clone with EFI only (disable vTPM, test vTPM is not clone)
#### Source VM Setup

1. Create Ubuntu Server VM with **vTPM disable**

```bash
# Setup SSH
sudo apt install openssh-server -y
sudo systemctl enable --now ssh
sudo passwd ubuntu  # set password: ubuntu

# Install TPM tools
sudo add-apt-repository universe
sudo apt update
sudo apt install tpm2-tools -y
```

3. Seal a secret into TPM:

```bash
# Create primary key
sudo tpm2_createprimary -C e -c primary.ctx

# Seal secret
echo "my-secret" | sudo tpm2_create \
  -C primary.ctx \
  -i - \
  -u sealed.pub \
  -r sealed.priv \
  -p "myauth"

# Load
sudo tpm2_load -C primary.ctx \
  -u sealed.pub \
  -r sealed.priv \
  -c sealed.ctx

# Persist into TPM NV (survives reboot)
sudo tpm2_evictcontrol -C o -c sealed.ctx 0x81000001

# Verify on source VM
sudo tpm2_unseal -c 0x81000001 -p "myauth"
# Expected output: my-secret
```

#### Clone VM Setup
1. Clone source VM, **disable EFI** in clone config
2. Boot clone VM
3. Verify TPM state is **not** inherited:

```bash
sudo tpm2_unseal -c 0x81000001 -p "myauth"
# Expected output: error
```
<img width="750" height="486" alt="Screenshot 2026-05-13 at 4 40 12 PM" src="https://github.com/user-attachments/assets/b477ccb9-0a4b-4f4a-9451-4d842d41fa71" />

---

#### Test 3: Clone with both EFI + vTPM
#### Source VM Setup

1. Create Ubuntu Server VM with **vTPM enabled + TPM persistence + EFI + EFI persistence**

```bash
# Setup SSH
sudo apt install openssh-server -y
sudo systemctl enable --now ssh
sudo passwd ubuntu  # set password: ubuntu

# Install TPM tools
sudo add-apt-repository universe
sudo apt update
sudo apt install tpm2-tools -y
```

3. Seal a secret into TPM:

```bash
# Create primary key
sudo tpm2_createprimary -C e -c primary.ctx

# Seal secret
echo "my-secret" | sudo tpm2_create \
  -C primary.ctx \
  -i - \
  -u sealed.pub \
  -r sealed.priv \
  -p "myauth"

# Load
sudo tpm2_load -C primary.ctx \
  -u sealed.pub \
  -r sealed.priv \
  -c sealed.ctx

# Persist into TPM NV (survives reboot)
sudo tpm2_evictcontrol -C o -c sealed.ctx 0x81000001

# Verify on source VM
sudo tpm2_unseal -c 0x81000001 -p "myauth"
# Expected output: my-secret
```

#### Clone VM Setup
1. Clone source VM
3. Verify TPM state is inherited:

```bash
sudo tpm2_unseal -c 0x81000001 -p "myauth"
# Expected output: my-secret
```

4. Verify EFI rename job ran and cleaned up:

```bash
kubectl get job -n default
# Expected: No resources found
```

---

### EFI Verification (TinyCore) — Test 1

1. Create TinyCore VM with **EFI + EFI persistence enabled**
2. Boot and change EFI setting (e.g., set language to French)
3. Clone VM with target config
4. Boot clone and verify EFI setting is preserved

---

### EFI Verification (TinyCore) — Test 2

1. Create TinyCore VM with **vTPM + vTPM persistence enabled**
2. Boot and change EFI setting (e.g., set language to French)
3. Clone VM with target config
4. Boot clone and verify EFI setting is **not** preserved

---

### Windows vTPM Verification — Test 3

1. Create Windows-server-2022 VM with **EFI (to activate the vTPM) + vTPM + vTPM persistence enabled**, follow the instruction [here](https://docs.harvesterhci.io/v1.8/vm/create-windows-vm/) 
2. eject booting cdrom
3. Boot and into the Windows VM with commands, ensure it fully encrypt, then move to 3.
4. Clone VM with target config
5. Boot clone and verify the cloned VM is able to access

```bash
# Install the bitlocker
Install-WindowsFeature BitLocker -IncludeAllSubFeature -IncludeManagementTools
Get-WindowsFeature -Name BitLocker

# Restart 
Restart-Computer

# Mount booting file
mountvol b: /s

# check if boot file exist
dir b:\EFI\Microsoft\Boot\

# Ensure we boot with :c
bcdboot C:\Windows /s b: /f UEFI

# Eject the CDROM Image
default/windows_server_2022_en-us.iso (harvester-longhorn / 4.7 Gi)

Restart-Computer

# Initialize TPM
Initialize-Tpm -AllowClear -AllowPhysicalPresence

# Enable bitlcok on C
Enable-BitLocker -MountPoint "C:" -TpmProtector

# Restart to avtivate
Restart-Computer

# Check the progress
Get-BitLockerVolume -MountPoint "C:"
```

#### Ensure both vTPM are the same
<img width="2438" height="694" alt="tpm" src="https://github.com/user-attachments/assets/19bfec3f-fd27-4dab-af41-8ac3d9a3d199" />

---

### Windows vTPM Verification (no vTPM persist) — Test 3

1. Create Windows-server-2022 VM with **EFI (to activate the vTPM) + vTPM **, follow the instruction [here](https://docs.harvesterhci.io/v1.8/vm/create-windows-vm/) 
2. eject booting cdrom
3. Boot and into the Windows VM with commands, ensure it fully encrypt, then move to 3.
4. Clone VM with target config
5. Boot clone and verify the cloned VM is able to access

```bash
# Install the bitlocker
Install-WindowsFeature BitLocker -IncludeAllSubFeature -IncludeManagementTools
Get-WindowsFeature -Name BitLocker

# Restart 
Restart-Computer

# Mount booting file
mountvol b: /s

# check if boot file exist
dir b:\EFI\Microsoft\Boot\

# Ensure we boot with :c
bcdboot C:\Windows /s b: /f UEFI

# Eject the CDROM Image
default/windows_server_2022_en-us.iso (harvester-longhorn / 4.7 Gi)

Restart-Computer

# Initialize TPM
Initialize-Tpm -AllowClear -AllowPhysicalPresence

# Enable bitlcok on C
Enable-BitLocker -MountPoint "C:" -TpmProtector

# Restart to avtivate
Restart-Computer

# Check the progress
Get-BitLockerVolume -MountPoint "C:"
```

#### Ensure the clone one is not able to turn on 
<img width="1157" height="870" alt="Screenshot 2026-06-17 at 10 37 11 AM" src="https://github.com/user-attachments/assets/713dab86-e866-4f64-870d-c5a9333d2bce" />


--- 

### Cleanup Check (all tests)

After each test, verify no orphaned jobs or pods:

```bash
kubectl get job -n default
```
--- 

#### Additional documentation or context
- The Job is only for post-processing to align the cloned data with the target VM's configuration
