### PR TITLE
Patch rke2-multus chart failurepolicy to abort

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -5,12 +5,69 @@ UPGRADE_TMP_DIR="/tmp/upgrade"
 
 source $SCRIPT_DIR/lib.sh
 
+# The default RKE2 failurePolicy is `reinstall`.
+# Recreating the NAD CRD can cause all VM networking to be lost.
+patch_rke2_multus_config() {
+  echo "Check and patch rke2-multus failurePolicy to abort, to avoid a reinstall of the chart and recreation of the NAD CRD."
+
+  local name="rke2-multus"
+  local namespace="kube-system"
+  local manifest="$UPGRADE_TMP_DIR/rke2-multus-helmchartconfig.yaml"
+
+  mkdir -p "$UPGRADE_TMP_DIR"
+
+  # 1. Prepare Manifest
+  cat > "$manifest" <<EOF
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: $name
+  namespace: $namespace
+spec:
+  failurePolicy: abort
+EOF
+
+  # 2. Check if the resource exists
+  local get_output
+  get_output=$(kubectl get helmchartconfig "$name" -n "$namespace" 2>&1) || true
+  if [[ "$get_output" == *"NotFound"* || "$get_output" == *"not found"* ]]; then
+      echo "Resource '$name' not found. Creating..."
+      kubectl apply -f "$manifest"
+      echo "Waiting 10s for RKE2 controller to sync new config..."
+      sleep 10
+  elif [[ "$get_output" == *"Error from server"* ]]; then
+      # This catches RBAC or API errors that aren't "NotFound"
+      echo "CRITICAL ERROR: kubectl check failed with: $get_output"
+      return 1
+  else
+
+    # 3. Resource exists, check policy
+    local current_policy
+    current_policy=$(kubectl get helmchartconfig "$name" -n "$namespace" -o jsonpath='{.spec.failurePolicy}')
+
+    if [ "$current_policy" != "abort" ]; then
+      echo "Current policy is '${current_policy:-unset}'. Patching to 'abort'..."
+      kubectl patch helmchartconfig "$name" -n "$namespace" \
+        --type merge -p '{"spec":{"failurePolicy":"abort"}}'
+      echo "Waiting 10s for RKE2 controller to sync patch..."
+      sleep 10
+    else
+      echo "Verified: failurePolicy is already 'abort'. No action required."
+    fi
+  fi
+}
+
 pre_upgrade_manifest() {
   if [ -e "/usr/local/share/migrations/upgrade_manifests/${UPGRADE_PREVIOUS_VERSION}/pre-hook.sh" ]; then
     echo "Executing ${UPGRADE_PREVIOUS_VERSION} pre-hook..."
     # Use source to pass current shell's variables to target script
     source "/usr/local/share/migrations/upgrade_manifests/${UPGRADE_PREVIOUS_VERSION}/pre-hook.sh"
   fi
+
+  # Safety Gate: Ensure rke2-multus helmchart failurePolicy is 'abort' before proceeding.
+  # Since 'set -e' is active, any failure here will safely halt the upgrade
+  # to prevent potential NAD CRD deletion and VM networking loss.
+  patch_rke2_multus_config
 }
 
 # Preserve the current overcommit-config value before upgrade.

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -28,32 +28,40 @@ spec:
 EOF
 
   # 2. Check if the resource exists
-  local get_output
-  get_output=$(kubectl get helmchartconfig "$name" -n "$namespace" 2>&1) || true
-  if [[ "$get_output" == *"NotFound"* || "$get_output" == *"not found"* ]]; then
+  local EXIT_CODE=0
+  # Using a global variable to ensure EXIT_CODE is captured correctly under 'set -e'
+  rke2_multus_chart_config_output=$(kubectl get helmchartconfig "$name" -n "$namespace" 2>&1) || EXIT_CODE=$?
+
+  if [[ $EXIT_CODE -ne 0 ]]; then
+    if [[ "$rke2_multus_chart_config_output" == *"NotFound"* || "$rke2_multus_chart_config_output" == *"not found"* ]]; then
       echo "Resource '$name' not found. Creating..."
       kubectl apply -f "$manifest"
       echo "Waiting 10s for RKE2 controller to sync new config..."
       sleep 10
-  elif [[ "$get_output" == *"Error from server"* ]]; then
-      # This catches RBAC or API errors that aren't "NotFound"
-      echo "CRITICAL ERROR: kubectl check failed with: $get_output"
-      return 1
-  else
-
-    # 3. Resource exists, check policy
-    local current_policy
-    current_policy=$(kubectl get helmchartconfig "$name" -n "$namespace" -o jsonpath='{.spec.failurePolicy}')
-
-    if [ "$current_policy" != "abort" ]; then
-      echo "Current policy is '${current_policy:-unset}'. Patching to 'abort'..."
-      kubectl patch helmchartconfig "$name" -n "$namespace" \
-        --type merge -p '{"spec":{"failurePolicy":"abort"}}'
-      echo "Waiting 10s for RKE2 controller to sync patch..."
-      sleep 10
+      # When 'kubectl apply' is successful, we don't check helm-install job;
+      # RKE2 controller ensures the HelmChartConfig is used.
+      return 0
     else
-      echo "Verified: failurePolicy is already 'abort'. No action required."
+      # Catch critical errors (RBAC, API timeouts, etc.)
+      echo "CRITICAL ERROR: kubectl check failed with: $rke2_multus_chart_config_output EXIT_CODE:$EXIT_CODE"
+      return 1
     fi
+  fi
+
+  # 3. Resource exists, check current policy
+  local current_policy
+  current_policy=$(kubectl get helmchartconfig "$name" -n "$namespace" -o jsonpath='{.spec.failurePolicy}' 2>/dev/null || echo "unset")
+
+  if [[ "$current_policy" != "abort" ]]; then
+    echo "Current policy is '$current_policy'. Patching to 'abort'..."
+    kubectl patch helmchartconfig "$name" -n "$namespace" \
+      --type merge -p '{"spec":{"failurePolicy":"abort"}}'
+    echo "Waiting 10s for RKE2 controller to sync patch..."
+    sleep 10
+    # When 'kubectl patch' is successful, we don't check helm-install job;
+    # RKE2 controller ensures the HelmChartConfig is used.
+  else
+    echo "Verified: failurePolicy is already 'abort'. No action required."
   fi
 }
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

`rke2-multus` could be reinstalled and cause the existing NADs are lost

code: 
https://github.com/k3s-io/klipper-helm/blob/293bbdb989cf138f680d1eb6ea04672312bce1b4/entry#L69

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Patch rke2-multus chart failurepolicy to abort, to avoid `reinstall` to remove all existing NADs

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10359

#### Test plan:
<!-- Describe the test plan by steps. -->

As the issue is hard to reproduce, we run the script locally to ensure it's function:

```
fresh run:
...
check and patch rke-multus failurepolicy to abort, to avoid it potentially reinstall chart and caused NAD CRD recreated
Resource 'rke2-multus' not found. Creating...
helmchartconfig.helm.cattle.io/rke2-multus created
Waiting 10s for RKE2 controller to sync new config...


kubectl get job -n kube-system helm-install-rke2-multus -oyaml
        - name: FAILURE_POLICY
          value: abort

re-run:

check and patch rke-multus failurepolicy to abort, to avoid it potentially reinstall chart and caused NAD CRD recreated
Verified: failurePolicy is already 'abort'.

```



#### Additional documentation or context

We have another PR https://github.com/harvester/harvester/pull/10402 to drop&remove a .skip file under rke2 manifest path, to guide rke2 only upgrade rke2-multus chart when then upgrade is done, to reduce the racing window.