### PR TITLE
Enhance the RQ processing when overhead-ratio is involving (only core changes)

### DIFF
--- a/pkg/controller/master/migration/register.go
+++ b/pkg/controller/master/migration/register.go
@@ -23,21 +23,24 @@ func Register(ctx context.Context, management *config.Management, options config
 	rqs := management.HarvesterCoreFactory.Core().V1().ResourceQuota()
 	vms := management.VirtFactory.Kubevirt().V1().VirtualMachine()
 	pods := management.CoreFactory.Core().V1().Pod()
+	nss := management.CoreFactory.Core().V1().Namespace()
 	vmis := management.VirtFactory.Kubevirt().V1().VirtualMachineInstance()
 	vmims := management.VirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration()
 	settingCache := management.HarvesterFactory.Harvesterhci().V1beta1().Setting().Cache()
 
 	handler := &Handler{
-		namespace:    options.Namespace,
-		rqs:          rqs,
-		rqCache:      rqs.Cache(),
-		vmiCache:     vmis.Cache(),
-		vms:          vms,
-		vmCache:      vms.Cache(),
-		pods:         pods,
-		podCache:     pods.Cache(),
-		settingCache: settingCache,
-		restClient:   virtv1Client.RESTClient(),
+		namespace:      options.Namespace,
+		nsCache:        nss.Cache(),
+		rqs:            rqs,
+		rqCache:        rqs.Cache(),
+		vmiCache:       vmis.Cache(),
+		vms:            vms,
+		vmCache:        vms.Cache(),
+		vmimController: vmims,
+		pods:           pods,
+		podCache:       pods.Cache(),
+		settingCache:   settingCache,
+		restClient:     virtv1Client.RESTClient(),
 	}
 
 	vmis.OnChange(ctx, vmiControllerName, handler.OnVmiChanged)

--- a/pkg/controller/master/migration/vmi_controller.go
+++ b/pkg/controller/master/migration/vmi_controller.go
@@ -19,16 +19,18 @@ import (
 
 // Handler resets vmi annotations and nodeSelector when a migration completes
 type Handler struct {
-	namespace    string
-	rqs          ctlharvcorev1.ResourceQuotaClient
-	rqCache      ctlharvcorev1.ResourceQuotaCache
-	vmiCache     ctlvirtv1.VirtualMachineInstanceCache
-	vms          ctlvirtv1.VirtualMachineClient
-	vmCache      ctlvirtv1.VirtualMachineCache
-	podCache     ctlcorev1.PodCache
-	pods         ctlcorev1.PodClient
-	settingCache ctlharvesterv1.SettingCache
-	restClient   rest.Interface
+	namespace      string
+	nsCache        ctlcorev1.NamespaceCache
+	rqs            ctlharvcorev1.ResourceQuotaClient
+	rqCache        ctlharvcorev1.ResourceQuotaCache
+	vmiCache       ctlvirtv1.VirtualMachineInstanceCache
+	vms            ctlvirtv1.VirtualMachineClient
+	vmCache        ctlvirtv1.VirtualMachineCache
+	vmimController ctlvirtv1.VirtualMachineInstanceMigrationController
+	podCache       ctlcorev1.PodCache
+	pods           ctlcorev1.PodClient
+	settingCache   ctlharvesterv1.SettingCache
+	restClient     rest.Interface
 }
 
 func (h *Handler) OnVmiChanged(_ string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
@@ -68,11 +70,15 @@ func (h *Handler) OnVmiChanged(_ string, vmi *kubevirtv1.VirtualMachineInstance)
 func (h *Handler) resetHarvesterMigrationStateInVMI(vmi *kubevirtv1.VirtualMachineInstance) error {
 	toUpdate := vmi.DeepCopy()
 
+	initialLen := len(toUpdate.Annotations)
 	delete(toUpdate.Annotations, util.AnnotationMigrationUID)
 	delete(toUpdate.Annotations, util.AnnotationMigrationState)
+	delete(toUpdate.Annotations, util.AnnotationMigrationTarget)
 
-	if vmi.Annotations[util.AnnotationMigrationTarget] != "" {
-		delete(toUpdate.Annotations, util.AnnotationMigrationTarget)
+	// skip unnecessary update
+	// also for the convenience of unit test code, it can bypass following call upon VirtClient
+	if initialLen == len(toUpdate.Annotations) {
+		return nil
 	}
 
 	if err := util.VirtClientUpdateVmi(context.Background(), h.restClient, h.namespace, vmi.Namespace, vmi.Name, toUpdate); err != nil {

--- a/pkg/controller/master/migration/vmim_controller.go
+++ b/pkg/controller/master/migration/vmim_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
@@ -25,8 +26,7 @@ const (
 )
 
 // The handler adds the AnnotationMigrationUID annotation to the VMI when vmim starts.
-// This is mainly for the period when vmim is created but VMI.status.migrationState is not updated before
-// the target pod is running.
+// And also adjusts the ResourceQuota per vmim phase
 func (h *Handler) OnVmimChanged(_ string, vmim *kubevirtv1.VirtualMachineInstanceMigration) (*kubevirtv1.VirtualMachineInstanceMigration, error) {
 	if vmim == nil {
 		return nil, nil
@@ -34,40 +34,77 @@ func (h *Handler) OnVmimChanged(_ string, vmim *kubevirtv1.VirtualMachineInstanc
 
 	vmi, err := h.vmiCache.Get(vmim.Namespace, vmim.Spec.VMIName)
 	if err != nil {
-		return vmim, err
+		// the vmim might be a leftover object when its parent vmi object was deleted
+		if apierrors.IsNotFound(err) {
+			return vmim, nil
+		}
+		return nil, err
 	}
 
-	// restore the resource quota when the migration is completed
-	if err := h.restoreResourceQuota(vmim, vmi); err != nil {
-		return vmim, err
-	}
-
+	// when a migration is aborted, the phase will transfer to kubevirtv1.MigrationFailed finally
 	abortRequested := isAbortRequest(vmim)
 	phase := vmim.Status.Phase
 	// debug log shows, after vmim was deleted, the OnChange here may be called two times
 	logrus.Debugf("syncing vmim %s/%s/%s phase %v abortRequested %v deleted %t", vmim.Namespace, vmim.Name, vmi.Name, phase, abortRequested, vmim.DeletionTimestamp != nil)
 
-	if phase == kubevirtv1.MigrationPhaseUnset && !abortRequested {
-		// set StatePending for UI status showing and menu rendering
+	switch phase {
+	case kubevirtv1.MigrationPhaseUnset:
+		if abortRequested {
+			return vmim, h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StateAbortingMigration)
+		}
 		return vmim, h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StatePending)
-	} else if phase == kubevirtv1.MigrationPending && !abortRequested {
-		err := h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StatePending)
-		if err != nil {
-			return nil, err
+	case kubevirtv1.MigrationPending:
+		if abortRequested {
+			return vmim, h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StateAbortingMigration)
 		}
-		return vmim, h.scaleResourceQuota(vmi)
-	} else if phase != kubevirtv1.MigrationFailed && abortRequested {
-		return vmim, h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StateAbortingMigration)
-	} else if phase == kubevirtv1.MigrationScheduling || phase == kubevirtv1.MigrationScheduled || phase == kubevirtv1.MigrationPreparingTarget || phase == kubevirtv1.MigrationTargetReady || phase == kubevirtv1.MigrationRunning {
+		return h.handlePendingMigration(vmi, vmim)
+	case kubevirtv1.MigrationScheduling,
+		kubevirtv1.MigrationScheduled,
+		kubevirtv1.MigrationPreparingTarget,
+		kubevirtv1.MigrationTargetReady,
+		kubevirtv1.MigrationRunning:
+		if abortRequested {
+			return vmim, h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StateAbortingMigration)
+		}
 		return vmim, h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StateMigrating)
-	} else if vmi.Annotations[util.AnnotationMigrationUID] == string(vmim.UID) && phase == kubevirtv1.MigrationFailed {
-		// There are cases when VMIM failed but the status is not reported in VMI.status.migrationState
-		// https://github.com/kubevirt/kubevirt/issues/5503
-		if err := h.resetHarvesterMigrationStateInVmiAndSyncVM(vmi); err != nil {
-			logrus.Infof("vmim %s/%s/%s has MigrationFailed but fail to reset vmi state %s", vmim.Namespace, vmim.Name, vmi.Name, err.Error())
-			return vmim, err
-		}
-		return vmim, nil
+	case kubevirtv1.MigrationFailed, kubevirtv1.MigrationSucceeded:
+		// restore the resource quota and clear vmi migration related information
+		return h.handleFinishedMigration(vmi, vmim)
+	}
+
+	return vmim, nil
+}
+
+// when vmim is pending
+func (h *Handler) handlePendingMigration(vmi *kubevirtv1.VirtualMachineInstance, vmim *kubevirtv1.VirtualMachineInstanceMigration) (*kubevirtv1.VirtualMachineInstanceMigration, error) {
+	err := h.setVmiMigrationUIDAnnotation(vmi, string(vmim.UID), StatePending)
+	if err != nil {
+		return nil, err
+	}
+
+	// scale ResourceQuota through VMI resource specifications
+	if err := h.scaleResourceQuota(vmi); err != nil {
+		return nil, fmt.Errorf("failed to scale resource quota with vmi %s/%s: %w", vmi.Namespace, vmi.Name, err)
+	}
+
+	// if vmim is blocked by RQ, it is on phase MigrationPending
+	err = h.compensatePendingMigration(vmim, vmi)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compensate resource quota with vmi %s/%s: %w", vmi.Namespace, vmi.Name, err)
+	}
+	return vmim, nil
+}
+
+// when vmim is finished
+func (h *Handler) handleFinishedMigration(vmi *kubevirtv1.VirtualMachineInstance, vmim *kubevirtv1.VirtualMachineInstanceMigration) (*kubevirtv1.VirtualMachineInstanceMigration, error) {
+	// restore the resource quota when the migration is completed
+	if err := h.restoreResourceQuota(vmim, vmi); err != nil {
+		logrus.Infof("vmim %s/%s is on phase %s but fail to restore vmi %s on resource quota %s", vmim.Namespace, vmim.Name, vmim.Status.Phase, vmi.Name, err.Error())
+		return nil, err
+	}
+	if err := h.resetHarvesterMigrationStateInVmiAndSyncVM(vmi); err != nil {
+		logrus.Infof("vmim %s/%s is on phase %s but fail to reset vmi %s state %s", vmim.Namespace, vmim.Name, vmim.Status.Phase, vmi.Name, err.Error())
+		return nil, err
 	}
 	return vmim, nil
 }
@@ -98,6 +135,10 @@ func (h *Handler) setVmiMigrationUIDAnnotation(vmi *kubevirtv1.VirtualMachineIns
 func (h *Handler) syncVM(vmi *kubevirtv1.VirtualMachineInstance) error {
 	vm, err := h.vmCache.Get(vmi.Namespace, vmi.Name)
 	if err != nil {
+		// headless vmi
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	toUpdateVM := vm.DeepCopy()
@@ -147,6 +188,13 @@ func (h *Handler) isNamespaceManagedByResourceQuota(namespace string) (bool, err
 
 // scaleResourceQuotaWithVMI scales ResourceQuota through VMI resource specifications
 func (h *Handler) scaleResourceQuotaWithVMI(vmi *kubevirtv1.VirtualMachineInstance) error {
+
+	// in this case, current code can do nothing
+	if vmi.Spec.Domain.Resources.Limits.Memory().IsZero() && vmi.Spec.Domain.Resources.Limits.Cpu().IsZero() {
+		logrus.Warnf("scaleResourceQuotaWithVMI: there is no cpu, memory limits on vmi %s/%s, but there is resourcequota, something might be wrong", vmi.Namespace, vmi.Name)
+		return nil
+	}
+
 	selector := labels.Set{util.LabelManagementDefaultResourceQuota: "true"}.AsSelector()
 	rqs, err := h.rqCache.List(vmi.Namespace, selector)
 	if err != nil {
@@ -155,8 +203,29 @@ func (h *Handler) scaleResourceQuotaWithVMI(vmi *kubevirtv1.VirtualMachineInstan
 		logrus.Debugf("scaleResourceQuotaWithVMI: can't find any default resource quota, skip updating namespace %s", vmi.Namespace)
 		return nil
 	}
+	rq := rqs[0]
+	// resourcequota_controller check this
+	// vmim_controller also adds the check to stop the auto-scaling asap.
+	if rqutils.IsResourceQuotaAutoScalingDisabled(rq) {
+		logrus.Debugf("scaleResourceQuotaWithVMI: resourcequota %s/%s annotation %s is set, skip scaling", rq.Namespace, rq.Name, util.AnnotationSkipResourceQuotaAutoScaling)
+		return nil
+	}
 
-	rqCpy := rqs[0].DeepCopy()
+	// ensure all parameters are set
+	ns, err := h.nsCache.Get(vmi.Namespace)
+	if err != nil {
+		return fmt.Errorf("scaleResourceQuotaWithVMI: failed to get vmi's namespace object %s: %w", vmi.Namespace, err)
+	}
+	managed, err := rqutils.IsResourceQuotaManagedByNamespaceAnnotation(rq, ns.Annotations[util.CattleAnnotationResourceQuota])
+	if err != nil {
+		return fmt.Errorf("scaleResourceQuotaWithVMI: failed to get all parameters to decide if this resourcequota %s/%s is managed: %w", rq.Namespace, rq.Name, err)
+	}
+	// not managed
+	if !managed {
+		return nil
+	}
+
+	rqCpy := rq.DeepCopy()
 	if ok := rqutils.ContainsMigratingVM(rqCpy, vmi.Name, string(vmi.UID)); ok {
 		logrus.Debugf("scaleResourceQuotaWithVMI: the resource quota in the namespace %s and vm %s is already scaled, skip updating", vmi.Namespace, vmi.Name)
 		return nil
@@ -173,6 +242,8 @@ func (h *Handler) scaleResourceQuotaWithVMI(vmi *kubevirtv1.VirtualMachineInstan
 	if err := rqutils.AddMigratingVM(rqToUpdate, vmi.Name, string(vmi.UID), rl); err != nil {
 		return err
 	}
+	// set the flag until ResourceQuota controller clears it
+	rqutils.SetAnnotationMigratingScalingResyncNeeded(rqToUpdate)
 	_, err = h.rqs.Update(rqToUpdate)
 	return err
 }
@@ -209,10 +280,18 @@ func (h *Handler) restoreResourceQuotaWithVMI(vmi *kubevirtv1.VirtualMachineInst
 		return nil
 	}
 
+	// restore does not care IsResourceQuotaAutoScalingDisabled to ensure any before-disabling-added scaling is still removed
+
 	rqCpy := rqs[0].DeepCopy()
 
 	// delete migrating vmi information from ResourceQuota annotation, then the ResourceQuota controller will re-calculate the final value
 	if rqutils.DeleteMigratingVM(rqCpy, vmi.Name, string(vmi.UID)) {
+		// when there is compensation, no matter for which vmim, delete it
+		// after the ResourceQuota is updated, kubevirt will re-schedule all ResourceQuota blocked VMs
+		// if some other VM is blocked due to ResourceQuota after the re-schedule,
+		// the ResourceQuota controller will compensate accordingly
+		_ = rqutils.DeleteMigratingCompensation(rqCpy)
+		rqutils.SetAnnotationMigratingScalingResyncNeeded(rqCpy)
 		_, err = h.rqs.Update(rqCpy)
 		return err
 	}
@@ -243,4 +322,100 @@ func (h *Handler) resetHarvesterMigrationStateInVmiAndSyncVM(vmi *kubevirtv1.Vir
 		return fmt.Errorf("fail to reset vmi migration to vm %w", err)
 	}
 	return nil
+}
+
+// compensate the ResourceQuota when the migration is blocked due to quota exceeds limit
+func (h *Handler) compensatePendingMigration(vmim *kubevirtv1.VirtualMachineInstanceMigration, vmi *kubevirtv1.VirtualMachineInstance) error {
+	if vmim.Status.Conditions == nil {
+		return nil
+	}
+	for _, cond := range vmim.Status.Conditions {
+		if cond.Type != kubevirtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota {
+			continue
+		}
+		// when condition is kubevirtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota
+		if cond.Status != corev1.ConditionTrue {
+			return nil
+		}
+		// vmim is blocked due to quota, compensate if necessary
+		return h.compensateResourceQuotaBase(vmim, vmi)
+	}
+
+	return nil
+}
+
+// compute the real usage of VM's Pod, if it exceeds the hard limit, then compensate the delta
+// when user changes the global setting additional-guest-memory-overhead-ratio after the VM is up and then migrates the vm
+// the RQ usage can exceed the hard limit
+// this function will ensure the already running VMs can still migrate
+func (h *Handler) compensateResourceQuotaBase(vmim *kubevirtv1.VirtualMachineInstanceMigration, vmi *kubevirtv1.VirtualMachineInstance) error {
+	// in this case, current code can do nothing
+	if vmi.Spec.Domain.Resources.Limits.Memory().IsZero() {
+		logrus.Warnf("compensateResourceQuotaBase: the vmim %s/%s is blocked due to resource quota, but there is no memory limits on vmi %s, might due to CPU limits", vmim.Namespace, vmim.Name, vmi.Name)
+		return nil
+	}
+
+	selector := labels.Set{util.LabelManagementDefaultResourceQuota: "true"}.AsSelector()
+	rqs, err := h.rqCache.List(vmi.Namespace, selector)
+	if err != nil {
+		return err
+	} else if len(rqs) == 0 {
+		logrus.Debugf("compensateResourceQuotaBase: can't find any default resource quota, skip updating namespace %s", vmi.Namespace)
+		return nil
+	}
+	rq := rqs[0]
+
+	// as there is EnqueueAfter operation, it is essential to check this flag
+	// to avoid: vmim_controller keeps updating but resourcequota_controller do nothing
+	if rqutils.IsResourceQuotaAutoScalingDisabled(rq) {
+		logrus.Debugf("compensateResourceQuotaBase: resourcequota %s/%s annotation %s is set, skip compensation", rq.Namespace, rq.Name, util.AnnotationSkipResourceQuotaAutoScaling)
+		return nil
+	}
+
+	// ensure all parameters are set
+	ns, err := h.nsCache.Get(vmi.Namespace)
+	if err != nil {
+		return fmt.Errorf("compensateResourceQuotaBase: failed to get vmi's namespace object %s: %w", vmi.Namespace, err)
+	}
+	managed, err := rqutils.IsResourceQuotaManagedByNamespaceAnnotationWithMemoryLimits(rq, ns.Annotations[util.CattleAnnotationResourceQuota])
+	if err != nil {
+		return fmt.Errorf("compensateResourceQuotaBase: failed to get all parameters to decide if this resourcequota %s/%s is managed: %w", rq.Namespace, rq.Name, err)
+	}
+	// not managed
+	if !managed {
+		return nil
+	}
+
+	// first, wait until auto-scaling has been applied to resource quota annotations
+	if ok := rqutils.ContainsMigratingVM(rq, vmi.Name, string(vmi.UID)); !ok {
+		logrus.Debugf("compensateResourceQuotaBase: the resource quota in the namespace %s does not include migrating vm %s resource scaling info, don't compensate, wait", vmi.Namespace, vmi.Name)
+		h.vmimController.EnqueueAfter(vmim.Namespace, vmim.Name, 1*time.Second)
+		return nil
+	}
+
+	// second, wait until the resourcequota_controller has calculated the base + annotation to update the quota limits
+	// note: after resourcequota_controller sets the rq.Spec to increase the quota, kubevirt controller will action upon it to reschedule all RQ blocked vmims
+	// there is still a lower chance that the compensation is done before kubevirt finishes the rescheduling
+	// it is taken care on containsEnoughResourceQuotaToStartVM
+	if rqutils.IsMigratingScalingResyncNeeded(rq) {
+		logrus.Debugf("compensateResourceQuotaBase: the resource quota in the namespace %s is not synced by controller, don't compensate, wait", vmi.Namespace)
+		h.vmimController.EnqueueAfter(vmim.Namespace, vmim.Name, 1*time.Second)
+		return nil
+	}
+
+	rqToUpdate := rq.DeepCopy()
+	needUpdate, rl := rqutils.CalculateCompensationResourceQuotaWithVMI(rqToUpdate, vmi, util.GetAdditionalGuestMemoryOverheadRatioWithoutError(h.settingCache))
+	if !needUpdate {
+		logrus.Debugf("compensateResourceQuotaBase: no need to update resource quota, skip updating namespace %s and vm %s", vmi.Namespace, vmi.Name)
+		return nil
+	}
+
+	logrus.Infof("compensateResourceQuotaBase: compensate resource quota %s in namespace %s for vm %s : %v", rq.Name, vmi.Namespace, vmi.Name, rl)
+	// add compensation information to ResourceQuota annotation, do not change ResourceQuota spec directly in this step
+	if err := rqutils.AddMigratingCompensation(rqToUpdate, rl); err != nil {
+		return err
+	}
+	rqutils.SetAnnotationMigratingScalingResyncNeeded(rqToUpdate)
+	_, err = h.rqs.Update(rqToUpdate)
+	return err
 }

--- a/pkg/controller/master/migration/vmim_controller_test.go
+++ b/pkg/controller/master/migration/vmim_controller_test.go
@@ -18,6 +18,7 @@ import (
 	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
+	rqutils "github.com/harvester/harvester/pkg/util/resourcequota"
 )
 
 const (
@@ -125,6 +126,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
 						util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi)),
+						util.AnnotationMigratingScalingResyncNeeded:   "true",
 					},
 					Namespace: resourceQuotaNamespace,
 					Name:      resourceQuotaName,
@@ -192,6 +194,7 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
 						util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi)),
+						util.AnnotationMigratingScalingResyncNeeded:   "true",
 					},
 					Namespace: resourceQuotaNamespace,
 					Name:      resourceQuotaName,
@@ -226,11 +229,12 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				},
 				vmi: &kubevirtv1.VirtualMachineInstance{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "vm1",
-						Namespace: resourceQuotaNamespace,
+						Name:        "vm1",
+						Namespace:   resourceQuotaNamespace,
+						UID:         uid,
 						Annotations: map[string]string{
-							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
-							util.AnnotationMigrationState: StatePending,
+							// util.AnnotationMigrationUID:   vmimUID,       // bypass vmi migration state updating
+							// util.AnnotationMigrationState: StatePending,
 						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
@@ -259,10 +263,12 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 			wantErr: false,
 			want: &corev1.ResourceQuota{
 				ObjectMeta: v1.ObjectMeta{
-					Namespace:   resourceQuotaNamespace,
-					Name:        resourceQuotaName,
-					Annotations: map[string]string{},
-					Labels:      map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Annotations: map[string]string{
+						util.AnnotationMigratingScalingResyncNeeded: "true",
+					},
+					Labels: map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
 				},
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: map[corev1.ResourceName]resource.Quantity{
@@ -293,12 +299,12 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				},
 				vmi: &kubevirtv1.VirtualMachineInstance{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "vm1",
-						Namespace: resourceQuotaNamespace,
-						UID:       uid,
+						Name:        "vm1",
+						Namespace:   resourceQuotaNamespace,
+						UID:         uid,
 						Annotations: map[string]string{
-							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
-							util.AnnotationMigrationState: StatePending,
+							// util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							// util.AnnotationMigrationState: StatePending,
 						},
 					},
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
@@ -327,10 +333,12 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 			wantErr: false,
 			want: &corev1.ResourceQuota{
 				ObjectMeta: v1.ObjectMeta{
-					Namespace:   resourceQuotaNamespace,
-					Name:        resourceQuotaName,
-					Annotations: map[string]string{},
-					Labels:      map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Annotations: map[string]string{
+						util.AnnotationMigratingScalingResyncNeeded: "true",
+					},
+					Labels: map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
 				},
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: map[corev1.ResourceName]resource.Quantity{
@@ -581,6 +589,314 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 			},
 		},
 	}
+	getNamespace := func() *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Name: resourceQuotaNamespace,
+				Annotations: map[string]string{
+					util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"1Gi\"}}",
+				},
+			},
+		}
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var clientset = fakecore.NewSimpleClientset()
+			var harvFakeClient = fakegenerated.NewSimpleClientset()
+
+			if tt.args.rq != nil {
+				err := clientset.Tracker().Add(tt.args.rq)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+			if tt.args.vmi != nil {
+				err := harvFakeClient.Tracker().Add(tt.args.vmi)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+			if tt.args.vmim != nil {
+				err := harvFakeClient.Tracker().Add(tt.args.vmim)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+			if ns := getNamespace(); ns != nil {
+				err := clientset.Tracker().Add(ns)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+
+			h := &Handler{
+				rqs:      fakeclients.ResourceQuotaClient(clientset.CoreV1().ResourceQuotas),
+				rqCache:  fakeclients.ResourceQuotaCache(clientset.CoreV1().ResourceQuotas),
+				nsCache:  fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
+				vmiCache: fakeclients.VirtualMachineInstanceCache(harvFakeClient.KubevirtV1().VirtualMachineInstances),
+				vmCache:  fakeclients.VirtualMachineCache(harvFakeClient.KubevirtV1().VirtualMachines),
+			}
+
+			_, err := h.OnVmimChanged("", tt.args.vmim)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnVmimChanged() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			rq, err := clientset.Tracker().Get(corev1.SchemeGroupVersion.WithResource("resourcequotas"), tt.args.rq.Namespace, tt.args.rq.Name)
+			assert.Nil(t, err, errMockTrackerGet)
+			assert.Equal(t, tt.want, rq, "case %q", tt.name)
+		})
+	}
+}
+
+func TestHandler_OnVmimChanged_WithResourceQuota_WithCompensation(t *testing.T) {
+	// compute the dynamic overhead per kubevirt
+	getMemWithOverhead := func(memLimit int64) int64 {
+		vmi := kubevirtv1.VirtualMachineInstance{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "vm1",
+				Namespace: resourceQuotaNamespace,
+			},
+			Spec: kubevirtv1.VirtualMachineInstanceSpec{
+				Domain: kubevirtv1.DomainSpec{
+					Resources: kubevirtv1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: *resource.NewQuantity(memLimit, resource.BinarySI),
+						},
+					},
+				},
+			},
+		}
+		overhead := kubevirtservices.GetMemoryOverhead(&vmi, runtime.GOARCH, util.GetAdditionalGuestMemoryOverheadRatioWithoutError(nil)) // use default ratio 1.5
+		return overhead.Value() + memLimit
+	}
+
+	type args struct {
+		rq   *corev1.ResourceQuota
+		vmi  *kubevirtv1.VirtualMachineInstance
+		vmim *kubevirtv1.VirtualMachineInstanceMigration
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    *corev1.ResourceQuota
+	}{
+		{
+			name: "VMIM is in Pending and with RQ Rejected status, RQ auto-scaling is disabled, no op",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.AnnotationSkipResourceQuotaAutoScaling: "true",
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vm1",
+						Namespace: resourceQuotaNamespace,
+						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID,
+							util.AnnotationMigrationState: StatePending,
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+						Conditions: []kubevirtv1.VirtualMachineInstanceMigrationCondition{
+							{
+								Type:   kubevirtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						util.AnnotationSkipResourceQuotaAutoScaling: "true",
+					},
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "Migration is finished(succeeded), RQ auto-scaling and compensation are both restored",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi*2)),
+							util.AnnotationMigratingCompensation:          "{\"limits.memory\":\"555745096\"}", // the quantity is not affected by version bumping
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),          // scaled
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*4, resource.BinarySI), // scaled
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:        "vm1",
+						Namespace:   resourceQuotaNamespace,
+						UID:         uid,
+						Annotations: map[string]string{
+							// util.AnnotationMigrationUID:   vmimUID,
+							// util.AnnotationMigrationState: StatePending,
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationSucceeded,
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						// vmim scaling and compensation annotations are removed
+						util.AnnotationMigratingScalingResyncNeeded: "true",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*4, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "Migration is failed (aborted), RQ auto-scaling and compensation restored",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi*2)),
+							util.AnnotationMigratingCompensation:          "{\"limits.memory\":\"555745096\"}", // the quantity is not affected by version bumping
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),          // scaled
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*4, resource.BinarySI), // scaled
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:        "vm1",
+						Namespace:   resourceQuotaNamespace,
+						UID:         uid,
+						Annotations: map[string]string{
+							// util.AnnotationMigrationUID:   vmimUID,
+							// util.AnnotationMigrationState: StatePending,
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationFailed,
+					},
+				},
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						// vmim scaling and compensation annotations are removed
+						util.AnnotationMigratingScalingResyncNeeded: "true",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*4, resource.BinarySI),
+					},
+				},
+			},
+		},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var clientset = fakecore.NewSimpleClientset()
@@ -602,7 +918,9 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 			h := &Handler{
 				rqs:      fakeclients.ResourceQuotaClient(clientset.CoreV1().ResourceQuotas),
 				rqCache:  fakeclients.ResourceQuotaCache(clientset.CoreV1().ResourceQuotas),
+				nsCache:  fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
 				vmiCache: fakeclients.VirtualMachineInstanceCache(harvFakeClient.KubevirtV1().VirtualMachineInstances),
+				vmCache:  fakeclients.VirtualMachineCache(harvFakeClient.KubevirtV1().VirtualMachines),
 			}
 
 			_, err := h.OnVmimChanged("", tt.args.vmim)
@@ -611,9 +929,378 @@ func TestHandler_OnVmimChanged_WithResourceQuota(t *testing.T) {
 				return
 			}
 
-			rq, err := clientset.Tracker().Get(corev1.SchemeGroupVersion.WithResource("resourcequotas"), tt.args.rq.Namespace, tt.args.rq.Name)
+			rq, err := h.rqCache.Get(tt.args.rq.Namespace, tt.args.rq.Name)
 			assert.Nil(t, err, errMockTrackerGet)
 			assert.Equal(t, tt.want, rq, "case %q", tt.name)
+		})
+	}
+}
+
+func TestHandler_OnVmimChanged_WithResourceQuota_WithCompensationResult(t *testing.T) {
+	// compute the dynamic overhead per kubevirt
+	getMemWithOverhead := func(memLimit int64) int64 {
+		vmi := kubevirtv1.VirtualMachineInstance{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "vm1",
+				Namespace: resourceQuotaNamespace,
+			},
+			Spec: kubevirtv1.VirtualMachineInstanceSpec{
+				Domain: kubevirtv1.DomainSpec{
+					Resources: kubevirtv1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: *resource.NewQuantity(memLimit, resource.BinarySI),
+						},
+					},
+				},
+			},
+		}
+		overhead := kubevirtservices.GetMemoryOverhead(&vmi, runtime.GOARCH, util.GetAdditionalGuestMemoryOverheadRatioWithoutError(nil)) // use default ratio 1.5
+		return overhead.Value() + memLimit
+	}
+
+	type args struct {
+		rq   *corev1.ResourceQuota
+		ns   *corev1.Namespace
+		vmi  *kubevirtv1.VirtualMachineInstance
+		vmim *kubevirtv1.VirtualMachineInstanceMigration
+	}
+
+	tests := []struct {
+		name            string
+		args            args
+		wantErr         bool
+		hasCompensation bool
+	}{
+		{
+			name: "VMIM is in Pending and with RQ Rejected status, RQ is compensated",
+			args: args{
+				ns: &corev1.Namespace{
+					ObjectMeta: v1.ObjectMeta{
+						Name: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"1Gi\"}}",
+						},
+					},
+				},
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi*2)),
+							util.AnnotationMigratingScalingResyncNeeded:   "false", // to bypass controller EnqueueAfter
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vm1",
+						Namespace: resourceQuotaNamespace,
+						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+						Conditions: []kubevirtv1.VirtualMachineInstanceMigrationCondition{
+							{
+								Type:   kubevirtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			hasCompensation: true,
+		},
+		{
+			name: "VMIM is in Pending and with RQ Rejected status, but namespace has no annotation CattleAnnotationResourceQuota, RQ is not compensated",
+			args: args{
+				ns: &corev1.Namespace{
+					ObjectMeta: v1.ObjectMeta{
+						Name:        resourceQuotaNamespace,
+						Annotations: map[string]string{
+							// namespace object does not have CattleAnnotationResourceQuota
+							// no compensation is applied
+							// util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"1Gi\"}}",
+						},
+					},
+				},
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi*2)),
+							util.AnnotationMigratingScalingResyncNeeded:   "false", // to bypass controller EnqueueAfter
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vm1",
+						Namespace: resourceQuotaNamespace,
+						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+						Conditions: []kubevirtv1.VirtualMachineInstanceMigrationCondition{
+							{
+								Type:   kubevirtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			hasCompensation: false,
+		},
+		{
+			name: "VMIM is in Pending and with RQ Rejected status, but namespace has annotation CattleAnnotationResourceQuota but zero memory limit, RQ is not compensated",
+			args: args{
+				ns: &corev1.Namespace{
+					ObjectMeta: v1.ObjectMeta{
+						Name: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							// namespace object has CattleAnnotationResourceQuota, but zero memory limit
+							// no compensation is applied
+							util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"0Gi\"}}",
+						},
+					},
+				},
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi*2)),
+							util.AnnotationMigratingScalingResyncNeeded:   "false", // to bypass controller EnqueueAfter
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vm1",
+						Namespace: resourceQuotaNamespace,
+						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+						Conditions: []kubevirtv1.VirtualMachineInstanceMigrationCondition{
+							{
+								Type:   kubevirtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			hasCompensation: false,
+		},
+		{
+			name: "VMIM is in Pending and with RQ Rejected status, but the default rq has no memory limits, RQ is not compensated",
+			args: args{
+				ns: &corev1.Namespace{
+					ObjectMeta: v1.ObjectMeta{
+						Name: resourceQuotaNamespace,
+						Annotations: map[string]string{
+							util.CattleAnnotationResourceQuota: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"1Gi\"}}",
+						},
+					},
+				},
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): fmt.Sprintf(vmResourceLimitStr, getMemWithOverhead(memory1Gi*2)),
+							util.AnnotationMigratingScalingResyncNeeded:   "false", // to bypass controller EnqueueAfter
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU: *resource.NewQuantity(1, resource.DecimalSI),
+							// no memory limit, no compensation
+							// corev1.ResourceLimitsMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+						},
+					},
+				},
+				vmi: &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vm1",
+						Namespace: resourceQuotaNamespace,
+						UID:       uid,
+						Annotations: map[string]string{
+							util.AnnotationMigrationUID:   vmimUID, // bypass vmi migration state updating
+							util.AnnotationMigrationState: StatePending,
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Resources: kubevirtv1.ResourceRequirements{
+								Limits: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(memory1Gi*2, resource.BinarySI),
+								},
+							},
+						},
+					},
+				},
+				vmim: &kubevirtv1.VirtualMachineInstanceMigration{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "vmim1",
+						Namespace: resourceQuotaNamespace,
+						UID:       vmimUID,
+					},
+					Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: "vm1"},
+					Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+						Phase: kubevirtv1.MigrationPending,
+						Conditions: []kubevirtv1.VirtualMachineInstanceMigrationCondition{
+							{
+								Type:   kubevirtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			hasCompensation: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var clientset = fakecore.NewSimpleClientset()
+			var harvFakeClient = fakegenerated.NewSimpleClientset()
+
+			if tt.args.rq != nil {
+				err := clientset.Tracker().Add(tt.args.rq)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+			if tt.args.ns != nil {
+				err := clientset.Tracker().Add(tt.args.ns)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+			if tt.args.vmi != nil {
+				err := harvFakeClient.Tracker().Add(tt.args.vmi)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+			if tt.args.vmim != nil {
+				err := harvFakeClient.Tracker().Add(tt.args.vmim)
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+
+			h := &Handler{
+				rqs:      fakeclients.ResourceQuotaClient(clientset.CoreV1().ResourceQuotas),
+				rqCache:  fakeclients.ResourceQuotaCache(clientset.CoreV1().ResourceQuotas),
+				nsCache:  fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
+				vmiCache: fakeclients.VirtualMachineInstanceCache(harvFakeClient.KubevirtV1().VirtualMachineInstances),
+				vmCache:  fakeclients.VirtualMachineCache(harvFakeClient.KubevirtV1().VirtualMachines),
+			}
+
+			_, err := h.OnVmimChanged("", tt.args.vmim)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnVmimChanged() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			rq, err := h.rqCache.Get(tt.args.rq.Namespace, tt.args.rq.Name)
+			assert.Nil(t, err, errMockTrackerGet)
+			// compensation value might vary, test code does not stick to a specific number
+			// when test code runs, it has output like below line:
+			// INFO[0000] compensateResourceQuotaBase: compensate resource quota rq1 in namespace rs for vm vm1 : map[limits.memory:{{555745096 0} {<nil>}  BinarySI}]
+			assert.Equal(t, tt.hasCompensation, rqutils.HasMigratingCompensation(rq), "case %q", tt.name)
 		})
 	}
 }

--- a/pkg/controller/master/resourcequota/resourcequota_controller.go
+++ b/pkg/controller/master/resourcequota/resourcequota_controller.go
@@ -34,7 +34,7 @@ func (h *Handler) OnResourceQuotaChanged(_ string, rq *corev1.ResourceQuota) (*c
 	}
 
 	// for debugging or manually disabling this feature
-	if rq.Annotations[util.AnnotationSkipResourceQuotaAutoScaling] == "true" {
+	if rqutils.IsResourceQuotaAutoScalingDisabled(rq) {
 		logrus.Debugf("resourcequota %s/%s annotation %s is set, skip auto scaling", rq.Namespace, rq.Name, util.AnnotationSkipResourceQuotaAutoScaling)
 		return rq, nil
 	}
@@ -49,12 +49,28 @@ func (h *Handler) OnResourceQuotaChanged(_ string, rq *corev1.ResourceQuota) (*c
 	update, err := scaleResourceQuotaOnDemand(rqCopy, ns.Annotations[util.CattleAnnotationResourceQuota])
 	if err != nil {
 		if errors.Is(err, errSkipScaling) {
+			// rq scaling is skipped, but the sync flag is set, clear it
+			if rqutils.IsMigratingScalingResyncNeeded(rqCopy) {
+				logrus.Debugf("OnResourceQuotaChanged: resourcequota %s/%s auto-scale is skipped, but sync flag is set, clear it", rq.Namespace, rq.Name)
+				rqutils.ClearAnnotationMigratingScalingResyncNeeded(rqCopy)
+				return h.rqs.Update(rqCopy)
+			}
+			// rq scaling is skipped and no sync is needed; treat as successful no-op
 			return rq, nil
 		}
 		return rq, err
 	}
 	if update {
 		logrus.Debugf("resourcequota %s/%s is updated from %+v to %+v", rq.Namespace, rq.Name, rq.Spec, rqCopy.Spec)
+		// the sync will be done, clear the flag
+		rqutils.ClearAnnotationMigratingScalingResyncNeeded(rqCopy)
+		return h.rqs.Update(rqCopy)
+	}
+
+	// rq is not updated, but the sync flag is set, clear it
+	if rqutils.IsMigratingScalingResyncNeeded(rqCopy) {
+		logrus.Debugf("resourcequota %s/%s is not changed but sync flag is set, clear it", rq.Namespace, rq.Name)
+		rqutils.ClearAnnotationMigratingScalingResyncNeeded(rqCopy)
 		return h.rqs.Update(rqCopy)
 	}
 
@@ -87,11 +103,18 @@ func scaleResourceQuotaOnDemand(rq *corev1.ResourceQuota, rqStr string) (bool, e
 
 	cpuDelta, memDelta, _, err := rqutils.GetVMIMResourcesFromRQAnnotation(rq)
 	if err != nil {
-		logrus.Warnf("resourcequota %s/%s can't get valid Quantity values from Harvester vm annotations, skip scaling, error %s", rq.Namespace, rq.Name, err.Error())
+		logrus.Warnf("resourcequota %s/%s can't get valid Quantity values from annotations, skip scaling, error %s", rq.Namespace, rq.Name, err.Error())
+		return update, errSkipScaling
+	}
+
+	// compensation if real usage already more than base
+	memCompensation, err := rqutils.GetCompensationFromResourceQuota(rq)
+	if err != nil {
+		logrus.Warnf("resourcequota %s/%s can't get valid Compensation values from annotations, skip scaling, error %s", rq.Namespace, rq.Name, err.Error())
 		return update, errSkipScaling
 	}
 
 	// note: if any base has no limit, the delta is not added
-	_, update = rqutils.CalculateNewResourceQuotaFromBaseDelta(rq, rCPULimit, rMemoryLimit, cpuDelta, memDelta)
+	_, update = rqutils.CalculateNewResourceQuotaFromBaseDelta(rq, rCPULimit, rMemoryLimit, cpuDelta, memDelta, memCompensation)
 	return update, nil
 }

--- a/pkg/controller/master/resourcequota/resourcequota_controller_test.go
+++ b/pkg/controller/master/resourcequota/resourcequota_controller_test.go
@@ -9,8 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakecore "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
 
 const (
@@ -22,8 +24,12 @@ const (
 	cpuCore1  = 1
 	cpuCore2  = 2
 	cpuCore3  = 3
+
+	errMockTrackerAdd = "mock resource should add into fake controller tracker"
+	errMockTrackerGet = "mock resource should get into fake controller tracker"
 )
 
+// this test only covers the function scaleResourceQuotaOnDemand which handles the errors while processing quota related annotations
 func TestHandler_OnResourceQuotaChanged(t *testing.T) {
 
 	type args struct {
@@ -38,7 +44,7 @@ func TestHandler_OnResourceQuotaChanged(t *testing.T) {
 		want    *corev1.ResourceQuota
 	}{
 		{
-			name: "ResourceQuota has all zero CPU and memory limits value, skip scalling",
+			name: "ResourceQuota has all zero CPU and memory limits value, skip scaling",
 			args: args{
 				rq: &corev1.ResourceQuota{
 					ObjectMeta: v1.ObjectMeta{
@@ -58,7 +64,7 @@ func TestHandler_OnResourceQuotaChanged(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "ResourceQuota has no or empty CattleAnnotationResourceQuota on namespace annotation, skip scalling",
+			name: "ResourceQuota has no or empty CattleAnnotationResourceQuota on namespace annotation, skip scaling",
 			args: args{
 				rq: &corev1.ResourceQuota{
 					ObjectMeta: v1.ObjectMeta{
@@ -78,7 +84,7 @@ func TestHandler_OnResourceQuotaChanged(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "ResourceQuota has invalid CattleAnnotationResourceQuota on namespace annotation, skip scalling",
+			name: "ResourceQuota has invalid CattleAnnotationResourceQuota on namespace annotation, skip scaling",
 			args: args{
 				rq: &corev1.ResourceQuota{
 					ObjectMeta: v1.ObjectMeta{
@@ -98,7 +104,7 @@ func TestHandler_OnResourceQuotaChanged(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "ResourceQuota has invalid invalid Harvester VM migration annotation, skip scalling",
+			name: "ResourceQuota has invalid Harvester VM migration annotation, skip scaling",
 			args: args{
 				rq: &corev1.ResourceQuota{
 					ObjectMeta: v1.ObjectMeta{
@@ -429,6 +435,7 @@ func TestHandler_OnResourceQuotaChanged(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.args.rq == nil {
@@ -443,6 +450,273 @@ func TestHandler_OnResourceQuotaChanged(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tt.want, tt.args.rq, "case %q", tt.name)
+		})
+
+	}
+}
+
+// this test covers the full process of OnResourceQuotaChanged by controller
+func TestHandler_OnResourceQuotaChanged_ByController(t *testing.T) {
+
+	type args struct {
+		rq             *corev1.ResourceQuota
+		nsrqAnnotation string // util.CattleAnnotationResourceQuota on namespace object
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    *corev1.ResourceQuota
+	}{
+		{
+			name: "ResourceQuota is scaled up per Harvester VM migration annotation, flag is cleared",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							util.AnnotationMigratingScalingResyncNeeded:   "true",
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+				nsrqAnnotation: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.AnnotationMigratingScalingResyncNeeded:   "false",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI), // scaled up
+					},
+				},
+			},
+		},
+		{
+			name: "ResourceQuota is scaled up per Harvester VM migration annotation, no flag is set by legacy controller",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							// util.AnnotationMigratingScalingResyncNeeded:   "true", // legacy controller did not set this flag
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+				nsrqAnnotation: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						// util.AnnotationMigratingScalingResyncNeeded:   "false", // without this annotation also means sync is done
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI), // scaled up
+					},
+				},
+			},
+		},
+		{
+			name: "ResourceQuota has sync requests per Harvester VM migration annotation, but no real changes, the flag is cleared when it is set",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							util.AnnotationMigratingScalingResyncNeeded:   "true", // flag is set, but no real changes
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI), // already scaled
+						},
+					},
+				},
+				nsrqAnnotation: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.AnnotationMigratingScalingResyncNeeded:   "false", // flag is cleared
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "ResourceQuota is processed, no quota annotation change , no sync flag; then no change",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore1, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI), // already scaled
+						},
+					},
+				},
+				nsrqAnnotation: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.GenerateAnnotationKeyMigratingVMUID(uid): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore2, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(12*memory1Gi, resource.BinarySI),
+					},
+				},
+			},
+		},
+		{
+			name: "ResourceQuota auto scaling is disabled",
+			args: args{
+				rq: &corev1.ResourceQuota{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: resourceQuotaNamespace,
+						Name:      resourceQuotaName,
+						Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+						Annotations: map[string]string{
+							util.GenerateAnnotationKeyMigratingVMName("vm1"): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							util.GenerateAnnotationKeyMigratingVMName("vm2"): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+							util.AnnotationMigratingScalingResyncNeeded:      "true",
+							util.AnnotationSkipResourceQuotaAutoScaling:      "true",
+						},
+					},
+					Spec: corev1.ResourceQuotaSpec{
+						Hard: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore3, resource.DecimalSI),
+							corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI),
+						},
+					},
+				},
+				nsrqAnnotation: "{\"limit\":{\"limitsCpu\":\"1\", \"limitsMemory\":\"10Gi\"}}",
+			},
+			wantErr: false,
+			want: &corev1.ResourceQuota{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: resourceQuotaNamespace,
+					Name:      resourceQuotaName,
+					Labels:    map[string]string{util.LabelManagementDefaultResourceQuota: "true"},
+					Annotations: map[string]string{
+						util.GenerateAnnotationKeyMigratingVMName("vm1"): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.GenerateAnnotationKeyMigratingVMName("vm2"): `{"limits.cpu":"1","limits.memory":"2Gi"}`,
+						util.AnnotationMigratingScalingResyncNeeded:      "true",
+						util.AnnotationSkipResourceQuotaAutoScaling:      "true",
+					},
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceLimitsCPU:    *resource.NewQuantity(cpuCore3, resource.DecimalSI),
+						corev1.ResourceLimitsMemory: *resource.NewQuantity(10*memory1Gi, resource.BinarySI), // no change
+					},
+				},
+			},
+		},
+	}
+
+	getNamespace := func(nrqAnnotation string) *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Name: resourceQuotaNamespace,
+				Annotations: map[string]string{
+					util.CattleAnnotationResourceQuota: nrqAnnotation,
+				},
+			},
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.rq == nil {
+				return
+			}
+
+			var clientset = fakecore.NewSimpleClientset()
+			if tt.args.rq != nil {
+				err := clientset.Tracker().Add(tt.args.rq)
+				assert.Nil(t, err, errMockTrackerAdd)
+
+				err = clientset.Tracker().Add(getNamespace(tt.args.nsrqAnnotation))
+				assert.Nil(t, err, errMockTrackerAdd)
+			}
+
+			h := &Handler{
+				nsCache: fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
+				rqs:     fakeclients.ResourceQuotaClient(clientset.CoreV1().ResourceQuotas),
+				rqCache: fakeclients.ResourceQuotaCache(clientset.CoreV1().ResourceQuotas),
+			}
+			_, err := h.OnResourceQuotaChanged(tt.args.rq.Name, tt.args.rq)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnResourceQuotaChanged() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			rq, err := h.rqCache.Get(tt.args.rq.Namespace, tt.args.rq.Name)
+			assert.Nil(t, err, errMockTrackerGet)
+			assert.Equal(t, tt.want, rq, "case %q", tt.name)
 		})
 	}
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -59,6 +59,12 @@ const (
 	// AnnotationMigratingPrefix is replaced by AnnotationMigratingNamePrefix, and is kept for compatibility
 	AnnotationMigratingPrefix = AnnotationMigratingNamePrefix
 
+	// AnnotationMigratingCompensation is used to add compensating quota to help already blocked VMIMs, due to insufficient ResourceQuota, to proceed
+	AnnotationMigratingCompensation = prefix + "/migratingCompensation"
+
+	// AnnotationMigratingScalingResyncNeeded is used for ping-pong between vmim_controller and resourcequota_controller
+	AnnotationMigratingScalingResyncNeeded = prefix + "/migratingScalingResyncNeeded"
+
 	// AnnotationInsufficientResourceQuota is indicated the resource is insufficient of Namespace
 	AnnotationInsufficientResourceQuota = prefix + "/insufficient-resource-quota"
 

--- a/pkg/util/resourcequota/calculator.go
+++ b/pkg/util/resourcequota/calculator.go
@@ -235,6 +235,11 @@ func GetVMIMResourcesFromRQAnnotation(rq *corev1.ResourceQuota) (cpu, mem, stora
 
 // Get Rancher NamespaceResourceQuota LimitsCPU and LimitsMemory
 func GetCPUMemoryLimitsFromRancherNamespaceResourceQuota(nrq *v3.NamespaceResourceQuota) (cpu, mem resource.Quantity, err error) {
+	if nrq == nil {
+		cpu = *resource.NewQuantity(0, resource.DecimalSI)
+		mem = *resource.NewQuantity(0, resource.BinarySI)
+		return
+	}
 	if nrq.Limit.LimitsCPU == "" {
 		cpu = *resource.NewQuantity(0, resource.DecimalSI)
 	} else {
@@ -243,6 +248,22 @@ func GetCPUMemoryLimitsFromRancherNamespaceResourceQuota(nrq *v3.NamespaceResour
 		}
 	}
 
+	if nrq.Limit.LimitsMemory == "" {
+		mem = *resource.NewQuantity(0, resource.BinarySI)
+	} else {
+		if mem, err = resource.ParseQuantity(nrq.Limit.LimitsMemory); err != nil {
+			return
+		}
+	}
+	return
+}
+
+// Get Rancher NamespaceResourceQuota LimitsMemory
+func GetMemoryLimitsFromRancherNamespaceResourceQuota(nrq *v3.NamespaceResourceQuota) (mem resource.Quantity, err error) {
+	if nrq == nil {
+		mem = *resource.NewQuantity(0, resource.BinarySI)
+		return
+	}
 	if nrq.Limit.LimitsMemory == "" {
 		mem = *resource.NewQuantity(0, resource.BinarySI)
 	} else {
@@ -413,7 +434,7 @@ func CalculateRestoreResourceQuotaWithVMI(
 }
 
 // If base is zero, delta is not added
-func CalculateNewResourceQuotaFromBaseDelta(rq *corev1.ResourceQuota, cpuBase, memBase, cpuDelta, memDelta resource.Quantity) (*corev1.ResourceQuota, bool) {
+func CalculateNewResourceQuotaFromBaseDelta(rq *corev1.ResourceQuota, cpuBase, memBase, cpuDelta, memDelta, memCompensation resource.Quantity) (*corev1.ResourceQuota, bool) {
 	needUpdate := false
 	if !cpuBase.IsZero() {
 		cpuBase.Add(cpuDelta)
@@ -424,6 +445,7 @@ func CalculateNewResourceQuotaFromBaseDelta(rq *corev1.ResourceQuota, cpuBase, m
 	}
 	if !memBase.IsZero() {
 		memBase.Add(memDelta)
+		memBase.Add(memCompensation)
 		if !rq.Spec.Hard[corev1.ResourceLimitsMemory].Equal(memBase) {
 			needUpdate = true
 			rq.Spec.Hard[corev1.ResourceLimitsMemory] = memBase
@@ -456,6 +478,17 @@ func isEmpty(rq *corev1.ResourceQuota) bool {
 	return false
 }
 
+func isMemoryLimitEmpty(rq *corev1.ResourceQuota) bool {
+	if rq == nil {
+		return true
+	}
+	hard := rq.Spec.Hard
+	if hard == nil || hard.Name(corev1.ResourceLimitsMemory, resource.BinarySI).IsZero() {
+		return true
+	}
+	return false
+}
+
 func IsEmptyResourceQuota(rq *corev1.ResourceQuota) bool {
 	return isEmpty(rq)
 }
@@ -478,4 +511,51 @@ func calculateVMStorageQuantity(vm *kubevirtv1.VirtualMachine) (resource.Quantit
 	}
 
 	return storage, nil
+}
+
+// Get ResourceQuota annotations about compensation, only memory is supported
+func GetCompensationFromResourceQuota(rq *corev1.ResourceQuota) (mem resource.Quantity, err error) {
+	mem = *resource.NewQuantity(0, resource.BinarySI)
+	rl, err := getResourceListOfMigratingCompensation(rq)
+	if err != nil {
+		return mem, err
+	}
+	if rl == nil {
+		return mem, nil
+	}
+
+	mem.Add(*rl.Name(corev1.ResourceLimitsMemory, resource.BinarySI))
+	return mem, nil
+}
+
+func CalculateCompensationResourceQuotaWithVMI(
+	rq *corev1.ResourceQuota,
+	vmi *kubevirtv1.VirtualMachineInstance,
+	ratio *string,
+) (needUpdate bool, rl corev1.ResourceList) {
+	if rq == nil || vmi == nil || ratio == nil {
+		return false, nil
+	}
+	vmiLimits := vmi.Spec.Domain.Resources.Limits
+	if isMemoryLimitEmpty(rq) || vmiLimits.Memory().IsZero() {
+		return false, nil
+	}
+
+	rl = corev1.ResourceList{}
+	mem := vmiLimits[corev1.ResourceMemory]
+	mem.Add(kubevirtservices.GetMemoryOverhead(vmi, runtime.GOARCH, ratio)) // add overhead
+
+	// hard limit, used
+	limitMem := rq.Spec.Hard.Name(corev1.ResourceLimitsMemory, resource.BinarySI)
+	usedMem := rq.Status.Used.Name(corev1.ResourceLimitsMemory, resource.BinarySI)
+	usedMem.Add(mem)
+	// used + migration target pod exceeds limit, compensate the delta
+	if usedMem.Cmp(*limitMem) == 1 {
+		usedMem.Sub(*limitMem)
+		usedMem.Add(*resource.NewQuantity(additionalCompensationMemory, resource.BinarySI))
+		rl[corev1.ResourceLimitsMemory] = *usedMem
+		return true, rl
+	}
+
+	return false, nil
 }

--- a/pkg/util/resourcequota/utils.go
+++ b/pkg/util/resourcequota/utils.go
@@ -5,13 +5,23 @@ import (
 	"fmt"
 	"strings"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/util"
 )
 
+const (
+	// even kubevirt can't 100% precisely calculate the exact memory a vmi POD will consume
+	// we add an additional 128Mi when compensating RQ, to ensure the vmi migration target pod can be created
+	additionalCompensationMemory = 128 << 20
+
+	stringTrue  = "true"
+	stringFalse = "false"
+)
+
 func HasMigratingVM(rq *corev1.ResourceQuota) bool {
-	if rq.Annotations == nil {
+	if rq == nil || rq.Annotations == nil {
 		return false
 	}
 
@@ -27,6 +37,9 @@ func HasMigratingVM(rq *corev1.ResourceQuota) bool {
 }
 
 func AddMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string, rl corev1.ResourceList) error {
+	if rq == nil {
+		return fmt.Errorf("failed to call AddMigratingVM as input rq is nil")
+	}
 	rlb, err := json.Marshal(rl)
 	if err != nil {
 		return err
@@ -42,9 +55,9 @@ func AddMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string, rl corev1.Re
 	return nil
 }
 
-// delete the may existing VM Miration, return true if it exists
+// delete the maybe existing VM Migration, return true if it exists
 func DeleteMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string) bool {
-	if rq.Annotations == nil {
+	if rq == nil || rq.Annotations == nil {
 		return false
 	}
 	len1 := len(rq.Annotations)
@@ -55,7 +68,7 @@ func DeleteMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string) bool {
 }
 
 func ContainsMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string) bool {
-	if rq.Annotations == nil {
+	if rq == nil || rq.Annotations == nil {
 		return false
 	}
 	// check both possible keys
@@ -71,7 +84,7 @@ func ContainsMigratingVM(rq *corev1.ResourceQuota, vmName, vmUID string) bool {
 // check both possible keys
 func getResourceListFromMigratingVMs(rq *corev1.ResourceQuota) (map[string]corev1.ResourceList, error) {
 	vms := make(map[string]corev1.ResourceList)
-	if rq.Annotations == nil {
+	if rq == nil || rq.Annotations == nil {
 		return vms, nil
 	}
 
@@ -93,4 +106,131 @@ func getResourceListFromMigratingVMs(rq *corev1.ResourceQuota) (map[string]corev
 		}
 	}
 	return vms, nil
+}
+
+func HasMigratingCompensation(rq *corev1.ResourceQuota) bool {
+	if rq == nil || rq.Annotations == nil {
+		return false
+	}
+	return rq.Annotations[util.AnnotationMigratingCompensation] != ""
+}
+
+func AddMigratingCompensation(rq *corev1.ResourceQuota, rl corev1.ResourceList) error {
+	if rq == nil {
+		return fmt.Errorf("failed to call AddMigratingCompensation as input rq is nil")
+	}
+	rlb, err := json.Marshal(rl)
+	if err != nil {
+		return err
+	}
+
+	if rq.Annotations == nil {
+		rq.Annotations = make(map[string]string)
+	}
+
+	rq.Annotations[util.AnnotationMigratingCompensation] = string(rlb)
+	return nil
+}
+
+// delete the maybe existing Migration compensation, return true if it exists
+func DeleteMigratingCompensation(rq *corev1.ResourceQuota) bool {
+	if rq == nil || rq.Annotations == nil {
+		return false
+	}
+	initialLen := len(rq.Annotations)
+	delete(rq.Annotations, util.AnnotationMigratingCompensation)
+	return initialLen != len(rq.Annotations)
+}
+
+func getResourceListOfMigratingCompensation(rq *corev1.ResourceQuota) (corev1.ResourceList, error) {
+	if rq == nil || rq.Annotations == nil {
+		return nil, nil
+	}
+	compensation := rq.Annotations[util.AnnotationMigratingCompensation]
+	if compensation == "" {
+		return nil, nil
+	}
+	var rl corev1.ResourceList
+	if err := json.Unmarshal([]byte(compensation), &rl); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal compensation quantity %v %w", compensation, err)
+	}
+
+	return rl, nil
+}
+
+func SetAnnotationMigratingScalingResyncNeeded(rq *corev1.ResourceQuota) {
+	if rq == nil {
+		return
+	}
+	// set true
+	if rq.Annotations == nil {
+		rq.Annotations = make(map[string]string)
+	}
+	rq.Annotations[util.AnnotationMigratingScalingResyncNeeded] = stringTrue
+}
+
+func ClearAnnotationMigratingScalingResyncNeeded(rq *corev1.ResourceQuota) {
+	if rq == nil || rq.Annotations == nil {
+		return
+	}
+
+	// clear the flag if it exists and is "true"
+	val, ok := rq.Annotations[util.AnnotationMigratingScalingResyncNeeded]
+	if !ok || val != stringTrue {
+		return
+	}
+
+	rq.Annotations[util.AnnotationMigratingScalingResyncNeeded] = stringFalse
+}
+
+func IsMigratingScalingResyncNeeded(rq *corev1.ResourceQuota) bool {
+	if rq == nil || rq.Annotations == nil {
+		return false
+	}
+	return rq.Annotations[util.AnnotationMigratingScalingResyncNeeded] == stringTrue
+}
+
+func IsResourceQuotaAutoScalingDisabled(rq *corev1.ResourceQuota) bool {
+	if rq == nil || rq.Annotations == nil {
+		return false
+	}
+	return rq.Annotations[util.AnnotationSkipResourceQuotaAutoScaling] == stringTrue
+}
+
+// check if a resourcequota is managed by the namespace annotation util.CattleAnnotationResourceQuota
+func IsResourceQuotaManagedByNamespaceAnnotation(rq *corev1.ResourceQuota, rqStr string) (bool, error) {
+	if rqStr == "" {
+		return false, nil
+	}
+	if IsEmptyResourceQuota(rq) {
+		return false, nil
+	}
+	var rqBase v3.NamespaceResourceQuota
+	if err := json.Unmarshal([]byte(rqStr), &rqBase); err != nil {
+		return false, err
+	}
+	rCPULimit, rMemoryLimit, err := GetCPUMemoryLimitsFromRancherNamespaceResourceQuota(&rqBase)
+	if err != nil {
+		return false, err
+	}
+	return !rCPULimit.IsZero() || !rMemoryLimit.IsZero(), nil
+}
+
+// check if a resourcequota is managed by the namespace annotation util.CattleAnnotationResourceQuota and has MemoryLimits
+func IsResourceQuotaManagedByNamespaceAnnotationWithMemoryLimits(rq *corev1.ResourceQuota, rqStr string) (bool, error) {
+	if rqStr == "" {
+		return false, nil
+	}
+	if isMemoryLimitEmpty(rq) {
+		return false, nil
+	}
+	var rqBase v3.NamespaceResourceQuota
+	if err := json.Unmarshal([]byte(rqStr), &rqBase); err != nil {
+		return false, err
+	}
+	rMemoryLimit, err := GetMemoryLimitsFromRancherNamespaceResourceQuota(&rqBase)
+	if err != nil {
+		return false, err
+	}
+	return !rMemoryLimit.IsZero(), nil
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

This is a simplified version of PR https://github.com/harvester/harvester/pull/9942, it removes all refactors, only keep the core `compesation` mechanism.

To make the PR review easier.

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

An already running VM might fail to migration if the system level setting [additional-guest-memory-overhead-ratio](https://docs.harvesterhci.io/v1.7/advanced/index#additional-guest-memory-overhead-ratio) is changed after the VM has started to run.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

For already running VMs, try best to let them continue to migrate, when they are stopped and then the quota will strictly restrict them to start again only if the quota has enough free space.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/9753

document PR to explain the details:

https://github.com/harvester/docs/pull/981

#### Test plan:
<!-- Describe the test plan by steps. -->

Per https://github.com/harvester/harvester/pull/9942#issuecomment-3915516457

Local test report: https://github.com/harvester/harvester/pull/10197#issuecomment-4077756611

#### Additional documentation or context

Future enhancement: https://github.com/harvester/harvester/issues/10093 https://github.com/harvester/harvester/issues/10232