### PR TITLE
feat: add more explanation when checking hostDevice during upgrade

### DIFF
--- a/pkg/util/virtualmachineinstance/virtualmachineinstance.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance.go
@@ -39,8 +39,9 @@ func GetAllNonLiveMigratableVMINames(vmis []*kubevirtv1.VirtualMachineInstance, 
 		}
 
 		// PCIe devices
-		if vmi.Spec.Domain.Devices.HostDevices != nil {
-			logrus.Infof("%s considered non-live migratable due to pcie or usb devices", vmiNamespacedName)
+		// Starting from v1.8.0, vGPU is moved to HostDevices, so we only need to check HostDevices here
+		if len(vmi.Spec.Domain.Devices.HostDevices) != 0 {
+			logrus.Infof("%s considered non-live migratable due to pcie, usb or vgpu devices", vmiNamespacedName)
 			nonLiveMigratableVMINames = append(nonLiveMigratableVMINames, vmiNamespacedName)
 			continue
 		}

--- a/pkg/util/virtualmachineinstance/virtualmachineinstance_test.go
+++ b/pkg/util/virtualmachineinstance/virtualmachineinstance_test.go
@@ -497,7 +497,12 @@ func Test_GetNonLiveMigratableVMIs(t *testing.T) {
 					Spec: kubevirtv1.VirtualMachineInstanceSpec{
 						Domain: kubevirtv1.DomainSpec{
 							Devices: kubevirtv1.Devices{
-								HostDevices: []kubevirtv1.HostDevice{},
+								HostDevices: []kubevirtv1.HostDevice{
+									{
+										Name:       "test",
+										DeviceName: "test",
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Actually, there are no problems here. 

Starting from v1.8.0, vgpu is moved to hostDevices. So, we just need to check hostDevices.

#### Solution:
Add more words in log.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10388

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
