### PR TITLE
fix: sync vmdp image version with harvester-installer

### DIFF
--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -506,7 +506,7 @@ spec:
               claimName: pvc-rootdisk
             name: rootdisk
           - containerDisk:
-              image: registry.suse.com/suse/vmdp/vmdp:2.5.4.3
+              image: registry.suse.com/suse/vmdp/vmdp:2.5.5
               imagePullPolicy: IfNotPresent
             name: virtio-container-disk
 `


### PR DESCRIPTION
#### Problem:
The vmdp image version in template.go is 2.5.4.3, but the image packaged by harvester installer is 2.5.5.

#### Solution:
Update template.go to match the value in harvester installer.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10119

#### Test plan:
Verify the Windows VM templates show the update vmdp image version.

#### Additional documentation or context
