### PR TITLE
sync harvester specific namespaces into System project

### DIFF
--- a/pkg/controller/master/rancher/namespace.go
+++ b/pkg/controller/master/rancher/namespace.go
@@ -3,6 +3,8 @@ package rancher
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +16,11 @@ import (
 
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+)
+
+const (
+	projectAnnotationKey   = "field.cattle.io/projectId"
+	defaultRecheckInterval = 300 * time.Second
 )
 
 func (h *Handler) onNamespaceRemoved(_ string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
@@ -105,4 +112,86 @@ func (h *Handler) onNamespaceRemoved(_ string, namespace *corev1.Namespace) (*co
 		}
 	}
 	return namespace, nil
+}
+
+// onNamespaceChanged watches changes to kube-system namespace which indicate if the namespace has been moved to a project
+// and based on the project annotation, it will add/remove the projectId label to the harvester system namesapces.
+func (h *Handler) onNamespaceChanged(key string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+	if namespace == nil || namespace.DeletionTimestamp != nil || namespace.Name != util.KubeSystemNamespace {
+		return namespace, nil
+	}
+	projectID, hasProjectAnnotation := namespace.Annotations[projectAnnotationKey]
+	if hasProjectAnnotation {
+		if err := h.addProjectIDToHarvesterSystemNamespaces(projectID); err != nil {
+			return namespace, err
+		}
+	} else {
+		if err := h.removeProjectIDFromHarvesterSystemNamespaces(); err != nil {
+			return namespace, err
+		}
+	}
+
+	h.NamespaceController.EnqueueAfter(key, defaultRecheckInterval)
+	return namespace, nil
+}
+
+// addProjectIDToHarvesterSystemNamespaces adds the projectID to the harvester system namespaces if the kube-system namespace is added to a project.
+func (h *Handler) addProjectIDToHarvesterSystemNamespaces(projectID string) error {
+	for _, ns := range util.DefaultHarvesterNamespaceWhiteList {
+		namespace, err := h.NamespaceCache.Get(ns)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("error getting namespace %s: %w", ns, err)
+		}
+
+		// namespace is being deleted, skip it
+		if namespace.DeletionTimestamp != nil {
+			continue
+		}
+
+		namespaceCopy := namespace.DeepCopy()
+		if namespaceCopy.Annotations == nil {
+			namespaceCopy.Annotations = make(map[string]string)
+		}
+		namespaceCopy.Annotations[projectAnnotationKey] = projectID
+		if !reflect.DeepEqual(namespace, namespaceCopy) {
+			_, err = h.NamespaceClient.Update(namespaceCopy)
+			if err != nil {
+				return fmt.Errorf("error updating namespace %s: %w", ns, err)
+			}
+		}
+	}
+	return nil
+}
+
+// removeProjectIDFromHarvesterSystemNamespaces removes the projectID from the harvester system namespaces if the kube-system namespace is removed from a project.
+func (h *Handler) removeProjectIDFromHarvesterSystemNamespaces() error {
+	for _, ns := range util.DefaultHarvesterNamespaceWhiteList {
+		namespace, err := h.NamespaceCache.Get(ns)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("error getting namespace %s: %w", ns, err)
+		}
+
+		// namespace is being deleted, skip it
+		if namespace.DeletionTimestamp != nil {
+			continue
+		}
+
+		namespaceCopy := namespace.DeepCopy()
+		if namespaceCopy.Annotations != nil {
+			delete(namespaceCopy.Annotations, projectAnnotationKey)
+		}
+		if !reflect.DeepEqual(namespace, namespaceCopy) {
+			_, err = h.NamespaceClient.Update(namespaceCopy)
+			if err != nil {
+				return fmt.Errorf("error updating namespace %s: %w", ns, err)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/controller/master/rancher/namespaces_test.go
+++ b/pkg/controller/master/rancher/namespaces_test.go
@@ -1,0 +1,69 @@
+package rancher
+
+import (
+	"testing"
+
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corefake "k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	projectAnnotationValue        = "c-fz4vx:p-lbm6g"
+	invalidProjectAnnotationValue = "c-fz4vx:p-98lps"
+
+	harvesterSystemNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-system",
+		},
+	}
+
+	forkliftNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "forklift",
+			Annotations: map[string]string{
+				projectAnnotationKey: invalidProjectAnnotationValue,
+			},
+		},
+	}
+
+	demoNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-demo",
+		},
+	}
+)
+
+func Test_ProjectAddition(t *testing.T) {
+	clientset := corefake.NewSimpleClientset(harvesterSystemNamespace, forkliftNamespace, demoNamespace)
+
+	h := &Handler{
+		NamespaceClient: fakeclients.NamespaceClient(clientset.CoreV1().Namespaces),
+		NamespaceCache:  fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
+	}
+
+	assert := require.New(t)
+	err := h.addProjectIDToHarvesterSystemNamespaces(projectAnnotationValue)
+	assert.NoError(err, "expected no error during namespace reconcile")
+	updatedNS, err := h.NamespaceCache.Get(harvesterSystemNamespace.Name)
+	assert.NoError(err, "expected no error when getting namespace from cache")
+	assert.Equal(projectAnnotationValue, updatedNS.Annotations[projectAnnotationKey], "expected to find  project annotation in harvester system namespace")
+}
+
+func Test_ProjectRemoval(t *testing.T) {
+	clientset := corefake.NewSimpleClientset(harvesterSystemNamespace, forkliftNamespace, demoNamespace)
+
+	h := &Handler{
+		NamespaceClient: fakeclients.NamespaceClient(clientset.CoreV1().Namespaces),
+		NamespaceCache:  fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
+	}
+
+	assert := require.New(t)
+	err := h.removeProjectIDFromHarvesterSystemNamespaces()
+	assert.NoError(err, "expected no error during namespace reconcile")
+	updatedNS, err := h.NamespaceCache.Get(forkliftNamespace.Name)
+	assert.NoError(err, "expected no error when getting namespace from cache")
+	assert.Empty(updatedNS.Annotations[projectAnnotationKey], "expected project annotation to be removed from forklift namespace")
+}

--- a/pkg/controller/master/rancher/namespaces_test.go
+++ b/pkg/controller/master/rancher/namespaces_test.go
@@ -1,0 +1,79 @@
+package rancher
+
+import (
+	"testing"
+
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corefake "k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	projectAnnotationValue        = "c-fz4vx:p-lbm6g"
+	invalidProjectAnnotationValue = "c-fz4vx:p-98lps"
+
+	harvesterSystemNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-system",
+		},
+	}
+
+	forkliftNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "forklift",
+			Annotations: map[string]string{
+				projectAnnotationKey: invalidProjectAnnotationValue,
+			},
+		},
+	}
+
+	demoNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "harvester-demo",
+		},
+	}
+)
+
+func Test_ProjectAddition(t *testing.T) {
+	clientset := corefake.NewSimpleClientset(harvesterSystemNamespace, forkliftNamespace, demoNamespace)
+
+	h := &Handler{
+		NamespaceClient: fakeclients.NamespaceClient(clientset.CoreV1().Namespaces),
+		NamespaceCache:  fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
+	}
+
+	assert := require.New(t)
+	err := h.addProjectIDToHarvesterSystemNamespaces(projectAnnotationValue)
+	assert.NoError(err, "expected no error during namespace reconcile")
+	updatedNS, err := h.NamespaceCache.Get(harvesterSystemNamespace.Name)
+	assert.NoError(err, "expected no error when getting namespace from cache")
+	assert.Equal(projectAnnotationValue, updatedNS.Annotations[projectAnnotationKey], "expected to find  project annotation in harvester system namespace")
+	demoNSObj, err := h.NamespaceCache.Get(demoNamespace.Name)
+	assert.NoError(err, "expected no error when getting demo namespace from cache")
+	assert.Empty(demoNSObj.Annotations[projectAnnotationKey], "expected project annotation to be empty in demo namespace")
+}
+
+func Test_ProjectRemoval(t *testing.T) {
+	demoNSCopy := demoNamespace.DeepCopy()
+	demoNSCopy.Annotations = map[string]string{
+		projectAnnotationKey: invalidProjectAnnotationValue,
+	}
+	clientset := corefake.NewSimpleClientset(harvesterSystemNamespace, forkliftNamespace, demoNSCopy)
+
+	h := &Handler{
+		NamespaceClient: fakeclients.NamespaceClient(clientset.CoreV1().Namespaces),
+		NamespaceCache:  fakeclients.NamespaceCache(clientset.CoreV1().Namespaces),
+	}
+
+	assert := require.New(t)
+	err := h.removeProjectIDFromHarvesterSystemNamespaces()
+	assert.NoError(err, "expected no error during namespace reconcile")
+	updatedNS, err := h.NamespaceCache.Get(forkliftNamespace.Name)
+	assert.NoError(err, "expected no error when getting namespace from cache")
+	assert.Empty(updatedNS.Annotations[projectAnnotationKey], "expected project annotation to be removed from forklift namespace")
+	demoNSObj, err := h.NamespaceCache.Get(demoNamespace.Name)
+	assert.NoError(err, "expected no error when getting demo namespace from cache")
+	assert.Equal(invalidProjectAnnotationValue, demoNSObj.Annotations[projectAnnotationKey], "expected project annotation to be unchanged in demo namespace")
+}

--- a/pkg/controller/master/rancher/register.go
+++ b/pkg/controller/master/rancher/register.go
@@ -68,6 +68,9 @@ type Handler struct {
 	Namespace                string
 	RancherTokenController   rancherv3.TokenController
 	SettingCache             v1beta1.SettingCache
+	NamespaceCache           ctlcorev1.NamespaceCache
+	NamespaceController      ctlcorev1.NamespaceController
+	NamespaceClient          ctlcorev1.NamespaceClient
 }
 
 type VIPConfig struct {
@@ -110,6 +113,9 @@ func Register(ctx context.Context, management *config.Management, options config
 			Namespace:                options.Namespace,
 			Deployments:              deployments,
 			SettingCache:             settings.Cache(),
+			NamespaceCache:           namespaces.Cache(),
+			NamespaceClient:          namespaces,
+			NamespaceController:      namespaces,
 		}
 		nodes.OnChange(ctx, controllerRancherName, h.PodResourcesOnChanged)
 		rancherSettings.OnChange(ctx, controllerRancherName, h.RancherSettingOnChange)
@@ -117,6 +123,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		deployments.OnChange(ctx, controllerCAPIDeployment, h.PatchCAPIDeployment)
 		rancherTokens.OnChange(ctx, controllerRancherName, h.RancherTokenOnChange)
 		namespaces.OnRemove(ctx, controllerNamespaceName, h.onNamespaceRemoved)
+		namespaces.OnChange(ctx, controllerNamespaceName, h.onNamespaceChanged)
 
 		if err := h.registerExposeService(); err != nil {
 			return err


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
For baremetal workload support, we need to ensure the Harvester specific system namespaces are moved to System project when Harvester is imported into a Rancher cluster. This will make it easier for rbac via rancher as admins could be assigned specific roles on the System project to get access to harvester components.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR adds a minor namespace handler to update a harvester system namespace list into the System project by looking up project details from `kube-system` namespace, which is auto-populated into the System namespace by rancher when a cluster is imported. 

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5820

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
