### PR TITLE
[v190] fix: reject cpumanager changes from user

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -92,10 +92,8 @@ func (m *vmMutator) Create(request *types.Request, newObj runtime.Object) (types
 
 	patchOps = patchDefaultCPU(vm, patchOps)
 
-	if request == nil || !request.IsFromController() {
-		if err := m.checkReservedAffinityKeys(nil, vm); err != nil {
-			return nil, err
-		}
+	if err := checkCpuManagerAffinityTermChanged(request, nil, vm); err != nil {
+		return nil, err
 	}
 
 	patchOps, err = m.patchAffinity(vm, patchOps)
@@ -153,10 +151,8 @@ func (m *vmMutator) Update(request *types.Request, oldObj runtime.Object, newObj
 		patchOps = patchRunStrategy(newVM, patchOps)
 	}
 
-	if request == nil || !request.IsFromController() {
-		if err := m.checkReservedAffinityKeys(oldVM, newVM); err != nil {
-			return nil, err
-		}
+	if err := checkCpuManagerAffinityTermChanged(request, oldVM, newVM); err != nil {
+		return nil, err
 	}
 
 	patchOps, err = m.patchAffinity(newVM, patchOps)
@@ -913,43 +909,43 @@ func isCreatedByForklift(vm *kubevirtv1.VirtualMachine) bool {
 	return migrationExists && planExists && vmIDExists
 }
 
-func (m *vmMutator) checkReservedAffinityKeys(oldVM, newVM *kubevirtv1.VirtualMachine) error {
-	if reflect.DeepEqual(vmAffinityNotNil(oldVM), vmAffinityNotNil(newVM)) {
+func checkCpuManagerAffinityTermChanged(request *types.Request, oldVM, newVM *kubevirtv1.VirtualMachine) error {
+	if request != nil && request.IsFromController() {
 		return nil
 	}
-	if reflect.DeepEqual(cpuManagerAffinityTerms(oldVM), cpuManagerAffinityTerms(newVM)) {
+	getCPUManagerExprs := func(vm *kubevirtv1.VirtualMachine) []v1.NodeSelectorRequirement {
+		if vm == nil || vm.Spec.Template == nil {
+			return nil
+		}
+		affinity := vm.Spec.Template.Spec.Affinity
+		if affinity == nil || affinity.NodeAffinity == nil ||
+			affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+			return nil
+		}
+		var exprs []v1.NodeSelectorRequirement
+		for _, term := range affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			for _, expr := range term.MatchExpressions {
+				if expr.Key == kubevirtv1.CPUManager {
+					exprs = append(exprs, expr)
+				}
+			}
+		}
+		if len(exprs) > 1 {
+			slices.SortFunc(exprs, func(a, b v1.NodeSelectorRequirement) int {
+				if cmp := strings.Compare(string(a.Operator), string(b.Operator)); cmp != 0 {
+					return cmp
+				}
+				return strings.Compare(fmt.Sprintf("%v", a.Values), fmt.Sprintf("%v", b.Values))
+			})
+		}
+		return exprs
+	}
+
+	if reflect.DeepEqual(getCPUManagerExprs(oldVM), getCPUManagerExprs(newVM)) {
 		return nil
 	}
 	return werror.NewInvalidError(
 		fmt.Sprintf("key %q is automatically operated by Harvester controller and can't be changed manually", kubevirtv1.CPUManager),
 		"spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution",
 	)
-}
-
-func vmAffinityNotNil(vm *kubevirtv1.VirtualMachine) *v1.Affinity {
-	if vm == nil || vm.Spec.Template == nil {
-		return nil
-	}
-	return vm.Spec.Template.Spec.Affinity
-}
-
-func cpuManagerAffinityTerms(vm *kubevirtv1.VirtualMachine) []v1.NodeSelectorTerm {
-	affinity := vmAffinityNotNil(vm)
-	if affinity == nil || affinity.NodeAffinity == nil ||
-		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-		return nil
-	}
-	var terms []v1.NodeSelectorTerm
-	for _, term := range affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
-		for _, expr := range term.MatchExpressions {
-			if expr.Key == kubevirtv1.CPUManager {
-				terms = append(terms, term)
-				break
-			}
-		}
-	}
-	slices.SortFunc(terms, func(a, b v1.NodeSelectorTerm) int {
-		return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
-	})
-	return terms
 }

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -916,11 +917,11 @@ func (m *vmMutator) checkReservedAffinityKeys(oldVM, newVM *kubevirtv1.VirtualMa
 	if reflect.DeepEqual(vmAffinityNotNil(oldVM), vmAffinityNotNil(newVM)) {
 		return nil
 	}
-	if reflect.DeepEqual(reservedAffinityTerms(oldVM), reservedAffinityTerms(newVM)) {
+	if reflect.DeepEqual(cpuManagerAffinityTerms(oldVM), cpuManagerAffinityTerms(newVM)) {
 		return nil
 	}
 	return werror.NewInvalidError(
-		fmt.Sprintf("key %q is reserved and managed by Harvester", kubevirtv1.CPUManager),
+		fmt.Sprintf("key %q is automatically operated by Harvester controller and can't be changed manually", kubevirtv1.CPUManager),
 		"spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution",
 	)
 }
@@ -932,7 +933,7 @@ func vmAffinityNotNil(vm *kubevirtv1.VirtualMachine) *v1.Affinity {
 	return vm.Spec.Template.Spec.Affinity
 }
 
-func reservedAffinityTerms(vm *kubevirtv1.VirtualMachine) []v1.NodeSelectorTerm {
+func cpuManagerAffinityTerms(vm *kubevirtv1.VirtualMachine) []v1.NodeSelectorTerm {
 	affinity := vmAffinityNotNil(vm)
 	if affinity == nil || affinity.NodeAffinity == nil ||
 		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
@@ -947,5 +948,8 @@ func reservedAffinityTerms(vm *kubevirtv1.VirtualMachine) []v1.NodeSelectorTerm 
 			}
 		}
 	}
+	slices.SortFunc(terms, func(a, b v1.NodeSelectorTerm) int {
+		return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
+	})
 	return terms
 }

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -3,6 +3,7 @@ package virtualmachine
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/network"
 	"github.com/harvester/harvester/pkg/util/virtualmachine"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 )
@@ -77,7 +79,7 @@ func (m *vmMutator) Resource() types.Resource {
 	}
 }
 
-func (m *vmMutator) Create(_ *types.Request, newObj runtime.Object) (types.PatchOps, error) {
+func (m *vmMutator) Create(request *types.Request, newObj runtime.Object) (types.PatchOps, error) {
 	vm := newObj.(*kubevirtv1.VirtualMachine)
 
 	logrus.Debugf("create VM %s/%s", vm.Namespace, vm.Name)
@@ -88,6 +90,12 @@ func (m *vmMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch
 	}
 
 	patchOps = patchDefaultCPU(vm, patchOps)
+
+	if request == nil || !request.IsFromController() {
+		if err := m.checkReservedAffinityKeys(nil, vm); err != nil {
+			return nil, err
+		}
+	}
 
 	patchOps, err = m.patchAffinity(vm, patchOps)
 	if err != nil {
@@ -113,7 +121,7 @@ func (m *vmMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch
 	return patchOps, err
 }
 
-func (m *vmMutator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) (types.PatchOps, error) {
+func (m *vmMutator) Update(request *types.Request, oldObj runtime.Object, newObj runtime.Object) (types.PatchOps, error) {
 	newVM := newObj.(*kubevirtv1.VirtualMachine)
 	oldVM := oldObj.(*kubevirtv1.VirtualMachine)
 
@@ -142,6 +150,12 @@ func (m *vmMutator) Update(_ *types.Request, oldObj runtime.Object, newObj runti
 
 	if needUpdateRunStrategy {
 		patchOps = patchRunStrategy(newVM, patchOps)
+	}
+
+	if request == nil || !request.IsFromController() {
+		if err := m.checkReservedAffinityKeys(oldVM, newVM); err != nil {
+			return nil, err
+		}
 	}
 
 	patchOps, err = m.patchAffinity(newVM, patchOps)
@@ -896,4 +910,42 @@ func isCreatedByForklift(vm *kubevirtv1.VirtualMachine) bool {
 	_, planExists := vm.Labels[planKey]
 	_, vmIDExists := vm.Labels[vmIDKey]
 	return migrationExists && planExists && vmIDExists
+}
+
+func (m *vmMutator) checkReservedAffinityKeys(oldVM, newVM *kubevirtv1.VirtualMachine) error {
+	if reflect.DeepEqual(vmAffinityNotNil(oldVM), vmAffinityNotNil(newVM)) {
+		return nil
+	}
+	if reflect.DeepEqual(reservedAffinityTerms(oldVM), reservedAffinityTerms(newVM)) {
+		return nil
+	}
+	return werror.NewInvalidError(
+		fmt.Sprintf("key %q is reserved and managed by Harvester", kubevirtv1.CPUManager),
+		"spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution",
+	)
+}
+
+func vmAffinityNotNil(vm *kubevirtv1.VirtualMachine) *v1.Affinity {
+	if vm == nil || vm.Spec.Template == nil {
+		return nil
+	}
+	return vm.Spec.Template.Spec.Affinity
+}
+
+func reservedAffinityTerms(vm *kubevirtv1.VirtualMachine) []v1.NodeSelectorTerm {
+	affinity := vmAffinityNotNil(vm)
+	if affinity == nil || affinity.NodeAffinity == nil ||
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return nil
+	}
+	var terms []v1.NodeSelectorTerm
+	for _, term := range affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Key == kubevirtv1.CPUManager {
+				terms = append(terms, term)
+				break
+			}
+		}
+	}
+	return terms
 }

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -12,8 +12,11 @@ import (
 
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/patch"
+	"github.com/rancher/wrangler/v3/pkg/webhook"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,13 +29,15 @@ import (
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
+	"github.com/harvester/harvester/pkg/webhook/config"
 	"github.com/harvester/harvester/pkg/webhook/types"
 	kubeovnapiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
 
 const (
-	replaceOP        = "replace"
-	nodeAffinityPath = "/spec/template/spec/affinity"
+	replaceOP                   = "replace"
+	nodeAffinityPath            = "/spec/template/spec/affinity"
+	harvesterControllerUsername = "harvester-controller"
 )
 
 func setupTestMutator(clientset *fake.Clientset) types.Mutator {
@@ -58,6 +63,7 @@ func createTestVM(
 	memory *kubevirtv1.Memory,
 	annotations map[string]string,
 	namespace, name string,
+	affinity *v1.Affinity,
 ) *kubevirtv1.VirtualMachine {
 	return &kubevirtv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -69,6 +75,7 @@ func createTestVM(
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Affinity: affinity,
 					Domain: kubevirtv1.DomainSpec{
 						Resources: resourceReq,
 						Memory:    memory,
@@ -349,7 +356,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			createDefaultKubeVirt(clientset)
 			mutator := setupTestMutator(clientset)
 
-			vm := createTestVM(tc.resourceReq, tc.memory, annotations, "", "")
+			vm := createTestVM(tc.resourceReq, tc.memory, annotations, "", "", nil)
 
 			actual, err := mutator.(*vmMutator).patchResourceOvercommit(vm)
 
@@ -543,7 +550,7 @@ func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testin
 			setConfig(clientset, tc)
 			createDefaultKubeVirt(clientset)
 			mutator := setupTestMutator(clientset)
-			vm := createTestVM(tc.resourceReq, tc.memory, annotations, "", "")
+			vm := createTestVM(tc.resourceReq, tc.memory, annotations, "", "", nil)
 
 			actual, err := mutator.(*vmMutator).patchResourceOvercommit(vm)
 			assert.Nil(t, err, tc.name)
@@ -1792,6 +1799,193 @@ func TestPatchManagedTapBinding(t *testing.T) {
 				assert.Equal(t, expected.Value, actual.Value)
 			}
 		})
+	}
+}
+
+func TestMutatorCreate(t *testing.T) {
+	createReq := kubevirtv1.ResourceRequirements{
+		Limits: map[v1.ResourceName]resource.Quantity{
+			v1.ResourceMemory: resource.MustParse("1Gi"),
+			v1.ResourceCPU:    resource.MustParse("1"),
+		},
+	}
+	tests := []struct {
+		name          string
+		request       *types.Request
+		vm            *kubevirtv1.VirtualMachine
+		expectedError bool
+	}{
+		{
+			name:    "user injects cpumanager term on create – rejected",
+			request: newMutatorUserRequest("alice"),
+			vm: createTestVM(createReq, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			expectedError: true,
+		},
+		{
+			name:    "controller sets cpumanager term on create – allowed",
+			request: newMutatorControllerRequest(),
+			vm: createTestVM(createReq, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			expectedError: false,
+		},
+		{
+			name:          "user creates VM without cpumanager term – allowed",
+			request:       newMutatorUserRequest("alice"),
+			vm:            createTestVM(createReq, nil, nil, "default", "test-vm", nil),
+			expectedError: false,
+		},
+	}
+
+	setup := func() types.Mutator {
+		clientset := fake.NewSimpleClientset()
+		createDefaultKubeVirt(clientset)
+		_ = clientset.Tracker().Add(&harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: "overcommit-config"},
+			Default:    `{"cpu":100,"memory":100,"storage":100}`,
+		})
+		return setupTestMutator(clientset)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := setup().(*vmMutator).Create(tc.request, tc.vm)
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMutatorUpdate(t *testing.T) {
+	tests := []struct {
+		name          string
+		request       *types.Request
+		oldVM         *kubevirtv1.VirtualMachine
+		newVM         *kubevirtv1.VirtualMachine
+		expectedError bool
+	}{
+		{
+			name:    "user passes through unchanged cpumanager term – allowed",
+			request: newMutatorUserRequest("alice"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			expectedError: false,
+		},
+		{
+			name:    "user modifies cpumanager term value – rejected",
+			request: newMutatorUserRequest("alice"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"false"},
+				}},
+			})),
+			expectedError: true,
+		},
+		{
+			name:    "cpumanager term removed (CPU pinning off) – rejected",
+			request: newMutatorUserRequest("alice"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			newVM:         createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", nil),
+			expectedError: true,
+		},
+		{
+			name:          "no cpumanager term in either VM – allowed",
+			request:       newMutatorUserRequest("alice"),
+			oldVM:         createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", nil),
+			newVM:         createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", nil),
+			expectedError: false,
+		},
+	}
+
+	setup := func() types.Mutator {
+		clientset := fake.NewSimpleClientset()
+		createDefaultKubeVirt(clientset)
+		return setupTestMutator(clientset)
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := setup().(*vmMutator).Update(tc.request, tc.oldVM, tc.newVM)
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newMutatorUserRequest(username string) *types.Request {
+	return types.NewRequest(
+		&webhook.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UserInfo: authenticationv1.UserInfo{Username: username},
+			},
+		},
+		&config.Options{HarvesterControllerUsername: harvesterControllerUsername},
+	)
+}
+
+func newMutatorControllerRequest() *types.Request {
+	return types.NewRequest(
+		&webhook.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UserInfo: authenticationv1.UserInfo{Username: harvesterControllerUsername},
+			},
+		},
+		&config.Options{HarvesterControllerUsername: harvesterControllerUsername},
+	)
+}
+
+func affinityForTerm(term *v1.NodeSelectorTerm) *v1.Affinity {
+	if term == nil {
+		return nil
+	}
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{*term},
+			},
+		},
 	}
 }
 

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -1817,7 +1817,7 @@ func TestMutatorCreate(t *testing.T) {
 	}{
 		{
 			name:    "user injects cpumanager term on create – rejected",
-			request: newMutatorUserRequest("alice"),
+			request: newMutatorUserRequest("harvester"),
 			vm: createTestVM(createReq, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
 				MatchExpressions: []v1.NodeSelectorRequirement{{
 					Key:      kubevirtv1.CPUManager,
@@ -1841,7 +1841,7 @@ func TestMutatorCreate(t *testing.T) {
 		},
 		{
 			name:          "user creates VM without cpumanager term – allowed",
-			request:       newMutatorUserRequest("alice"),
+			request:       newMutatorUserRequest("harvester"),
 			vm:            createTestVM(createReq, nil, nil, "default", "test-vm", nil),
 			expectedError: false,
 		},
@@ -1879,7 +1879,7 @@ func TestMutatorUpdate(t *testing.T) {
 	}{
 		{
 			name:    "user passes through unchanged cpumanager term – allowed",
-			request: newMutatorUserRequest("alice"),
+			request: newMutatorUserRequest("harvester"),
 			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
 				MatchExpressions: []v1.NodeSelectorRequirement{{
 					Key:      kubevirtv1.CPUManager,
@@ -1898,7 +1898,7 @@ func TestMutatorUpdate(t *testing.T) {
 		},
 		{
 			name:    "user modifies cpumanager term value – rejected",
-			request: newMutatorUserRequest("alice"),
+			request: newMutatorUserRequest("harvester"),
 			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
 				MatchExpressions: []v1.NodeSelectorRequirement{{
 					Key:      kubevirtv1.CPUManager,
@@ -1917,7 +1917,7 @@ func TestMutatorUpdate(t *testing.T) {
 		},
 		{
 			name:    "cpumanager term removed (CPU pinning off) – rejected",
-			request: newMutatorUserRequest("alice"),
+			request: newMutatorUserRequest("harvester"),
 			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
 				MatchExpressions: []v1.NodeSelectorRequirement{{
 					Key:      kubevirtv1.CPUManager,
@@ -1930,9 +1930,28 @@ func TestMutatorUpdate(t *testing.T) {
 		},
 		{
 			name:          "no cpumanager term in either VM – allowed",
-			request:       newMutatorUserRequest("alice"),
+			request:       newMutatorUserRequest("harvester"),
 			oldVM:         createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", nil),
 			newVM:         createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", nil),
+			expectedError: false,
+		},
+		{
+			name:    "controller modifies cpumanager term – allowed",
+			request: newMutatorControllerRequest(),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      kubevirtv1.CPUManager,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"false"},
+				}},
+			})),
 			expectedError: false,
 		},
 	}

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -1845,15 +1845,47 @@ func TestMutatorCreate(t *testing.T) {
 			vm:            createTestVM(createReq, nil, nil, "default", "test-vm", nil),
 			expectedError: false,
 		},
+		{
+			name:    "user injects cpumanager among other keys on create – rejected",
+			request: newMutatorUserRequest("harvester"),
+			vm: createTestVM(createReq, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{
+					{
+						Key:      "custom/node-label",
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"zone-a"},
+					},
+					{
+						Key:      kubevirtv1.CPUManager,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			})),
+			expectedError: true,
+		},
+		{
+			name:    "user creates VM with non-cpumanager affinity only – allowed",
+			request: newMutatorUserRequest("harvester"),
+			vm: createTestVM(createReq, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      "custom/node-label",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"zone-a"},
+				}},
+			})),
+			expectedError: false,
+		},
 	}
 
 	setup := func() types.Mutator {
 		clientset := fake.NewSimpleClientset()
 		createDefaultKubeVirt(clientset)
-		_ = clientset.Tracker().Add(&harvesterv1.Setting{
-			ObjectMeta: metav1.ObjectMeta{Name: "overcommit-config"},
+		err := clientset.Tracker().Add(&harvesterv1.Setting{
+			ObjectMeta: metav1.ObjectMeta{Name: settings.OvercommitConfigSettingName},
 			Default:    `{"cpu":100,"memory":100,"storage":100}`,
 		})
+		assert.NoError(t, err)
 		return setupTestMutator(clientset)
 	}
 
@@ -1936,6 +1968,141 @@ func TestMutatorUpdate(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:    "user modifies non-cpumanager node affinity – allowed",
+			request: newMutatorUserRequest("harvester"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      "custom/node-label",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"zone-a"},
+				}},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      "custom/node-label",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"zone-b"},
+				}},
+			})),
+			expectedError: false,
+		},
+		{
+			name:    "user modifies network.harvesterhci.io affinity key – allowed (key is later dropped by mutator)",
+			request: newMutatorUserRequest("harvester"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      networkGroup + "/mgmt",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      networkGroup + "/vlan100",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				}},
+			})),
+			expectedError: false,
+		},
+		{
+			name:    "user modifies non-cpumanager key in mixed term (cpumanager unchanged) – allowed",
+			request: newMutatorUserRequest("harvester"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{
+					{Key: "custom/node-label", Operator: v1.NodeSelectorOpIn, Values: []string{"zone-a"}},
+					{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+				},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{
+					{Key: "custom/node-label", Operator: v1.NodeSelectorOpIn, Values: []string{"zone-b"}},
+					{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+				},
+			})),
+			expectedError: false,
+		},
+		{
+			name:    "user modifies cpumanager key in mixed term – rejected",
+			request: newMutatorUserRequest("harvester"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{
+					{Key: "custom/node-label", Operator: v1.NodeSelectorOpIn, Values: []string{"zone-a"}},
+					{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+				},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{
+					{Key: "custom/node-label", Operator: v1.NodeSelectorOpIn, Values: []string{"zone-a"}},
+					{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"false"}},
+				},
+			})),
+			expectedError: true,
+		},
+		{
+			name:    "user injects cpumanager in second term while first term unchanged – rejected",
+			request: newMutatorUserRequest("harvester"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{MatchExpressions: []v1.NodeSelectorRequirement{
+								{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+							}},
+						},
+					},
+				},
+			}),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{MatchExpressions: []v1.NodeSelectorRequirement{
+								{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+							}},
+							{MatchExpressions: []v1.NodeSelectorRequirement{
+								{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"false"}},
+							}},
+						},
+					},
+				},
+			}),
+			expectedError: true,
+		},
+		{
+			name:    "two cpumanager exprs with different operators in reversed term order – allowed (sort by operator)",
+			request: newMutatorUserRequest("harvester"),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{MatchExpressions: []v1.NodeSelectorRequirement{
+								{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+							}},
+							{MatchExpressions: []v1.NodeSelectorRequirement{
+								{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpNotIn, Values: []string{"false"}},
+							}},
+						},
+					},
+				},
+			}),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{MatchExpressions: []v1.NodeSelectorRequirement{
+								{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpNotIn, Values: []string{"false"}},
+							}},
+							{MatchExpressions: []v1.NodeSelectorRequirement{
+								{Key: kubevirtv1.CPUManager, Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+							}},
+						},
+					},
+				},
+			}),
+			expectedError: false,
+		},
+		{
 			name:    "controller modifies cpumanager term – allowed",
 			request: newMutatorControllerRequest(),
 			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
@@ -1950,6 +2117,25 @@ func TestMutatorUpdate(t *testing.T) {
 					Key:      kubevirtv1.CPUManager,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{"false"},
+				}},
+			})),
+			expectedError: false,
+		},
+		{
+			name:    "controller modifies non-cpumanager term – allowed",
+			request: newMutatorControllerRequest(),
+			oldVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      "custom/node-label",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"zone-a"},
+				}},
+			})),
+			newVM: createTestVM(kubevirtv1.ResourceRequirements{}, nil, nil, "default", "test-vm", affinityForTerm(&v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{{
+					Key:      "custom/node-label",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"zone-b"},
 				}},
 			})),
 			expectedError: false,


### PR DESCRIPTION
Rejecting cpu manager changes coming from users as harvester controller is already using the value to configure it and we silently drop it.

Now we determine if request is coming from controller or user and reject it in case of user request as opposed to silen drop.

#### Problem:
We silently [clear node selector terms](https://github.com/harvester/harvester/blob/d8985bcddfd0f3ba016470197a4170f5ebe8b740/pkg/webhook/resources/virtualmachine/mutator.go#L439-L453) related with `cpumanager` and starting with prefix `network.harvesterhci.io`.

#### Solution:
Reject user requests on a webhook level when they try to configure the `cpumanager`

> Note: original issue did not discuss the prefix `network.harvesterhci.io` so this is the reason the change only rejects on cpumanger config. We can extend the scope and reject the network as well

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7583

#### Test plan:
Unit tests added for Create/Update in the mutator

E2E Test plan covers both user and command line interfaces:

* Basic Scenarios:
  * Create VM with cpumanager affinity - rejection  (`vm-1`)
  * Create VM with other affinity key - accepted (`vm-1`)
  * Create VM with no affinity - accepted (`vm-2`)
  * Add cpumanager term to `vm-2` - rejected
  * Add other affinity to `vm-2` - accepted

* CPU Pinning tests (`vm-3`):
  * Create VM with cpu pinning - accepted (controller changes it) (`vm-3`)
  * Update the cpumanager field on rejected (users can't change it)
  * Change requests.memory of vm-3 - accepted (other updates are allowed) (user interface + command line interface edit + view)
  * Remove cpumanager annotation - rejected
  * Turn off cpu pinning on vm-3 - accepted (controller manages it) (edit through command line interface view result in user interface)

* CPU Pinning odd values (`vm-1`):
  * Update with empty values slice
  * Update with null values slice
  * Update with multiple values slice 
  * Update with multiple cpumanager duplicate key slice

Basic Scenarios Results:
<details>
<summary> :green_circle: Built and ran environment with the commit</summary>
<img width="1296" height="882" alt="image" src="https://github.com/user-attachments/assets/ccebd877-0735-4653-bff5-fc8c24496a77" />
</details>

<details>
<summary> :green_circle: Create VM with cpumanager affinity - rejection</summary>
<img width="2560" height="992" alt="image" src="https://github.com/user-attachments/assets/0c7e6021-f8ee-4d75-97de-b720beb896e5" />
</details>

<details>
<summary> :green_circle: Create VM with other affinity key - accepted</summary>
<img width="1920" height="664" alt="image" src="https://github.com/user-attachments/assets/a663ec97-6567-491e-a8f3-631cfedfa5bf" />
<img width="1920" height="920" alt="image" src="https://github.com/user-attachments/assets/80b17b62-3ef8-4bf3-97f7-159663969bea" />
</details>

<details>
<summary> :green_circle: Create VM with no affinity - accepted</summary>
<img width="2560" height="841" alt="image" src="https://github.com/user-attachments/assets/0ff8cc55-ff8c-427a-871e-ce3c4f9a048e" />
</details>

<details>
<summary> :green_circle: Add cpumanager term to vm-2 - rejected</summary>
<img width="2560" height="841" alt="image" src="https://github.com/user-attachments/assets/f63dfa40-085d-4950-a39a-f3313f5a47a9" />
</details>

<details>
<summary> :green_circle: Add other affinity to `vm-2` - accepted</summary>
<img width="2560" height="841" alt="image" src="https://github.com/user-attachments/assets/81906d74-16d2-422c-aeb2-666752d1e809" />
</details>

CPU Pinning tests Results:
<details>
<summary> :green_circle: Create VM with cpu pinning - accepted</summary>
<img width="1920" height="835" alt="image" src="https://github.com/user-attachments/assets/8994ecfc-c290-47f6-9e32-8a354f54b461" />
<img width="1920" height="1041" alt="image" src="https://github.com/user-attachments/assets/0544784e-1c0d-46a0-b4cb-d6f90df47e08" />
</details>

<details>
<summary> :green_circle: Update the cpumanager field on - rejected </summary>
<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/a878946a-7fa9-4015-a7f7-f38e06864e88" />
<img width="1795" height="907" alt="image" src="https://github.com/user-attachments/assets/a1fd543c-315e-4dd4-997d-176c337dfc65" />
</details>

<details>
<summary> :green_circle: Change requests.memory of vm-3 - accepted (user interface + command line interface)</summary>
in cli result:
<img width="1795" height="907" alt="image" src="https://github.com/user-attachments/assets/26b3f805-ad81-49d8-9cf2-9bee5826a8c0" />

```
node-1:/home/rancher # kubectl get vm vm-3 -o yaml | grep memory
        memory:
            memory: 2Gi
            memory: 2Gi
node-1:/home/rancher # kubectl edit vm vm-3 
virtualmachine.kubevirt.io/vm-3 edited
node-1:/home/rancher # kubectl get vm vm-3 -o yaml | grep memory
        memory:
            memory: 3Gi
            memory: 3Gi
```

</details>

<details>
<summary> :green_circle:  Remove cpumanager annotation - rejected </summary>
<img width="2556" height="852" alt="image" src="https://github.com/user-attachments/assets/d5effada-4654-4081-b4b3-32f43410d798" />
<img width="2556" height="852" alt="image" src="https://github.com/user-attachments/assets/a470b34b-8439-48fe-b72f-04ebee16d25b" />

</details>

<details>
<summary> :green_circle: Turn off cpu pinning on vm-3 - accepted (command line interface edit user interface view)</summary>
<img width="1920" height="925" alt="image" src="https://github.com/user-attachments/assets/b088a0fd-6cf8-4592-a92c-928cf05e4725" />
<img width="1920" height="839" alt="image" src="https://github.com/user-attachments/assets/bcf4bb3a-a60e-4a1e-ac70-d08c7786725c" />
<img width="1920" height="1028" alt="image" src="https://github.com/user-attachments/assets/49be6253-781a-4163-8799-978e5b6635ad" />
</details>

CPU Pinning odd values all rejected 

<details>
<summary> :green_circle: All rejected (`vm-1`) </summary>

```
node-1:/home/rancher # kubectl patch vm vm-1 -n default --type=merge -p='{"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"cpumanager","operator":"In","values":[]}]}]}}}}}}}'
The request is invalid: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution: key "cpumanager" is automatically operated by Harvester controller and can't be changed manually
node-1:/home/rancher # kubectl patch vm vm-1 -n default --type=merge -p='{"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"cpumanager","operator":"In","values":null}]}]}}}}}}}'
The request is invalid: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution: key "cpumanager" is automatically operated by Harvester controller and can't be changed manually
node-1:/home/rancher # kubectl patch vm vm-1 -n default --type=merge   -p='{"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"cpumanager","operator":"In","values":["true","false"]}]}]}}}}}}}'
The request is invalid: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution: key "cpumanager" is automatically operated by Harvester controller and can't be changed manually
node-1:/home/rancher # kubectl patch vm vm-1 -n default --type=merge -p='{"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"cpumanager","operator":"In","values":["true"]}]},{"matchExpressions":[{"key":"cpumanager","operator":"In","values":["false"]}]}]}}}}}}}'
The request is invalid: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution: key "cpumanager" is automatically operated by Harvester controller and can't be changed manually
node-1:/home/rancher # 
```
</details>

#### Additional documentation or context
