### PR TITLE
Fix validation order in VM webhook

### DIFF
--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -289,6 +289,10 @@ func (v *vmValidator) Update(_ *types.Request, oldObj runtime.Object, newObj run
 		return err
 	}
 
+	if err := v.checkMaintenanceModeStrategyIsValid(newVM, oldVM); err != nil {
+		return err
+	}
+
 	// This logic will return in case interfaces are existing and not changed
 	// make sure new validation logic is added above this comment
 	if oldVM.Spec.Template != nil && newVM.Spec.Template != nil && reflect.DeepEqual(oldVM.Spec.Template.Spec.Domain.Devices.Interfaces, newVM.Spec.Template.Spec.Domain.Devices.Interfaces) {
@@ -296,10 +300,6 @@ func (v *vmValidator) Update(_ *types.Request, oldObj runtime.Object, newObj run
 	}
 
 	if err := v.checkForDuplicateMacAddrs(newVM); err != nil {
-		return err
-	}
-
-	if err := v.checkMaintenanceModeStrategyIsValid(newVM, oldVM); err != nil {
 		return err
 	}
 

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -955,6 +955,20 @@ func TestVmValidator_Update(t *testing.T) {
 		expectedError bool
 	}{
 		{
+			name:  "Ensure that maintenance mode strategy is checked if there is no change to VM spec",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			newObjMeta: func() *metav1.ObjectMeta {
+				m := templateVM.ObjectMeta.DeepCopy()
+				m.Labels = map[string]string{
+					util.LabelMaintainModeStrategy: "foobar",
+				}
+				return m
+			}(),
+			newSpec:       nil,
+			expectedError: true,
+		},
+		{
 			name:  "storage class name is changed which results in rejection",
 			oldVM: templateVM.DeepCopy(),
 			newVM: templateVM.DeepCopy(),


### PR DESCRIPTION
#### Problem:

Order of validations in the VirtualMachine validation webhook could lead to changes to VM metadata being wrongfully accepted if the VM spec does not change.

#### Solution:

Change order of validations in the VirtualMachine validation webhook such that the short-circuit logic comes after the validation of metadata.

#### Related Issue(s):

related-to: harvester/harvester#6835

#### Test plan:

- Create test VM
- Update test VM with invalid label `harvesterhci.io/maintain-mode-strategy: fail`
- Update to test VM should be rejected

#### Additional documentation or context

https://github.com/harvester/harvester/issues/6835#issuecomment-4110302850 test case "Valid strategy creation UI through Advanced Options"