### PR TITLE
chore: bump csi-snapshotter to v8.5.0

### DIFF
--- a/deploy/charts/harvester/dependency_charts/csi-snapshotter/Chart.yaml
+++ b/deploy/charts/harvester/dependency_charts/csi-snapshotter/Chart.yaml
@@ -20,5 +20,5 @@ version: 0.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 8.4.0
+appVersion: 8.5.0
 home: https://github.com/kubernetes-csi/external-snapshotter

--- a/deploy/charts/harvester/dependency_charts/csi-snapshotter/values.yaml
+++ b/deploy/charts/harvester/dependency_charts/csi-snapshotter/values.yaml
@@ -3,5 +3,5 @@
 # Declare variables to be passed into your templates.
 image:
   repository: registry.k8s.io/sig-storage/snapshot-controller
-  tag: v8.4.0
+  tag: v8.5.0
   pullPolicy: IfNotPresent

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -476,7 +476,7 @@ csi-snapshotter:
 
   image:
     repository: registry.k8s.io/sig-storage/snapshot-controller
-    tag: v8.4.0
+    tag: v8.5.0
 
 longhorn:
   ## Specify whether to install longhorn,


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:

longhorn v1.11.1 use csi-snapshotter v8.5.0
https://github.com/longhorn/longhorn/blob/v1.11.1/deploy/longhorn.yaml#L4485

#### Solution:

bump snapshot-controller to v8.5.0

#### Related Issue(s):

https://github.com/harvester/harvester/issues/9978

#### Test plan:

create vm snapshot successfully

#### Additional documentation or context
