### PR TITLE
adding bond network condition for mac address

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -641,7 +641,11 @@ set_nic_names_by_mac_address() {
     [ -e "$i" ] || continue
     [ -e "$i/address" ] || continue
     local name=$(basename $i)
-    local mac=$(cat "$i/address")
+    if [ -f "$i/bonding_slave/perm_hwaddr" ]; then
+      mac=$(cat "$i/bonding_slave/perm_hwaddr")
+    else
+      mac=$(cat "$i/address")
+    fi
     # don't add duplicates if there's already an ifname= for this mac address
     [[ "$args" =~ ifname=[^[:space:]]+:$mac ]] && continue
     args="$args ifname=$name:$mac"

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -641,7 +641,7 @@ set_nic_names_by_mac_address() {
     [ -e "$i" ] || continue
     [ -e "$i/address" ] || continue
     local name=$(basename $i)
-    mac=$(cat "$i/address")
+    local mac=$(cat "$i/address")
     if [ -f "$i/bonding_slave/perm_hwaddr" ]; then
       mac=$(cat "$i/bonding_slave/perm_hwaddr")
     fi

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -641,10 +641,9 @@ set_nic_names_by_mac_address() {
     [ -e "$i" ] || continue
     [ -e "$i/address" ] || continue
     local name=$(basename $i)
+    mac=$(cat "$i/address")
     if [ -f "$i/bonding_slave/perm_hwaddr" ]; then
       mac=$(cat "$i/bonding_slave/perm_hwaddr")
-    else
-      mac=$(cat "$i/address")
     fi
     # don't add duplicates if there's already an ifname= for this mac address
     [[ "$args" =~ ifname=[^[:space:]]+:$mac ]] && continue


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/10397

#### Problem:
The workaround introduced in Harvester 1.7.1 to pin NIC names (via ifname=NAME:MAC in GRUB) does not account for bonded network interfaces. In a bond, all slave interfaces inherit the MAC address of the bond master. The current upgrade script sees these identical MAC addresses and skips pinning subsequent slave interfaces, leading to potential network outages after the upgrade when interface names shift.

#### Solution:
Add the condition to check if the network configuration is bond typed

```
if [ -f "$i/bonding_slave/perm_hwaddr" ]; then
      mac=$(cat "$i/bonding_slave/perm_hwaddr")
fi
```

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
