### PR TITLE
feat: disable LiveMigrate strategy during upgrades

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -924,6 +924,39 @@ patch_longhorn_settings() {
   yq -e '.spec.values.longhorn' $target || echo "fail to get info .spec.values.longhorn"
 }
 
+patch_kubevirt_compare_patches() {
+  local target=$1
+  # patch diff compare patches to avoid complaining kubevirt resource is modified
+
+  # Check if the kubevirt comparePatches entry already exists
+  local EXIT_CODE=0
+  yq -e '.spec.diff.comparePatches[] | select(.apiVersion == "kubevirt.io/v1" and .kind == "KubeVirt" and .name == "kubevirt")' $target > /dev/null 2>&1 || EXIT_CODE=$?
+
+  if [ $EXIT_CODE != 0 ]; then
+    echo "Adding kubevirt comparePatches entry to $target"
+    # Ensure spec.diff.comparePatches exists as an array
+    yq -i '.spec.diff.comparePatches = .spec.diff.comparePatches // []' $target
+    # Add the kubevirt entry
+    yq -i '.spec.diff.comparePatches += [{"apiVersion": "kubevirt.io/v1", "kind": "KubeVirt", "name": "kubevirt", "jsonPointers": ["/spec/workloadUpdateStrategy/workloadUpdateMethods"]}]' $target
+  else
+    echo "kubevirt comparePatches entry already exists in $target, skip adding"
+  fi
+}
+
+disable_kubevirt_live_migrate() {
+  echo "Setting kubevirt workloadUpdateMethods to empty array"
+
+  local kubevirt_patch_file="kubevirt-workload-update-patch.yaml"
+  cat > ${kubevirt_patch_file} <<EOF
+spec:
+  workloadUpdateStrategy:
+    workloadUpdateMethods: []
+EOF
+
+  kubectl patch kubevirts.kubevirt.io kubevirt -n harvester-system --patch-file ${kubevirt_patch_file} --type merge
+  rm -f ${kubevirt_patch_file}
+}
+
 upgrade_managedchart_harvester_crd() {
   echo "Upgrading Harvester CRD managedchart fleet-local/harvester-crd"
 
@@ -973,6 +1006,8 @@ EOF
   fi
 
   patch_longhorn_settings ${hpatch}
+  patch_kubevirt_compare_patches ${hpatch}
+  disable_kubevirt_live_migrate
 
   update_managedchart_patch_file_annotations ${hpatch} $REPO_HARVESTER_CHART_VERSION
   update_managedchart_patch_file_unpause ${hpatch}

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -926,6 +926,7 @@ patch_longhorn_settings() {
 
 patch_kubevirt_compare_patches() {
   local target=$1
+  local json_pointer="/spec/workloadUpdateStrategy/workloadUpdateMethods"
   # patch diff compare patches to avoid complaining kubevirt resource is modified
 
   # Check if the kubevirt comparePatches entry already exists
@@ -937,13 +938,23 @@ patch_kubevirt_compare_patches() {
     # Ensure spec.diff.comparePatches exists as an array
     yq -i '.spec.diff.comparePatches = .spec.diff.comparePatches // []' $target
     # Add the kubevirt entry
-    yq -i '.spec.diff.comparePatches += [{"apiVersion": "kubevirt.io/v1", "kind": "KubeVirt", "name": "kubevirt", "jsonPointers": ["/spec/workloadUpdateStrategy/workloadUpdateMethods"]}]' $target
+    JSON_POINTER=$json_pointer yq -i '.spec.diff.comparePatches += [{"apiVersion": "kubevirt.io/v1", "kind": "KubeVirt", "name": "kubevirt", "jsonPointers": [strenv(JSON_POINTER)]}]' $target
   else
-    echo "kubevirt comparePatches entry already exists in $target, skip adding"
+    # Entry exists, check if the specific jsonPointer is already in the array
+    local POINTER_EXISTS=0
+    JSON_POINTER=$json_pointer yq -e '.spec.diff.comparePatches[] | select(.apiVersion == "kubevirt.io/v1" and .kind == "KubeVirt" and .name == "kubevirt") | .jsonPointers[] | select(. == strenv(JSON_POINTER))' $target > /dev/null 2>&1 || POINTER_EXISTS=$?
+
+    if [ $POINTER_EXISTS != 0 ]; then
+      echo "kubevirt comparePatches entry exists but jsonPointer $json_pointer not found, adding it"
+      # Find the index of the kubevirt entry and append the jsonPointer
+      JSON_POINTER=$json_pointer yq -i '(.spec.diff.comparePatches[] | select(.apiVersion == "kubevirt.io/v1" and .kind == "KubeVirt" and .name == "kubevirt") | .jsonPointers) += [strenv(JSON_POINTER)]' $target
+    else
+      echo "kubevirt comparePatches entry with jsonPointer $json_pointer already exists in $target, skip adding"
+    fi
   fi
 }
 
-disable_kubevirt_live_migrate() {
+disable_kubevirt_live_migrate_workload_update() {
   echo "Setting kubevirt workloadUpdateMethods to empty array"
 
   local kubevirt_patch_file="kubevirt-workload-update-patch.yaml"
@@ -994,6 +1005,8 @@ metadata:
   namespace: fleet-local
 EOF
 
+  disable_kubevirt_live_migrate_workload_update
+
   kubectl get managedcharts.management.cattle.io -n fleet-local harvester -o yaml | yq e '{"spec": .spec}' - >>${hpatch}
   pre_generation_harvester=$(kubectl get managedcharts.management.cattle.io harvester -n fleet-local -o=jsonpath='{.status.observedGeneration}')
 
@@ -1007,7 +1020,6 @@ EOF
 
   patch_longhorn_settings ${hpatch}
   patch_kubevirt_compare_patches ${hpatch}
-  disable_kubevirt_live_migrate
 
   update_managedchart_patch_file_annotations ${hpatch} $REPO_HARVESTER_CHART_VERSION
   update_managedchart_patch_file_unpause ${hpatch}

--- a/pkg/controller/master/upgrade/filter_compare_patches_test.go
+++ b/pkg/controller/master/upgrade/filter_compare_patches_test.go
@@ -1,0 +1,266 @@
+package upgrade
+
+import (
+	"testing"
+
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+// Test_filterKubevirtComparePatches tests the filterKubevirtComparePatches function
+// which removes the specific jsonPointer "/spec/workloadUpdateStrategy/workloadUpdateMethods"
+// from kubevirt comparePatches while preserving other jsonPointers and patches.
+func Test_filterKubevirtComparePatches(t *testing.T) {
+	const targetJsonPointer = "/spec/workloadUpdateStrategy/workloadUpdateMethods"
+
+	tests := []struct {
+		name               string
+		inputPatches       []fleet.ComparePatch
+		expectedRemoved    bool
+		expectedPatchCount int
+		validateResult     func(t *testing.T, result []fleet.ComparePatch)
+	}{
+		{
+			name:               "empty comparePatches",
+			inputPatches:       []fleet.ComparePatch{},
+			expectedRemoved:    false,
+			expectedPatchCount: 0,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "kubevirt patch with only target jsonPointer - should be removed entirely",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "KubeVirt",
+					Name:       "kubevirt",
+					JsonPointers: []string{
+						targetJsonPointer,
+					},
+				},
+			},
+			expectedRemoved:    true,
+			expectedPatchCount: 0,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				assert.Empty(t, result, "patch should be completely removed when it only contains target jsonPointer")
+			},
+		},
+		{
+			name: "kubevirt patch with target and other jsonPointers - should keep patch with other pointers",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "KubeVirt",
+					Name:       "kubevirt",
+					JsonPointers: []string{
+						targetJsonPointer,
+						"/spec/someOtherField",
+						"/spec/configuration/developerConfiguration",
+					},
+				},
+			},
+			expectedRemoved:    true,
+			expectedPatchCount: 1,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				require.Len(t, result, 1, "should keep one patch")
+				patch := result[0]
+				assert.Equal(t, "kubevirt.io/v1", patch.APIVersion)
+				assert.Equal(t, "KubeVirt", patch.Kind)
+				assert.Equal(t, "kubevirt", patch.Name)
+				assert.Len(t, patch.JsonPointers, 2, "should have 2 remaining jsonPointers")
+				assert.Equal(t, []string{"/spec/someOtherField", "/spec/configuration/developerConfiguration"}, patch.JsonPointers)
+				assert.NotContains(t, patch.JsonPointers, targetJsonPointer, "target jsonPointer should be removed")
+			},
+		},
+		{
+			name: "kubevirt patch without target jsonPointer - should remain unchanged",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "KubeVirt",
+					Name:       "kubevirt",
+					JsonPointers: []string{
+						"/spec/someOtherField",
+						"/spec/anotherField",
+					},
+				},
+			},
+			expectedRemoved:    false,
+			expectedPatchCount: 1,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				require.Len(t, result, 1)
+				assert.Equal(t, []string{"/spec/someOtherField", "/spec/anotherField"}, result[0].JsonPointers)
+			},
+		},
+		{
+			name: "non-kubevirt patches should remain unchanged",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "test-deployment",
+					JsonPointers: []string{
+						"/spec/replicas",
+					},
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Name:       "test-service",
+					JsonPointers: []string{
+						"/spec/ports",
+					},
+				},
+			},
+			expectedRemoved:    false,
+			expectedPatchCount: 2,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				require.Len(t, result, 2)
+				assert.Equal(t, "apps/v1", result[0].APIVersion)
+				assert.Equal(t, "v1", result[1].APIVersion)
+			},
+		},
+		{
+			name: "mixed patches - kubevirt with target and other patches",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "test-deployment",
+					JsonPointers: []string{
+						"/spec/replicas",
+					},
+				},
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "KubeVirt",
+					Name:       "kubevirt",
+					JsonPointers: []string{
+						targetJsonPointer,
+					},
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Name:       "test-service",
+					JsonPointers: []string{
+						"/spec/ports",
+					},
+				},
+			},
+			expectedRemoved:    true,
+			expectedPatchCount: 2,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				require.Len(t, result, 2, "should have 2 patches after removing kubevirt patch")
+				assert.Equal(t, "apps/v1", result[0].APIVersion)
+				assert.Equal(t, "v1", result[1].APIVersion)
+				// Verify kubevirt patch is not present
+				for _, patch := range result {
+					assert.NotEqual(t, "kubevirt.io/v1", patch.APIVersion)
+				}
+			},
+		},
+		{
+			name: "kubevirt patch with wrong name - should remain unchanged",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "KubeVirt",
+					Name:       "different-kubevirt",
+					JsonPointers: []string{
+						targetJsonPointer,
+					},
+				},
+			},
+			expectedRemoved:    false,
+			expectedPatchCount: 1,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				require.Len(t, result, 1)
+				assert.Equal(t, "different-kubevirt", result[0].Name)
+				assert.Contains(t, result[0].JsonPointers, targetJsonPointer, "should not filter patches with different name")
+			},
+		},
+		{
+			name: "kubevirt patch with wrong kind - should remain unchanged",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "VirtualMachine",
+					Name:       "kubevirt",
+					JsonPointers: []string{
+						targetJsonPointer,
+					},
+				},
+			},
+			expectedRemoved:    false,
+			expectedPatchCount: 1,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				require.Len(t, result, 1)
+				assert.Equal(t, "VirtualMachine", result[0].Kind)
+				assert.Contains(t, result[0].JsonPointers, targetJsonPointer, "should not filter patches with different kind")
+			},
+		},
+		{
+			name: "multiple kubevirt patches - only matching one should be modified",
+			inputPatches: []fleet.ComparePatch{
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "KubeVirt",
+					Name:       "kubevirt",
+					Namespace:  util.HarvesterSystemNamespaceName,
+					JsonPointers: []string{
+						targetJsonPointer,
+						"/spec/otherField",
+					},
+				},
+				{
+					APIVersion: "kubevirt.io/v1",
+					Kind:       "KubeVirt",
+					Name:       "other-kubevirt",
+					JsonPointers: []string{
+						"/spec/someField",
+					},
+				},
+			},
+			expectedRemoved:    true,
+			expectedPatchCount: 2,
+			validateResult: func(t *testing.T, result []fleet.ComparePatch) {
+				require.Len(t, result, 2)
+				// Find the kubevirt patch
+				var kubevirtPatch *fleet.ComparePatch
+				var otherPatch *fleet.ComparePatch
+				for i := range result {
+					switch result[i].Name {
+					case "kubevirt":
+						kubevirtPatch = &result[i]
+					case "other-kubevirt":
+						otherPatch = &result[i]
+					}
+				}
+				require.NotNil(t, kubevirtPatch, "kubevirt patch should still exist")
+				require.NotNil(t, otherPatch, "other-kubevirt patch should exist")
+
+				assert.Equal(t, []string{"/spec/otherField"}, kubevirtPatch.JsonPointers, "target jsonPointer should be removed from matching patch")
+				assert.Equal(t, []string{"/spec/someField"}, otherPatch.JsonPointers, "non-matching patch should be unchanged")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualPatches, actualRemoved := filterKubevirtComparePatches(tt.inputPatches, targetJsonPointer)
+
+			assert.Equal(t, tt.expectedRemoved, actualRemoved, "removed flag should match expected")
+			assert.Equal(t, tt.expectedPatchCount, len(actualPatches), "patch count should match expected")
+
+			if tt.validateResult != nil {
+				tt.validateResult(t, actualPatches)
+			}
+		})
+	}
+}

--- a/pkg/controller/master/upgrade/register.go
+++ b/pkg/controller/master/upgrade/register.go
@@ -104,6 +104,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	deployments := management.AppsFactory.Apps().V1().Deployment()
 	vmImages := management.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage()
 	vms := management.VirtFactory.Kubevirt().V1().VirtualMachine()
+	kubevirts := management.VirtFactory.Kubevirt().V1().KubeVirt()
 	services := management.CoreFactory.Core().V1().Service()
 	namespaces := management.CoreFactory.Core().V1().Namespace()
 	clusters := management.ProvisioningFactory.Provisioning().V1().Cluster()
@@ -146,6 +147,8 @@ func Register(ctx context.Context, management *config.Management, options config
 		vmImageCache:       vmImages.Cache(),
 		vmClient:           vms,
 		vmCache:            vms.Cache(),
+		kubevirtClient:     kubevirts,
+		kubevirtCache:      kubevirts.Cache(),
 		serviceClient:      services,
 		pvcClient:          pvcs,
 		clusterClient:      clusters,

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -991,34 +990,8 @@ func (h *upgradeHandler) removeKubevirtComparePatches() error {
 		return nil
 	}
 
-	// Filter out the kubevirt comparePatch entry or update its jsonPointers
-	var updatedComparePatches []fleet.ComparePatch
-	removed := false
-	for _, patch := range managedChart.Spec.Diff.ComparePatches {
-		if patch.APIVersion == "kubevirt.io/v1" && patch.Kind == "KubeVirt" && patch.Name == "kubevirt" {
-			// Check if JsonPointers contains the specific path we're looking for
-			containsWorkloadUpdateMethods := slices.Contains(patch.JsonPointers, "/spec/workloadUpdateStrategy/workloadUpdateMethods")
-			if containsWorkloadUpdateMethods {
-				logrus.Info("Found kubevirt comparePatches entry with workloadUpdateMethods JsonPointer, removing it")
-				// Filter out only the specific jsonPointer
-				var updatedJsonPointers []string
-				for _, jsonPointer := range patch.JsonPointers {
-					if jsonPointer != "/spec/workloadUpdateStrategy/workloadUpdateMethods" {
-						updatedJsonPointers = append(updatedJsonPointers, jsonPointer)
-					}
-				}
-				// Only keep the patch if it has remaining jsonPointers
-				if len(updatedJsonPointers) > 0 {
-					patchCopy := patch
-					patchCopy.JsonPointers = updatedJsonPointers
-					updatedComparePatches = append(updatedComparePatches, patchCopy)
-				}
-				removed = true
-				continue
-			}
-		}
-		updatedComparePatches = append(updatedComparePatches, patch)
-	}
+	const jsonPointer = "/spec/workloadUpdateStrategy/workloadUpdateMethods"
+	updatedComparePatches, removed := filterKubevirtComparePatches(managedChart.Spec.Diff.ComparePatches, jsonPointer)
 
 	// Only update if we actually removed something
 	if !removed {
@@ -1035,6 +1008,39 @@ func (h *upgradeHandler) removeKubevirtComparePatches() error {
 
 	logrus.Info("Successfully removed kubevirt comparePatches from harvester managedchart")
 	return nil
+}
+
+// filterKubevirtComparePatches filters comparePatches to remove the specific jsonPointer
+// "/spec/workloadUpdateStrategy/workloadUpdateMethods" from kubevirt patches.
+// It returns the filtered slice and a boolean indicating if anything was removed.
+func filterKubevirtComparePatches(comparePatches []fleet.ComparePatch, targetJsonPointer string) ([]fleet.ComparePatch, bool) {
+	var updatedComparePatches []fleet.ComparePatch
+	removed := false
+
+	for _, patch := range comparePatches {
+		if patch.APIVersion == "kubevirt.io/v1" && patch.Kind == "KubeVirt" && patch.Name == "kubevirt" {
+			var updatedJsonPointers []string
+			for _, jsonPointer := range patch.JsonPointers {
+				if jsonPointer == targetJsonPointer {
+					removed = true
+				} else {
+					updatedJsonPointers = append(updatedJsonPointers, jsonPointer)
+				}
+			}
+
+			// Only keep the patch if it has remaining jsonPointers
+			if len(updatedJsonPointers) > 0 {
+				patchCopy := patch
+				patchCopy.JsonPointers = updatedJsonPointers
+				updatedComparePatches = append(updatedComparePatches, patchCopy)
+			}
+			// Skip adding the original patch - we either added the modified one or nothing
+			continue
+		}
+		updatedComparePatches = append(updatedComparePatches, patch)
+	}
+
+	return updatedComparePatches, removed
 }
 
 func (h *upgradeHandler) reenableAddons(upgrade *harvesterv1.Upgrade) (*harvesterv1.Upgrade, error) {

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -108,6 +110,8 @@ type upgradeHandler struct {
 	vmImageCache     ctlharvesterv1.VirtualMachineImageCache
 	vmClient         kubevirtctrl.VirtualMachineClient
 	vmCache          kubevirtctrl.VirtualMachineCache
+	kubevirtClient   kubevirtctrl.KubeVirtClient
+	kubevirtCache    kubevirtctrl.KubeVirtCache
 	serviceClient    ctlcorev1.ServiceClient
 	pvcClient        ctlcorev1.PersistentVolumeClaimClient
 	deploymentClient ctlappsv1.DeploymentClient
@@ -577,6 +581,11 @@ func (h *upgradeHandler) cleanup(upgrade *harvesterv1.Upgrade, cleanJobs bool) (
 	if upgrade, err = h.reenableAddons(upgrade); err != nil {
 		return upgrade, err
 	}
+
+	if upgrade, err = h.enableKubevirtWorkloadLiveMigrate(upgrade); err != nil {
+		return upgrade, err
+	}
+
 	return upgrade, h.resumeManagedCharts()
 }
 
@@ -933,6 +942,83 @@ func (h *upgradeHandler) addUpgradeLabelToDeschedulerAddons(upgrade *harvesterv1
 			return err
 		}
 	}
+	return nil
+}
+
+// enableKubevirtWorkloadLiveMigrate enables KubeVirt workload live migration
+// This brings back vCPU/memory hotplug features.
+// We disable the feature to avoid messy live migration during upgrade because virt-launcher pod images are outdated
+func (h *upgradeHandler) enableKubevirtWorkloadLiveMigrate(upgrade *harvesterv1.Upgrade) (*harvesterv1.Upgrade, error) {
+	logrus.Info("Enabling KubeVirt workload live migration for upgrade")
+	kubevirt, err := h.kubevirtCache.Get(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubevirt object: %w", err)
+	}
+
+	kubevirtCopy := kubevirt.DeepCopy()
+	kubevirtCopy.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []kubevirtv1.WorkloadUpdateMethod{
+		kubevirtv1.WorkloadUpdateMethodLiveMigrate,
+	}
+
+	if !reflect.DeepEqual(kubevirt.Spec.WorkloadUpdateStrategy, kubevirtCopy.Spec.WorkloadUpdateStrategy) {
+		logrus.Infof("Updating KubeVirt workload update strategy to LiveMigrate")
+		if _, err := h.kubevirtClient.Update(kubevirtCopy); err != nil {
+			return nil, fmt.Errorf("failed to update kubevirt workload update strategy: %w", err)
+		}
+	}
+
+	// remove harvester ManagedChart comparePatches
+	if err := h.removeKubevirtComparePatches(); err != nil {
+		logrus.Warnf("Failed to remove kubevirt comparePatches from harvester managedchart: %v", err)
+	}
+
+	return upgrade, nil
+}
+
+func (h *upgradeHandler) removeKubevirtComparePatches() error {
+	logrus.Info("Removing kubevirt comparePatches from harvester managedchart")
+	managedChart, err := h.managedChartCache.Get(util.FleetLocalNamespaceName, util.HarvesterManagedChart)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Info("harvester managedchart not found, skip removing kubevirt comparePatches")
+			return nil
+		}
+		return fmt.Errorf("failed to get harvester managedchart: %w", err)
+	}
+
+	if managedChart.Spec.Diff == nil || len(managedChart.Spec.Diff.ComparePatches) == 0 {
+		logrus.Info("No comparePatches found in harvester managedchart, skip removing")
+		return nil
+	}
+
+	// Filter out the kubevirt comparePatch entry
+	var updatedComparePatches []fleet.ComparePatch
+	for _, patch := range managedChart.Spec.Diff.ComparePatches {
+		if patch.APIVersion == "kubevirt.io/v1" && patch.Kind == "KubeVirt" && patch.Name == "kubevirt" {
+			// Check if JsonPointers contains the specific path we're looking for
+			containsWorkloadUpdateMethods := slices.Contains(patch.JsonPointers, "/spec/workloadUpdateStrategy/workloadUpdateMethods")
+			if containsWorkloadUpdateMethods {
+				logrus.Info("Found kubevirt comparePatches entry with workloadUpdateMethods JsonPointer, removing it")
+				continue
+			}
+		}
+		updatedComparePatches = append(updatedComparePatches, patch)
+	}
+
+	// Only update if we actually removed something
+	if len(updatedComparePatches) == len(managedChart.Spec.Diff.ComparePatches) {
+		logrus.Info("kubevirt comparePatches entry not found, nothing to remove")
+		return nil
+	}
+
+	mcToUpdate := managedChart.DeepCopy()
+	mcToUpdate.Spec.Diff.ComparePatches = updatedComparePatches
+
+	if _, err := h.managedChartClient.Update(mcToUpdate); err != nil {
+		return fmt.Errorf("failed to update harvester managedchart: %w", err)
+	}
+
+	logrus.Info("Successfully removed kubevirt comparePatches from harvester managedchart")
 	return nil
 }
 

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -991,14 +991,29 @@ func (h *upgradeHandler) removeKubevirtComparePatches() error {
 		return nil
 	}
 
-	// Filter out the kubevirt comparePatch entry
+	// Filter out the kubevirt comparePatch entry or update its jsonPointers
 	var updatedComparePatches []fleet.ComparePatch
+	removed := false
 	for _, patch := range managedChart.Spec.Diff.ComparePatches {
 		if patch.APIVersion == "kubevirt.io/v1" && patch.Kind == "KubeVirt" && patch.Name == "kubevirt" {
 			// Check if JsonPointers contains the specific path we're looking for
 			containsWorkloadUpdateMethods := slices.Contains(patch.JsonPointers, "/spec/workloadUpdateStrategy/workloadUpdateMethods")
 			if containsWorkloadUpdateMethods {
 				logrus.Info("Found kubevirt comparePatches entry with workloadUpdateMethods JsonPointer, removing it")
+				// Filter out only the specific jsonPointer
+				var updatedJsonPointers []string
+				for _, jsonPointer := range patch.JsonPointers {
+					if jsonPointer != "/spec/workloadUpdateStrategy/workloadUpdateMethods" {
+						updatedJsonPointers = append(updatedJsonPointers, jsonPointer)
+					}
+				}
+				// Only keep the patch if it has remaining jsonPointers
+				if len(updatedJsonPointers) > 0 {
+					patchCopy := patch
+					patchCopy.JsonPointers = updatedJsonPointers
+					updatedComparePatches = append(updatedComparePatches, patchCopy)
+				}
+				removed = true
 				continue
 			}
 		}
@@ -1006,8 +1021,8 @@ func (h *upgradeHandler) removeKubevirtComparePatches() error {
 	}
 
 	// Only update if we actually removed something
-	if len(updatedComparePatches) == len(managedChart.Spec.Diff.ComparePatches) {
-		logrus.Info("kubevirt comparePatches entry not found, nothing to remove")
+	if !removed {
+		logrus.Info("kubevirt comparePatches entry with workloadUpdateMethods JsonPointer not found, nothing to remove")
 		return nil
 	}
 

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -133,6 +133,20 @@ func newManagedChart(namespace, name string) *mgmtv3.ManagedChart {
 	}
 }
 
+func newManagedChartWithComparePatches(namespace, name string, patches []fleet.ComparePatch) *mgmtv3.ManagedChart {
+	return &mgmtv3.ManagedChart{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: mgmtv3.ManagedChartSpec{
+			Diff: &fleet.DiffOptions{
+				ComparePatches: patches,
+			},
+		},
+	}
+}
+
 func TestUpgradeHandler_OnChanged(t *testing.T) {
 	type input struct {
 		key          string
@@ -146,11 +160,13 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 		nodes        []*v1.Node
 	}
 	type output struct {
-		plan       *upgradeapiv1.Plan
-		upgrade    *harvesterv1.Upgrade
-		upgradeLog *harvesterv1.UpgradeLog
-		vmi        *harvesterv1.VirtualMachineImage
-		err        error
+		plan         *upgradeapiv1.Plan
+		upgrade      *harvesterv1.Upgrade
+		upgradeLog   *harvesterv1.UpgradeLog
+		vmi          *harvesterv1.VirtualMachineImage
+		kubevirt     *kubevirtv1.KubeVirt
+		managedChart *mgmtv3.ManagedChart
+		err          error
 	}
 	var testCases = []struct {
 		name     string
@@ -282,6 +298,118 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 					WithLabel(upgradeCleanupLabel, StateSucceeded).Build(),
 			},
 		},
+		{
+			name: "kubevirt comparePatches should be removed after cleanup",
+			given: input{
+				key: testUpgradeName,
+				upgrade: newTestUpgradeBuilder().
+					InitStatus().
+					LogReadyCondition(v1.ConditionFalse, "Disabled", "Upgrade observability is administratively disabled").
+					ImageReadyCondition(v1.ConditionTrue, "", "").
+					RepoProvisionedCondition(v1.ConditionTrue, "", "").
+					NodesPreparedCondition(v1.ConditionTrue, "", "").
+					ChartUpgradeStatus(v1.ConditionTrue, "", "").
+					NodesUpgradedCondition(v1.ConditionTrue, "", "").
+					WithAnnotation(imageCleanupPlanCompletedAnnotation, strconv.FormatBool(true)).Build(),
+				version:  newVersionBuilder(testVersion).Build(),
+				vmi:      newTestExistingVirtualMachineImage(upgradeNamespace, testUpgradeImage),
+				cluster:  newCluster(util.FleetLocalNamespaceName, util.LocalClusterName),
+				kubevirt: newKubeVirt(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName),
+				managedChart: newManagedChartWithComparePatches(util.FleetLocalNamespaceName, util.HarvesterManagedChart, []fleet.ComparePatch{
+					{
+						APIVersion: "kubevirt.io/v1",
+						Kind:       "KubeVirt",
+						Name:       util.KubeVirtObjectName,
+						Namespace:  util.HarvesterSystemNamespaceName,
+						Operations: []fleet.Operation{
+							{
+								Op:    "replace",
+								Path:  "/spec/workloadUpdateStrategy/workloadUpdateMethods",
+								Value: "[]",
+							},
+						},
+						JsonPointers: []string{
+							"/spec/workloadUpdateStrategy/workloadUpdateMethods",
+						},
+					},
+					{
+						APIVersion: "kubevirt.io/v1",
+						Kind:       "KubeVirt",
+						Name:       util.KubeVirtObjectName,
+						Namespace:  util.HarvesterSystemNamespaceName,
+						Operations: []fleet.Operation{
+							{
+								Op:    "replace",
+								Path:  "/spec/someOtherField",
+								Value: "test",
+							},
+						},
+						JsonPointers: []string{
+							"/spec/someOtherField",
+						},
+					},
+				}),
+				nodes: []*v1.Node{
+					newNodeBuilder("node-1").Managed().ControlPlane().Build(),
+					newNodeBuilder("node-2").Managed().ControlPlane().Build(),
+					newNodeBuilder("node-3").Managed().ControlPlane().Build(),
+				},
+			},
+			expected: output{
+				upgrade: newTestUpgradeBuilder().
+					InitStatus().
+					LogReadyCondition(v1.ConditionFalse, "Disabled", "Upgrade observability is administratively disabled").
+					ImageReadyCondition(v1.ConditionTrue, "", "").
+					RepoProvisionedCondition(v1.ConditionTrue, "", "").
+					NodesPreparedCondition(v1.ConditionTrue, "", "").
+					ChartUpgradeStatus(v1.ConditionTrue, "", "").
+					NodesUpgradedCondition(v1.ConditionTrue, "", "").
+					WithAnnotation(imageCleanupPlanCompletedAnnotation, strconv.FormatBool(true)).
+					WithAnnotation(longhornSettingsRestoredAnnotation, strconv.FormatBool(true)).
+					WithLabel(upgradeCleanupLabel, StateSucceeded).Build(),
+				kubevirt: &kubevirtv1.KubeVirt{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: util.HarvesterSystemNamespaceName,
+						Name:      util.KubeVirtObjectName,
+					},
+					Spec: kubevirtv1.KubeVirtSpec{
+						WorkloadUpdateStrategy: kubevirtv1.KubeVirtWorkloadUpdateStrategy{
+							WorkloadUpdateMethods: []kubevirtv1.WorkloadUpdateMethod{
+								kubevirtv1.WorkloadUpdateMethodLiveMigrate,
+							},
+						},
+					},
+				},
+				managedChart: &mgmtv3.ManagedChart{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: util.FleetLocalNamespaceName,
+						Name:      util.HarvesterManagedChart,
+					},
+					Spec: mgmtv3.ManagedChartSpec{
+						Diff: &fleet.DiffOptions{
+							ComparePatches: []fleet.ComparePatch{
+								{
+									APIVersion: "kubevirt.io/v1",
+									Kind:       "KubeVirt",
+									Name:       util.KubeVirtObjectName,
+									Namespace:  util.HarvesterSystemNamespaceName,
+									Operations: []fleet.Operation{
+										{
+											Op:    "replace",
+											Path:  "/spec/someOtherField",
+											Value: "test",
+										},
+									},
+									JsonPointers: []string{
+										"/spec/someOtherField",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		var defaultObjs = []runtime.Object{tc.given.upgrade, tc.given.version, tc.given.vmi, tc.given.cluster}
@@ -371,6 +499,20 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, tc.expected.upgradeLog, actual.upgradeLog, "case %q", tc.name)
+		}
+
+		if tc.expected.kubevirt != nil {
+			var err error
+			actual.kubevirt, err = handler.kubevirtClient.Get(tc.expected.kubevirt.Namespace, tc.expected.kubevirt.Name, metav1.GetOptions{})
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected.kubevirt.Spec, actual.kubevirt.Spec, "case %q: kubevirt spec mismatch", tc.name)
+		}
+
+		if tc.expected.managedChart != nil {
+			var err error
+			actual.managedChart, err = handler.managedChartClient.Get(tc.expected.managedChart.Namespace, tc.expected.managedChart.Name, metav1.GetOptions{})
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected.managedChart.Spec.Diff.ComparePatches, actual.managedChart.Spec.Diff.ComparePatches, "case %q: managedChart comparePatches mismatch", tc.name)
 		}
 	}
 }

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -327,17 +327,6 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 								Path:  "/spec/workloadUpdateStrategy/workloadUpdateMethods",
 								Value: "[]",
 							},
-						},
-						JsonPointers: []string{
-							"/spec/workloadUpdateStrategy/workloadUpdateMethods",
-						},
-					},
-					{
-						APIVersion: "kubevirt.io/v1",
-						Kind:       "KubeVirt",
-						Name:       util.KubeVirtObjectName,
-						Namespace:  util.HarvesterSystemNamespaceName,
-						Operations: []fleet.Operation{
 							{
 								Op:    "replace",
 								Path:  "/spec/someOtherField",
@@ -345,6 +334,7 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 							},
 						},
 						JsonPointers: []string{
+							"/spec/workloadUpdateStrategy/workloadUpdateMethods",
 							"/spec/someOtherField",
 						},
 					},
@@ -394,6 +384,11 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 									Name:       util.KubeVirtObjectName,
 									Namespace:  util.HarvesterSystemNamespaceName,
 									Operations: []fleet.Operation{
+										{
+											Op:    "replace",
+											Path:  "/spec/workloadUpdateStrategy/workloadUpdateMethods",
+											Value: "[]",
+										},
 										{
 											Op:    "replace",
 											Path:  "/spec/someOtherField",

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
+	mgmtv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	upgradeapiv1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
@@ -14,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -102,15 +105,45 @@ func newCluster(namespace, name string) *provisioningv1.Cluster {
 	}
 }
 
+func newKubeVirt(namespace, name string) *kubevirtv1.KubeVirt {
+	return &kubevirtv1.KubeVirt{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: kubevirtv1.KubeVirtSpec{
+			WorkloadUpdateStrategy: kubevirtv1.KubeVirtWorkloadUpdateStrategy{
+				WorkloadUpdateMethods: []kubevirtv1.WorkloadUpdateMethod{},
+			},
+		},
+	}
+}
+
+func newManagedChart(namespace, name string) *mgmtv3.ManagedChart {
+	return &mgmtv3.ManagedChart{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: mgmtv3.ManagedChartSpec{
+			Diff: &fleet.DiffOptions{
+				ComparePatches: []fleet.ComparePatch{},
+			},
+		},
+	}
+}
+
 func TestUpgradeHandler_OnChanged(t *testing.T) {
 	type input struct {
-		key        string
-		upgrade    *harvesterv1.Upgrade
-		version    *harvesterv1.Version
-		vmi        *harvesterv1.VirtualMachineImage
-		cluster    *provisioningv1.Cluster
-		lhsettings []*lhv1beta2.Setting
-		nodes      []*v1.Node
+		key          string
+		upgrade      *harvesterv1.Upgrade
+		version      *harvesterv1.Version
+		vmi          *harvesterv1.VirtualMachineImage
+		cluster      *provisioningv1.Cluster
+		kubevirt     *kubevirtv1.KubeVirt
+		managedChart *mgmtv3.ManagedChart
+		lhsettings   []*lhv1beta2.Setting
+		nodes        []*v1.Node
 	}
 	type output struct {
 		plan       *upgradeapiv1.Plan
@@ -218,9 +251,11 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 					WithAnnotation(imageCleanupPlanCompletedAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(autoCleanupSystemGeneratedSnapshotAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(replicaReplenishmentAnnotation, strconv.Itoa(600)).Build(),
-				version: newVersionBuilder(testVersion).Build(),
-				vmi:     newTestExistingVirtualMachineImage(upgradeNamespace, testUpgradeImage),
-				cluster: newCluster(util.FleetLocalNamespaceName, util.LocalClusterName),
+				version:      newVersionBuilder(testVersion).Build(),
+				vmi:          newTestExistingVirtualMachineImage(upgradeNamespace, testUpgradeImage),
+				cluster:      newCluster(util.FleetLocalNamespaceName, util.LocalClusterName),
+				kubevirt:     newKubeVirt(util.HarvesterSystemNamespaceName, util.KubeVirtObjectName),
+				managedChart: newManagedChart(util.FleetLocalNamespaceName, util.HarvesterManagedChart),
 				lhsettings: []*lhv1beta2.Setting{
 					newLonghornSetting(replicaReplenishmentWaitIntervalSetting, strconv.Itoa(1200)),
 					newLonghornSetting(autoCleanupSystemGeneratedSnapshotSetting, strconv.FormatBool(false)),
@@ -252,6 +287,12 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 		var defaultObjs = []runtime.Object{tc.given.upgrade, tc.given.version, tc.given.vmi, tc.given.cluster}
 		objs := make([]runtime.Object, 0, len(defaultObjs)+len(tc.given.lhsettings)+len(tc.given.nodes))
 		objs = append(objs, defaultObjs...)
+		if tc.given.kubevirt != nil {
+			objs = append(objs, tc.given.kubevirt)
+		}
+		if tc.given.managedChart != nil {
+			objs = append(objs, tc.given.managedChart)
+		}
 		for _, setting := range tc.given.lhsettings {
 			objs = append(objs, setting)
 		}
@@ -261,28 +302,31 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 		var clientset = fake.NewSimpleClientset(objs...)
 
 		var handler = &upgradeHandler{
-			namespace:         harvesterSystemNamespace,
-			nodeCache:         fakeclients.NodeCache(clientset.CoreV1().Nodes),
-			planClient:        fakeclients.PlanClient(clientset.UpgradeV1().Plans),
-			planCache:         fakeclients.PlanCache(clientset.UpgradeV1().Plans),
-			upgradeClient:     fakeclients.UpgradeClient(clientset.HarvesterhciV1beta1().Upgrades),
-			upgradeCache:      fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
-			upgradeLogClient:  fakeclients.UpgradeLogClient(clientset.HarvesterhciV1beta1().UpgradeLogs),
-			versionCache:      fakeclients.VersionCache(clientset.HarvesterhciV1beta1().Versions),
-			vmClient:          fakeclients.VirtualMachineClient(clientset.KubevirtV1().VirtualMachines),
-			vmImageClient:     fakeclients.VirtualMachineImageClient(clientset.HarvesterhciV1beta1().VirtualMachineImages),
-			vmImageCache:      fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
-			vmCache:           fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines),
-			serviceClient:     fakeclients.ServiceClient(clientset.CoreV1().Services),
-			lhSettingCache:    fakeclients.LonghornSettingCache(clientset.LonghornV1beta2().Settings),
-			lhSettingClient:   fakeclients.LonghornSettingClient(clientset.LonghornV1beta2().Settings),
-			managedChartCache: fakeclients.ManagedChartCache(clientset.ManagementV3().ManagedCharts),
-			clusterClient:     fakeclients.ClusterClient(clientset.ProvisioningV1().Clusters),
-			clusterCache:      fakeclients.ClusterCache(clientset.ProvisioningV1().Clusters),
-			deploymentClient:  fakeclients.DeploymentClient(clientset.AppsV1().Deployments),
-			deploymentCache:   fakeclients.DeploymentCache(clientset.AppsV1().Deployments),
-			scClient:          fakeclients.StorageClassClient(clientset.StorageV1().StorageClasses),
-			scCache:           fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+			namespace:          harvesterSystemNamespace,
+			nodeCache:          fakeclients.NodeCache(clientset.CoreV1().Nodes),
+			planClient:         fakeclients.PlanClient(clientset.UpgradeV1().Plans),
+			planCache:          fakeclients.PlanCache(clientset.UpgradeV1().Plans),
+			upgradeClient:      fakeclients.UpgradeClient(clientset.HarvesterhciV1beta1().Upgrades),
+			upgradeCache:       fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
+			upgradeLogClient:   fakeclients.UpgradeLogClient(clientset.HarvesterhciV1beta1().UpgradeLogs),
+			versionCache:       fakeclients.VersionCache(clientset.HarvesterhciV1beta1().Versions),
+			vmClient:           fakeclients.VirtualMachineClient(clientset.KubevirtV1().VirtualMachines),
+			vmImageClient:      fakeclients.VirtualMachineImageClient(clientset.HarvesterhciV1beta1().VirtualMachineImages),
+			vmImageCache:       fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
+			vmCache:            fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines),
+			kubevirtClient:     fakeclients.KubeVirtClient(clientset.KubevirtV1().KubeVirts),
+			kubevirtCache:      fakeclients.KubeVirtCache(clientset.KubevirtV1().KubeVirts),
+			serviceClient:      fakeclients.ServiceClient(clientset.CoreV1().Services),
+			lhSettingCache:     fakeclients.LonghornSettingCache(clientset.LonghornV1beta2().Settings),
+			lhSettingClient:    fakeclients.LonghornSettingClient(clientset.LonghornV1beta2().Settings),
+			managedChartCache:  fakeclients.ManagedChartCache(clientset.ManagementV3().ManagedCharts),
+			managedChartClient: fakeclients.ManagedChartClient(clientset.ManagementV3().ManagedCharts),
+			clusterClient:      fakeclients.ClusterClient(clientset.ProvisioningV1().Clusters),
+			clusterCache:       fakeclients.ClusterCache(clientset.ProvisioningV1().Clusters),
+			deploymentClient:   fakeclients.DeploymentClient(clientset.AppsV1().Deployments),
+			deploymentCache:    fakeclients.DeploymentCache(clientset.AppsV1().Deployments),
+			scClient:           fakeclients.StorageClassClient(clientset.StorageV1().StorageClasses),
+			scCache:            fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
 		}
 		var actual output
 		actual.upgrade, actual.err = handler.OnChanged(tc.given.key, tc.given.upgrade)

--- a/pkg/util/fakeclients/kubevirt.go
+++ b/pkg/util/fakeclients/kubevirt.go
@@ -2,14 +2,98 @@ package fakeclients
 
 import (
 	"context"
+	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	kubevirtv1api "kubevirt.io/api/core/v1"
 
 	kubevirtv1 "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/kubevirt.io/v1"
 )
+
+type KubeVirtClient func(string) kubevirtv1.KubeVirtInterface
+
+func (c KubeVirtClient) Update(kubevirt *kubevirtv1api.KubeVirt) (*kubevirtv1api.KubeVirt, error) {
+	return c(kubevirt.Namespace).Update(context.TODO(), kubevirt, metav1.UpdateOptions{})
+}
+
+func (c KubeVirtClient) Get(namespace, name string, options metav1.GetOptions) (*kubevirtv1api.KubeVirt, error) {
+	return c(namespace).Get(context.TODO(), name, options)
+}
+
+func (c KubeVirtClient) Create(kubevirt *kubevirtv1api.KubeVirt) (*kubevirtv1api.KubeVirt, error) {
+	return c(kubevirt.Namespace).Create(context.TODO(), kubevirt, metav1.CreateOptions{})
+}
+
+func (c KubeVirtClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) List(_ string, _ metav1.ListOptions) (*kubevirtv1api.KubeVirtList, error) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) UpdateStatus(_ *kubevirtv1api.KubeVirt) (*kubevirtv1api.KubeVirt, error) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) Patch(_, _ string, _ types.PatchType, _ []byte, _ ...string) (result *kubevirtv1api.KubeVirt, err error) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) Informer() cache.SharedIndexInformer {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) GroupVersionKind() schema.GroupVersionKind {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) AddGenericHandler(_ context.Context, _ string, _ generic.Handler) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) AddGenericRemoveHandler(_ context.Context, _ string, _ generic.Handler) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) Updater() generic.Updater {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) OnChange(_ context.Context, _ string, _ generic.ObjectHandler[*kubevirtv1api.KubeVirt]) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) OnRemove(_ context.Context, _ string, _ generic.ObjectHandler[*kubevirtv1api.KubeVirt]) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) Enqueue(_, _ string) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) EnqueueAfter(_, _ string, _ time.Duration) {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) Cache() generic.CacheInterface[*kubevirtv1api.KubeVirt] {
+	panic("implement me")
+}
+
+func (c KubeVirtClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*kubevirtv1api.KubeVirt, *kubevirtv1api.KubeVirtList], error) {
+	panic("implement me")
+}
 
 type KubeVirtCache func(string) kubevirtv1.KubeVirtInterface
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
In v1.7, CPU and memory hot-plugging were enabled via LiveMigrate. However, this causes the KubeVirt controller to migrate all VMs simultaneously to update virt-launcher pods immediately after an operator upgrade.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Temporarily remove LiveMigrate from workloadUpdateMethods. VMs will instead migrate naturally during node upgrades, updating the virt-launcher image at that time.
- Re-enable the method post-upgrade to restore hot-plugging.

Note: CPU/Memory hot-plugging is unavailable during the upgrade period.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

- https://github.com/harvester/harvester/issues/10349

#### Test plan:
<!-- Describe the test plan by steps. -->


- Build the ISO and upgrade from the previous version.
- Create some VMs
- After the apply-manifest job, you can see the managed chart has this diff compare patches
  ``` 
      - apiVersion: kubevirt.io/v1
        jsonPointers:
        - /spec/workloadUpdateStrategy/workloadUpdateMethods
        kind: KubeVirt
        name: kubevirt
  ```
  and the kubevirt CR should have workloadUpdateMethod set to an empty list:

  ```
     workloadUpdateStrategy:                                                                                                                                                                 
       workloadUpdateMethods: []
  ```

- You should not see any `-workload-update-*` `virtualmachineinstancemigrations` after the upgrade.
- After the upgrade, the Harvester managed chart should not have the diff compare patches, and kubevirt CR should be set to
  ```
     workloadUpdateStrategy:                                                                                                                                                                 
       workloadUpdateMethods:
         - LiveMigrate
  ```

#### Additional documentation or context
