### PR TITLE
Enqueue plans when all nodes are not updated to latestHash

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/name"
@@ -25,6 +26,10 @@ const (
 	labelArch               = "kubernetes.io/arch"
 	labelCriticalAddonsOnly = "CriticalAddonsOnly"
 
+	// upgradeHeartbeatInterval defines a coarse re-enqueue interval for the upgrade controller.
+	upgradeHeartbeatInterval = time.Minute * 2
+	// upgradeCommonRequeueInterval defines a fast re-enqueue interval for plan/node handlers.
+	upgradeCommonRequeueInterval = time.Second * 20
 	// keep jobs for 7 days
 	defaultTTLSecondsAfterFinished = 604800
 	// Give up to an hour for slower hardware to preload images.

--- a/pkg/controller/master/upgrade/node_controller.go
+++ b/pkg/controller/master/upgrade/node_controller.go
@@ -21,12 +21,13 @@ import (
 // If `harvesterhci.io/pendingOSImage` is equals to the value of `harvesterhci.io/pendingOSImage`, we know the
 // the reboot is done.
 type nodeHandler struct {
-	namespace     string
-	nodeClient    ctlcorev1.NodeClient
-	nodeCache     ctlcorev1.NodeCache
-	upgradeClient ctlharvesterv1.UpgradeClient
-	upgradeCache  ctlharvesterv1.UpgradeCache
-	secretClient  ctlcorev1.SecretClient
+	namespace        string
+	nodeClient       ctlcorev1.NodeClient
+	nodeCache        ctlcorev1.NodeCache
+	upgradeClient    ctlharvesterv1.UpgradeClient
+	upgradeCache     ctlharvesterv1.UpgradeCache
+	secretClient     ctlcorev1.SecretClient
+	nodeEnqueueAfter func(nodeName string, timeout time.Duration)
 }
 
 func (h *nodeHandler) OnChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
@@ -109,6 +110,10 @@ func (h *nodeHandler) OnChanged(_ string, node *corev1.Node) (*corev1.Node, erro
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// node may still be rebooting, or the watch event after reboot was dropped.
+		// Schedule a re-check so we don't permanently miss the transition.
+		h.nodeEnqueueAfter(node.Name, upgradeCommonRequeueInterval)
 	}
 	return node, nil
 }

--- a/pkg/controller/master/upgrade/plan_controller.go
+++ b/pkg/controller/master/upgrade/plan_controller.go
@@ -2,29 +2,32 @@ package upgrade
 
 import (
 	"strconv"
+	"time"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	upgradectlv1 "github.com/harvester/harvester/pkg/generated/controllers/upgrade.cattle.io/v1"
 	"github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
 	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-
-	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
-	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	upgradectlv1 "github.com/harvester/harvester/pkg/generated/controllers/upgrade.cattle.io/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // planHandler syncs on plan completions
 // When a plan completes, it set the NodesPrepared condition of upgrade CRD to be true.
 type planHandler struct {
-	namespace     string
-	upgradeClient ctlharvesterv1.UpgradeClient
-	upgradeCache  ctlharvesterv1.UpgradeCache
-	nodeCache     v1.NodeCache
-	planClient    upgradectlv1.PlanClient
+	namespace        string
+	upgradeClient    ctlharvesterv1.UpgradeClient
+	upgradeCache     ctlharvesterv1.UpgradeCache
+	nodeCache        v1.NodeCache
+	planClient       upgradectlv1.PlanClient
+	planEnqueueAfter func(planNamespace, planName string, timeout time.Duration)
 }
 
 func (h *planHandler) OnChanged(_ string, plan *upgradev1.Plan) (*upgradev1.Plan, error) {
@@ -36,25 +39,26 @@ func (h *planHandler) OnChanged(_ string, plan *upgradev1.Plan) (*upgradev1.Plan
 		return plan, nil
 	}
 
-	upgradeControllerLock.Lock()
-	defer upgradeControllerLock.Unlock()
+	planLogrus := logrus.WithFields(logrus.Fields{
+		"plan":      plan.Name,
+		"namespace": plan.Namespace,
+	})
 
-	requirementPlanNotLatest, err := labels.NewRequirement(upgrade.LabelPlanName(plan.Name), selection.NotIn, []string{"disabled", plan.Status.LatestHash})
+	nodesAtLatestHash, err := allAtLatestHash(h.nodeCache, plan)
 	if err != nil {
 		return plan, err
 	}
-	selector, err := metav1.LabelSelectorAsSelector(plan.Spec.NodeSelector)
-	if err != nil {
-		return plan, err
-	}
-	selector = selector.Add(*requirementPlanNotLatest)
-	nodes, err := h.nodeCache.List(selector)
-	if err != nil {
-		return plan, err
-	}
-	if len(nodes) != 0 {
+	if !nodesAtLatestHash {
+		// Add jitter to avoid multiple plans re-enqueuing simultaneously
+		planLogrus.Info("Nodes pending hash update, requeuing")
+		jitter := time.Duration(rand.Intn(5)) * time.Second
+		h.planEnqueueAfter(plan.Namespace, plan.Name, upgradeCommonRequeueInterval+jitter)
 		return plan, nil
 	}
+
+	planLogrus.Info("All nodes at latest hash")
+	upgradeControllerLock.Lock()
+	defer upgradeControllerLock.Unlock()
 
 	// All nodes for a plan are done at this stage
 	upgradeName, ok := plan.Labels[harvesterUpgradeLabel]
@@ -88,4 +92,24 @@ func (h *planHandler) OnChanged(_ string, plan *upgradev1.Plan) (*upgradev1.Plan
 	}
 
 	return plan, nil
+}
+
+// allAtLatestHash returns true if all nodes matching the plan's NodeSelector
+// are updated to plan.Status.LatestHash (or are disabled), and returns false if any node is still pending.
+func allAtLatestHash(nodeCache v1.NodeCache, plan *upgradev1.Plan) (bool, error) {
+	requirementPlanNotLatest, err := labels.NewRequirement(upgrade.LabelPlanName(plan.Name), selection.NotIn, []string{"disabled", plan.Status.LatestHash})
+	if err != nil {
+		return false, err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(plan.Spec.NodeSelector)
+	if err != nil {
+		return false, err
+	}
+	selector = selector.Add(*requirementPlanNotLatest)
+	nodes, err := nodeCache.List(selector)
+	if err != nil {
+		return false, err
+	}
+
+	return len(nodes) == 0, nil
 }

--- a/pkg/controller/master/upgrade/plan_controller_test.go
+++ b/pkg/controller/master/upgrade/plan_controller_test.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"testing"
+	"time"
 
 	"github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io"
 	upgradeapiv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
@@ -29,9 +30,10 @@ func TestPlanHandler_OnChanged(t *testing.T) {
 		nodes   []*v1.Node
 	}
 	type output struct {
-		plan    *upgradeapiv1.Plan
-		upgrade *harvesterv1.Upgrade
-		err     error
+		plan          *upgradeapiv1.Plan
+		upgrade       *harvesterv1.Upgrade
+		err           error
+		enqueueCalled bool
 	}
 	var testCases = []struct {
 		name     string
@@ -51,8 +53,9 @@ func TestPlanHandler_OnChanged(t *testing.T) {
 				},
 			},
 			expected: output{
-				plan: newTestPreparePlan(),
-				err:  nil,
+				plan:          newTestPreparePlan(),
+				err:           nil,
+				enqueueCalled: true,
 			},
 		},
 		{
@@ -82,7 +85,40 @@ func TestPlanHandler_OnChanged(t *testing.T) {
 					NodeUpgradeStatus("node-4", nodeStateImagesPreloaded, "", "").
 					NodesPreparedCondition(v1.ConditionTrue, "", "").
 					Build(),
-				err: nil,
+				err:           nil,
+				enqueueCalled: false,
+			},
+		},
+		{
+			name: "requeue plan when nodes are not yet at latest hash",
+			given: input{
+				key:  testPlanName,
+				plan: newTestPreparePlan(),
+				upgrade: newTestUpgradeBuilder().
+					NodeUpgradeStatus("node-1", nodeStateImagesPreloaded, "", "").
+					NodeUpgradeStatus("node-2", nodeStateImagesPreloaded, "", "").
+					NodeUpgradeStatus("node-3", nodeStateImagesPreloaded, "", "").
+					NodeUpgradeStatus("node-4", nodeStateImagesPreloaded, "", "").
+					NodesPreparedCondition(v1.ConditionUnknown, "", "").
+					Build(),
+				nodes: []*v1.Node{
+					// node-2 & node-4 are still at old hash — not done yet
+					newNodeBuilder("node-1").Managed().ControlPlane().WithLabel(upgrade.LabelPlanName(newTestPreparePlan().Name), testPlanHash).Build(),
+					newNodeBuilder("node-2").Managed().ControlPlane().WithLabel(upgrade.LabelPlanName(newTestPreparePlan().Name), "old-hash").Build(),
+					newNodeBuilder("node-3").Managed().ControlPlane().WithLabel(upgrade.LabelPlanName(newTestPreparePlan().Name), testPlanHash).Build(),
+					newNodeBuilder("node-4").Managed().ControlPlane().WithLabel(upgrade.LabelPlanName(newTestPreparePlan().Name), "old-hash").Build(),
+				},
+			},
+			expected: output{
+				upgrade: newTestUpgradeBuilder().
+					NodeUpgradeStatus("node-1", nodeStateImagesPreloaded, "", "").
+					NodeUpgradeStatus("node-2", nodeStateImagesPreloaded, "", "").
+					NodeUpgradeStatus("node-3", nodeStateImagesPreloaded, "", "").
+					NodeUpgradeStatus("node-4", nodeStateImagesPreloaded, "", "").
+					NodesPreparedCondition(v1.ConditionUnknown, "", "").
+					Build(),
+				err:           nil,
+				enqueueCalled: true,
 			},
 		},
 	}
@@ -94,12 +130,16 @@ func TestPlanHandler_OnChanged(t *testing.T) {
 			objects = append(objects, node)
 		}
 		var clientset = fake.NewSimpleClientset(objects...)
+		enqueueCalled := false
 		var handler = &planHandler{
 			namespace:     harvesterSystemNamespace,
 			upgradeClient: fakeclients.UpgradeClient(clientset.HarvesterhciV1beta1().Upgrades),
 			upgradeCache:  fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
 			nodeCache:     fakeclients.NodeCache(clientset.CoreV1().Nodes),
 			planClient:    fakeclients.PlanClient(clientset.UpgradeV1().Plans),
+			planEnqueueAfter: func(planNamespace, planName string, timeout time.Duration) {
+				enqueueCalled = true
+			},
 		}
 		var actual output
 		var err error
@@ -119,6 +159,7 @@ func TestPlanHandler_OnChanged(t *testing.T) {
 			tc.expected.plan.Status = expectedPlanStatus
 		}
 
+		actual.enqueueCalled = enqueueCalled
 		assert.Equal(t, tc.expected, actual, "case %q", tc.name)
 	}
 }

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
@@ -167,6 +168,9 @@ func Register(ctx context.Context, management *config.Management, options config
 		upgradeCache:  upgrades.Cache(),
 		nodeCache:     nodes.Cache(),
 		planClient:    plans,
+		planEnqueueAfter: func(planNamespace, planName string, timeout time.Duration) {
+			plans.EnqueueAfter(planNamespace, planName, timeout)
+		},
 	}
 	plans.OnChange(ctx, planControllerName, planHandler.OnChanged)
 
@@ -217,6 +221,9 @@ func Register(ctx context.Context, management *config.Management, options config
 		upgradeClient: upgrades,
 		upgradeCache:  upgrades.Cache(),
 		secretClient:  secrets,
+		nodeEnqueueAfter: func(nodeName string, timeout time.Duration) {
+			nodes.EnqueueAfter(nodeName, timeout)
+		},
 	}
 	nodes.OnChange(ctx, nodeControllerName, nodeHandler.OnChanged)
 

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -437,6 +437,12 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 		return h.upgradeClient.Update(toUpdate)
 	}
 
+	if harvesterv1.UpgradeCompleted.IsUnknown(upgrade) {
+		logrus.Debugf("Upgrade %s/%s is in-progress, scheduling heartbeat re-check in %s",
+			upgrade.Namespace, upgrade.Name, upgradeHeartbeatInterval)
+		h.upgradeController.EnqueueAfter(upgrade.Namespace, upgrade.Name, upgradeHeartbeatInterval)
+	}
+
 	return upgrade, nil
 }
 


### PR DESCRIPTION
#### Problem:
During plan completion checks for nodes, stale nodeCache could lead to silent failures.

#### Solution:
This commit ensures enqueuing of following Handlers:
- upgradeHandler when `UpgradeCompleted.IsUnknown`
- nodeHandler when `node.Status.NodeInfo.OSImage` is not yet at  expectedVersion 
- planHandler in case not all the nodes are not at latestPlanHash.

#### Related Issue(s):
#10101 

#### Test plan:
- Unit tests to cover all discussed scenarios were added

#### Additional documentation or context
