### PR TITLE
chore: remove pull_request_target

### DIFF
--- a/.github/auto-assign-config.yaml
+++ b/.github/auto-assign-config.yaml
@@ -1,4 +1,3 @@
 addAssignees: author
 addReviewers: true
-numberOfReviewers: 0
 reviewers: []

--- a/.github/workflows/issue-management-link-backport-pr-action.yaml
+++ b/.github/workflows/issue-management-link-backport-pr-action.yaml
@@ -1,0 +1,85 @@
+name: "Issue Management Link Backport PR Issue"
+
+on:
+  workflow_run:
+    workflows: ["Issue Management Backport PR Collect Data"]
+    types: [completed]
+
+env:
+  REPO_NAME: harvester/harvester
+
+jobs:
+  link-backport-issue:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+    - name: Download PR data artifact
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        name: pr-data
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+
+    - name: Load PR data
+      run: |
+        cat pr-data.env >> $GITHUB_ENV
+
+    - name: Link the PR with the backport issue
+      if: ${{ env.BACKPORT == 'true' && env.ORIGINAL_ISSUE_NUMBER != '' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      run: |
+        for issue_number in ${{ env.ORIGINAL_ISSUE_NUMBER }}; do
+          echo "Found source issue ${REPO_NAME}#${issue_number}"
+          issue_title=$(gh issue view "$issue_number" --repo "${REPO_NAME}" --json title --jq ".title")
+          
+          # Reset backport_issue_number for each iteration
+          backport_issue_number=""
+
+          if [[ -n "$issue_number" && -n "$issue_title" ]]; then
+            search_title="[backport ${BRANCH}] ${issue_title}"
+
+            echo "Searching for backport issue with title: '${search_title}'"
+
+            # Get both number and title from the search results
+            backport_issues_json=$(gh search issues "${search_title}" --repo "${REPO_NAME}" --state open --match title  --json number,title)
+
+            if [[ "$backport_issues_json" != "[]" && -n "$backport_issues_json" ]]; then
+              # Get the length of the JSON array
+              array_length=$(echo "$backport_issues_json" | jq 'length')
+              
+              # Loop through each issue in the JSON array
+              for ((i=0; i<$array_length; i++)); do
+                found_number=$(echo "$backport_issues_json" | jq -r ".[$i].number")
+                found_title=$(echo "$backport_issues_json" | jq -r ".[$i].title")
+                
+                # Compare the found title with our expected title
+                if [[ "$found_title" == "$search_title" ]]; then
+                  echo "Found exact match backport issue ${REPO_NAME}#${found_number} with title: '${found_title}'"
+                  echo "Linking backport issue ${REPO_NAME}#${found_number}"
+                  backport_issue_number="$found_number"
+                  break
+                else
+                  echo "Found partial match ${REPO_NAME}#${found_number} but title doesn't match exactly: '${found_title}'"
+                fi
+              done
+            fi
+
+            if [[ -n "$backport_issue_number" ]]; then
+
+              # comment on the backport issue
+              gh issue comment "${backport_issue_number}" --repo "${REPO_NAME}" --body "Backport PR (${BRANCH}): $HTML_URL"
+
+              # comment on the PR
+              backport_issue_url=$(gh issue view "${backport_issue_number}" --repo "${REPO_NAME}" --json url --jq ".url")
+              gh pr comment "$PR_NUMBER" --repo "${REPO_NAME}" --body "Backport issue (${BRANCH}): ${backport_issue_url}"
+              continue
+            fi
+          fi
+
+          echo "No issue title found"
+        done

--- a/.github/workflows/issue-management-link-backport-pr.yaml
+++ b/.github/workflows/issue-management-link-backport-pr.yaml
@@ -1,11 +1,11 @@
-name: "[Issue Management] Link Backport PR Issue"
+name: "Issue Management Backport PR Collect Data"
 
 on:
-  pull_request_target:
-    types: [ opened ]
+  pull_request:
+    types: [opened]
     branches:
-    - master
-    - "v*"
+      - master
+      - "v*"
 
 env:
   REPO_NAME: harvester/harvester
@@ -14,10 +14,9 @@ jobs:
   check-backport:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      actions: write
+      pull-requests: read
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Check if PR is a backport
       env:
@@ -34,8 +33,6 @@ jobs:
     - name: Extract backport branch and issue number
       if: env.BACKPORT == 'true'
       env:
-        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
         BASE_REF: ${{ github.event.pull_request.base.ref }}
         BODY: ${{ github.event.pull_request.body }}
       run: |
@@ -57,59 +54,18 @@ jobs:
         ORIGINAL_ISSUE_NUMBER=$(echo $ALL_ISSUES | xargs) # trim
         echo "ORIGINAL_ISSUE_NUMBER=$ORIGINAL_ISSUE_NUMBER" >> $GITHUB_ENV
 
-    - name: Link the PR with the backport issue
-      if: ${{ env.BACKPORT == 'true' && env.ORIGINAL_ISSUE_NUMBER != '' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+    - name: Save PR data to artifact
       run: |
-        for issue_number in ${{ env.ORIGINAL_ISSUE_NUMBER }}; do
-          echo "Found source issue ${REPO_NAME}#${issue_number}"
-          issue_title=$(gh issue view "$issue_number" --json title --jq ".title")
-          
-          # Reset backport_issue_number for each iteration
-          backport_issue_number=""
+        {
+          echo "BACKPORT=${{ env.BACKPORT }}"
+          echo "BRANCH=${{ env.BRANCH }}"
+          echo "ORIGINAL_ISSUE_NUMBER=${{ env.ORIGINAL_ISSUE_NUMBER }}"
+          echo "HTML_URL=${{ github.event.pull_request.html_url }}"
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}"
+        } > pr-data.env
 
-          if [[ -n "$issue_number" && -n "$issue_title" ]]; then
-            search_title="[backport ${BRANCH}] ${issue_title}"
-
-            echo "Searching for backport issue with title: '${search_title}'"
-
-            # Get both number and title from the search results
-            backport_issues_json=$(gh search issues "${search_title}" --state open --match title  --json number,title)
-
-            if [[ "$backport_issues_json" != "[]" && -n "$backport_issues_json" ]]; then
-              # Get the length of the JSON array
-              array_length=$(echo "$backport_issues_json" | jq 'length')
-              
-              # Loop through each issue in the JSON array
-              for ((i=0; i<$array_length; i++)); do
-                found_number=$(echo "$backport_issues_json" | jq -r ".[$i].number")
-                found_title=$(echo "$backport_issues_json" | jq -r ".[$i].title")
-                
-                # Compare the found title with our expected title
-                if [[ "$found_title" == "$search_title" ]]; then
-                  echo "Found exact match backport issue ${REPO_NAME}#${found_number} with title: '${found_title}'"
-                  echo "Linking backport issue ${REPO_NAME}#${found_number}"
-                  backport_issue_number="$found_number"
-                  break
-                else
-                  echo "Found partial match ${REPO_NAME}#${found_number} but title doesn't match exactly: '${found_title}'"
-                fi
-              done
-            fi
-
-            if [[ -n "$backport_issue_number" ]]; then
-
-              # comment on the backport issue
-              gh issue comment "${backport_issue_number}" --body "Backport PR (${BRANCH}): ${{ github.event.pull_request.html_url }}"
-
-              # comment on the PR
-              backport_issue_url=$(gh issue view "${backport_issue_number}" --json url --jq ".url")
-              gh pr comment "${{ github.event.pull_request.number }}" --body "Backport issue (${BRANCH}): ${backport_issue_url}"
-              continue
-            fi
-          fi
-
-          echo "No issue title found"
-        done
+    - name: Upload PR data artifact
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: pr-data
+        path: pr-data.env

--- a/.github/workflows/pr-management-auto-assign-action.yaml
+++ b/.github/workflows/pr-management-auto-assign-action.yaml
@@ -1,0 +1,52 @@
+name: "PR Management Auto Assign"
+
+on:
+  workflow_run:
+    workflows: ["PR Management Auto Assign Collect Data"]
+    types: [completed]
+
+env:
+  REPO_NAME: harvester/harvester
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+    - name: Download PR data artifact
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        name: pr-auto-assign-data
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+
+    - name: Load PR data
+      run: |
+        cat pr-auto-assign-data.env >> $GITHUB_ENV
+
+    - name: Auto assign based on config
+      env:
+        GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      run: |
+        # Read config
+        ADD_ASSIGNEES=$(yq e '.addAssignees' .github/auto-assign-config.yaml)
+        ADD_REVIEWERS=$(yq e '.addReviewers' .github/auto-assign-config.yaml)
+        REVIEWERS=$(yq e '.reviewers[]' .github/auto-assign-config.yaml 2>/dev/null || true)
+
+        # Assign author if addAssignees is 'author'
+        if [[ "$ADD_ASSIGNEES" == "author" ]]; then
+          echo "Assigning PR author: $PR_AUTHOR"
+          gh pr edit "$PR_NUMBER" --repo "${REPO_NAME}" --add-assignee "$PR_AUTHOR"
+        fi
+
+        # Add reviewers if addReviewers is true and reviewers list is non-empty
+        if [[ "$ADD_REVIEWERS" == "true" && -n "$REVIEWERS" ]]; then
+          SELECTED=$(echo "$REVIEWERS" | xargs)
+          echo "Adding reviewers: $SELECTED"
+          for reviewer in $SELECTED; do
+            gh pr edit "$PR_NUMBER" --repo "${REPO_NAME}" --add-reviewer "$reviewer"
+          done
+        fi

--- a/.github/workflows/pr-management-auto-assign.yaml
+++ b/.github/workflows/pr-management-auto-assign.yaml
@@ -1,0 +1,25 @@
+name: "PR Management Auto Assign Collect Data"
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+    - name: Save PR data to artifact
+      run: |
+        {
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}"
+          echo "PR_AUTHOR=${{ github.event.pull_request.user.login }}"
+        } > pr-auto-assign-data.env
+
+    - name: Upload PR data artifact
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: pr-auto-assign-data
+        path: pr-auto-assign-data.env


### PR DESCRIPTION
This's for RST requirement to remove all `pull_request_target`. Use two steps workflows to achieve the goal with workflow event trigger.

- First workflow saves all data we need in next workflow.
- Second workflow can have the write permission to add the comment or change the assignee in the PR.

I've tested this in my private repo. It seems good. We can try this.