### PR TITLE
Make sure `spec.displaName` is a valid K8s label value

### DIFF
--- a/pkg/image/common/validator.go
+++ b/pkg/image/common/validator.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -85,7 +86,8 @@ func (v *vmiValidator) GetStatusSC(vmi *v1beta1.VirtualMachineImage) string {
 	return vmi.Status.StorageClassName
 }
 
-func (v *vmiValidator) CheckDisplayName(vmi *v1beta1.VirtualMachineImage) error {
+// commonCheckDisplayName performs several validations on the `DisplayName` field.
+func (v *vmiValidator) commonCheckDisplayName(vmi *v1beta1.VirtualMachineImage) error {
 	if vmi.Spec.DisplayName == "" {
 		return werror.NewInvalidError("displayName is required", fieldDisplayName)
 	}
@@ -106,11 +108,23 @@ func (v *vmiValidator) CheckDisplayName(vmi *v1beta1.VirtualMachineImage) error 
 	return nil
 }
 
+func (v *vmiValidator) CheckDisplayName(vmi *v1beta1.VirtualMachineImage) error {
+	// The `displayName` field is later used as a Kubernetes label value.
+	// This check in only performed on new `VirtualMachineImage` resources
+	// to do not break existing resources.
+	if errs := validation.IsValidLabelValue(vmi.Spec.DisplayName); len(errs) > 0 {
+		return werror.NewInvalidError(fmt.Sprintf("displayName is not a valid Kubernetes label value: %s", strings.Join(errs, "; ")), fieldDisplayName)
+	}
+
+	return v.commonCheckDisplayName(vmi)
+}
+
 func (v *vmiValidator) CheckUpdateDisplayName(oldVMI, newVMI *v1beta1.VirtualMachineImage) error {
 	if oldVMI.Spec.DisplayName != newVMI.Spec.DisplayName {
 		return werror.NewInvalidError("displayName cannot be modified", fieldDisplayName)
 	}
-	return v.CheckDisplayName(newVMI)
+
+	return v.commonCheckDisplayName(newVMI)
 }
 
 func (v *vmiValidator) CheckURL(vmi *v1beta1.VirtualMachineImage) error {

--- a/pkg/image/common/validator_test.go
+++ b/pkg/image/common/validator_test.go
@@ -1,0 +1,162 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestCheckDisplayName(t *testing.T) {
+	maxLenDisplayName := strings.Repeat("a", 63)
+	tooLongDisplayName := strings.Repeat("a", 64)
+
+	testCases := []struct {
+		name           string
+		displayName    string
+		existingImages []*harvesterv1.VirtualMachineImage
+		expectErr      bool
+		errContains    string
+	}{
+		{
+			name:        "rejects empty displayName",
+			displayName: "",
+			expectErr:   true,
+			errContains: "displayName is required",
+		},
+		{
+			name:        "accepts displayName with 63 chars",
+			displayName: maxLenDisplayName,
+			expectErr:   false,
+		},
+		{
+			name:        "rejects displayName with more than 63 chars",
+			displayName: tooLongDisplayName,
+			expectErr:   true,
+			errContains: "must be no more than 63 characters",
+		},
+		{
+			name:        "rejects displayName with invalid Kubernetes label value",
+			displayName: "Invalid/Name",
+			expectErr:   true,
+			errContains: "displayName is not a valid Kubernetes label value",
+		},
+		{
+			name:        "rejects duplicate displayName",
+			displayName: "duplicate-name",
+			existingImages: []*harvesterv1.VirtualMachineImage{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-image",
+						Namespace: "default",
+						UID:       "existing-uid",
+						Labels: map[string]string{
+							util.LabelImageDisplayName: "duplicate-name",
+						},
+					},
+				},
+			},
+			expectErr:   true,
+			errContains: "A resource with the same name exists",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientSet := fake.NewSimpleClientset()
+			for _, image := range tc.existingImages {
+				err := clientSet.Tracker().Add(image)
+				assert.NoError(t, err)
+			}
+
+			validator := &vmiValidator{
+				vmiCache: fakeclients.VirtualMachineImageCache(clientSet.HarvesterhciV1beta1().VirtualMachineImages),
+			}
+
+			vmi := &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-image",
+					Namespace: "default",
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					DisplayName: tc.displayName,
+				},
+			}
+
+			err := validator.CheckDisplayName(vmi)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckUpdateDisplayName(t *testing.T) {
+	testCases := []struct {
+		name           string
+		oldDisplayName string
+		newDisplayName string
+		expectErr      bool
+		errContains    string
+	}{
+		{
+			name:           "accepts unchanged valid displayName",
+			oldDisplayName: "valid-name",
+			newDisplayName: "valid-name",
+			expectErr:      false,
+		},
+		{
+			name:           "rejects changed displayName",
+			oldDisplayName: "old-name",
+			newDisplayName: "new-name",
+			expectErr:      true,
+			errContains:    "displayName cannot be modified",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientSet := fake.NewSimpleClientset()
+			validator := &vmiValidator{
+				vmiCache: fakeclients.VirtualMachineImageCache(clientSet.HarvesterhciV1beta1().VirtualMachineImages),
+			}
+
+			oldVMI := &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "update-image",
+					Namespace: "default",
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					DisplayName: tc.oldDisplayName,
+				},
+			}
+
+			newVMI := &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "update-image",
+					Namespace: "default",
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					DisplayName: tc.newDisplayName,
+				},
+			}
+
+			err := validator.CheckUpdateDisplayName(oldVMI, newVMI)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Problem:
Create an image which name length over the limitaion via YAML, the image still can be created.

#### Solution:
Add an additional check in the `VirtualMachineImage` validator that validates the `spec.displaName` field is a valid K8s label value; e.g. the length is limited to 63 chars because the field is later used as a label.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9515

#### Test plan:
***Case 1***
- Go to the `Images` page and press the `Create` button.
- Insert `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
- Insert `https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img` into the `URL` field.
- Press the `Edit as YAML` button.
- Press the `Create` button.
- The following error message must be displayed.
<img width="1264" height="788" alt="grafik" src="https://github.com/user-attachments/assets/38164d1c-8def-440c-b4f7-49a918afff1c" />

***Case 2***
Run the following command:
```
$ cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineImage
metadata:
  name: image-1abcd
  namespace: default
spec:
  backend: backingimage
  displayName: >-
    _xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
  sourceType: download
  targetStorageClassName: harvester-longhorn
  url: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
EOF
```
The output must look like:
```
harvester-node-0:/home/rancher # cat <<EOF | kubectl apply -f -
> apiVersion: harvesterhci.io/v1beta1
> kind: VirtualMachineImage
> metadata:
...
>   sourceType: download
>   targetStorageClassName: harvester-longhorn
>   url: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
> EOF
The request is invalid: spec.displayName: displayName is not a valid Kubernetes label value: must be no more than 63 characters; a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```
#### Additional documentation or context
