### PR TITLE
PR adds minor changes to harvester-webhook to improve UX for forklift integration

### DIFF
--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -113,18 +113,7 @@ func (v *pvcValidator) Delete(request *types.Request, oldObj runtime.Object) err
 		return nil
 	}
 
-	var ownerList []string
-	for _, owner := range pvc.OwnerReferences {
-		if owner.Kind == kubevirtv1.VirtualMachineGroupVersionKind.Kind {
-			ownerList = append(ownerList, owner.Name)
-		}
-	}
-	if len(ownerList) > 0 {
-		message := fmt.Sprintf("can not delete the volume %s which is currently owned by these VMs: %s", oldPVC.Name, strings.Join(ownerList, ","))
-		return werror.NewInvalidError(message, "")
-	}
-
-	return nil
+	return v.validateOwnerReferences(pvc)
 }
 
 func (v *pvcValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
@@ -279,4 +268,30 @@ func isManagedByKubeVirt(pvc *corev1.PersistentVolumeClaim) bool {
 	}
 
 	return hasValidOwner
+}
+
+func (v *pvcValidator) validateOwnerReferences(pvc *corev1.PersistentVolumeClaim) error {
+	var ownerList []string
+	for _, owner := range pvc.OwnerReferences {
+		if owner.Kind == kubevirtv1.VirtualMachineGroupVersionKind.Kind {
+			// check if VM exists and is not in deleting status, if so, block the deletion of PVC
+			vmObj, err := v.vmCache.Get(pvc.Namespace, owner.Name)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return werror.NewInternalError(fmt.Sprintf("failed to get VM %s/%s: %v", pvc.Namespace, owner.Name, err))
+			}
+			if vmObj.DeletionTimestamp == nil {
+				ownerList = append(ownerList, owner.Name)
+			}
+
+		}
+	}
+
+	if len(ownerList) > 0 {
+		message := fmt.Sprintf("can not delete the volume %s which is currently owned by these VMs: %s", pvc.Name, strings.Join(ownerList, ","))
+		return werror.NewInvalidError(message, "")
+	}
+	return nil
 }

--- a/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 func TestIsBelongToUpgradeImage(t *testing.T) {
@@ -323,6 +324,84 @@ func TestCreate(t *testing.T) {
 				if tc.errorContains != "" {
 					assert.Contains(t, err.Error(), tc.errorContains, tc.name)
 				}
+			} else {
+				assert.Nil(t, err, tc.name)
+			}
+		})
+	}
+}
+
+func Test_PVCDeletion(t *testing.T) {
+	deletingVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting-vm",
+			Namespace:         "default",
+			DeletionTimestamp: ptr.To(metav1.Now()),
+		},
+	}
+
+	nonDeletingVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "non-deleting-vm",
+			Namespace: "default",
+		},
+	}
+
+	for _, tc := range []struct {
+		name        string
+		pvc         *corev1.PersistentVolumeClaim
+		expectError bool
+	}{
+		{
+			name: "PVC owned by deleting VM",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "kubevirt.io/v1",
+							Kind:       "VirtualMachine",
+							Name:       deletingVM.Name,
+							UID:        "test-uid",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "PVC owned by non-deleting VM",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "kubevirt.io/v1",
+							Kind:       "VirtualMachine",
+							Name:       nonDeletingVM.Name,
+							UID:        "test-uid",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(deletingVM, nonDeletingVM, tc.pvc)
+
+			validator := &pvcValidator{
+				vmCache:    fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines),
+				pvcCache:   fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+				imageCache: fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
+			}
+
+			err := validator.validateOwnerReferences(tc.pvc)
+
+			if tc.expectError {
+				assert.NotNil(t, err, tc.name)
 			} else {
 				assert.Nil(t, err, tc.name)
 			}

--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -3,6 +3,7 @@ package virtualmachine
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
@@ -31,9 +33,12 @@ const (
 	overlayNetwork    = "OverlayNetwork"
 	keyNetworkType    = networkGroup + "/type"
 
-	memory10M  = 10485760
-	memory100M = 104857600
-	memory256M = 268435456
+	memory10M    = 10485760
+	memory100M   = 104857600
+	memory256M   = 268435456
+	migrationKey = "migration"
+	planKey      = "plan"
+	vmIDKey      = "vmID"
 )
 
 func NewMutator(
@@ -104,7 +109,8 @@ func (m *vmMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch
 		return nil, err
 	}
 
-	return patchOps, nil
+	patchOps = m.patchMissingForkliftLimits(vm, patchOps)
+	return patchOps, err
 }
 
 func (m *vmMutator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) (types.PatchOps, error) {
@@ -845,4 +851,49 @@ func (m *vmMutator) patchManagedTapBinding(vm *kubevirtv1.VirtualMachine, patchO
 	}
 
 	return patchOps, nil
+}
+
+func (m *vmMutator) patchMissingForkliftLimits(vm *kubevirtv1.VirtualMachine, patchOps types.PatchOps) types.PatchOps {
+	// this scenario only arises for VM's imported from forklift, and we need to copy cpu and memory in to resource limits
+	// if the vm is created by forklift
+	if !isCreatedByForklift(vm) {
+		return patchOps
+	}
+	if len(vm.Spec.Template.Spec.Domain.Resources.Limits) != 0 {
+		return patchOps
+	}
+	limits := buildForkliftResourceLimits(vm)
+	if len(limits) == 0 {
+		return patchOps
+	}
+	bytes, err := json.Marshal(limits)
+	if err != nil {
+		logrus.Errorf("error generating resource limit patch for vm %s/%s: %v", vm.Namespace, vm.Name, err)
+		return patchOps
+	}
+	return append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/resources/limits", "value": %s}`, string(bytes)))
+}
+
+func buildForkliftResourceLimits(vm *kubevirtv1.VirtualMachine) v1.ResourceList {
+	limits := v1.ResourceList{}
+	if vm.Spec.Template.Spec.Domain.CPU != nil {
+		totalCPUs := hardware.GetNumberOfVCPUs(vm.Spec.Template.Spec.Domain.CPU)
+		limits[v1.ResourceCPU] = resource.MustParse(strconv.FormatInt(totalCPUs, 10))
+	}
+	if vm.Spec.Template.Spec.Domain.Memory != nil && vm.Spec.Template.Spec.Domain.Memory.Guest != nil {
+		limits[v1.ResourceMemory] = *vm.Spec.Template.Spec.Domain.Memory.Guest
+	}
+	return limits
+}
+
+// isCreatedByForklift checks if the VM is created by forklift by checking the existence of forklift related labels
+func isCreatedByForklift(vm *kubevirtv1.VirtualMachine) bool {
+	if vm.Labels == nil {
+		return false
+	}
+
+	_, migrationExists := vm.Labels[migrationKey]
+	_, planExists := vm.Labels[planKey]
+	_, vmIDExists := vm.Labels[vmIDKey]
+	return migrationExists && planExists && vmIDExists
 }

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -6,15 +6,20 @@ import (
 	"math"
 	"net"
 	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/rancher/wrangler/v3/pkg/patch"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -1851,5 +1856,86 @@ func TestPatchManagedTapBindingWithoutSubnetCRD(t *testing.T) {
 				assert.Equal(t, expected.Value, actual.Value)
 			}
 		})
+	}
+}
+
+func Test_ForkliftPatch(t *testing.T) {
+	memory := resource.MustParse("1G")
+
+	forkliftVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "forklift-vm",
+			Namespace: "default",
+			Labels: map[string]string{
+				migrationKey: "sample-migration",
+				planKey:      "plan-uid",
+				vmIDKey:      "vm-id",
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{
+							Cores:   4,
+							Sockets: 1,
+							Threads: 1,
+						},
+						Memory: &kubevirtv1.Memory{
+							Guest: &memory,
+						},
+						Resources: kubevirtv1.ResourceRequirements{},
+					},
+				},
+			},
+		},
+	}
+
+	nonForkliftVM := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "non-forklift-vm",
+			Namespace: "default",
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{
+							Cores:   4,
+							Sockets: 1,
+							Threads: 1,
+						},
+						Memory: &kubevirtv1.Memory{
+							Guest: &memory,
+						},
+					},
+				},
+			},
+		},
+	}
+	mutator := vmMutator{}
+	testVMs := []*kubevirtv1.VirtualMachine{forkliftVM, nonForkliftVM}
+	assertions := require.New(t)
+	for _, vm := range testVMs {
+		var patchOps types.PatchOps
+		patchOps = mutator.patchMissingForkliftLimits(vm, patchOps)
+		patchData := fmt.Sprintf("[%s]", strings.Join(patchOps, ","))
+		vmJsonBytes, err := json.Marshal(vm)
+		assertions.NoError(err, "expected no error marshaling VM to JSON", vm.Name)
+		patchedVMJson, err := patch.Apply(vmJsonBytes, []byte(patchData))
+		assertions.NoError(err, "expected no error applying patch to VM JSON", vm.Name)
+		patchedVMObj := &kubevirtv1.VirtualMachine{}
+		err = json.Unmarshal(patchedVMJson, patchedVMObj)
+		assertions.NoError(err, "expected no error unmarshaling patched VM JSON", vm.Name)
+		if isCreatedByForklift(vm) {
+			totalCPUs := hardware.GetNumberOfVCPUs(vm.Spec.Template.Spec.Domain.CPU)
+			cpuLimit := resource.MustParse(strconv.FormatInt(totalCPUs, 10))
+			assertions.NotNil(patchedVMObj.Spec.Template.Spec.Domain.Resources.Limits.Cpu(), "expected CPU limit to be set for forklift VM", vm.Name)
+			assertions.NotNil(patchedVMObj.Spec.Template.Spec.Domain.Resources.Limits.Memory(), "expected Memory limit to be set for forklift VM", vm.Name)
+			assertions.True(patchedVMObj.Spec.Template.Spec.Domain.Resources.Limits.Cpu().Equal(cpuLimit), "expected CPU limit to equal total vCPUs for forklift VM", vm.Name)
+			assertions.True(patchedVMObj.Spec.Template.Spec.Domain.Resources.Limits.Memory().Equal(*vm.Spec.Template.Spec.Domain.Memory.Guest), "expected Memory limit to equal specified memory for forklift VM", vm.Name)
+		}
 	}
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
During QA we have observed the following issues with VM's created by forklift:
* [VM's migrated by forklift are stuck in terminating phase when deleted by user](https://github.com/harvester/suse-virtualization-mgmt/issues/30)
* [VM's migrated by forklift cannot be edited by Harvester UI ](https://github.com/harvester/suse-virtualization-mgmt/issues/28)
 
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
###### Forklift VM stuck in terminating phase
VM deletion is stuck due to logic in harvester-webhook to validate if pvc has VM owners.
If an owner reference is found the VM is blocked from deletion.
```
harvester-687cf4f67c-bjkpm apiserver time="2026-04-16T00:43:54Z" level=error msg="error syncing 'default/bun-multi-disk-efi-no-nic': handler VMController.CleanupPVCAndSnapshot: can't delete PVC default/bun-multi-disk-efi-no-nic-plan-vm-60325-h7ggv, err: admission webhook \"validator.harvesterhci.io\" denied the request: can not delete the volume bun-multi-disk-efi-no-nic-plan-vm-60325-h7ggv which is currently owned by these VMs: bun-multi-disk-efi-no-nic, requeuing"
```
The fix introduced in the PR involves a minor change to pvc owner reference logic, where we validate if the VM exists or is already marked for deletion, in which case pvc deletion is allowed.

####### Forklift VM not editable
This is cause as forklift does not set `vm.spec.template.spec.domain.resources.limits` on the VM object, which is used by the UI to render the basics panel in VM config.
The vm mutator now has additional logic to verify if VM creation request is due to forklift and accordingly patches the `vm.spec.template.spec.domain.resources.limits`

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/suse-virtualization-mgmt/issues/30
https://github.com/harvester/suse-virtualization-mgmt/issues/28

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
