### PR TITLE
fix: use known schema constants when updating the CSI Snapshot’s owner reference to the PVC

### DIFF
--- a/pkg/controller/master/virtualmachine/vm_controller.go
+++ b/pkg/controller/master/virtualmachine/vm_controller.go
@@ -297,8 +297,8 @@ func (h *VMController) removeVMBackupSnapshot(vm *kubevirtv1.VirtualMachine) err
 			volumeSnapshotCpy := volumeSnapshot.DeepCopy()
 			volumeSnapshotCpy.OwnerReferences = []metav1.OwnerReference{
 				{
-					APIVersion: pvc.APIVersion,
-					Kind:       pvc.Kind,
+					APIVersion: util.PersistentVolumeClaimsKind.GroupVersion().String(),
+					Kind:       util.PersistentVolumeClaimsKind.Kind,
 					Name:       pvc.Name,
 					UID:        pvc.UID,
 				},


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
#10294 

#### Solution:
use known schema constants when updating the CSI Snapshot’s owner reference to the PVC

#### Related Issue(s):
#10294 

#### Test plan:
1. Take backup and snapshot
2. Restore backup to a new VM **r-ug-vm**
3. Again restore backup to a new VM **new-r-ug-vm**, then remove **new-r-ug-vm**.
4. Restore snapshot to a new VM **snap-r-ug-vm**, then remove **snap-r-ug-vm**.
5. Delete the original VM **ug-vm**


#### Additional documentation or context
