### PR TITLE
[v190] fix: volumeClaimTemplates annotation bypass on re-add

### DIFF
--- a/pkg/util/fakeclients/storageclass.go
+++ b/pkg/util/fakeclients/storageclass.go
@@ -2,6 +2,7 @@ package fakeclients
 
 import (
 	"context"
+	"fmt"
 
 	storagev1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/storage.k8s.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
@@ -97,4 +98,21 @@ func (c StorageClassCache) GetByIndex(indexName, key string) ([]*storagev1.Stora
 	default:
 		return nil, nil
 	}
+}
+
+type ErroringStorageClassCache struct{}
+
+func (e ErroringStorageClassCache) Get(_ string) (*storagev1.StorageClass, error) {
+	return nil, fmt.Errorf("simulated internal cache error")
+}
+
+func (e ErroringStorageClassCache) List(_ labels.Selector) ([]*storagev1.StorageClass, error) {
+	return nil, nil
+}
+
+func (e ErroringStorageClassCache) AddIndexer(_ string, _ generic.Indexer[*storagev1.StorageClass]) {
+}
+
+func (e ErroringStorageClassCache) GetByIndex(_, _ string) ([]*storagev1.StorageClass, error) {
+	return nil, nil
 }

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -412,23 +412,31 @@ func (v *vmValidator) checkVolumeClaimTemplatesAnnotation(vm *kubevirtv1.Virtual
 func (v *vmValidator) checkVolumeAnnotations(oldVM, newVM *kubevirtv1.VirtualMachine) ([]util.VolumeClaimTemplateEntry, error) {
 	oldAnn := oldVM.Annotations[util.AnnotationVolumeClaimTemplates]
 	newAnn := newVM.Annotations[util.AnnotationVolumeClaimTemplates]
-	if oldAnn == "" || newAnn == "" || oldAnn == newAnn {
+
+	if newAnn == "" || oldAnn == newAnn {
 		return nil, nil
 	}
 
 	fieldPath := fmt.Sprintf("metadata.annotations.%s", util.AnnotationVolumeClaimTemplates)
 
-	oldEntries, err := util.UnmarshalVolumeClaimTemplates(oldAnn)
-	if err != nil {
-		return nil, werror.NewInvalidError(
-			fmt.Sprintf("failed to unmarshal %s", oldAnn),
-			fieldPath,
-		)
-	}
 	newEntries, err := util.UnmarshalVolumeClaimTemplates(newAnn)
 	if err != nil {
 		return nil, werror.NewInvalidError(
 			fmt.Sprintf("failed to unmarshal %s", newAnn),
+			fieldPath,
+		)
+	}
+
+	// this means the annotation is being added for the first time and
+	// we need to validate the new entries exist and are correct
+	if oldAnn == "" {
+		return newEntries, v.checkStorageClassesExist(newEntries)
+	}
+
+	oldEntries, err := util.UnmarshalVolumeClaimTemplates(oldAnn)
+	if err != nil {
+		return nil, werror.NewInvalidError(
+			fmt.Sprintf("failed to unmarshal %s", oldAnn),
 			fieldPath,
 		)
 	}
@@ -449,6 +457,24 @@ func (v *vmValidator) checkVolumeAnnotations(oldVM, newVM *kubevirtv1.VirtualMac
 	}
 
 	return newEntries, v.checkPVCsStorageRequestsAndClass(oldPvcMap, newPvcMap)
+}
+
+func (v *vmValidator) checkStorageClassesExist(entries []util.VolumeClaimTemplateEntry) error {
+	for _, entry := range entries {
+		if entry.Spec.StorageClassName == nil || *entry.Spec.StorageClassName == "" {
+			continue
+		}
+		if _, err := v.scCache.Get(*entry.Spec.StorageClassName); err != nil {
+			if apierrors.IsNotFound(err) {
+				return werror.NewInvalidError(
+					fmt.Sprintf("storage class %s does not exist", *entry.Spec.StorageClassName),
+					fmt.Sprintf("metadata.annotations.%s", util.AnnotationVolumeClaimTemplates),
+				)
+			}
+			return werror.NewInternalError(fmt.Sprintf("failed to get storage class %s: %v", *entry.Spec.StorageClassName, err))
+		}
+	}
+	return nil
 }
 
 // checkPVCsStorageRequestsAndClass checks for storage request changes and storage class changes.

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -461,18 +461,21 @@ func (v *vmValidator) checkVolumeAnnotations(oldVM, newVM *kubevirtv1.VirtualMac
 
 func (v *vmValidator) checkStorageClassesExist(entries []util.VolumeClaimTemplateEntry) error {
 	for _, entry := range entries {
-		if entry.Spec.StorageClassName == nil || *entry.Spec.StorageClassName == "" {
+		scName := entry.Spec.StorageClassName
+		if scName == nil || *scName == "" {
 			continue
 		}
-		if _, err := v.scCache.Get(*entry.Spec.StorageClassName); err != nil {
-			if apierrors.IsNotFound(err) {
-				return werror.NewInvalidError(
-					fmt.Sprintf("storage class %s does not exist", *entry.Spec.StorageClassName),
-					fmt.Sprintf("metadata.annotations.%s", util.AnnotationVolumeClaimTemplates),
-				)
-			}
-			return werror.NewInternalError(fmt.Sprintf("failed to get storage class %s: %v", *entry.Spec.StorageClassName, err))
+		_, err := v.scCache.Get(*scName)
+		if err == nil {
+			continue
 		}
+		if apierrors.IsNotFound(err) {
+			return werror.NewInvalidError(
+				fmt.Sprintf("storage class %s does not exist", *scName),
+				fmt.Sprintf("metadata.annotations.%s", util.AnnotationVolumeClaimTemplates),
+			)
+		}
+		return werror.NewInternalError(fmt.Sprintf("failed to get storage class %s: %v", *scName, err))
 	}
 	return nil
 }

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -422,7 +422,7 @@ func (v *vmValidator) checkVolumeAnnotations(oldVM, newVM *kubevirtv1.VirtualMac
 	newEntries, err := util.UnmarshalVolumeClaimTemplates(newAnn)
 	if err != nil {
 		return nil, werror.NewInvalidError(
-			fmt.Sprintf("failed to unmarshal %s", newAnn),
+			fmt.Sprintf("failed to unmarshal %s: %v", newAnn, err.Error()),
 			fieldPath,
 		)
 	}
@@ -436,7 +436,7 @@ func (v *vmValidator) checkVolumeAnnotations(oldVM, newVM *kubevirtv1.VirtualMac
 	oldEntries, err := util.UnmarshalVolumeClaimTemplates(oldAnn)
 	if err != nil {
 		return nil, werror.NewInvalidError(
-			fmt.Sprintf("failed to unmarshal %s", oldAnn),
+			fmt.Sprintf("failed to unmarshal %s: %v", oldAnn, err.Error()),
 			fieldPath,
 		)
 	}

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -6,6 +6,7 @@ import (
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -946,13 +947,14 @@ func TestVmValidator_Update(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		oldVM         *kubevirtv1.VirtualMachine
-		newVM         *kubevirtv1.VirtualMachine
-		oldObjMeta    *metav1.ObjectMeta
-		newObjMeta    *metav1.ObjectMeta
-		newSpec       *kubevirtv1.VirtualMachineSpec
-		expectedError bool
+		name                    string
+		oldVM                   *kubevirtv1.VirtualMachine
+		newVM                   *kubevirtv1.VirtualMachine
+		scErr                   bool
+		oldObjMeta              *metav1.ObjectMeta
+		newObjMeta              *metav1.ObjectMeta
+		newSpec                 *kubevirtv1.VirtualMachineSpec
+		expectedValidationError bool
 	}{
 		{
 			name:  "Ensure that maintenance mode strategy is checked if there is no change to VM spec",
@@ -965,8 +967,8 @@ func TestVmValidator_Update(t *testing.T) {
 				}
 				return m
 			}(),
-			newSpec:       nil,
-			expectedError: true,
+			newSpec:                 nil,
+			expectedValidationError: true,
 		},
 		{
 			name:  "storage class name is changed which results in rejection",
@@ -982,8 +984,8 @@ func TestVmValidator_Update(t *testing.T) {
 						`,"volumeMode":"Block","storageClassName":"longhorn"}}]`,
 				},
 			},
-			newSpec:       nil,
-			expectedError: true,
+			newSpec:                 nil,
+			expectedValidationError: true,
 		},
 		{
 			name:  "annotation removed resulting in success",
@@ -993,8 +995,8 @@ func TestVmValidator_Update(t *testing.T) {
 				Name:      templateVM.Name,
 				Namespace: templateVM.Namespace,
 			},
-			newSpec:       nil,
-			expectedError: false,
+			newSpec:                 nil,
+			expectedValidationError: false,
 		},
 		{
 			name:  "annotation added resulting in success",
@@ -1013,8 +1015,8 @@ func TestVmValidator_Update(t *testing.T) {
 						`"Block","storageClassName":"longhorn"}}]`,
 				},
 			},
-			newSpec:       nil,
-			expectedError: false,
+			newSpec:                 nil,
+			expectedValidationError: false,
 		},
 		{
 			name:  "annotations with bad json are rejected",
@@ -1027,8 +1029,8 @@ func TestVmValidator_Update(t *testing.T) {
 					"harvesterhci.io/volumeClaimTemplates": `[{"]`,
 				},
 			},
-			newSpec:       nil,
-			expectedError: true,
+			newSpec:                 nil,
+			expectedValidationError: true,
 		},
 		{
 			name:  "empty annotation is allowed on both objects",
@@ -1048,8 +1050,8 @@ func TestVmValidator_Update(t *testing.T) {
 					"harvesterhci.io/volumeClaimTemplates": "",
 				},
 			},
-			newSpec:       nil,
-			expectedError: false,
+			newSpec:                 nil,
+			expectedValidationError: false,
 		},
 		{
 			name:  "nil storage class name is handled properly",
@@ -1068,8 +1070,115 @@ func TestVmValidator_Update(t *testing.T) {
 						`"Block"}}]`,
 				},
 			},
-			newSpec:       nil,
-			expectedError: false,
+			newSpec:                 nil,
+			expectedValidationError: false,
+		},
+		{
+			name:  "re-adding annotation after deletion with non-existing storage class is rejected",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			oldObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+			},
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0",` +
+						`"annotations":{"harvesterhci.io/imageId":"default/image"}},` +
+						`"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}}` +
+						`,"volumeMode":"Block","storageClassName":"non-existing-sc"}}]`,
+				},
+			},
+			expectedValidationError: true,
+		},
+		{
+			name:  "adding annotation for the first time with existing storage class is allowed",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			oldObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+			},
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0",` +
+						`"annotations":{"harvesterhci.io/imageId":"default/image"}},` +
+						`"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}}` +
+						`,"volumeMode":"Block","storageClassName":"longhorn-image"}}]`,
+				},
+			},
+			expectedValidationError: false,
+		},
+		{
+			name:  "adding annotation with invalid JSON when old annotation is absent is rejected",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			oldObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+			},
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"broken json`,
+				},
+			},
+			expectedValidationError: true,
+		},
+		{
+			name:                    "nil old VM is handled safely",
+			oldVM:                   nil,
+			newVM:                   templateVM.DeepCopy(),
+			expectedValidationError: false,
+		},
+		{
+			name:  "storage class cache internal error on first-time annotation add is surfaced",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			scErr: true,
+			oldObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+			},
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0",` +
+						`"annotations":{"harvesterhci.io/imageId":"default/image"}},` +
+						`"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}}` +
+						`,"volumeMode":"Block","storageClassName":"longhorn-image"}}]`,
+				},
+			},
+			expectedValidationError: true,
+		},
+		{
+			name:  "malformed old annotation with valid new annotation is rejected",
+			oldVM: templateVM.DeepCopy(),
+			newVM: templateVM.DeepCopy(),
+			oldObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"broken`,
+				},
+			},
+			newObjMeta: &metav1.ObjectMeta{
+				Name:      templateVM.Name,
+				Namespace: templateVM.Namespace,
+				Annotations: map[string]string{
+					"harvesterhci.io/volumeClaimTemplates": `[{"metadata":{"name":"test-disk-0",` +
+						`"annotations":{"harvesterhci.io/imageId":"default/image"}},` +
+						`"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}}` +
+						`,"volumeMode":"Block","storageClassName":"longhorn-image"}}]`,
+				},
+			},
+			expectedValidationError: true,
 		},
 	}
 
@@ -1079,7 +1188,15 @@ func TestVmValidator_Update(t *testing.T) {
 	}})
 	assert.NoError(t, err)
 	fakeNSCache := fakeclients.NamespaceCache(corefakeclientset.CoreV1().Namespaces)
-	validator := NewValidator(fakeNSCache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*vmValidator)
+
+	harvesterFakeClientset := fake.NewSimpleClientset()
+	err = harvesterFakeClientset.Tracker().Add(&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{
+		Name: "longhorn-image",
+	}})
+	assert.NoError(t, err)
+	fakeScCache := fakeclients.StorageClassCache(harvesterFakeClientset.StorageV1().StorageClasses)
+
+	validator := NewValidator(fakeNSCache, nil, nil, nil, nil, nil, nil, nil, nil, nil, fakeScCache, nil).(*vmValidator)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1092,9 +1209,14 @@ func TestVmValidator_Update(t *testing.T) {
 			if test.newSpec != nil {
 				test.newVM.Spec = *test.newSpec
 			}
+			if test.scErr {
+				validator.scCache = fakeclients.ErroringStorageClassCache{}
+			} else {
+				validator.scCache = fakeScCache
+			}
 			err := validator.Update(nil, test.oldVM, test.newVM)
 
-			if test.expectedError {
+			if test.expectedValidationError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)


### PR DESCRIPTION
Fixing volumeClaimTemplates bypassing the following scenarios:
* oldAnn being nil is now a separate case and once we assign storage class we make sure the new annotation is valid json format for further unmarshalling and comparison and storage class exists
* now we reject bad formats on the new annotation from the get go
* oldVM being nil was concern which we discussed but nil guard is done in upper level so nil poiner panic is not possible
* added storage class fakes which return error and extended test cases to cover all the discussed problematic scenarios; all existing tests pass meaning no changes in already existing validation logic only fixing the uncovered bugs

#### Problem:

Old check allowed if oldAnnotation is empty to bypass the check and allow injecting malformed value to the new annotation. Malformed being - non existing storage class/invalid json etc.

#### Solution:
Make sure we don't skip validation if oldAnnotation is empty and extract that case in separate check to validate the flow of new annotation being added with proper format.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10165

#### Test plan:
Unit tests to cover all discussed scenarios were added

E2E Test Plan:
1. SC name change - rejected
2. Storage size reduction - rejected
3. Normal disk add to existing annotation - allowed
4. Normal annotation removal - allowed
5. Re-add with tampered SC after deletion - is now rejection
6. Re-add with invalid JSON after deletion - rejected
7. Re-add with valid SC after deletion - allowed

E2E Test Results:

<details>
<summary>Built environment with the change and created vms and storage classes</summary>

<img width="1049" height="475" alt="image" src="https://github.com/user-attachments/assets/f843a346-2ad6-43b6-887f-81082a551caf" />
<img width="1277" height="862" alt="image" src="https://github.com/user-attachments/assets/f81e173f-af58-4fb4-97db-82b182493dfd" />

```
node-1:/home/rancher # kubectl get storageclass
NAME                                      PROVISIONER          RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
default-sc (default)                      driver.longhorn.io   Delete          Immediate           true                   119s
harvester-longhorn                        driver.longhorn.io   Delete          Immediate           true                   10m
lh-869693c8-2368-4f27-8a4c-95e655a1c99b   driver.longhorn.io   Delete          Immediate           true                   88s
longhorn                                  driver.longhorn.io   Delete          Immediate           true                   9m46s
longhorn-static                           driver.longhorn.io   Delete          Immediate           true                   9m44s
sc-1                                      driver.longhorn.io   Delete          Immediate           true                   12s
sc-2                                      driver.longhorn.io   Delete          Immediate           true                   5s
vmstate-persistence                       driver.longhorn.io   Delete          Immediate           true                   10m
node-1:/home/rancher # kubectl get vm
NAME   AGE   STATUS    READY
vm-1   28s   Running   True
```
</details>

<details>
<summary>Store test values in variables</summary>

```
node-1:/home/rancher # VM=vm-1
node-1:/home/rancher # NS=default
node-1:/home/rancher # ORIG='[{"metadata":{"name":"vm-1-disk-0-bzdyy","annotations":{"harvesterhci.io/imageId":"default/image-rf8gs"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"lh-869693c8-2368-4f27-8a4c-95e655a1c99b"}}]'
```
</details>

<details>
<summary> :green_circle: 1. SC name change - rejected</summary>

```
node-1:/home/rancher # kubectl annotate vm $VM -n $NS --overwrite \
>   harvesterhci.io/volumeClaimTemplates='[{"metadata":{"name":"vm-1-disk-0-bzdyy","annotations":{"harvesterhci.io/imageId":"default/image-rf8gs"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"sc-1"}}]'
Error from server (InternalError): admission webhook "validator.harvesterhci.io" denied the request: storage class names for the volumes in the harvesterhci.io/volumeClaimTemplates annotation cannot be changed; new name sc-1 in volume vm-1-disk-0-bzdyy;
```
</details>

<details>
<summary> :green_circle: 2. Storage size reduction - rejected</summary>

```
node-1:/home/rancher # kubectl annotate vm $VM -n $NS --overwrite \
>   harvesterhci.io/volumeClaimTemplates='[{"metadata":{"name":"vm-1-disk-0-bzdyy","annotations":{"harvesterhci.io/imageId":"default/image-rf8gs"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"5Gi"}},"volumeMode":"Block","storageClassName":"lh-869693c8-2368-4f27-8a4c-95e655a1c99b"}}]'
The request is invalid: metadata.annotations.harvesterhci.io/volumeClaimTemplates: vm-1-disk-0-bzdyy PVC requests storage can't be less than previous value
```
</details>

<details>
<summary> :green_circle: 3. Normal disk add to existing annotation - allowed</summary>

```
node-1:/home/rancher # kubectl annotate vm $VM -n $NS --overwrite \
>   harvesterhci.io/volumeClaimTemplates='[{"metadata":{"name":"vm-1-disk-0-bzdyy","annotations":{"harvesterhci.io/imageId":"default/image-rf8gs"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"lh-869693c8-2368-4f27-8a4c-95e655a1c99b"}},{"metadata":{"name":"vm-1-disk-1-new","annotations":{"harvesterhci.io/imageId":"default/image-rf8gs"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"lh-869693c8-2368-4f27-8a4c-95e655a1c99b"}}]'
virtualmachine.kubevirt.io/vm-1 annotated
```
</details>

<details>
<summary> :green_circle: 4. Normal annotation removal - allowed</summary>

```
node-1:/home/rancher # kubectl annotate vm $VM -n $NS harvesterhci.io/volumeClaimTemplates-
virtualmachine.kubevirt.io/vm-1 annotated
```
</details>

<details>
<summary>:green_circle: 5. Re-add with tampered SC after deletion - is now rejection</summary>

```
node-1:/home/rancher # kubectl annotate vm $VM -n $NS \
>   harvesterhci.io/volumeClaimTemplates='[{"metadata":{"name":"vm-1-disk-0-bzdyy","annotations":{"harvesterhci.io/imageId":"default/image-rf8gs"}},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"10Gi"}},"volumeMode":"Block","storageClassName":"non-existent-sc"}}]'
The request is invalid: metadata.annotations.harvesterhci.io/volumeClaimTemplates: storage class non-existent-sc does not exist
```
</details>

<details>
<summary> :green_circle: 6. Re-add with invalid JSON after deletion - rejected</summary>

```
node-1:/home/rancher # kubectl annotate vm $VM -n $NS \
>   harvesterhci.io/volumeClaimTemplates='[{"broken json'
The request is invalid: metadata.annotations: the volumeClaimTemplates annotaion is invalid: unexpected end of JSON input
```
</details>

<details>
<summary> :green_circle: 7. Re-add with valid SC after deletion - allowed</summary>

```
node-1:/home/rancher # kubectl annotate vm $VM -n $NS harvesterhci.io/volumeClaimTemplates="$ORIG"
virtualmachine.kubevirt.io/vm-1 annotated
```
</details>

#### Additional documentation or context
I wanted to fix the bug, but not change the validation behaviour so traced historical evolution of the function body:

https://github.com/harvester/harvester/issues/2810 - added to address the original issue - core logic being added
https://github.com/harvester/harvester/issues/8772 - storage class validation logic building on top of the previous assumptions
https://github.com/harvester/harvester/issues/8669 - mostly refactoring but no logical changes
https://github.com/harvester/harvester/issues/10165 - the actual bug and current change