### PR TITLE
VMBuilder: Add host devices conditionally

### DIFF
--- a/pkg/builder/device.go
+++ b/pkg/builder/device.go
@@ -24,6 +24,7 @@ func (v *VMBuilder) Input(inputName string, inputType kubevirtv1.InputType, inpu
 	return v
 }
 
+// Unconditionally adds the specified host device
 func (v *VMBuilder) HostDevice(name, hostDeviceName, tag string) *VMBuilder {
 	hostDevices := v.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices
 	hostDevice := kubevirtv1.HostDevice{
@@ -38,8 +39,57 @@ func (v *VMBuilder) HostDevice(name, hostDeviceName, tag string) *VMBuilder {
 	return v
 }
 
-func (v *VMBuilder) GPU(name, hostDeviceName, tag string, _ *kubevirtv1.VGPUOptions) *VMBuilder {
-	return v.HostDevice(name, hostDeviceName, tag)
+// Adds the specified host device if it does not yet exist
+func (v *VMBuilder) AddHostDevice(name, hostDeviceName, tag string) *VMBuilder {
+	hostDevices := v.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices
+
+	found := false
+	for _, hdev := range hostDevices {
+		if hdev.Name == name && hdev.DeviceName == hostDeviceName {
+			found = true
+		}
+	}
+
+	if !found {
+		v.HostDevice(name, hostDeviceName, tag)
+	}
+	return v
+}
+
+// Unconditionally adds the speficied GPU device
+func (v *VMBuilder) GPU(name, hostDeviceName, tag string, opts *kubevirtv1.VGPUOptions) *VMBuilder {
+	GPUs := v.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs
+	gpu := kubevirtv1.GPU{
+		Name:              name,
+		DeviceName:        hostDeviceName,
+		Tag:               tag,
+		VirtualGPUOptions: opts,
+	}
+
+	if tag != "" {
+		gpu.Tag = tag
+	}
+
+	GPUs = append(GPUs, gpu)
+	v.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs = GPUs
+	return v
+}
+
+// Adds the specified GPU if it does not yet exist
+func (v *VMBuilder) AddGPU(name, hostDeviceName, tag string, opts *kubevirtv1.VGPUOptions) *VMBuilder {
+	GPUs := v.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs
+
+	found := false
+	for _, gpu := range GPUs {
+		if gpu.Name == name && gpu.DeviceName == hostDeviceName {
+			found = true
+		}
+	}
+
+	if !found {
+		v.GPU(name, hostDeviceName, tag, opts)
+	}
+	return v
 }
 
 func (v *VMBuilder) TPM() *VMBuilder {

--- a/pkg/builder/device_test.go
+++ b/pkg/builder/device_test.go
@@ -1,0 +1,119 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+func TestHostDevice(t *testing.T) {
+	builder := NewVMBuilder("test")
+
+	// First host device
+	builder.HostDevice("qat", "intel.com/qat", "")
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, 1)
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, kubevirtv1.HostDevice{
+		Name:       "qat",
+		DeviceName: "intel.com/qat",
+		Tag:        "",
+	})
+
+	// Can force-add same host device again
+	builder.HostDevice("qat", "intel.com/qat", "")
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, 2)
+}
+
+func TestAddHostDevice(t *testing.T) {
+	builder := NewVMBuilder("test")
+
+	// Add first Host device
+	builder.AddHostDevice("qat1", "intel.com/qat", "")
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, 1)
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, kubevirtv1.HostDevice{
+		Name:       "qat1",
+		DeviceName: "intel.com/qat",
+		Tag:        "",
+	})
+
+	// Can not add same device again
+	builder.AddHostDevice("qat1", "intel.com/qat", "")
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, 1)
+
+	// Can add different device
+	builder.AddHostDevice("qat2", "intel.com/qat", "")
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, 2)
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, kubevirtv1.HostDevice{
+		Name:       "qat1",
+		DeviceName: "intel.com/qat",
+		Tag:        "",
+	})
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.HostDevices, kubevirtv1.HostDevice{
+		Name:       "qat2",
+		DeviceName: "intel.com/qat",
+		Tag:        "",
+	})
+}
+
+func TestGPU(t *testing.T) {
+	builder := NewVMBuilder("test")
+
+	// First GPU
+	builder.GPU("gpu", "nvidia.com/TU104GL_Tesla_T4", "", &kubevirtv1.VGPUOptions{})
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, 1)
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, kubevirtv1.GPU{
+		Name:              "gpu",
+		DeviceName:        "nvidia.com/TU104GL_Tesla_T4",
+		Tag:               "",
+		VirtualGPUOptions: &kubevirtv1.VGPUOptions{},
+	})
+
+	// Can force-add same GPU again
+	builder.GPU("gpu", "nvidia.com/TU104GL_Tesla_T4", "", &kubevirtv1.VGPUOptions{})
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, 2)
+}
+
+func TestAddGPU(t *testing.T) {
+	builder := NewVMBuilder("test")
+
+	// Add first GPU
+	builder.AddGPU("gpu1", "nvidia.com/TU104GL_Tesla_T4", "", &kubevirtv1.VGPUOptions{})
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, 1)
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, kubevirtv1.GPU{
+		Name:              "gpu1",
+		DeviceName:        "nvidia.com/TU104GL_Tesla_T4",
+		Tag:               "",
+		VirtualGPUOptions: &kubevirtv1.VGPUOptions{},
+	})
+
+	// Can not add the same GPU again
+	builder.AddGPU("gpu1", "nvidia.com/TU104GL_Tesla_T4", "", &kubevirtv1.VGPUOptions{})
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, 1)
+
+	// Can add different GPU
+	builder.AddGPU("gpu2", "nvidia.com/TU104GL_Tesla_T4", "", &kubevirtv1.VGPUOptions{})
+	assert.NotEmpty(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs)
+	assert.Len(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, 2)
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, kubevirtv1.GPU{
+		Name:              "gpu1",
+		DeviceName:        "nvidia.com/TU104GL_Tesla_T4",
+		Tag:               "",
+		VirtualGPUOptions: &kubevirtv1.VGPUOptions{},
+	})
+	assert.Contains(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Devices.GPUs, kubevirtv1.GPU{
+		Name:              "gpu2",
+		DeviceName:        "nvidia.com/TU104GL_Tesla_T4",
+		Tag:               "",
+		VirtualGPUOptions: &kubevirtv1.VGPUOptions{},
+	})
+}


### PR DESCRIPTION
Add methods to the VM builder for adding host devices conditionally. These methods contain checks to avoid adding the same host device multiple times.
By doing these checks in the VMBuilder interface, integrations like the Terraform provider do not need to implement them in multiple locations separately.

#### Problem:

The VMBuilder only offers basic support for adding host devices to VMs and no support for adding GPUs.
This leaves a lot of the logic, like checking for duplicated devices, to the integrations.

#### Solution:

Implement the missing functionality in the VMBuilder.

#### Related Issue(s):

related-to: harvester/harvester#6422
related-to: harvester/harvester#6423
related-to: harvester/harvester#6424

#### Test plan:

Unit test included.

#### Additional documentation or context
