### PR TITLE
Task: Pin actions to commit SHA

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Download Rancher's VEX Hub report
         run: curl -fsSO https://raw.githubusercontent.com/rancher/vexhub/refs/heads/main/reports/rancher.openvex.json
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -30,6 +30,6 @@ jobs:
           TRIVY_SHOW_SUPPRESSED: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3  # v3.34.1
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Pin GitHub Actions to specific commit SHA as per org policy.

#### Problem:

Non-compliance with company guidelines.

#### Solution:

Pin GitHub Actions to specific commit SHAs

#### Related Issue(s):

N/A

#### Test plan:

CI and build integrations should continue to work as before.

#### Additional documentation or context

Guidelines in question (last two bullet points):
https://github.com/rancher/security-team/blob/main/docs/guides/security-checklist-devs.md#working-with-github-actions-gha-or-apps
