### PR TITLE
fix: check if host device has parent sriovgpu label

### DIFF
--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -1,17 +1,22 @@
 package addon
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	validationutil "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
@@ -30,9 +35,17 @@ const (
 	vCluster0190           = "v0.19.0"
 	vCluster0300           = "v0.30.0"
 	kubeOVNOperatorAddon   = util.KubeOVNOperatorName
+
+	labelParentSRIOVGPUDevice = "harvesterhci.io/parentSRIOVGPUDevice"
 )
 
-func NewValidator(addons ctlharvesterv1.AddonCache, flowCache ctlloggingv1.FlowCache, outputCache ctlloggingv1.OutputCache, clusterFlowCache ctlloggingv1.ClusterFlowCache, clusterOutputCache ctlloggingv1.ClusterOutputCache, upgradeLogCache ctlharvesterv1.UpgradeLogCache, nodeCache ctlcorev1.NodeCache, vmCache ctlkubevirtv1.VirtualMachineCache, kubeovnSubnet ctlkubeovnv1.SubnetCache) types.Validator {
+var vgpuDeviceGVR = schema.GroupVersionResource{
+	Group:    "devices.harvesterhci.io",
+	Version:  "v1beta1",
+	Resource: "vgpudevices",
+}
+
+func NewValidator(addons ctlharvesterv1.AddonCache, flowCache ctlloggingv1.FlowCache, outputCache ctlloggingv1.OutputCache, clusterFlowCache ctlloggingv1.ClusterFlowCache, clusterOutputCache ctlloggingv1.ClusterOutputCache, upgradeLogCache ctlharvesterv1.UpgradeLogCache, nodeCache ctlcorev1.NodeCache, vmCache ctlkubevirtv1.VirtualMachineCache, kubeovnSubnet ctlkubeovnv1.SubnetCache, k8sClient client.Client) types.Validator {
 	return &addonValidator{
 		addons:             addons,
 		flowCache:          flowCache,
@@ -43,6 +56,7 @@ func NewValidator(addons ctlharvesterv1.AddonCache, flowCache ctlloggingv1.FlowC
 		nodeCache:          nodeCache,
 		vmCache:            vmCache,
 		kubeovnSubnet:      kubeovnSubnet,
+		k8sClient:          k8sClient,
 	}
 }
 
@@ -58,6 +72,7 @@ type addonValidator struct {
 	nodeCache          ctlcorev1.NodeCache
 	vmCache            ctlkubevirtv1.VirtualMachineCache
 	kubeovnSubnet      ctlkubeovnv1.SubnetCache
+	k8sClient          client.Client
 }
 
 func (v *addonValidator) Resource() types.Resource {
@@ -331,7 +346,6 @@ func (v *addonValidator) validateDeschedulerAddon(newAddon *v1beta1.Addon) error
 }
 
 func (v *addonValidator) validatePCIDevicesControllerAddon() error {
-	// Check if any VMs are using HostDevices (PCI devices, USB devices) or GPUs (vGPU devices)
 	vms, err := v.vmCache.List(metav1.NamespaceAll, labels.Everything())
 	if err != nil {
 		return werror.NewInternalError(fmt.Sprintf("error listing virtual machines: %v", err.Error()))
@@ -342,13 +356,7 @@ func (v *addonValidator) validatePCIDevicesControllerAddon() error {
 		if vm.Spec.Template == nil {
 			continue
 		}
-		// Check for HostDevices (PCI devices and USB devices)
 		if len(vm.Spec.Template.Spec.Domain.Devices.HostDevices) > 0 {
-			vmsWithDevices = append(vmsWithDevices, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
-			continue
-		}
-		// Check for GPUs (vGPU devices)
-		if len(vm.Spec.Template.Spec.Domain.Devices.GPUs) > 0 {
 			vmsWithDevices = append(vmsWithDevices, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
 		}
 	}
@@ -361,25 +369,57 @@ func (v *addonValidator) validatePCIDevicesControllerAddon() error {
 }
 
 func (v *addonValidator) validateNvidiaDriverToolkitAddon() error {
-	// Check if any VMs are using GPUs (vGPU devices and SR-IOV GPU devices)
 	vms, err := v.vmCache.List(metav1.NamespaceAll, labels.Everything())
 	if err != nil {
 		return werror.NewInternalError(fmt.Sprintf("error listing virtual machines: %v", err.Error()))
 	}
 
-	var vmsWithGPUs []string
+	// Collect all HostDevice names across all VMs
+	hostDeviceNames := map[string]string{} // device name -> vm namespace/name
 	for _, vm := range vms {
 		if vm.Spec.Template == nil {
 			continue
 		}
-		// Check for GPUs (vGPU devices and SR-IOV GPU devices)
-		if len(vm.Spec.Template.Spec.Domain.Devices.GPUs) > 0 {
-			vmsWithGPUs = append(vmsWithGPUs, fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
+		for _, hd := range vm.Spec.Template.Spec.Domain.Devices.HostDevices {
+			hostDeviceNames[hd.Name] = fmt.Sprintf("%s/%s", vm.Namespace, vm.Name)
 		}
 	}
 
-	if len(vmsWithGPUs) > 0 {
-		return werror.NewBadRequest(fmt.Sprintf("nvidia-driver-toolkit addon cannot be disabled as the following VMs are using GPU devices: %v", vmsWithGPUs))
+	if len(hostDeviceNames) == 0 {
+		return nil
+	}
+
+	// List all VGPUDevice resources that have the parentSRIOVGPUDevice label,
+	// which indicates they are vGPU devices managed by nvidia-driver-toolkit.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	vgpuList := &unstructured.UnstructuredList{}
+	vgpuList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   vgpuDeviceGVR.Group,
+		Version: vgpuDeviceGVR.Version,
+		Kind:    "VGPUDeviceList",
+	})
+	if err := v.k8sClient.List(ctx, vgpuList, client.HasLabels{labelParentSRIOVGPUDevice}); err != nil {
+		return werror.NewInternalError(fmt.Sprintf("error listing VGPUDevices: %v", err.Error()))
+	}
+
+	// Build a set of VGPUDevice names for fast lookup
+	vgpuDeviceNames := make(map[string]struct{}, len(vgpuList.Items))
+	for _, item := range vgpuList.Items {
+		vgpuDeviceNames[item.GetName()] = struct{}{}
+	}
+
+	// Check if any VM HostDevice matches a VGPUDevice
+	var vmsWithVGPU []string
+	for devName, vmRef := range hostDeviceNames {
+		if _, ok := vgpuDeviceNames[devName]; ok {
+			vmsWithVGPU = append(vmsWithVGPU, vmRef)
+		}
+	}
+
+	if len(vmsWithVGPU) > 0 {
+		return werror.NewBadRequest(fmt.Sprintf("nvidia-driver-toolkit addon cannot be disabled as the following VMs are using vGPU devices: %v", vmsWithVGPU))
 	}
 
 	return nil

--- a/pkg/webhook/resources/addon/validator_test.go
+++ b/pkg/webhook/resources/addon/validator_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	fake "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -472,7 +474,7 @@ func Test_validateUpdatedAddon(t *testing.T) {
 	upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
 	fakeNodeCache := fakeclients.NodeCache(clientset.CoreV1().Nodes)
 	fakeVMCache := fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines)
-	validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, fakeVMCache, nil).(*addonValidator)
+	validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, fakeVMCache, nil, nil).(*addonValidator)
 
 	for _, tc := range testCases {
 		err := validator.validateUpdatedAddon(tc.newAddon, tc.oldAddon)
@@ -550,7 +552,7 @@ func Test_validateNewAddon(t *testing.T) {
 		fakeNodeCache := fakeclients.NodeCache(clientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
 
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil, nil).(*addonValidator)
 		for _, addon := range tc.addonList {
 			err := clientset.Tracker().Add(addon)
 			assert.Nil(t, err)
@@ -912,7 +914,7 @@ func Test_validateRancherLoggingAddonWithClusterFlow(t *testing.T) {
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(clientset.LoggingV1beta1().ClusterOutputs)
 		fakeNodeCache := fakeclients.NodeCache(clientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil, nil).(*addonValidator)
 		for _, cf := range tc.clusterFlows {
 			err := clientset.Tracker().Add(cf)
 			assert.Nil(t, err)
@@ -1194,7 +1196,7 @@ func Test_validateRancherLoggingAddonWithFlow(t *testing.T) {
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(clientset.LoggingV1beta1().ClusterOutputs)
 		fakeNodeCache := fakeclients.NodeCache(clientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil, nil).(*addonValidator)
 		for _, cf := range tc.flows {
 			err := clientset.Tracker().Add(cf)
 			assert.Nil(t, err)
@@ -1425,7 +1427,7 @@ func Test_validateRancherLoggingWithUpgradeLog(t *testing.T) {
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(clientset.LoggingV1beta1().ClusterOutputs)
 		fakeNodeCache := fakeclients.NodeCache(clientset.CoreV1().Nodes)
 		upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, fakeNodeCache, nil, nil, nil).(*addonValidator)
 		for _, upgradeLog := range tc.upgradeLogs {
 			err := clientset.Tracker().Add(upgradeLog)
 			assert.Nil(t, err)
@@ -1537,7 +1539,7 @@ func Test_validateRancherLoggingWithUpgradeLogThenUpgradeAddon(t *testing.T) {
 		fakeClusterFlowCache := fakeclients.ClusterFlowCache(clientset.LoggingV1beta1().ClusterFlows)
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(clientset.LoggingV1beta1().ClusterOutputs)
 		upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, nil, nil, nil).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, nil, nil, nil, nil).(*addonValidator)
 		for _, upgradeLog := range tc.upgradeLogs {
 			err := clientset.Tracker().Add(upgradeLog)
 			assert.Nil(t, err)
@@ -1642,7 +1644,7 @@ func Test_validateDeleteAddon(t *testing.T) {
 		fakeClusterFlowCache := fakeclients.ClusterFlowCache(clientset.LoggingV1beta1().ClusterFlows)
 		fakeClusterOutputCache := fakeclients.ClusterOutputCache(clientset.LoggingV1beta1().ClusterOutputs)
 		upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
-		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, nil, nil, nil).(*addonValidator)
+		validator := NewValidator(fakeAddonCache, fakeFlowCache, fakeOutputCache, fakeClusterFlowCache, fakeClusterOutputCache, upgradeLogCache, nil, nil, nil, nil).(*addonValidator)
 
 		err := validator.Delete(nil, tc.oldAddon)
 		if tc.expectedError {
@@ -1742,11 +1744,11 @@ func Test_validatePCIDevicesControllerAddon(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "VM with no passthrough devices, should allow disable",
+			name: "VM with no devices, should allow disable",
 			vms: []*kubevirtv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-no-passthrough",
+						Name:      "vm-no-devices",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -1791,11 +1793,11 @@ func Test_validatePCIDevicesControllerAddon(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "VM with GPUs, should block disable",
+			name: "VM with GPUs only, should allow disable",
 			vms: []*kubevirtv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-with-gpu",
+						Name:      "vm-with-gpu-only",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -1816,7 +1818,7 @@ func Test_validatePCIDevicesControllerAddon(t *testing.T) {
 					},
 				},
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 		{
 			name: "VM with both host devices and GPUs, should block disable",
@@ -1857,7 +1859,7 @@ func Test_validatePCIDevicesControllerAddon(t *testing.T) {
 			vms: []*kubevirtv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-no-passthrough",
+						Name:      "vm-no-devices",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -1899,24 +1901,18 @@ func Test_validatePCIDevicesControllerAddon(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create fake kubevirt clientset
 			clientset := fake.NewSimpleClientset()
 
-			// Add VMs to the tracker
 			for _, vm := range tc.vms {
 				err := clientset.Tracker().Add(vm)
 				require.NoError(t, err, "failed to add VM to fake tracker")
 			}
 
-			// Create VM cache
 			vmCache := fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines)
-
-			// Create validator
 			validator := &addonValidator{
 				vmCache: vmCache,
 			}
 
-			// Test the validation
 			err := validator.validatePCIDevicesControllerAddon()
 			if tc.expectedError {
 				assert.NotNil(t, err, tc.name)
@@ -1931,7 +1927,24 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 	type testCase struct {
 		name          string
 		vms           []*kubevirtv1.VirtualMachine
+		vgpuDevices   []*unstructured.Unstructured
 		expectedError bool
+	}
+
+	newVGPUDevice := func(name string, hasParentLabel bool) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "devices.harvesterhci.io",
+			Version: "v1beta1",
+			Kind:    "VGPUDevice",
+		})
+		obj.SetName(name)
+		if hasParentLabel {
+			obj.SetLabels(map[string]string{
+				labelParentSRIOVGPUDevice: "sriov-gpu-parent",
+			})
+		}
+		return obj
 	}
 
 	testCases := []testCase{
@@ -1941,11 +1954,11 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "VM with no GPUs, should allow disable",
+			name: "VM with no devices, should allow disable",
 			vms: []*kubevirtv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-no-gpu",
+						Name:      "vm-no-devices",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -1962,11 +1975,11 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "VM with host devices but no GPUs, should allow disable",
+			name: "VM uses HostDevice that is not a vGPU device, should allow disable",
 			vms: []*kubevirtv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-with-hostdev-only",
+						Name:      "vm-with-pci-device",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -1987,42 +2000,15 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 					},
 				},
 			},
+			vgpuDevices:   []*unstructured.Unstructured{newVGPUDevice("other-vgpu-device", true)},
 			expectedError: false,
 		},
 		{
-			name: "VM with GPUs, should block disable",
+			name: "VM uses HostDevice matching a vGPU device with parent label, should block disable",
 			vms: []*kubevirtv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-with-gpu",
-						Namespace: "default",
-					},
-					Spec: kubevirtv1.VirtualMachineSpec{
-						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-							Spec: kubevirtv1.VirtualMachineInstanceSpec{
-								Domain: kubevirtv1.DomainSpec{
-									Devices: kubevirtv1.Devices{
-										GPUs: []kubevirtv1.GPU{
-											{
-												Name:       "gpu-1",
-												DeviceName: "nvidia.com/GPU",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedError: true,
-		},
-		{
-			name: "VM with both host devices and GPUs, should block disable",
-			vms: []*kubevirtv1.VirtualMachine{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-with-both",
+						Name:      "vm-with-vgpu",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -2032,14 +2018,8 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 									Devices: kubevirtv1.Devices{
 										HostDevices: []kubevirtv1.HostDevice{
 											{
-												Name:       "pci-device-1",
-												DeviceName: "pci.example.com/device",
-											},
-										},
-										GPUs: []kubevirtv1.GPU{
-											{
-												Name:       "gpu-1",
-												DeviceName: "nvidia.com/GPU",
+												Name:       "vgpu-device-1",
+												DeviceName: "nvidia.com/GRID-V100D-8C",
 											},
 										},
 									},
@@ -2049,14 +2029,44 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 					},
 				},
 			},
+			vgpuDevices:   []*unstructured.Unstructured{newVGPUDevice("vgpu-device-1", true)},
 			expectedError: true,
 		},
 		{
-			name: "multiple VMs, one with GPU, should block disable",
+			name: "VM uses HostDevice matching VGPUDevice name but without parent label, should allow disable",
 			vms: []*kubevirtv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-no-gpu",
+						Name:      "vm-with-unlabeled-vgpu",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										HostDevices: []kubevirtv1.HostDevice{
+											{
+												Name:       "vgpu-device-2",
+												DeviceName: "nvidia.com/GRID-V100D-8C",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			vgpuDevices:   []*unstructured.Unstructured{newVGPUDevice("vgpu-device-2", false)},
+			expectedError: false,
+		},
+		{
+			name: "multiple VMs, one uses vGPU device, should block disable",
+			vms: []*kubevirtv1.VirtualMachine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vm-no-devices",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -2071,7 +2081,7 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm-with-gpu",
+						Name:      "vm-with-vgpu",
 						Namespace: "default",
 					},
 					Spec: kubevirtv1.VirtualMachineSpec{
@@ -2079,10 +2089,10 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 							Spec: kubevirtv1.VirtualMachineInstanceSpec{
 								Domain: kubevirtv1.DomainSpec{
 									Devices: kubevirtv1.Devices{
-										GPUs: []kubevirtv1.GPU{
+										HostDevices: []kubevirtv1.HostDevice{
 											{
-												Name:       "gpu-1",
-												DeviceName: "nvidia.com/GPU",
+												Name:       "vgpu-device-1",
+												DeviceName: "nvidia.com/GRID-V100D-8C",
 											},
 										},
 									},
@@ -2092,30 +2102,31 @@ func Test_validateNvidiaDriverToolkitAddon(t *testing.T) {
 					},
 				},
 			},
+			vgpuDevices:   []*unstructured.Unstructured{newVGPUDevice("vgpu-device-1", true)},
 			expectedError: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create fake kubevirt clientset
 			clientset := fake.NewSimpleClientset()
 
-			// Add VMs to the tracker
 			for _, vm := range tc.vms {
 				err := clientset.Tracker().Add(vm)
 				require.NoError(t, err, "failed to add VM to fake tracker")
 			}
 
-			// Create VM cache
 			vmCache := fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines)
-
-			// Create validator
+			builder := ctrlruntimefake.NewClientBuilder()
+			for _, d := range tc.vgpuDevices {
+				builder = builder.WithObjects(d)
+			}
+			k8sClient := builder.Build()
 			validator := &addonValidator{
-				vmCache: vmCache,
+				vmCache:   vmCache,
+				k8sClient: k8sClient,
 			}
 
-			// Test the validation
 			err := validator.validateNvidiaDriverToolkitAddon()
 			if tc.expectedError {
 				assert.NotNil(t, err, tc.name)

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -205,6 +205,7 @@ func Validation(clients *clients.Clients, options *config.Options, crdExists boo
 			clients.Core.Node().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 			kubeovnSubnetCache,
+			client,
 		),
 		version.NewValidator(),
 		volumesnapshot.NewValidator(


### PR DESCRIPTION
#### Problem:
Because vm.domain.devices.gpus is no longer used ([reason](https://github.com/harvester/pcidevices/pull/159)), we don't need to check gpus anymore.

#### Solution:
Use dynamic client to fetch details.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9531
https://github.com/harvester/pcidevices/pull/159

#### Test plan:

disabling case 01 : VM with a vgpu device in host device filed.

https://github.com/user-attachments/assets/e9f34a2c-1be1-4c55-a093-9ce95819dae0

disabling case 02: VM with a nvidia host device. Allow disabling nvidia-toolkit addon because it's a host device.

https://github.com/user-attachments/assets/487a4a7b-b143-468f-b0d5-9b8a72c90f8f


#### Additional documentation or context
