### PR TITLE
Prevent VM start after restore from backup or snapshot

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9231,6 +9231,9 @@
           "deletionPolicy": {
             "type": "string"
           },
+          "haltAfterRestore": {
+            "type": "boolean"
+          },
           "keepMacAddress": {
             "type": "boolean"
           },

--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinerestores.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinerestores.yaml
@@ -62,6 +62,11 @@ spec:
                 description: DeletionPolicy defines that to do with resources when
                   VirtualMachineRestore is deleted
                 type: string
+              haltAfterRestore:
+                description: |-
+                  HaltAfterRestore defines whether the VM should remain halted after the restore is complete.
+                  If false (default), the VM will be started after a successful restore.
+                type: boolean
               keepMacAddress:
                 description: |-
                   KeepMacAddress only works when NewVM is true.

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -876,7 +876,18 @@ func (h *vmActionHandler) restoreBackup(vmName, vmNamespace string, input Restor
 	if _, err := h.backupCache.Get(vmNamespace, input.BackupName); err != nil {
 		return err
 	}
-	apiGroup := kubevirtv1.SchemeGroupVersion.Group
+
+	restore := buildVirtualMachineRestore(vmName, vmNamespace, input)
+
+	_, err := h.restoreClient.Create(restore)
+	if err != nil {
+		return fmt.Errorf("failed to create restore, error: %v", err)
+	}
+
+	return nil
+}
+
+func buildVirtualMachineRestore(vmName, vmNamespace string, input RestoreInput) *harvesterv1.VirtualMachineRestore {
 	restore := &harvesterv1.VirtualMachineRestore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      input.Name,
@@ -884,7 +895,7 @@ func (h *vmActionHandler) restoreBackup(vmName, vmNamespace string, input Restor
 		},
 		Spec: harvesterv1.VirtualMachineRestoreSpec{
 			Target: corev1.TypedLocalObjectReference{
-				APIGroup: &apiGroup,
+				APIGroup: ptr.To(kubevirtv1.SchemeGroupVersion.Group),
 				Kind:     kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 				Name:     vmName,
 			},
@@ -893,12 +904,16 @@ func (h *vmActionHandler) restoreBackup(vmName, vmNamespace string, input Restor
 			NewVM:                         false,
 		},
 	}
-	_, err := h.restoreClient.Create(restore)
-	if err != nil {
-		return fmt.Errorf("failed to create restore, error: %s", err.Error())
+
+	if input.KeepMacAddress {
+		restore.Spec.KeepMacAddress = true
 	}
 
-	return nil
+	if input.HaltAfterRestore {
+		restore.Spec.HaltAfterRestore = true
+	}
+
+	return restore
 }
 
 func (h *vmActionHandler) checkBackupTargetConfigured() error {

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -16,12 +16,13 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kubevirtutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/controller/master/migration"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
-	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
 func TestMigrateAction(t *testing.T) {
@@ -1586,4 +1587,48 @@ func TestEjectCdRomVolumeAction(t *testing.T) {
 
 	_, err = pvcCache.Get(pvcNamespace, pvcName)
 	assert.True(t, apierrors.IsNotFound(err), "Should delete pvc")
+}
+
+func TestBuildVirtualMachineRestore(t *testing.T) {
+	tests := []struct {
+		name        string
+		vmName      string
+		vmNamespace string
+		input       RestoreInput
+	}{
+		{
+			name:        "builds restore with default flags",
+			vmName:      "vm-default",
+			vmNamespace: "ns-default",
+			input: RestoreInput{
+				Name:       "restore-default",
+				BackupName: "backup-default",
+			},
+		},
+		{
+			name:        "builds restore with keep mac and halt flags",
+			vmName:      "vm-flags",
+			vmNamespace: "ns-flags",
+			input: RestoreInput{
+				Name:             "restore-flags",
+				BackupName:       "backup-flags",
+				KeepMacAddress:   true,
+				HaltAfterRestore: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildVirtualMachineRestore(tt.vmName, tt.vmNamespace, tt.input)
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.vmName, got.Spec.Target.Name)
+			assert.Equal(t, tt.vmNamespace, got.Namespace)
+			assert.Equal(t, tt.vmNamespace, got.Spec.VirtualMachineBackupNamespace)
+			assert.Equal(t, tt.input.Name, got.Name)
+			assert.Equal(t, tt.input.BackupName, got.Spec.VirtualMachineBackupName)
+			assert.Equal(t, tt.input.KeepMacAddress, got.Spec.KeepMacAddress)
+			assert.Equal(t, tt.input.HaltAfterRestore, got.Spec.HaltAfterRestore)
+		})
+	}
 }

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -20,8 +20,10 @@ type BackupInput struct {
 }
 
 type RestoreInput struct {
-	Name       string `json:"name"`
-	BackupName string `json:"backupName"`
+	Name             string `json:"name"`
+	BackupName       string `json:"backupName"`
+	KeepMacAddress   bool   `json:"keepMacAddress,omitempty"`
+	HaltAfterRestore bool   `json:"haltAfterRestore,omitempty"`
 }
 
 type MigrateInput struct {

--- a/pkg/apis/harvesterhci.io/v1beta1/backup.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/backup.go
@@ -211,6 +211,11 @@ type VirtualMachineRestoreSpec struct {
 	// KeepMacAddress only works when NewVM is true.
 	// For replacing original VM, the macaddress will be the same.
 	KeepMacAddress bool `json:"keepMacAddress,omitempty"`
+
+	// +optional
+	// HaltAfterRestore defines whether the VM should remain halted after the restore is complete.
+	// If false (default), the VM will be started after a successful restore.
+	HaltAfterRestore bool `json:"haltAfterRestore,omitempty"`
 }
 
 // VirtualMachineRestoreStatus is the spec for a VirtualMachineRestore resource

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -4647,6 +4647,13 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineRestoreSpec(ref common
 							Format:      "",
 						},
 					},
+					"haltAfterRestore": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HaltAfterRestore defines whether the VM should remain halted after the restore is complete. If false (default), the VM will be started after a successful restore.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"target", "virtualMachineBackupName", "virtualMachineBackupNamespace"},
 			},

--- a/pkg/controller/master/backup/restore.go
+++ b/pkg/controller/master/backup/restore.go
@@ -732,10 +732,7 @@ func (h *RestoreHandler) createNewVM(restore *harvesterv1.VirtualMachineRestore,
 		return nil, err
 	}
 
-	defaultRunStrategy := kubevirtv1.RunStrategyRerunOnFailure
-	if backup.Status.SourceSpec.Spec.RunStrategy != nil {
-		defaultRunStrategy = *backup.Status.SourceSpec.Spec.RunStrategy
-	}
+	defaultRunStrategy := resolveRunStrategyFromRestoreAndBackup(restore, backup)
 
 	vm := &kubevirtv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -744,7 +741,7 @@ func (h *RestoreHandler) createNewVM(restore *harvesterv1.VirtualMachineRestore,
 			Annotations: newVMAnnotations,
 		},
 		Spec: kubevirtv1.VirtualMachineSpec{
-			RunStrategy: &defaultRunStrategy,
+			RunStrategy: ptr.To(defaultRunStrategy),
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: newVMSpecAnnotations,
@@ -1132,7 +1129,7 @@ func (h *RestoreHandler) startVM(vm *kubevirtv1.VirtualMachine) error {
 		return err
 	}
 
-	logrus.Infof("starting the vm %s, current state running:%v", vm.Name, runStrategy)
+	logrus.Infof("starting the vm %s, current run strategy: %v", vm.Name, runStrategy)
 	switch runStrategy {
 	case kubevirtv1.RunStrategyAlways:
 		return nil
@@ -1265,22 +1262,24 @@ func (h *RestoreHandler) updateStatus(
 		return nil
 	}
 
-	// start VM before checking status
-	if err := h.startVM(vm); err != nil {
-		return h.updateStatusError(vmRestore, fmt.Errorf("failed to start vm, err:%s", err.Error()), false)
-	}
-
-	if !vm.Status.Ready {
-		h.recifyProgressBeforeVMStart(restoreCpy)
-		message := "Waiting for target vm to be ready"
-		setCondition(restoreCpy, harvesterv1.BackupConditionProgressing, true, "", message)
-		setCondition(restoreCpy, harvesterv1.BackupConditionReady, false, "", message)
-		if !reflect.DeepEqual(vmRestore, restoreCpy) {
-			if _, err := h.restores.Update(restoreCpy); err != nil {
-				return err
-			}
+	if !vmRestore.Spec.HaltAfterRestore {
+		// start VM before checking status
+		if err := h.startVM(vm); err != nil {
+			return h.updateStatusError(vmRestore, fmt.Errorf("failed to start vm, err:%s", err.Error()), false)
 		}
-		return nil
+
+		if !vm.Status.Ready {
+			h.recifyProgressBeforeVMStart(restoreCpy)
+			message := "Waiting for target vm to be ready"
+			setCondition(restoreCpy, harvesterv1.BackupConditionProgressing, true, "", message)
+			setCondition(restoreCpy, harvesterv1.BackupConditionReady, false, "", message)
+			if !reflect.DeepEqual(vmRestore, restoreCpy) {
+				if _, err := h.restores.Update(restoreCpy); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 	}
 
 	if err := h.deleteOldPVC(restoreCpy, vm); err != nil {
@@ -1337,4 +1336,14 @@ func (h *RestoreHandler) constructVolumeSnapshotContentName(restoreNamespace, re
 	// VolumeSnapshotContent is cluster-scoped resource,
 	// so adding restoreNamespace to its name to prevent conflict in different namespace with same restore name and backup
 	return name.SafeConcatName("restore", restoreNamespace, restoreName, volumeBackupName)
+}
+
+func resolveRunStrategyFromRestoreAndBackup(restore *harvesterv1.VirtualMachineRestore, backup *harvesterv1.VirtualMachineBackup) kubevirtv1.VirtualMachineRunStrategy {
+	defaultRunStrategy := kubevirtv1.RunStrategyRerunOnFailure
+	if restore != nil && restore.Spec.HaltAfterRestore {
+		defaultRunStrategy = kubevirtv1.RunStrategyHalted
+	} else if backup != nil && backup.Status.SourceSpec != nil && backup.Status.SourceSpec.Spec.RunStrategy != nil {
+		defaultRunStrategy = *backup.Status.SourceSpec.Spec.RunStrategy
+	}
+	return defaultRunStrategy
 }

--- a/pkg/controller/master/backup/restore_test.go
+++ b/pkg/controller/master/backup/restore_test.go
@@ -1,0 +1,112 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+)
+
+func TestResolveRunStrategyFromRestoreAndBackup(t *testing.T) {
+	tests := []struct {
+		name     string
+		restore  *harvesterv1.VirtualMachineRestore
+		backup   *harvesterv1.VirtualMachineBackup
+		expected kubevirtv1.VirtualMachineRunStrategy
+	}{
+		{
+			name: "halt after restore overrides source run strategy",
+			restore: &harvesterv1.VirtualMachineRestore{
+				Spec: harvesterv1.VirtualMachineRestoreSpec{HaltAfterRestore: true},
+			},
+			backup: &harvesterv1.VirtualMachineBackup{
+				Status: harvesterv1.VirtualMachineBackupStatus{
+					SourceSpec: &harvesterv1.VirtualMachineSourceSpec{Spec: kubevirtv1.VirtualMachineSpec{RunStrategy: ptr.To(kubevirtv1.RunStrategyManual)}},
+				},
+			},
+			expected: kubevirtv1.RunStrategyHalted,
+		},
+		{
+			name: "uses source run strategy manual when provided",
+			restore: &harvesterv1.VirtualMachineRestore{
+				Spec: harvesterv1.VirtualMachineRestoreSpec{HaltAfterRestore: false},
+			},
+			backup: &harvesterv1.VirtualMachineBackup{
+				Status: harvesterv1.VirtualMachineBackupStatus{
+					SourceSpec: &harvesterv1.VirtualMachineSourceSpec{Spec: kubevirtv1.VirtualMachineSpec{RunStrategy: ptr.To(kubevirtv1.RunStrategyManual)}},
+				},
+			},
+			expected: kubevirtv1.RunStrategyManual,
+		},
+		{
+			name: "uses source run strategy always when provided",
+			restore: &harvesterv1.VirtualMachineRestore{
+				Spec: harvesterv1.VirtualMachineRestoreSpec{HaltAfterRestore: false},
+			},
+			backup: &harvesterv1.VirtualMachineBackup{
+				Status: harvesterv1.VirtualMachineBackupStatus{
+					SourceSpec: &harvesterv1.VirtualMachineSourceSpec{Spec: kubevirtv1.VirtualMachineSpec{RunStrategy: ptr.To(kubevirtv1.RunStrategyAlways)}},
+				},
+			},
+			expected: kubevirtv1.RunStrategyAlways,
+		},
+		{
+			name: "uses source run strategy halted when provided",
+			restore: &harvesterv1.VirtualMachineRestore{
+				Spec: harvesterv1.VirtualMachineRestoreSpec{HaltAfterRestore: false},
+			},
+			backup: &harvesterv1.VirtualMachineBackup{
+				Status: harvesterv1.VirtualMachineBackupStatus{
+					SourceSpec: &harvesterv1.VirtualMachineSourceSpec{Spec: kubevirtv1.VirtualMachineSpec{RunStrategy: ptr.To(kubevirtv1.RunStrategyHalted)}},
+				},
+			},
+			expected: kubevirtv1.RunStrategyHalted,
+		},
+		{
+			name: "falls back to rerun on failure when source run strategy is nil",
+			restore: &harvesterv1.VirtualMachineRestore{
+				Spec: harvesterv1.VirtualMachineRestoreSpec{HaltAfterRestore: false},
+			},
+			backup: &harvesterv1.VirtualMachineBackup{
+				Status: harvesterv1.VirtualMachineBackupStatus{
+					SourceSpec: &harvesterv1.VirtualMachineSourceSpec{Spec: kubevirtv1.VirtualMachineSpec{RunStrategy: nil}},
+				},
+			},
+			expected: kubevirtv1.RunStrategyRerunOnFailure,
+		},
+		{
+			name: "falls back to rerun on failure when backup is nil",
+			restore: &harvesterv1.VirtualMachineRestore{
+				Spec: harvesterv1.VirtualMachineRestoreSpec{HaltAfterRestore: false},
+			},
+			backup:   nil,
+			expected: kubevirtv1.RunStrategyRerunOnFailure,
+		},
+		{
+			name: "falls back to rerun on failure when source spec is nil",
+			restore: &harvesterv1.VirtualMachineRestore{
+				Spec: harvesterv1.VirtualMachineRestoreSpec{HaltAfterRestore: false},
+			},
+			backup: &harvesterv1.VirtualMachineBackup{
+				Status: harvesterv1.VirtualMachineBackupStatus{SourceSpec: nil},
+			},
+			expected: kubevirtv1.RunStrategyRerunOnFailure,
+		},
+		{
+			name:     "falls back to rerun on failure when restore is nil",
+			restore:  nil,
+			backup:   nil,
+			expected: kubevirtv1.RunStrategyRerunOnFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveRunStrategyFromRestoreAndBackup(tt.restore, tt.backup)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
#### Problem:
VMs restored from backup or snapshot are always automatically started.

#### Solution:
This PR introduces a new `haltAfterRestore` field to the `VirtualMachineRestoreSpec` and the `RestoreInput`, which allows users to prevent a VM from automatically starting after it's been restored from a backup or created from a snapshot/clone.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10422

#### Test plan:
***Prereqs***
- Create a VM named `test01`.
- Setup a NFS or S3 backup target. You can run a S3 bakup target easily by running
```
$ docker run -p 9000:9000 -p 9001:9001 quay.io/minio/minio server /data --console-address ":9001"
```
You need to access the UI by `http://127.0.0.1:9001/login` and create the "data" bucket that is used in these tests.
<img width="1187" height="936" alt="grafik" src="https://github.com/user-attachments/assets/e5c6cfa3-4b98-4eec-8624-0d1590cba800" />
- Create a backup of `test01` and name it `back01`.
<img width="1187" height="509" alt="grafik" src="https://github.com/user-attachments/assets/39c32442-4194-4160-b152-72cc84efba0e" />
- Create a snapshot of `test01` and name it `snap01`.
<img width="1187" height="550" alt="grafik" src="https://github.com/user-attachments/assets/7f2b7bb2-2b97-42db-9c75-7462179ab480" />

***Case 1***
- Apply the following manifest `restore-backup.yaml`:
```
$ cat <<EOF | k apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineRestore
metadata:
  name: restore-back01-test02
  namespace: default
spec:
  newVM: true
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test02
  virtualMachineBackupName: back01
  virtualMachineBackupNamespace: default
  haltAfterRestore: true
EOF
```
- There should be a VM named `test02` which is in halted mode.
<img width="1001" height="367" alt="grafik" src="https://github.com/user-attachments/assets/5aac6a53-21aa-4f2a-97ff-a0b9285843fb" />

***Case 2***
- Apply the following manifest `restore-snapshot.yaml`:
```
$ cat <<EOF | k apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineRestore
metadata:
  name: restore-snap01-test03
  namespace: default
spec:
  newVM: true
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test03
  virtualMachineBackupName: snap01
  virtualMachineBackupNamespace: default
  haltAfterRestore: true
EOF
```
- There should be a VM named `test03` which is in halted mode.
<img width="1001" height="367" alt="grafik" src="https://github.com/user-attachments/assets/b630ddb8-b599-4139-8b54-c86ef3e33a69" />

***Case 3***
- Delete VM `test02`.
- Apply the following manifest `restore-backup.yaml`:
```
$ cat <<EOF | k apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineRestore
metadata:
  name: restore-back01-test02
  namespace: default
spec:
  newVM: true
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test02
  virtualMachineBackupName: back01
  virtualMachineBackupNamespace: default
  haltAfterRestore: false
EOF
```
- There should be a VM named `test02` which is running.

***Case 4***
- Delete VM `test03`.
- Apply the following manifest `restore-snapshot.yaml`:
```
$ cat <<EOF | k apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineRestore
metadata:
  name: restore-snap01-test03
  namespace: default
spec:
  newVM: true
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test03
  virtualMachineBackupName: snap01
  virtualMachineBackupNamespace: default
  haltAfterRestore: false
EOF
```
- There should be a VM named `test03` which is running.

***Case 5***
- Delete VM `test02`.
- Apply the following manifest `restore-backup.yaml`:
```
$ cat <<EOF | k apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineRestore
metadata:
  name: restore-back01-test02
  namespace: default
spec:
  newVM: true
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test02
  virtualMachineBackupName: back01
  virtualMachineBackupNamespace: default
EOF
```
- There should be a VM named `test02` which is running.

***Case 6***
- Delete VM `test03`.
- Apply the following manifest `restore-snapshot.yaml`:
```
$ cat <<EOF | k apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineRestore
metadata:
  name: restore-snap01-test03
  namespace: default
spec:
  newVM: true
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test03
  virtualMachineBackupName: snap01
  virtualMachineBackupNamespace: default
EOF
```
- There should be a VM named `test03` which is running.

#### Additional documentation or context
