### PR TITLE
Add vm patch access controler to csi-driver cluster role

### DIFF
--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -215,3 +215,9 @@ rules:
   - volumesnapshotcontents/status
   verbs:
   - '*'
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - patch

--- a/deploy/charts/harvester/templates/rbac.yaml
+++ b/deploy/charts/harvester/templates/rbac.yaml
@@ -169,55 +169,55 @@ metadata:
     app.kubernetes.io/component: apiserver
   name: harvesterhci.io:csi-driver
 rules:
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  - volumeattachments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - harvesterhci.io
-  resources:
-  - networkfilesystems
-  - networkfilesystems/status
-  - volumeremotebackups
-  - volumeremoterestores
-  verbs:
-  - '*'
-- apiGroups:
-  - harvesterhci.io
-  resources:
-  - settings
-  verbs:
-  - get
-  - list
-  resourceNames:
-  - csi-online-expand-validation
-  - csi-driver-config
-- apiGroups:
-  - longhorn.io
-  resources:
-  - volumes
-  - volumes/status
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  - volumesnapshotcontents
-  - volumesnapshotclasses
-  - volumesnapshots/status
-  - volumesnapshotcontents/status
-  verbs:
-  - '*'
-- apiGroups:
-  - kubevirt.io
-  resources:
-  - virtualmachines
-  verbs:
-  - patch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - networkfilesystems
+      - networkfilesystems/status
+      - volumeremotebackups
+      - volumeremoterestores
+    verbs:
+      - '*'
+  - apiGroups:
+      - harvesterhci.io
+    resources:
+      - settings
+    verbs:
+      - get
+      - list
+    resourceNames:
+      - csi-online-expand-validation
+      - csi-driver-config
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - volumes
+      - volumes/status
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+      - volumesnapshotcontents
+      - volumesnapshotclasses
+      - volumesnapshots/status
+      - volumesnapshotcontents/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+    verbs:
+      - patch


### PR DESCRIPTION

#### Problem:

this is a follow up of https://github.com/harvester/harvester-csi-driver/pull/75, now we need the vm patch permission in  https://github.com/harvester/harvester-csi-driver/blob/master/pkg/csi/controller_server.go#L868

#### Solution:

Add vm patch permission to `harvesterhci.io:csi-driver`

#### Related Issue(s):

https://github.com/harvester/harvester/issues/10243

#### Test plan:

1. Prepare a harvester cluster that include this patch.
2. Provision a rke2 guest cluster
3. Update harvester-cloud-provider image to `v0.2.17`, you can run the cmd below
```
kubectl set image daemonset/harvester-csi-driver -n kube-system harvester-csi-driver=rancher/harvester-csi-driver:v0.2.7
```
4. create a pvc
```
kubectl apply -f - <<EOF
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: fs-vol
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 2Gi
EOF
```
5. make sure the pvc is in Bound Status
```
root@rke2-pool1-znpgh-jfwrv:~# kubectl get pvc
NAME     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
fs-vol   Bound    pvc-ef88c4d3-ac53-46c2-a6ca-ba4f2461cae7   2Gi        RWO            harvester      <unset>                 15m
```

#### Additional documentation or context
