### PR TITLE
[v190]Add resourcequota related alerts

### DIFF
--- a/deploy/charts/harvester/templates/prometheusrules.yaml
+++ b/deploy/charts/harvester/templates/prometheusrules.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.monitoring.prometheusrules.enabled -}}
+{{- $config := .Values.monitoring.prometheusrules.harvesterResourceQuotaAlerts -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: harvester-resource-quota-alerts
+  namespace: {{ .Values.monitoring.prometheusrules.namespaceOverride | default "cattle-monitoring-system" | quote }}
+  labels:
+    {{- if and $config $config.labels }}
+    {{- toYaml $config.labels | nindent 4 }}
+    {{- end }}
+    harvesterhci.io/prometheusRuleGroup: "ResourceQuota"    
+spec:
+  groups:
+  - name: harvester-resource-quota.rules
+    rules:
+    # --- CPU Alerts ---
+    - alert: ResourceQuotaCPUUsageWarning
+      expr: |
+        (
+          kube_resourcequota{resource="limits.cpu", type="used"} 
+          / on(namespace, resource, resourcequota) group_left() 
+          kube_resourcequota{resource="limits.cpu", type="hard"}
+        ) > 0.85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: |
+          CPU Quota usage > 85% (Namespace: {{ "{{" }} $labels.namespace {{ "}}" }})
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is using {{ "{{" }} $value | humanizePercentage {{ "}}" }} of its CPU limit.
+        runbook_url: "https://docs.harvesterhci.io/v1.8/monitoring/harvester-alerts#quota-cpu-warning"
+
+    - alert: ResourceQuotaCPUUsageCritical
+      expr: |
+        (
+          kube_resourcequota{resource="limits.cpu", type="used"} 
+          / on(namespace, resource, resourcequota) group_left() 
+          kube_resourcequota{resource="limits.cpu", type="hard"}
+        ) > 0.95
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: |
+          CRITICAL: CPU Quota exhausted in {{ "{{" }} $labels.namespace {{ "}}" }}
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is at {{ "{{" }} $value | humanizePercentage {{ "}}" }}. New pods may fail to schedule.
+        runbook_url: "https://docs.harvesterhci.io/v1.8/monitoring/harvester-alerts#quota-exhausted-critical"
+
+    # --- Memory Alerts ---
+    - alert: ResourceQuotaMemoryUsageWarning
+      expr: |
+        (
+          kube_resourcequota{resource="limits.memory", type="used"} 
+          / on(namespace, resource, resourcequota) group_left() 
+          kube_resourcequota{resource="limits.memory", type="hard"}
+        ) > 0.85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: |
+          Memory Quota usage > 85% (Namespace: {{ "{{" }} $labels.namespace {{ "}}" }})
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is using {{ "{{" }} $value | humanizePercentage {{ "}}" }} of its Memory limit.
+        runbook_url: "https://docs.harvesterhci.io/v1.8/monitoring/harvester-alerts#quota-mem-warning"
+
+    - alert: ResourceQuotaMemoryUsageCritical
+      expr: |
+        (
+          kube_resourcequota{resource="limits.memory", type="used"} 
+          / on(namespace, resource, resourcequota) group_left() 
+          kube_resourcequota{resource="limits.memory", type="hard"}
+        ) > 0.95
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: |
+          CRITICAL: Memory Quota exhausted in {{ "{{" }} $labels.namespace {{ "}}" }}
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is at {{ "{{" }} $value | humanizePercentage {{ "}}" }}.
+        runbook_url: "https://docs.harvesterhci.io/v1.8/monitoring/harvester-alerts#quota-exhausted-critical"
+{{- end -}}

--- a/deploy/charts/harvester/templates/prometheusrules.yaml
+++ b/deploy/charts/harvester/templates/prometheusrules.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.monitoring.prometheusrules.enabled -}}
+{{- $config := .Values.monitoring.prometheusrules.harvesterResourceQuotaAlerts -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: harvester-resource-quota-alerts
+  namespace: {{ .Values.monitoring.prometheusrules.namespaceOverride | default "cattle-monitoring-system" | quote }}
+  labels:
+    {{- if and $config $config.labels }}
+    {{- toYaml $config.labels | nindent 4 }}
+    {{- end }}
+    harvesterhci.io/prometheusRuleGroup: ResourceQuota
+spec:
+  groups:
+  - name: harvester-resource-quota.rules
+    rules:
+    # --- CPU Alerts ---
+    - alert: ResourceQuotaCPUUsageWarning
+      expr: |
+        (
+          kube_resourcequota{resource="limits.cpu", type="used"}
+          / on(namespace, resource, resourcequota) group_left()
+          kube_resourcequota{resource="limits.cpu", type="hard"}
+        ) > 0.85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: |
+          CPU Quota usage > 85% (Namespace: {{ "{{" }} $labels.namespace {{ "}}" }})
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is using {{ "{{" }} $value | humanizePercentage {{ "}}" }} of its CPU limit.
+        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-cpu-warning"
+
+    - alert: ResourceQuotaCPUUsageCritical
+      expr: |
+        (
+          kube_resourcequota{resource="limits.cpu", type="used"}
+          / on(namespace, resource, resourcequota) group_left()
+          kube_resourcequota{resource="limits.cpu", type="hard"}
+        ) > 0.95
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: |
+          CRITICAL: CPU Quota exhausted in {{ "{{" }} $labels.namespace {{ "}}" }}
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is at {{ "{{" }} $value | humanizePercentage {{ "}}" }}. New pods may fail to schedule.
+        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-exhausted-critical"
+
+    # --- Memory Alerts ---
+    - alert: ResourceQuotaMemoryUsageWarning
+      expr: |
+        (
+          kube_resourcequota{resource="limits.memory", type="used"}
+          / on(namespace, resource, resourcequota) group_left()
+          kube_resourcequota{resource="limits.memory", type="hard"}
+        ) > 0.85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: |
+          Memory Quota usage > 85% (Namespace: {{ "{{" }} $labels.namespace {{ "}}" }})
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is using {{ "{{" }} $value | humanizePercentage {{ "}}" }} of its Memory limit.
+        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-mem-warning"
+
+    - alert: ResourceQuotaMemoryUsageCritical
+      expr: |
+        (
+          kube_resourcequota{resource="limits.memory", type="used"}
+          / on(namespace, resource, resourcequota) group_left()
+          kube_resourcequota{resource="limits.memory", type="hard"}
+        ) > 0.95
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: |
+          CRITICAL: Memory Quota exhausted in {{ "{{" }} $labels.namespace {{ "}}" }}
+        description: |
+          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is at {{ "{{" }} $value | humanizePercentage {{ "}}" }}.
+        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-exhausted-critical"
+{{- end -}}

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -630,3 +630,13 @@ promote:
   clusterPodCIDR: 10.52.0.0/16
   clusterServiceCIDR: 10.53.0.0/16
   clusterDNS: 10.53.0.10
+
+# Harvester related monitoring metrics, alerts ...
+monitoring:
+  prometheusrules:
+    namespaceOverride: cattle-monitoring-system
+    enabled: true
+    harvesterResourceQuotaAlerts:
+      labels:
+        app: rancher-monitoring
+        release: rancher-monitoring

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -633,3 +633,13 @@ promote:
   clusterPodCIDR: 10.52.0.0/16
   clusterServiceCIDR: 10.53.0.0/16
   clusterDNS: 10.53.0.10
+
+# Harvester related monitoring metrics, alerts ...
+monitoring:
+  prometheusrules:
+    namespaceOverride: cattle-monitoring-system
+    enabled: true
+    harvesterResourceQuotaAlerts:
+      labels:
+        app: rancher-monitoring
+        release: rancher-monitoring


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When resourcequota reachs limits, there is no direct hint.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add resourcequota related alerts definition

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10093

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Install v190 cluster
2. Enable rancher-monitoring addon
3. Install prometheus manually if the cluster does not have it
4. Import Harvester to Rancher
5. Create Project/Namespace with resourcequota limits
6. Create VM to trigger the resourcequota usage > 85% > 95%, check alerts

Local test report:

<details>

<summary> Local test  steps and reports </summary>

1. Manuall install the prometheus alert rules

```
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: harvester-resource-quota-alerts
  namespace: cattle-monitoring-system
  labels:
    app: rancher-monitoring
    release: rancher-monitoring
    harvesterhci.io/prometheusRuleGroup: ResourceQuota
spec:
  groups:
  - name: harvester-resource-quota.rules
    rules:
    # --- CPU Alerts ---
    - alert: ResourceQuotaCPUUsageWarning
      expr: |
        (
          kube_resourcequota{resource="limits.cpu", type="used"}
          / on(namespace, resource, resourcequota) group_left()
          kube_resourcequota{resource="limits.cpu", type="hard"}
        ) > 0.85
      for: 5m
      labels:
        severity: warning
      annotations:
        summary: |
          CPU Quota usage > 85% (Namespace: {{ "{{" }} $labels.namespace {{ "}}" }})
        description: |
          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is using {{ "{{" }} $value | humanizePercentage {{ "}}" }} of its CPU limit.
        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-cpu-warning"

    - alert: ResourceQuotaCPUUsageCritical
      expr: |
        (
          kube_resourcequota{resource="limits.cpu", type="used"}
          / on(namespace, resource, resourcequota) group_left()
          kube_resourcequota{resource="limits.cpu", type="hard"}
        ) > 0.95
      for: 2m
      labels:
        severity: critical
      annotations:
        summary: |
          CRITICAL: CPU Quota exhausted in {{ "{{" }} $labels.namespace {{ "}}" }}
        description: |
          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is at {{ "{{" }} $value | humanizePercentage {{ "}}" }}. New pods may fail to schedule.
        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-exhausted-critical"

    # --- Memory Alerts ---
    - alert: ResourceQuotaMemoryUsageWarning
      expr: |
        (
          kube_resourcequota{resource="limits.memory", type="used"}
          / on(namespace, resource, resourcequota) group_left()
          kube_resourcequota{resource="limits.memory", type="hard"}
        ) > 0.85
      for: 5m
      labels:
        severity: warning
      annotations:
        summary: |
          Memory Quota usage > 85% (Namespace: {{ "{{" }} $labels.namespace {{ "}}" }})
        description: |
          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is using {{ "{{" }} $value | humanizePercentage {{ "}}" }} of its Memory limit.
        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-mem-warning"

    - alert: ResourceQuotaMemoryUsageCritical
      expr: |
        (
          kube_resourcequota{resource="limits.memory", type="used"}
          / on(namespace, resource, resourcequota) group_left()
          kube_resourcequota{resource="limits.memory", type="hard"}
        ) > 0.95
      for: 2m
      labels:
        severity: critical
      annotations:
        summary: |
          CRITICAL: Memory Quota exhausted in {{ "{{" }} $labels.namespace {{ "}}" }}
        description: |
          Quota "{{ "{{" }} $labels.resourcequota {{ "}}" }}" is at {{ "{{" }} $value | humanizePercentage {{ "}}" }}.
        runbook_url: "https://docs.harvesterhci.io/v1.9/monitoring/harvester-alerts#quota-exhausted-critical"
```

2. Check the prometheusrules
```
harv41:/home/rancher # kubectl get prometheusrules -A
NAMESPACE                  NAME                                                              AGE
cattle-monitoring-system   harvester-resource-quota-alerts                                   18m
cattle-monitoring-system   rancher-monitoring-alertmanager.rules                             27h
cattle-monitoring-system   rancher-monitoring-config-reloaders                               27h
...
```

3. Create resourcequota and trigger the usage

```

kubectl get resourcequota -A
NAMESPACE    NAME            REQUEST   LIMIT                                                   AGE
quota-test   default-kflsw             limits.cpu: 2015m/3, limits.memory: 4797464313/5000Mi   13m
```

4. Check from Harvester UI -> Addons -> Prometheus -> Alerts
<img width="3606" height="1712" alt="image" src="https://github.com/user-attachments/assets/7389c6cf-da1f-4b72-806f-2be4edea8c17" />

5. Check pod `prometheus-rancher-monitoring-prometheus-0` logs, there is no complains about the new proemetheus alerts

```
get pods -n cattle-monitoring-system
NAME                                                    READY   STATUS      RESTARTS        AGE
alertmanager-rancher-monitoring-alertmanager-0          2/2     Running     0               4h13m
helm-install-rancher-monitoring-52v6v                   0/1     Completed   0               28h
prometheus-rancher-monitoring-prometheus-0              3/3     Running     0               4h13m
rancher-monitoring-grafana-6f88968b-hxfbk               3/3     Running     0               4h14m
rancher-monitoring-kube-state-metrics-9585db8c8-2kbbq   1/1     Running     1 (4h16m ago)   28h
rancher-monitoring-operator-646c5bbdc8-p9s4b            1/1     Running     1 (4h16m ago)   28h
rancher-monitoring-prometheus-adapter-556dfcbc4-825z6   1/1     Running     1 (4h16m ago)   28h
rancher-monitoring-prometheus-node-exporter-b4bbr       1/1     Running     1 (4h16m ago)   28h
```

</details>


#### Additional documentation or context
