### PR TITLE
chore: bump general job image

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -599,7 +599,7 @@ generalJob:
     # In the Golang limitation, we couldn't parse like "tag": 12.20.
     # So, we must use "tag": "12.20" instead.
     # More details in PR-4896 (https://github.com/harvester/harvester/pull/4896)
-    tag: 15.7
+    tag: "16.0"
 
 whereabouts:
   enabled: true


### PR DESCRIPTION
This ensures the bci-base image is packaged in the ISO as well.

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

- The general job image is not bumped and packaged. The controller promotion jobs still use an outdated version.
- outdated version bci image is packaged in the ISO. This cause image not found failure when ugprading a cluster in an air-gapped environment. ([Related change](https://github.com/harvester/harvester/pull/10122/changes#diff-8c5fdd3c29c4031d6332031bafd4f1c97820a492be51384b2b22689c6322d31fR1106))

<img width="1473" height="506" alt="Screenshot 2026-03-17 at 8 20 45 AM" src="https://github.com/user-attachments/assets/abd5a1b2-98d0-42b6-a4de-7ea59c86687d" />


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Bump the bci-base image to 16.0

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

- https://github.com/harvester/harvester/issues/10110

#### Test plan:
<!-- Describe the test plan by steps. -->

- Create a new installation and make sure registry.suse.com/bci/bci-base:16.0 is pre-loaded.
- Upgrade v1.7.1 to the build ISO in an air-gapped environment and make sure the upgrade succeeds.


#### Additional documentation or context

