### PR TITLE
skip vlanconfig with empty matched nodes for storage network

### DIFF
--- a/pkg/util/fakeclients/clusternetwork.go
+++ b/pkg/util/fakeclients/clusternetwork.go
@@ -1,0 +1,74 @@
+package fakeclients
+
+import (
+	"context"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+	networktype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/network.harvesterhci.io/v1beta1"
+)
+
+type ClusterNetworkClient func() networktype.ClusterNetworkInterface
+
+func (c ClusterNetworkClient) Create(s *v1beta1.ClusterNetwork) (*v1beta1.ClusterNetwork, error) {
+	return c().Create(context.TODO(), s, metav1.CreateOptions{})
+}
+
+func (c ClusterNetworkClient) Update(s *v1beta1.ClusterNetwork) (*v1beta1.ClusterNetwork, error) {
+	return c().Update(context.TODO(), s, metav1.UpdateOptions{})
+}
+
+func (c ClusterNetworkClient) UpdateStatus(_ *v1beta1.ClusterNetwork) (*v1beta1.ClusterNetwork, error) {
+	panic("implement me")
+}
+
+func (c ClusterNetworkClient) Delete(name string, options *metav1.DeleteOptions) error {
+	return c().Delete(context.TODO(), name, *options)
+}
+
+func (c ClusterNetworkClient) Get(name string, options metav1.GetOptions) (*v1beta1.ClusterNetwork, error) {
+	return c().Get(context.TODO(), name, options)
+}
+
+func (c ClusterNetworkClient) List(opts metav1.ListOptions) (*v1beta1.ClusterNetworkList, error) {
+	return c().List(context.TODO(), opts)
+}
+
+func (c ClusterNetworkClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	return c().Watch(context.TODO(), opts)
+}
+
+func (c ClusterNetworkClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterNetwork, err error) {
+	return c().Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}
+
+type ClusterNetworkCache func() networktype.ClusterNetworkInterface
+
+func (c ClusterNetworkCache) Get(name string) (*v1beta1.ClusterNetwork, error) {
+	return c().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c ClusterNetworkCache) List(selector labels.Selector) ([]*v1beta1.ClusterNetwork, error) {
+	list, err := c().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*v1beta1.ClusterNetwork, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, err
+}
+
+func (c ClusterNetworkCache) AddIndexer(_ string, _ generic.Indexer[*v1beta1.ClusterNetwork]) {
+	panic("implement me")
+}
+
+func (c ClusterNetworkCache) GetByIndex(_, _ string) ([]*v1beta1.ClusterNetwork, error) {
+	panic("implement me")
+}

--- a/pkg/util/fakeclients/vlanconfig.go
+++ b/pkg/util/fakeclients/vlanconfig.go
@@ -1,0 +1,74 @@
+package fakeclients
+
+import (
+	"context"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+	networktype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/network.harvesterhci.io/v1beta1"
+)
+
+type VlanConfigClient func() networktype.VlanConfigInterface
+
+func (c VlanConfigClient) Create(s *v1beta1.VlanConfig) (*v1beta1.VlanConfig, error) {
+	return c().Create(context.TODO(), s, metav1.CreateOptions{})
+}
+
+func (c VlanConfigClient) Update(s *v1beta1.VlanConfig) (*v1beta1.VlanConfig, error) {
+	return c().Update(context.TODO(), s, metav1.UpdateOptions{})
+}
+
+func (c VlanConfigClient) UpdateStatus(_ *v1beta1.VlanConfig) (*v1beta1.VlanConfig, error) {
+	panic("implement me")
+}
+
+func (c VlanConfigClient) Delete(name string, options *metav1.DeleteOptions) error {
+	return c().Delete(context.TODO(), name, *options)
+}
+
+func (c VlanConfigClient) Get(name string, options metav1.GetOptions) (*v1beta1.VlanConfig, error) {
+	return c().Get(context.TODO(), name, options)
+}
+
+func (c VlanConfigClient) List(opts metav1.ListOptions) (*v1beta1.VlanConfigList, error) {
+	return c().List(context.TODO(), opts)
+}
+
+func (c VlanConfigClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	return c().Watch(context.TODO(), opts)
+}
+
+func (c VlanConfigClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.VlanConfig, err error) {
+	return c().Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}
+
+type VlanConfigCache func() networktype.VlanConfigInterface
+
+func (c VlanConfigCache) Get(name string) (*v1beta1.VlanConfig, error) {
+	return c().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c VlanConfigCache) List(selector labels.Selector) ([]*v1beta1.VlanConfig, error) {
+	list, err := c().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*v1beta1.VlanConfig, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, err
+}
+
+func (c VlanConfigCache) AddIndexer(_ string, _ generic.Indexer[*v1beta1.VlanConfig]) {
+	panic("implement me")
+}
+
+func (c VlanConfigCache) GetByIndex(_, _ string) ([]*v1beta1.VlanConfig, error) {
+	panic("implement me")
+}

--- a/pkg/util/fakeclients/vlanstatus.go
+++ b/pkg/util/fakeclients/vlanstatus.go
@@ -1,0 +1,74 @@
+package fakeclients
+
+import (
+	"context"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+	networktype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/network.harvesterhci.io/v1beta1"
+)
+
+type VlanStatusClient func() networktype.VlanStatusInterface
+
+func (c VlanStatusClient) Create(s *v1beta1.VlanStatus) (*v1beta1.VlanStatus, error) {
+	return c().Create(context.TODO(), s, metav1.CreateOptions{})
+}
+
+func (c VlanStatusClient) Update(s *v1beta1.VlanStatus) (*v1beta1.VlanStatus, error) {
+	return c().Update(context.TODO(), s, metav1.UpdateOptions{})
+}
+
+func (c VlanStatusClient) UpdateStatus(_ *v1beta1.VlanStatus) (*v1beta1.VlanStatus, error) {
+	panic("implement me")
+}
+
+func (c VlanStatusClient) Delete(name string, options *metav1.DeleteOptions) error {
+	return c().Delete(context.TODO(), name, *options)
+}
+
+func (c VlanStatusClient) Get(name string, options metav1.GetOptions) (*v1beta1.VlanStatus, error) {
+	return c().Get(context.TODO(), name, options)
+}
+
+func (c VlanStatusClient) List(opts metav1.ListOptions) (*v1beta1.VlanStatusList, error) {
+	return c().List(context.TODO(), opts)
+}
+
+func (c VlanStatusClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	return c().Watch(context.TODO(), opts)
+}
+
+func (c VlanStatusClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.VlanStatus, err error) {
+	return c().Patch(context.TODO(), name, pt, data, metav1.PatchOptions{}, subresources...)
+}
+
+type VlanStatusCache func() networktype.VlanStatusInterface
+
+func (c VlanStatusCache) Get(name string) (*v1beta1.VlanStatus, error) {
+	return c().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c VlanStatusCache) List(selector labels.Selector) ([]*v1beta1.VlanStatus, error) {
+	list, err := c().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*v1beta1.VlanStatus, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, err
+}
+
+func (c VlanStatusCache) AddIndexer(_ string, _ generic.Indexer[*v1beta1.VlanStatus]) {
+	panic("implement me")
+}
+
+func (c VlanStatusCache) GetByIndex(_, _ string) ([]*v1beta1.VlanStatus, error) {
+	panic("implement me")
+}

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -1724,11 +1724,12 @@ func (v *settingValidator) checkVlanStatusReady(config *networkutil.Config) erro
 }
 
 func getMatchNodes(vc *networkv1.VlanConfig) ([]string, error) {
-	if vc.Annotations == nil || vc.Annotations[utils.KeyMatchedNodes] == "" {
-		return nil, fmt.Errorf("vlan config annotations is absent for matched nodes")
+	var matchedNodes []string
+	//skip not ready vlan configs because they will not be applied to any nodes, and if there is at least one ready vlan config spanning all nodes, the network will work fine
+	if vc.Annotations == nil || vc.Annotations[utils.KeyMatchedNodes] == "" || vc.Annotations[utils.KeyMatchedNodes] == "[]" {
+		return matchedNodes, nil
 	}
 
-	var matchedNodes []string
 	if err := json.Unmarshal([]byte(vc.Annotations[utils.KeyMatchedNodes]), &matchedNodes); err != nil {
 		return nil, err
 	}
@@ -1755,6 +1756,7 @@ func (v *settingValidator) checkVCSpansAllNodes(config *networkutil.Config) erro
 		return fmt.Errorf("vlan config not present for cluster network %s", config.ClusterNetwork)
 	}
 
+	//There will be atleast 1 vlanconfig with non-empty matched nodes, else it will be caught by checkVlanStatusReady (len(vsList) will be 0 if there is no vlanconfig)
 	for _, vc := range vcs {
 		vnodes, err := getMatchNodes(vc)
 		if err != nil {

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -12,6 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester-network-controller/pkg/utils"
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/controller/master/storagenetwork"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -20,6 +22,12 @@ import (
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 	networkutil "github.com/harvester/harvester/pkg/util/network"
 	whTypes "github.com/harvester/harvester/pkg/webhook/types"
+)
+
+const (
+	testCnName     = "test-cn"
+	testNewVCName  = "newVC"
+	testNewVC1Name = "newVC1"
 )
 
 func Test_validateOvercommitConfig(t *testing.T) {
@@ -1364,7 +1372,220 @@ func Test_validateStorageNetworkConfig(t *testing.T) {
 				assert.True(t, strings.Contains(err.Error(), tt.errMsg))
 			}
 		})
+	}
+}
 
+func Test_validateStorageNetworkVlanConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      *v1beta1.Setting
+		currentCN *networkv1.ClusterNetwork
+		vc1       *networkv1.VlanConfig
+		vc2       *networkv1.VlanConfig
+		vs2       *networkv1.VlanStatus
+		vs1       *networkv1.VlanStatus
+		node1     *corev1.Node
+		node2     *corev1.Node
+		errMsg    string
+	}{
+		{
+			name:   "storage network with vlan config not spanning all nodes in the cluster network returns error",
+			errMsg: "vlanconfig does not span",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"vlan":51,"clusterNetwork":"` + testCnName + `","range":"192.168.50.0/24","exclude":["192.168.50.1/32","192.168.50.2/32"]}`,
+			},
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+
+			vc1: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVCName,
+					Annotations: map[string]string{"test": "test", utils.KeyMatchedNodes: ""},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+				},
+			},
+			vc2: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVC1Name,
+					Annotations: map[string]string{"test": "test", utils.KeyMatchedNodes: "[\"node1\"]"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+				},
+			},
+			vs2: &networkv1.VlanStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        utils.Name("", testCnName, "node1"),
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyVlanConfigLabel: testNewVC1Name, utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Status: networkv1.VlStatus{
+					ClusterNetwork: testCnName,
+					VlanConfig:     testNewVC1Name,
+					Conditions: []networkv1.Condition{
+						{
+							Type:   networkv1.Ready,
+							Status: "True",
+						},
+					},
+				},
+			},
+			node1: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			node2: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+			},
+		},
+		{
+			name:   "storage network with vlan config spanning all nodes in the cluster network and vlanconfig with empty matched nodes should be accepted",
+			errMsg: "",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"vlan":51,"clusterNetwork":"` + testCnName + `","range":"192.168.50.0/24","exclude":["192.168.50.1/32","192.168.50.2/32"]}`,
+			},
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+
+			vc1: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVCName,
+					Annotations: map[string]string{"test": "test", utils.KeyMatchedNodes: ""},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+				},
+			},
+			vc2: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVC1Name,
+					Annotations: map[string]string{"test": "test", utils.KeyMatchedNodes: "[\"node1\",\"node2\"]"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+				},
+			},
+			vs2: &networkv1.VlanStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        utils.Name("", testCnName, "node1"),
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyVlanConfigLabel: testNewVC1Name, utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Status: networkv1.VlStatus{
+					ClusterNetwork: testCnName,
+					VlanConfig:     testNewVC1Name,
+					Conditions: []networkv1.Condition{
+						{
+							Type:   networkv1.Ready,
+							Status: "True",
+						},
+					},
+				},
+			},
+			vs1: &networkv1.VlanStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        utils.Name("", testCnName, "node2"),
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyVlanConfigLabel: testNewVC1Name, utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Status: networkv1.VlStatus{
+					ClusterNetwork: testCnName,
+					VlanConfig:     testNewVC1Name,
+					Conditions: []networkv1.Condition{
+						{
+							Type:   networkv1.Ready,
+							Status: "True",
+						},
+					},
+				},
+			},
+			node1: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			node2: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		nchclientset := fake.NewSimpleClientset()
+		nodeClient := fakeclients.NodeClient(nchclientset.CoreV1().Nodes)
+		vcClient := fakeclients.VlanConfigClient(nchclientset.NetworkV1beta1().VlanConfigs)
+		vsClient := fakeclients.VlanStatusClient(nchclientset.NetworkV1beta1().VlanStatuses)
+		cnClient := fakeclients.ClusterNetworkClient(nchclientset.NetworkV1beta1().ClusterNetworks)
+
+		nodeCache := fakeclients.NodeCache(nchclientset.CoreV1().Nodes)
+		vcCache := fakeclients.VlanConfigCache(nchclientset.NetworkV1beta1().VlanConfigs)
+		vsCache := fakeclients.VlanStatusCache(nchclientset.NetworkV1beta1().VlanStatuses)
+		lhNodeCache := fakeclients.LonghornNodeCache(nchclientset.LonghornV1beta2().Nodes)
+		cnCache := fakeclients.ClusterNetworkCache(nchclientset.NetworkV1beta1().ClusterNetworks)
+		vmCache := fakeclients.VirtualMachineCache(nchclientset.KubevirtV1().VirtualMachines)
+		vmiCache := fakeclients.VirtualMachineInstanceCache(nchclientset.KubevirtV1().VirtualMachineInstances)
+
+		clientset := fake.NewSimpleClientset()
+		v := NewValidator(fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings), nodeCache, nil, nil, nil, vmCache, vmiCache, nil, nil, fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes), fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims), cnCache, vcCache, vsCache, lhNodeCache, nil)
+
+		if tt.currentCN != nil {
+			_, err := cnClient.Create(tt.currentCN)
+			assert.NoError(t, err)
+		}
+
+		if tt.vc1 != nil {
+			_, err := vcClient.Create(tt.vc1)
+			assert.NoError(t, err)
+		}
+
+		if tt.vc2 != nil {
+			_, err := vcClient.Create(tt.vc2)
+			assert.NoError(t, err)
+		}
+
+		if tt.vs2 != nil {
+			_, err := vsClient.Create(tt.vs2)
+			assert.NoError(t, err)
+		}
+
+		if tt.node1 != nil {
+			_, err := nodeClient.Create(tt.node1)
+			assert.NoError(t, err)
+		}
+		if tt.node2 != nil {
+			_, err := nodeClient.Create(tt.node2)
+			assert.NoError(t, err)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Create(nil, tt.args)
+			if err != nil {
+				assert.True(t, strings.Contains(err.Error(), tt.errMsg))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### Problem:
storage network cannot be created when it has vlanconfig with empty matched nodes.

#### Solution:
Allow creation of storage networks if it has vlanconfigs with empty matched nodes if there are other vlanconfigs present for the same cluster spanning all nodes.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9332

#### Test plan:
1.Create a cluster network "cluster"
2.Create a vlanconfig1 under "cluster" as  with some random node selector (select the nic, then add node selector)
3.Create another vlanconfig2 under the same cluster "cluster" selecting all nodes in the cluster and uplink physical interface.
4.The UI will show 2 vlanconfigs with vlanconfig1 as "not ready" and vlanconfig2 as ready.
5.Create a storage network using cluster network "cluster"
6.storage network creation should be successful

Without the fix:
The webhook will throw "vlanconfig annotations is absent for matched nodes" while storage network creation as one of the vlanconfig exists with empty matched nodes list.

#### Additional documentation or context

vlanconfig with node selectors can be in any order, say a vlanconfig with nodeselector "foo"/"bar" created but no nodes exists with that label.This vlanconfig will be "not ready" status until user adds the same label to any of the nodes.The vlanconfig now moves to ready state if any of the nodes in the cluster matches the same label and it will be added to the matched nodes list of vlanconfig annotations.Since change of vlanconfig status and matched node annotations is dynamic, a vlanconfig in the same cluster network with empty matched nodes list is a valid configuration.So storage network creation should not reject those vlanconfigs instead those vlanconfigs must be skipped if other vlanconfigs in the same cluster network are present which spans all the nodes in the cluster.
