### PR TITLE
fix(upgrade): add Plans to place/remove .skip files on RKE2 manifests

### DIFF
--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -308,6 +308,16 @@ func prepareSkipManifestPlan(upgrade *harvesterv1.Upgrade, manifests []string, s
 					Effect:   corev1.TaintEffectNoSchedule,
 					Value:    "arm",
 				},
+				{
+					Key:      corev1.TaintNodeNotReady,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      corev1.TaintNodeNetworkUnavailable,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
 			},
 			Upgrade: &upgradev1.ContainerSpec{
 				Image: upgrade.GetUpgradeImage(util.HarvesterUpgradeImageRepository, imageVersion),

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -19,9 +19,11 @@ import (
 )
 
 const (
-	nodeComponent     = "node"
-	manifestComponent = "manifest"
-	cleanupComponent  = "cleanup"
+	nodeComponent                = "node"
+	manifestComponent            = "manifest"
+	cleanupComponent             = "cleanup"
+	skipManifestsApplyComponent  = "apply-skip-manifests"
+	skipManifestsRemoveComponent = "remove-skip-manifests"
 
 	labelArch               = "kubernetes.io/arch"
 	labelCriticalAddonsOnly = "CriticalAddonsOnly"
@@ -34,7 +36,42 @@ const (
 	defaultTTLSecondsAfterFinished = 604800
 	// Give up to an hour for slower hardware to preload images.
 	defaultPrepareDeadlineSeconds = 3600
-	imageCleanupScript            = `
+	skipManifestScript            = `
+#!/usr/bin/env sh
+set -e
+
+HOST_DIR="${HOST_DIR:-/host}"
+MANIFESTS_DIR="$HOST_DIR/var/lib/rancher/rke2/server/manifests"
+
+if [ -z "$MANIFESTS" ]; then
+  echo "No manifests specified, nothing to do"
+  exit 0
+fi
+
+if [ ! -d "$MANIFESTS_DIR" ]; then
+  echo "Manifests directory $MANIFESTS_DIR does not exist, skipping"
+  exit 0
+fi
+
+for manifest in $MANIFESTS; do
+  skip_file="$MANIFESTS_DIR/${manifest}.skip"
+  case "$SKIP_ACTION" in
+    apply)
+      echo "Creating skip file: $skip_file"
+      touch "$skip_file"
+      ;;
+    remove)
+      echo "Removing skip file: $skip_file"
+      rm -vf "$skip_file"
+      ;;
+    *)
+      echo "Unknown SKIP_ACTION: $SKIP_ACTION (must be 'apply' or 'remove')"
+      exit 1
+      ;;
+  esac
+done
+`
+	imageCleanupScript = `
 #!/usr/bin/env sh
 set -e
 
@@ -203,6 +240,91 @@ func prepareUpgradeLog(upgrade *harvesterv1.Upgrade) *harvesterv1.UpgradeLog {
 		},
 		Spec: harvesterv1.UpgradeLogSpec{
 			UpgradeName: upgrade.Name,
+		},
+	}
+}
+
+func prepareSkipManifestPlan(upgrade *harvesterv1.Upgrade, manifests []string, skip bool) *upgradev1.Plan {
+	imageVersion := upgrade.Status.PreviousVersion
+
+	action, componentLabel := "remove", skipManifestsRemoveComponent
+	if skip {
+		action, componentLabel = "apply", skipManifestsApplyComponent
+	}
+
+	return &upgradev1.Plan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-skip-manifests-%s", upgrade.Name, action),
+			Namespace: sucNamespace,
+			Labels: map[string]string{
+				harvesterUpgradeLabel:          upgrade.Name,
+				harvesterUpgradeComponentLabel: componentLabel,
+			},
+		},
+		Spec: upgradev1.PlanSpec{
+			Concurrency: int64(len(upgrade.Status.NodeStatuses)),
+			Version:     upgrade.Name,
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					harvesterManagedLabel: "true",
+				},
+			},
+			ServiceAccountName: upgradeServiceAccount,
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      labelCriticalAddonsOnly,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "kubevirt.io/drain",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      util.KubeControlPlaneNodeLabelKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      util.KubeEtcdNodeLabelKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      labelArch,
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+					Value:    "amd64",
+				},
+				{
+					Key:      labelArch,
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+					Value:    "arm64",
+				},
+				{
+					Key:      labelArch,
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+					Value:    "arm",
+				},
+			},
+			Upgrade: &upgradev1.ContainerSpec{
+				Image: upgrade.GetUpgradeImage(util.HarvesterUpgradeImageRepository, imageVersion),
+				Command: []string{
+					"sh", "-c", skipManifestScript,
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "MANIFESTS",
+						Value: strings.Join(manifests, " "),
+					},
+					{
+						Name:  "SKIP_ACTION",
+						Value: action,
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/controller/master/upgrade/common.go
+++ b/pkg/controller/master/upgrade/common.go
@@ -22,8 +22,8 @@ const (
 	nodeComponent                = "node"
 	manifestComponent            = "manifest"
 	cleanupComponent             = "cleanup"
-	skipManifestsApplyComponent  = "apply-skip-manifests"
-	skipManifestsRemoveComponent = "remove-skip-manifests"
+	skipManifestsApplyComponent  = "apply-skip-rke2-manifests"
+	skipManifestsRemoveComponent = "remove-skip-rke2-manifests"
 
 	labelArch               = "kubernetes.io/arch"
 	labelCriticalAddonsOnly = "CriticalAddonsOnly"

--- a/pkg/controller/master/upgrade/plan_controller.go
+++ b/pkg/controller/master/upgrade/plan_controller.go
@@ -73,12 +73,17 @@ func (h *planHandler) OnChanged(_ string, plan *upgradev1.Plan) (*upgradev1.Plan
 	}
 
 	component := plan.Labels[harvesterUpgradeComponentLabel]
-	if component == cleanupComponent {
+	componentAnnotations := map[string]string{
+		skipManifestsApplyComponent:  skipManifestsApplyPlanCompletedAnnotation,
+		skipManifestsRemoveComponent: skipManifestsRemovePlanCompletedAnnotation,
+		cleanupComponent:             imageCleanupPlanCompletedAnnotation,
+	}
+	if annotation, ok := componentAnnotations[component]; ok {
 		toUpdate := upgrade.DeepCopy()
 		if toUpdate.Annotations == nil {
 			toUpdate.Annotations = make(map[string]string)
 		}
-		toUpdate.Annotations[imageCleanupPlanCompletedAnnotation] = strconv.FormatBool(true)
+		toUpdate.Annotations[annotation] = strconv.FormatBool(true)
 		if _, err := h.upgradeClient.Update(toUpdate); err != nil {
 			return plan, err
 		}

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -43,6 +43,7 @@ import (
 var (
 	upgradeControllerLock sync.Mutex
 	rke2DrainNodes        = true
+	manifestsToSkip       = []string{"rke2-multus.yaml"}
 )
 
 const (
@@ -74,10 +75,12 @@ const (
 	autoCleanupSystemGeneratedSnapshotSetting    = "auto-cleanup-system-generated-snapshot"
 	autoCleanupSystemGeneratedSnapshotAnnotation = "harvesterhci.io/" + autoCleanupSystemGeneratedSnapshotSetting
 
-	longhornSettingsRestoredAnnotation  = "harvesterhci.io/longhorn-settings-restored"
-	imageCleanupPlanCompletedAnnotation = "harvesterhci.io/image-cleanup-plan-completed"
-	skipVersionCheckAnnotation          = "harvesterhci.io/skip-version-check"
-	reenableDeschedulerAddonAnnotation  = "harvesterhci.io/reenable-descheduler-addon"
+	longhornSettingsRestoredAnnotation         = "harvesterhci.io/longhorn-settings-restored"
+	skipManifestsApplyPlanCompletedAnnotation  = "harvesterhci.io/apply-skip-manifests-plan-completed"
+	skipManifestsRemovePlanCompletedAnnotation = "harvesterhci.io/remove-skip-manifests-plan-completed"
+	imageCleanupPlanCompletedAnnotation        = "harvesterhci.io/image-cleanup-plan-completed"
+	skipVersionCheckAnnotation                 = "harvesterhci.io/skip-version-check"
+	reenableDeschedulerAddonAnnotation         = "harvesterhci.io/reenable-descheduler-addon"
 
 	defaultImagePreloadConcurrency = 1
 
@@ -227,6 +230,16 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 	// clean upgrade repo VMs and images if a upgrade succeeds.
 	if harvesterv1.UpgradeCompleted.IsTrue(upgrade) {
 		logrus.Infof("starting post-upgrade cleanup")
+		if upgrade.Status.SingleNode == "" {
+			// Remove .skip files placed before node upgrades so RKE2 resumes reconciling specified static manifests.
+			if _, err := h.planClient.Create(prepareSkipManifestPlan(upgrade, manifestsToSkip, false)); err != nil && !apierrors.IsAlreadyExists(err) {
+				return nil, err
+			}
+			if _, exists := upgrade.Annotations[skipManifestsRemovePlanCompletedAnnotation]; !exists {
+				logrus.Debugf("Waiting for %s plan to finish for upgrade %s", skipManifestsRemoveComponent, upgrade.Name)
+				return upgrade, nil
+			}
+		}
 		// try to clean up images before purging the repo VM
 		_, exists := upgrade.Annotations[imageCleanupPlanCompletedAnnotation]
 		if exists {
@@ -409,6 +422,17 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 				return h.upgradeClient.Update(toUpdate)
 			}
 		} else {
+			// Place .skip files to prevent RKE2 from reconciling specified static manifests during node upgrades.
+			// These will be removed in the post-upgrade cleanup phase.
+			if _, err := h.planClient.Create(prepareSkipManifestPlan(upgrade, manifestsToSkip, true)); err != nil && !apierrors.IsAlreadyExists(err) {
+				return nil, err
+			}
+
+			if _, exists := upgrade.Annotations[skipManifestsApplyPlanCompletedAnnotation]; !exists {
+				logrus.Debugf("Waiting for %s plan to finish for upgrade %s", skipManifestsApplyComponent, upgrade.Name)
+				return upgrade, nil
+			}
+
 			// save the original value of replica-replenishment-wait-interval setting and extend it with a longer value
 			// skip if the value is already larger than extendedReplicaReplenishmentWaitInterval
 			replicaReplenishmentWaitIntervalValue, err := h.getReplicaReplenishmentValue()
@@ -427,6 +451,7 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 			if err := h.addUpgradeLabelToDeschedulerAddons(toUpdate); err != nil {
 				return nil, err
 			}
+
 			// go with RKE2 pre-drain/post-drain hooks
 			logrus.Infof("Start upgrading Kubernetes runtime to %s", info.Release.Kubernetes)
 			if err := h.upgradeKubernetes(info.Release.Kubernetes); err != nil {

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -76,8 +76,8 @@ const (
 	autoCleanupSystemGeneratedSnapshotAnnotation = "harvesterhci.io/" + autoCleanupSystemGeneratedSnapshotSetting
 
 	longhornSettingsRestoredAnnotation         = "harvesterhci.io/longhorn-settings-restored"
-	skipManifestsApplyPlanCompletedAnnotation  = "harvesterhci.io/apply-skip-manifests-plan-completed"
-	skipManifestsRemovePlanCompletedAnnotation = "harvesterhci.io/remove-skip-manifests-plan-completed"
+	skipManifestsApplyPlanCompletedAnnotation  = "harvesterhci.io/apply-skip-rke2-manifests-plan-completed"
+	skipManifestsRemovePlanCompletedAnnotation = "harvesterhci.io/remove-skip-rke2-manifests-plan-completed"
 	imageCleanupPlanCompletedAnnotation        = "harvesterhci.io/image-cleanup-plan-completed"
 	skipVersionCheckAnnotation                 = "harvesterhci.io/skip-version-check"
 	reenableDeschedulerAddonAnnotation         = "harvesterhci.io/reenable-descheduler-addon"
@@ -230,16 +230,13 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 	// clean upgrade repo VMs and images if a upgrade succeeds.
 	if harvesterv1.UpgradeCompleted.IsTrue(upgrade) {
 		logrus.Infof("starting post-upgrade cleanup")
-		if upgrade.Status.SingleNode == "" {
-			// Remove .skip files placed before node upgrades so RKE2 resumes reconciling specified static manifests.
-			if _, err := h.planClient.Create(prepareSkipManifestPlan(upgrade, manifestsToSkip, false)); err != nil && !apierrors.IsAlreadyExists(err) {
-				return nil, err
-			}
-			if _, exists := upgrade.Annotations[skipManifestsRemovePlanCompletedAnnotation]; !exists {
-				logrus.Debugf("Waiting for %s plan to finish for upgrade %s", skipManifestsRemoveComponent, upgrade.Name)
-				return upgrade, nil
+
+		if _, exists := upgrade.Annotations[skipManifestsApplyPlanCompletedAnnotation]; exists {
+			if waiting, err := h.ensureSkipManifestPlanCompleted(upgrade, false); err != nil || waiting {
+				return upgrade, err
 			}
 		}
+
 		// try to clean up images before purging the repo VM
 		_, exists := upgrade.Annotations[imageCleanupPlanCompletedAnnotation]
 		if exists {
@@ -302,6 +299,13 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 	// upgrade failed
 	if harvesterv1.UpgradeCompleted.IsFalse(upgrade) {
 		logrus.Infof("upgrade failed... starting post-upgrade cleanup")
+
+		if _, exists := upgrade.Annotations[skipManifestsApplyPlanCompletedAnnotation]; exists {
+			if waiting, err := h.ensureSkipManifestPlanCompleted(upgrade, false); err != nil || waiting {
+				return upgrade, err
+			}
+		}
+
 		if upgrade.Labels[upgradeCleanupLabel] == StateSucceeded {
 			logrus.Infof("post-upgrade cleanup already completed")
 			return upgrade, nil
@@ -422,15 +426,8 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 				return h.upgradeClient.Update(toUpdate)
 			}
 		} else {
-			// Place .skip files to prevent RKE2 from reconciling specified static manifests during node upgrades.
-			// These will be removed in the post-upgrade cleanup phase.
-			if _, err := h.planClient.Create(prepareSkipManifestPlan(upgrade, manifestsToSkip, true)); err != nil && !apierrors.IsAlreadyExists(err) {
-				return nil, err
-			}
-
-			if _, exists := upgrade.Annotations[skipManifestsApplyPlanCompletedAnnotation]; !exists {
-				logrus.Debugf("Waiting for %s plan to finish for upgrade %s", skipManifestsApplyComponent, upgrade.Name)
-				return upgrade, nil
+			if waiting, err := h.ensureSkipManifestPlanCompleted(upgrade, true); err != nil || waiting {
+				return upgrade, err
 			}
 
 			// save the original value of replica-replenishment-wait-interval setting and extend it with a longer value
@@ -479,8 +476,35 @@ func (h *upgradeHandler) OnRemove(_ string, upgrade *harvesterv1.Upgrade) (*harv
 		return nil, nil
 	}
 
+	if _, exists := upgrade.Annotations[skipManifestsApplyPlanCompletedAnnotation]; exists {
+		if waiting, err := h.ensureSkipManifestPlanCompleted(upgrade, false); err != nil || waiting {
+			return upgrade, err
+		}
+	}
+
 	logrus.Debugf("Deleting upgrade %s", upgrade.Name)
 	return h.cleanup(upgrade, true)
+}
+
+// ensureSkipManifestPlanCompleted creates a Plan to apply/remove .skip files
+// and returns (true, nil) if still waiting, or (false, nil) if done.
+func (h *upgradeHandler) ensureSkipManifestPlanCompleted(upgrade *harvesterv1.Upgrade, skip bool) (bool, error) {
+	if _, err := h.planClient.Create(prepareSkipManifestPlan(upgrade, manifestsToSkip, skip)); err != nil && !apierrors.IsAlreadyExists(err) {
+		return false, err
+	}
+
+	annotation := skipManifestsRemovePlanCompletedAnnotation
+	component := skipManifestsRemoveComponent
+	if skip {
+		annotation = skipManifestsApplyPlanCompletedAnnotation
+		component = skipManifestsApplyComponent
+	}
+
+	if _, exists := upgrade.Annotations[annotation]; !exists {
+		logrus.Debugf("Waiting for %s plan to finish for upgrade %s", component, upgrade.Name)
+		return true, nil
+	}
+	return false, nil
 }
 
 func (h *upgradeHandler) cleanupImages(upgrade *harvesterv1.Upgrade, repo *Repo) error {

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -489,10 +489,6 @@ func (h *upgradeHandler) OnRemove(_ string, upgrade *harvesterv1.Upgrade) (*harv
 // ensureSkipManifestPlanCompleted creates a Plan to apply/remove .skip files
 // and returns (true, nil) if still waiting, or (false, nil) if done.
 func (h *upgradeHandler) ensureSkipManifestPlanCompleted(upgrade *harvesterv1.Upgrade, skip bool) (bool, error) {
-	if _, err := h.planClient.Create(prepareSkipManifestPlan(upgrade, manifestsToSkip, skip)); err != nil && !apierrors.IsAlreadyExists(err) {
-		return false, err
-	}
-
 	annotation := skipManifestsRemovePlanCompletedAnnotation
 	component := skipManifestsRemoveComponent
 	if skip {
@@ -500,11 +496,16 @@ func (h *upgradeHandler) ensureSkipManifestPlanCompleted(upgrade *harvesterv1.Up
 		component = skipManifestsApplyComponent
 	}
 
-	if _, exists := upgrade.Annotations[annotation]; !exists {
-		logrus.Debugf("Waiting for %s plan to finish for upgrade %s", component, upgrade.Name)
-		return true, nil
+	if _, exists := upgrade.Annotations[annotation]; exists {
+		return false, nil
 	}
-	return false, nil
+
+	if _, err := h.planClient.Create(prepareSkipManifestPlan(upgrade, manifestsToSkip, skip)); err != nil && !apierrors.IsAlreadyExists(err) {
+		return false, err
+	}
+
+	logrus.Debugf("Waiting for %s plan to finish for upgrade %s", component, upgrade.Name)
+	return true, nil
 }
 
 func (h *upgradeHandler) cleanupImages(upgrade *harvesterv1.Upgrade, repo *Repo) error {

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -265,6 +265,7 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 					ChartUpgradeStatus(v1.ConditionTrue, "", "").
 					NodesUpgradedCondition(v1.ConditionTrue, "", "").
 					WithAnnotation(imageCleanupPlanCompletedAnnotation, strconv.FormatBool(true)).
+					WithAnnotation(skipManifestsRemovePlanCompletedAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(autoCleanupSystemGeneratedSnapshotAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(replicaReplenishmentAnnotation, strconv.Itoa(600)).Build(),
 				version:      newVersionBuilder(testVersion).Build(),
@@ -292,6 +293,7 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 					ChartUpgradeStatus(v1.ConditionTrue, "", "").
 					NodesUpgradedCondition(v1.ConditionTrue, "", "").
 					WithAnnotation(imageCleanupPlanCompletedAnnotation, strconv.FormatBool(true)).
+					WithAnnotation(skipManifestsRemovePlanCompletedAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(longhornSettingsRestoredAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(autoCleanupSystemGeneratedSnapshotAnnotation, strconv.FormatBool(true)).
 					WithAnnotation(replicaReplenishmentAnnotation, strconv.Itoa(600)).
@@ -437,6 +439,8 @@ func TestUpgradeHandler_OnChanged(t *testing.T) {
 			vmImageClient:      fakeclients.VirtualMachineImageClient(clientset.HarvesterhciV1beta1().VirtualMachineImages),
 			vmImageCache:       fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
 			vmCache:            fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines),
+			jobClient:          fakeclients.JobClient(clientset.BatchV1().Jobs),
+			jobCache:           fakeclients.JobCache(clientset.BatchV1().Jobs),
 			kubevirtClient:     fakeclients.KubeVirtClient(clientset.KubevirtV1().KubeVirts),
 			kubevirtCache:      fakeclients.KubeVirtCache(clientset.KubevirtV1().KubeVirts),
 			serviceClient:      fakeclients.ServiceClient(clientset.CoreV1().Services),

--- a/pkg/util/fakeclients/plan.go
+++ b/pkg/util/fakeclients/plan.go
@@ -25,8 +25,8 @@ func (c PlanClient) Get(namespace, name string, options metav1.GetOptions) (*upg
 func (c PlanClient) Create(plan *upgradeapiv1.Plan) (*upgradeapiv1.Plan, error) {
 	return c(plan.Namespace).Create(context.TODO(), plan, metav1.CreateOptions{})
 }
-func (c PlanClient) Delete(_, _ string, _ *metav1.DeleteOptions) error {
-	panic("implement me")
+func (c PlanClient) Delete(namespace, name string, _ *metav1.DeleteOptions) error {
+	return c(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 func (c PlanClient) List(_ string, _ metav1.ListOptions) (*upgradeapiv1.PlanList, error) {
 	panic("implement me")


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Although the root cause remains unclear, interrupted rke2-multus upgrades could have removed the NAD CRD and thus the user-created NADs entirely.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Dropping a `.skip` file for the `rke2-multus.yaml` static manifest under the path `/var/lib/rancher/rke2/server/manifests/` on each node before performing node upgrades should prevent RKE2 from upgrading the rke2-multus chart release for the entire cluster. This could indirectly protect the cluster from losing the NAD CRD and thus the user-created NADs.
The `.skip` file will be removed after the node upgrade is completed on all nodes. RKE2 on each node should be able to upgrade the chart release.
The mechanism only applies to multi-node clusters.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#10359 

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Prepare a 3-node cluster in v1.7.1
2. Check the rke2-multus chart release version. It should be something like below:
   ```
   $ helm -n kube-system list | grep rke2-multus
   rke2-multus             kube-system     1               2026-04-16 03:03:23.273451045 +0000 UTC deployed        rke2-multus-v4.2.311                    4.2.3
   ```
3. Have the ISO image ready (should include the proposed change)
4. Trigger the upgrade with the ISO image
5. During the node upgrade stage, observe that there should be a `rke2-multus.yaml.skip` file under `/var/lib/rancher/rke2/server/manifests/` on each node
6. After the upgrade completed, the `rke2-multus.yaml.skip` should be gone
7. Check the rke2-multus chart release version. It should be newer than the one observed in step 2

#### Additional documentation or context
