### PR TITLE
gha: bump rancher-eio/read-vault-secrets

### DIFF
--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -99,7 +99,7 @@ jobs:
         cp -r ./bin/upgrade-helper ./package/upgrade/
 
     - name: Read Secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # main
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
@@ -172,7 +172,7 @@ jobs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Read Secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # main
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
@@ -267,7 +267,7 @@ jobs:
         DRONE_TAG: ${{ github.ref_name }}
 
     - name: Read Secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # main
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
@@ -337,7 +337,7 @@ jobs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Read Secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # main
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,7 +20,7 @@ jobs:
     # The FOSSA token is shared between all repos in Harvester's GH org. It can
     # be used directly and there is no need to request specific access to EIO.
     - name: Read FOSSA token
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # main
       with:
         secrets: |
           secret/data/github/org/harvester/fossa/credentials token | FOSSA_API_KEY_PUSH_ONLY


### PR DESCRIPTION
This new version of `rancher-eio/read-vault-secrets` pins `hashicorp/vault-action` to a specific commit, which complies with our new org-level GHA versioning setting requirement.
