### PR TITLE
fix: bind mount /lib during upgrade (needed for ARM)

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -712,6 +712,8 @@ EOF
   if [ -n "$glibc_too_old" ]; then
     echo "GLIBC on host is too old for new elemental build; bind mounting /lib64 to fix"
     mount -o bind /lib64 $HOST_DIR/lib64
+    # /lib is also necessary for ARM
+    mount -o bind /lib $HOST_DIR/lib
   fi
   chroot $HOST_DIR /tmp/elemental upgrade \
     --logfile "$elemental_upgrade_log" \
@@ -720,6 +722,7 @@ EOF
     --debug || ret=$?
   if [ -n "$glibc_too_old" ]; then
     umount $HOST_DIR/lib64
+    umount $HOST_DIR/lib
   fi
   if [ "$ret" != 0 ]; then
     echo "elemental upgrade failed with return code: $ret"


### PR DESCRIPTION
#### Problem:
The earlier fix to bind mount /lib64 during upgrade to ensure an updated glibc is available in the upgrade container worked on x86_64, but isn't enough on aarch64.  We need to also bring in /lib.  This is because, on SL Micro 5.5 on aarch64, /lib/ld-linux-aarch64.so.1 is a symlink to /lib64/ld-2.31.so, so if we bind mount /lib64 from the upgrade container over the host, we lose that link target and no binaries will run inside the chroot.

#### Solution:
Bind mounting /lib as well brings in an updated version of /lib/ld-linux-aarch64.so.1, which on SL Micro 6.1 is just a regular file, not a symlink.  Adding /lib  causes no trouble on x86_64 and saves us from having to complicate things with architecture specific conditionals.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10286

#### Test plan:
- Not possible to test properly when upgrading from v1.8.x -> master with this fix, because the $glibc_too_old check won't trigger during upgrades.
- If upgrading from v1.6.x -> v1.7.x with this fix, the affected code _will_ trigger, so just make sure upgrade succeeds on both x86_64 and aarch64. A single node cluster is fine.

#### Additional documentation or context
I've tested an upgrade from v1.6.1 -> v1.7.1 + this fix on x86_64 and the addition of /lib to the bind mount does not cause any trouble.

I've done a manual test of this on aarch64, as follows:

```
h161-aarch64:~ # docker run --rm -it --privileged -v/:/host rancher/harvester-upgrade:v1.7.1 /bin/bash
6e0f54145160:/ # cp /usr/local/bin/elemental /host/tmp/elemental
6e0f54145160:/ # chroot /host /tmp/elemental version
/tmp/elemental: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /tmp/elemental)
/tmp/elemental: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /tmp/elemental)
^ that's the original problem bind mounting /lib64 was meant to fix

6e0f54145160:/ # mount -o bind /lib64 /host/lib64
6e0f54145160:/ # chroot /host /tmp/elemental version
chroot: failed to run command '/tmp/elemental': No such file or directory
^ that's the subsequent failure on aarch64 (not a problem on x86_64, whose ld-linux-x86_64.so.* lives in /lib64, not /lib)

6e0f54145160:/ # mount -o bind /lib /host/lib
6e0f54145160:/ # chroot /host /tmp/elemental version
1.1.7+gd6f7ff8
^ proof bind mounting /lib fixes the problem
```

Update 2026-07-27: I did manage to test a single node upgrade from v1.6.1 -> v1.7.1 plus this fix on real arm hardware, and it went through fine.

There's no point backporting this to v1.8 because the affected code won't trigger when upgrading from v1.7.x to v1.8.x anyway.

IMO we should still put it into master first then backport to v1.7.  Even though the code doesn't trigger in master ATM it's not impossible we might hit another elemental/glibc upgrade mismatch in some future upgrade, so I'd like master to carry the fix just in case of future trouble.