### PR TITLE
chore: validate the checksums of build dependency artifacts

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -40,7 +40,7 @@ ENV HELM_URL=https://get.helm.sh/${HELM_TARBALL}
 RUN mkdir /usr/tmp && \
   curl -sSLO --output-dir /usr/tmp ${HELM_URL}  && \
   HELM_SHA256=HELM_SHA256_Linux_${ARCH} && \
-  echo "${!HELM_SHA256} /usr/tmp/${HELM_TARBALL}" | sha256sum -c - && \
+  echo "${!HELM_SHA256}  /usr/tmp/${HELM_TARBALL}" | sha256sum -c - && \
   tar xvzf /usr/tmp/${HELM_TARBALL} --strip-components=1 -C /usr/tmp/ && \
   mv /usr/tmp/helm /usr/bin/helm
 
@@ -74,12 +74,12 @@ RUN  GO111MODULE=on go install k8s.io/code-generator/cmd/openapi-gen@v0.29.13
 # install kind
 RUN curl -Lo /usr/bin/kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${ARCH} && \
   KIND_SHA256="KIND_SHA256_Linux_${ARCH}" && \
-  echo "${!KIND_SHA256} /usr/bin/kind" | sha256sum -c - && \
+  echo "${!KIND_SHA256}  /usr/bin/kind" | sha256sum -c - && \
   chmod +x /usr/bin/kind
 
 # install codecov
 RUN curl -Lo /usr/bin/codecov https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov && \
-  echo "${CODECOV_SHA256_Linux} /usr/bin/codecov" | sha256sum -c - && \
+  echo "${CODECOV_SHA256_Linux}  /usr/bin/codecov" | sha256sum -c - && \
   chmod +x /usr/bin/codecov
 
 # copy bootloaders

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -61,7 +61,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     docker-ce=5:20.10.* \
     && rm -rf /var/lib/apt/lists/*
 ## install golangci
-COPY --from=golangci/golangci-lint:v2.11.4-alpine@sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
+COPY --from=golangci/golangci-lint:v2.8.0-alpine@sha256:1194f3bfcbaeeb92d8d159fdfbe2a79d18ec0a222d9d984b1438906bca416b51 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 
 ## install controller-gen
 RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.1

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,6 +7,18 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH
 ENV GOTOOLCHAIN=auto
 
+ARG HELM_VERSION=v3.20.0
+ARG HELM_SHA256_Linux_amd64=dbb4c8fc8e19d159d1a63dda8db655f9ffa4aac1b9a6b188b34a40957119b286
+ARG HELM_SHA256_Linux_arm64=bfb14953295d5324d47ab55f3dfba6da28d46c848978c8fbf412d4271bdc29f1
+
+ARG KIND_VERSION=v0.31.0
+ARG KIND_SHA256_Linux_amd64=eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa
+ARG KIND_SHA256_Linux_arm64=8e1014e87c34901cc422a1445866835d1e666f2a61301c27e722bdeab5a1f7e4
+
+ARG CODECOV_VERSION=v0.8.0
+ARG CODECOV_SHA256_Linux=b37359013b48fbc3b0790d59fc474a52a260fb96e28e1b2c2ae001dc9b9cc996
+
+SHELL ["/bin/bash", "-c"]
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     xz-utils \
     unzip \
@@ -22,11 +34,15 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
 # install yq
 RUN GO111MODULE=on go install github.com/mikefarah/yq/v4@v4.27.5
 # set up helm
-ENV HELM_VERSION=v3.5.4
-ENV HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
+ENV HELM_VERSION=${HELM_VERSION}
+ENV HELM_TARBALL=helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
+ENV HELM_URL=https://get.helm.sh/${HELM_TARBALL}
 RUN mkdir /usr/tmp && \
-    curl ${HELM_URL} | tar xvzf - --strip-components=1 -C /usr/tmp/ && \
-    mv /usr/tmp/helm /usr/bin/helm
+  curl -sSLO --output-dir /usr/tmp ${HELM_URL}  && \
+  HELM_SHA256=HELM_SHA256_Linux_${ARCH} && \
+  echo "${!HELM_SHA256} /usr/tmp/${HELM_TARBALL}" | sha256sum -c - && \
+  tar xvzf /usr/tmp/${HELM_TARBALL} --strip-components=1 -C /usr/tmp/ && \
+  mv /usr/tmp/helm /usr/bin/helm
 
 # -- for make rules
 ## install docker client
@@ -45,7 +61,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     docker-ce=5:20.10.* \
     && rm -rf /var/lib/apt/lists/*
 ## install golangci
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
+COPY --from=golangci/golangci-lint:v2.11.4-alpine@sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 
 ## install controller-gen
 RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.1
@@ -56,10 +72,15 @@ RUN GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
 RUN  GO111MODULE=on go install k8s.io/code-generator/cmd/openapi-gen@v0.29.13
 
 # install kind
-RUN curl -Lo /usr/bin/kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64 && chmod +x /usr/bin/kind
+RUN curl -Lo /usr/bin/kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${ARCH} && \
+  KIND_SHA256="KIND_SHA256_Linux_${ARCH}" && \
+  echo "${!KIND_SHA256} /usr/bin/kind" | sha256sum -c - && \
+  chmod +x /usr/bin/kind
 
 # install codecov
-RUN curl -Lo /usr/bin/codecov https://uploader.codecov.io/latest/linux/codecov && chmod +x /usr/bin/codecov
+RUN curl -Lo /usr/bin/codecov https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov && \
+  echo "${CODECOV_SHA256_Linux} /usr/bin/codecov" | sha256sum -c - && \
+  chmod +x /usr/bin/codecov
 
 # copy bootloaders
 RUN mkdir /grub2-mbr

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 TARGETS := $(shell ls --ignore=help --ignore='*.txt' scripts)
 
+SHA512SUM_Linux_aarch64 := 781951b31e5ff018a04e755c6da7163b31a81edda61f1bed4def8d0e24229865c58a3d26aa0cc4184058d91ebcae300ead2cad16d3c46ccb1098419e3e41a016
+SHA512SUM_Linux_x86_64 := d2ec27ecf9362e2fafd27d76d85a5c5b92b53aefe07cffa76bf9887db6bee07b1023cca8fc32a2c9bdd2ecfadaee71397066b41bd37c9ebbbbce09913f0884d4
+SHA512SUM_Darwin_arm64 := 8a356c89ad32af1698ae8615a6e303773a8ac58b114368454d59965ec2aa8282e780d1e228d37c301ce6f87596f68bfe7f204eb5f4c019c386a58dd94153ddcf
+SHA512SUM_Darwin_x86_64 := dbab05de04dda26793f4ae7875d0fba96ee54b0228e192fd40c0b2116ed345b5444047fc2e0c90cb481f28cbe0e0452bcecb268c8d074cd8615eb2f5463c30b6
+SHA512SUM_Windows_x86_64 := 807aee2f68b6da35cb0885558f5cbc9a6c8747a56c7a200f0e1fcac9e2fd0da570cbb39e48b3192bd1a71805f2ab38fd19d77faebba97a89e5d9a8b430ee429e
+
 help:
 	@./scripts/help "$(MAKEFILE_LIST)" $(TARGETS)
 
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
+	@curl -sSfL https://releases.rancher.com/dapper/v0.6.0/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
+	@CHECKSUM=$$(shasum -a 512 .dapper.tmp | awk '{print $$1}'); \
+	if [ "$$CHECKSUM" != "$(SHA512SUM_$(shell uname -s)_$(shell uname -m))" ]; then \
+		echo "Checksum verification failed!"; \
+		exit 1; \
+	fi
 	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -24,11 +24,15 @@ ARG VERSION=dev
 ENV HARVESTER_SERVER_VERSION ${VERSION}
 ENV TINI_VERSION v0.19.0
 ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    TINI_URL_amd64_sha256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c \
     TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
+    TINI_URL_arm64_sha256=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81 \
     TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
-    TINI_URL=TINI_URL_${ARCH}
+    TINI_URL_s390x_sha256=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d \
+    TINI_URL=TINI_URL_${ARCH} \
+    TINI_URL_sha256=TINI_URL_${ARCH}_sha256
 
-RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && chmod +x /usr/bin/tini
+RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && echo "${!TINI_URL_sha256} /usr/bin/tini" | sha256sum -c - && chmod +x /usr/bin/tini
 
 RUN mkdir -p /usr/share/harvester/harvester && \
     cd /usr/share/harvester/harvester && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -32,7 +32,7 @@ ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERS
     TINI_URL=TINI_URL_${ARCH} \
     TINI_URL_sha256=TINI_URL_${ARCH}_sha256
 
-RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && echo "${!TINI_URL_sha256} /usr/bin/tini" | sha256sum -c - && chmod +x /usr/bin/tini
+RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && echo "${!TINI_URL_sha256}  /usr/bin/tini" | sha256sum -c - && chmod +x /usr/bin/tini
 
 RUN mkdir -p /usr/share/harvester/harvester && \
     cd /usr/share/harvester/harvester && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -27,8 +27,6 @@ ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERS
     TINI_URL_amd64_sha256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c \
     TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
     TINI_URL_arm64_sha256=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81 \
-    TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
-    TINI_URL_s390x_sha256=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d \
     TINI_URL=TINI_URL_${ARCH} \
     TINI_URL_sha256=TINI_URL_${ARCH}_sha256
 

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -10,8 +10,6 @@ ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERS
     TINI_URL_amd64_sha256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c \
     TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
     TINI_URL_arm64_sha256=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81 \
-    TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
-    TINI_URL_s390x_sha256=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d \
     TINI_URL=TINI_URL_${ARCH} \
     TINI_URL_sha256=TINI_URL_${ARCH}_sha256
 

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -15,7 +15,7 @@ ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERS
     TINI_URL=TINI_URL_${ARCH} \
     TINI_URL_sha256=TINI_URL_${ARCH}_sha256
 
-RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && echo "${!TINI_URL_sha256} /usr/bin/tini" | sha256sum -c - && chmod +x /usr/bin/tini
+RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && echo "${!TINI_URL_sha256}  /usr/bin/tini" | sha256sum -c - && chmod +x /usr/bin/tini
 
 COPY entrypoint-webhook.sh  /usr/bin/entrypoint.sh
 COPY harvester-webhook /usr/bin/

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -7,11 +7,15 @@ RUN zypper -n rm container-suseconnect && \
 ARG ARCH=amd64
 ENV TINI_VERSION v0.19.0
 ENV TINI_URL_amd64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    TINI_URL_amd64_sha256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c \
     TINI_URL_arm64=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 \
+    TINI_URL_arm64_sha256=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81 \
     TINI_URL_s390x=https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x \
-    TINI_URL=TINI_URL_${ARCH}
+    TINI_URL_s390x_sha256=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d \
+    TINI_URL=TINI_URL_${ARCH} \
+    TINI_URL_sha256=TINI_URL_${ARCH}_sha256
 
-RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && chmod +x /usr/bin/tini
+RUN curl -sLf ${!TINI_URL} > /usr/bin/tini && echo "${!TINI_URL_sha256} /usr/bin/tini" | sha256sum -c - && chmod +x /usr/bin/tini
 
 COPY entrypoint-webhook.sh  /usr/bin/entrypoint.sh
 COPY harvester-webhook /usr/bin/

--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -33,16 +33,16 @@ RUN KUBECTL_SHA256=KUBECTL_SHA256_${ARCH} && \
     YQ_SHA256=YQ_SHA256_${ARCH} && \
     WHARFIE_SHA256=WHARFIE_SHA256_${ARCH} && \
     curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
-    echo "${!KUBECTL_SHA256} /usr/bin/kubectl" | sha256sum -c - && \
+    echo "${!KUBECTL_SHA256}  /usr/bin/kubectl" | sha256sum -c - && \
     chmod +x /usr/bin/kubectl && \
     curl -sfL https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-${ARCH} -o /usr/bin/virtctl && \
-    echo "${!VIRTCTL_SHA256} /usr/bin/virtctl" | sha256sum -c - && \
+    echo "${!VIRTCTL_SHA256}  /usr/bin/virtctl" | sha256sum -c - && \
     chmod +x /usr/bin/virtctl && \
     curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH} -o /usr/bin/yq && \
-    echo "${!YQ_SHA256} /usr/bin/yq" | sha256sum -c - && \
+    echo "${!YQ_SHA256}  /usr/bin/yq" | sha256sum -c - && \
     chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/download/${WHARFIE_VERSION}/wharfie-${ARCH}  -o /usr/bin/wharfie && \
-    echo "${!WHARFIE_SHA256} /usr/bin/wharfie" | sha256sum -c - && \
+    echo "${!WHARFIE_SHA256}  /usr/bin/wharfie" | sha256sum -c - && \
     chmod +x /usr/bin/wharfie
 # Copy elemental binary to be used for upgrades
 COPY --from=baseos /usr/bin/elemental /usr/local/bin/elemental

--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -5,17 +5,45 @@ FROM registry.suse.com/bci/bci-base:16.0
 
 ARG ARCH=amd64
 ENV ARCH=${ARCH}
+
+ARG KUBECTL_VERSION=v1.33.7
+ARG KUBECTL_SHA256_amd64=471d94e208a89be62eb776700fc8206cbef11116a8de2dc06fc0086b0015375b
+ARG KUBECTL_SHA256_arm64=fa7ee98fdb6fba92ae05b5e0cde0abd5972b2d9a4a084f7052a1fd0dce6bc1de
+
+ARG KUBEVIRT_VERSION=v1.7.1
+ARG VIRTCTL_SHA256_amd64=e0efcfc708067fa45232f3bab9cb2de3dbcd812d4c9aab88c727025fb213079f
+ARG VIRTCTL_SHA256_arm64=7737d967bc8512abedfdaa8a61a3512f93894c12162f9dde4fab73402a4f42d5
+
+ARG YQ_VERSION=v4.52.4
+ARG YQ_SHA256_amd64=0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c
+ARG YQ_SHA256_arm64=4c2cc022a129be5cc1187959bb4b09bebc7fb543c5837b93001c68f97ce39a5d
+
+ARG WHARFIE_VERSION=v0.7.0
+ARG WHARFIE_SHA256_amd64=e5ff747b2f9f4155ce7b68917bac9dbe8a6a85727a94b0c8e6faca9252931e91
+ARG WHARFIE_SHA256_arm64=b8e02fe61d4f8cb1bd7927fd5e34b49b4dcf802c52670adfaa4527ed3d9afc41
+
+SHELL ["/bin/bash", "-c"]
 RUN zypper rm -y container-suseconnect && \
     zypper --no-gpg-checks ref && \
     zypper in -y curl e2fsprogs rsync awk zstd jq helm zip unzip nginx util-linux && zypper clean -a
 
-ENV KUBECTL_VERSION v1.32.3
-RUN curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
-    chmod +x /usr/bin/kubectl
-
-RUN curl -sfL https://github.com/kubevirt/kubevirt/releases/download/v1.4.0/virtctl-v1.4.0-linux-${ARCH} -o /usr/bin/virtctl && chmod +x /usr/bin/virtctl && \
-    curl -sfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
-    curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.8/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
+ENV KUBECTL_VERSION ${KUBECTL_VERSION}
+RUN KUBECTL_SHA256=KUBECTL_SHA256_${ARCH} && \
+    VIRTCTL_SHA256=VIRTCTL_SHA256_${ARCH} && \
+    YQ_SHA256=YQ_SHA256_${ARCH} && \
+    WHARFIE_SHA256=WHARFIE_SHA256_${ARCH} && \
+    curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
+    echo "${!KUBECTL_SHA256} /usr/bin/kubectl" | sha256sum -c - && \
+    chmod +x /usr/bin/kubectl && \
+    curl -sfL https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-${ARCH} -o /usr/bin/virtctl && \
+    echo "${!VIRTCTL_SHA256} /usr/bin/virtctl" | sha256sum -c - && \
+    chmod +x /usr/bin/virtctl && \
+    curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH} -o /usr/bin/yq && \
+    echo "${!YQ_SHA256} /usr/bin/yq" | sha256sum -c - && \
+    chmod +x /usr/bin/yq && \
+    curl -sfL https://github.com/rancher/wharfie/releases/download/${WHARFIE_VERSION}/wharfie-${ARCH}  -o /usr/bin/wharfie && \
+    echo "${!WHARFIE_SHA256} /usr/bin/wharfie" | sha256sum -c - && \
+    chmod +x /usr/bin/wharfie
 # Copy elemental binary to be used for upgrades
 COPY --from=baseos /usr/bin/elemental /usr/local/bin/elemental
 # Copy harvester-installer binary to be used to generate networkmanager config


### PR DESCRIPTION
This PR added checksum validation on the following build tools and artifacts. These dependencies are also bumped to newer versions to match those introduced by recent efforts in various component repositories.

* dapper
* helm
* kind
* yq
* wharfie
* codecov
* golangci-lint
* tini
* virtctl

Issue: https://github.com/rancher/rancher-security/issues/1505