### PR TITLE
chore: replace pull_request_target with two-step workflow for auto-assign, remove config file [skip ci]

### DIFF
--- a/.github/auto-assign-config.yaml
+++ b/.github/auto-assign-config.yaml
@@ -1,3 +1,0 @@
-addAssignees: author
-addReviewers: true
-reviewers: []

--- a/.github/workflows/auto-assign-check.yaml
+++ b/.github/workflows/auto-assign-check.yaml
@@ -1,0 +1,25 @@
+name: "PR Management Auto Assign Collect Data"
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Save PR data to artifact
+        run: |
+          {
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}"
+            echo "PR_AUTHOR=${{ github.event.pull_request.user.login }}"
+          } > pr-auto-assign-data.env
+
+      - name: Upload PR data artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pr-auto-assign-data
+          path: pr-auto-assign-data.env

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,16 +1,33 @@
-name: "[PR Management] Auto Assign"
+name: "PR Management Auto Assign"
 
 on:
-  pull_request_target:
-    types: [opened, ready_for_review]
-
-permissions:
-  pull-requests: write
+  workflow_run:
+    workflows:
+      - "PR Management Auto Assign Collect Data"
+    types: [completed]
 
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      pull-requests: write
     steps:
-      - uses: rancher/gh-issue-mgr/auto-assign-action@b70f0bdf12a03e5e3f33e4f92ccb6c89deb3ebd9 # main
+      - name: Download PR data artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          configuration-path: .github/auto-assign-config.yaml
+          name: pr-auto-assign-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Load PR data
+        run: |
+          cat pr-auto-assign-data.env >> $GITHUB_ENV
+
+      - name: Auto assign PR author
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Assigning PR author: $PR_AUTHOR"
+          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-assignee "$PR_AUTHOR"


### PR DESCRIPTION
Test: https://github.com/Yu-Jack/test/pull/224

Because we define reviewers in other place, this action just aims to assign the assignees.