### PR TITLE
[Backport v1.8] Fix validation order in VM webhook (#10272)

### DIFF
--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -284,6 +284,10 @@ func (v *vmValidator) Update(_ *types.Request, oldObj runtime.Object, newObj run
 		return err
 	}
 
+	if err := v.checkMaintenanceModeStrategyIsValid(newVM, oldVM); err != nil {
+		return err
+	}
+
 	// This logic will return in case interfaces are existing and not changed
 	// make sure new validation logic is added above this comment
 	if oldVM.Spec.Template != nil && newVM.Spec.Template != nil && reflect.DeepEqual(oldVM.Spec.Template.Spec.Domain.Devices.Interfaces, newVM.Spec.Template.Spec.Domain.Devices.Interfaces) {
@@ -291,10 +295,6 @@ func (v *vmValidator) Update(_ *types.Request, oldObj runtime.Object, newObj run
 	}
 
 	if err := v.checkForDuplicateMacAddrs(newVM); err != nil {
-		return err
-	}
-
-	if err := v.checkMaintenanceModeStrategyIsValid(newVM, oldVM); err != nil {
 		return err
 	}
 

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -955,6 +955,20 @@ func TestVmValidator_Update(t *testing.T) {
 		expectedError bool
 	}{
 		{
+			name:  "Ensure that maintenance mode strategy is checked if there is no change to VM spec",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			newObjMeta: func() *metav1.ObjectMeta {
+				m := templateVM.ObjectMeta.DeepCopy()
+				m.Labels = map[string]string{
+					util.LabelMaintainModeStrategy: "foobar",
+				}
+				return m
+			}(),
+			newSpec:       nil,
+			expectedError: true,
+		},
+		{
 			name:  "storage class name is changed which results in rejection",
 			oldVM: templateVM.DeepCopy(),
 			newVM: templateVM.DeepCopy(),


### PR DESCRIPTION
* Fix validation order in VM webhook
* Validation Webhook Tests: Test execution order

Test the execution order of the individual checks of the VM validation webhook. This ensures that the maintenance-mode strategy checks are not omitted from short-circuit returns.

related-to: harvester/harvester#6835

#### Problem:

Checks in the VirtualMachine validation webhook may be skipped by short-circuit logic, leading to admissions, when the resource should have been rejected.

#### Solution:

Re-order the checks in the VirtualMachine validation webhook to avoid skipping checks when short-circuiting to return.

#### Related Issue(s):

related-to: harvester/harvester#6835

#### Test plan:

Unit tests included.
Updating a VirtualMachine such that a) it should not be accepted by the validation webhook and b) only metadata is modified should result in rejection.

1) Create valid test VM
2) Update VM labels with `harvesterhci.io/maintain-mode-strategy: thisshouldfail` (e.g. with `kubectl edit`)
3) Observe rejection by webhook

#### Additional documentation or context
