### PR TITLE
Enable backup actions for vm created with longhorn v2

### DIFF
--- a/pkg/api/vm/formatter.go
+++ b/pkg/api/vm/formatter.go
@@ -9,11 +9,11 @@ import (
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	cdicommon "kubevirt.io/containerized-data-importer/pkg/controller/common"
 
 	apiutil "github.com/harvester/harvester/pkg/api/util"
 	"github.com/harvester/harvester/pkg/controller/master/migration"
@@ -327,7 +327,6 @@ func (vf *vmformatter) canDoBackup(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv
 		return false
 	}
 
-	// additional check, we did not support backup with CDI volume
 	volumes := vm.Spec.Template.Spec.Volumes
 	for _, vol := range volumes {
 		if vol.PersistentVolumeClaim == nil {
@@ -341,7 +340,8 @@ func (vf *vmformatter) canDoBackup(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv
 			logrus.Errorf("Can't get PVC %s/%s, err: %+v", vm.Namespace, vol.PersistentVolumeClaim.ClaimName, err)
 			return false
 		}
-		if _, find := pvc.Annotations[cdicommon.AnnCreatedForDataVolume]; find {
+		// backup is only available for volume with longhorn storage class
+		if !isLonghornPVC(pvc, vf.scCache) {
 			return false
 		}
 	}
@@ -360,6 +360,24 @@ func (vf *vmformatter) canDoBackup(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv
 		return false
 	}
 	return true
+}
+
+func isLonghornPVC(pvc *corev1.PersistentVolumeClaim, scCache ctlstoragev1.StorageClassCache) bool {
+	sc := getSCForPVC(pvc, scCache)
+	return sc != nil && sc.Provisioner == util.CSIProvisionerLonghorn
+}
+
+func getSCForPVC(pvc *corev1.PersistentVolumeClaim, scCache ctlstoragev1.StorageClassCache) *storagev1.StorageClass {
+	// if PVC does not have storage class, it will use default storage class
+	if pvc.Spec.StorageClassName == nil {
+		return util.GetDefaultSC(scCache)
+	}
+	sc, err := scCache.Get(*pvc.Spec.StorageClassName)
+	if err != nil {
+		logrus.Errorf("Can't get StorageClass %s, err: %v", *pvc.Spec.StorageClassName, err)
+		return nil
+	}
+	return sc
 }
 
 func (vf *vmformatter) canDoSnapshot(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance) bool {

--- a/pkg/api/vm/formatter_test.go
+++ b/pkg/api/vm/formatter_test.go
@@ -1,0 +1,168 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestCanDoBackup(t *testing.T) {
+	longhornSC := "longhorn"
+	lvmSC := "lvm"
+	backupTarget := `{"type":"s3","endpoint":"https://s3.amazonaws.com","bucketName":"test","bucketRegion":"us-west-1"}`
+
+	tests := []struct {
+		name           string
+		pvcNames       []string                        // PVC names to attach to VM
+		pvcs           []*corev1.PersistentVolumeClaim // PVCs to create
+		storageClasses []*storagev1.StorageClass       // Storage classes to create
+		expected       bool
+	}{
+		{
+			name:     "explicit Longhorn SC - allow backup",
+			pvcNames: []string{"pvc1"},
+			pvcs:     []*corev1.PersistentVolumeClaim{newTestPVC("pvc1", &longhornSC)},
+			storageClasses: []*storagev1.StorageClass{
+				newTestStorageClass(longhornSC, util.CSIProvisionerLonghorn, false),
+			},
+			expected: true,
+		},
+		{
+			name:     "explicit LVM SC - block backup",
+			pvcNames: []string{"pvc1"},
+			pvcs:     []*corev1.PersistentVolumeClaim{newTestPVC("pvc1", &lvmSC)},
+			storageClasses: []*storagev1.StorageClass{
+				newTestStorageClass(lvmSC, util.CSIProvisionerLVM, false),
+			},
+			expected: false,
+		},
+		{
+			name:     "default Longhorn SC - allow backup",
+			pvcNames: []string{"pvc1"},
+			pvcs:     []*corev1.PersistentVolumeClaim{newTestPVC("pvc1", nil)},
+			storageClasses: []*storagev1.StorageClass{
+				newTestStorageClass(longhornSC, util.CSIProvisionerLonghorn, true),
+			},
+			expected: true,
+		},
+		{
+			name:     "default LVM SC - block backup",
+			pvcNames: []string{"pvc1"},
+			pvcs:     []*corev1.PersistentVolumeClaim{newTestPVC("pvc1", nil)},
+			storageClasses: []*storagev1.StorageClass{
+				newTestStorageClass(lvmSC, util.CSIProvisionerLVM, true),
+			},
+			expected: false,
+		},
+		{
+			name:           "no SC and no default - block backup",
+			pvcNames:       []string{"pvc1"},
+			pvcs:           []*corev1.PersistentVolumeClaim{newTestPVC("pvc1", nil)},
+			storageClasses: []*storagev1.StorageClass{},
+			expected:       false,
+		},
+		{
+			name:     "mixed volumes (Longhorn + LVM) - block backup",
+			pvcNames: []string{"pvc1", "pvc2"},
+			pvcs: []*corev1.PersistentVolumeClaim{
+				newTestPVC("pvc1", &longhornSC),
+				newTestPVC("pvc2", &lvmSC),
+			},
+			storageClasses: []*storagev1.StorageClass{
+				newTestStorageClass(longhornSC, util.CSIProvisionerLonghorn, false),
+				newTestStorageClass(lvmSC, util.CSIProvisionerLVM, false),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build objects for fake clientset
+			objs := make([]runtime.Object, 0, 1+len(tt.pvcs)+len(tt.storageClasses))
+			objs = append(objs, &harvesterv1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.BackupTargetSettingName},
+				Value:      backupTarget,
+			})
+			for _, pvc := range tt.pvcs {
+				objs = append(objs, pvc)
+			}
+			for _, sc := range tt.storageClasses {
+				objs = append(objs, sc)
+			}
+
+			clientset := fake.NewSimpleClientset(objs...)
+			vf := &vmformatter{
+				pvcCache:     fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+				scCache:      fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+				settingCache: fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+			}
+
+			vm := newTestVM(tt.pvcNames...)
+			vmi := newTestVMI()
+			result := vf.canDoBackup(vm, vmi)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Test helpers
+func newTestVM(pvcNames ...string) *kubevirtv1.VirtualMachine {
+	volumes := make([]kubevirtv1.Volume, 0, len(pvcNames))
+	for i, name := range pvcNames {
+		volumes = append(volumes, kubevirtv1.Volume{
+			Name: "disk-" + string(rune('0'+i)),
+			VolumeSource: kubevirtv1.VolumeSource{
+				PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: name,
+					},
+				},
+			},
+		})
+	}
+	return &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vm", Namespace: "default"},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{Volumes: volumes},
+			},
+		},
+	}
+}
+
+func newTestVMI() *kubevirtv1.VirtualMachineInstance {
+	return &kubevirtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vm", Namespace: "default"},
+		Status:     kubevirtv1.VirtualMachineInstanceStatus{Phase: kubevirtv1.Running},
+	}
+}
+
+func newTestPVC(name string, scName *string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: scName},
+	}
+}
+
+func newTestStorageClass(name, provisioner string, isDefault bool) *storagev1.StorageClass {
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: name},
+		Provisioner: provisioner,
+	}
+	if isDefault {
+		sc.Annotations = map[string]string{util.AnnotationIsDefaultStorageClassName: "true"}
+	}
+	return sc
+}


### PR DESCRIPTION
#### Problem:
Following the changes in PR https://github.com/harvester/harvester/pull/9415, we are now able to back up VMs with Longhorn v2 volumes. However, the 'Take Backup' button is still missing from the UI.
This is because backup actions are currently blocked for VMs whose volumes were created via CDI. Since Longhorn v2 leverages CDI to build the VM root disk, the UI logic inadvertently hides the backup option. As a result, backups for Longhorn v2 VMs can currently only be triggered via kubectl.

#### Solution:
Do not block backup action when VM use volume with longhorn storage class

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10509

#### Test plan:
1. VM with Longhorn v2 CDI Volume - Backup Button Should Appear 
1. VM with Longhorn v1 Volume - Backup Button Should Appear
1. VM with LVM CDI Volume - Backup Button Should NOT Appear
1. VM with Mixed Volumes (Longhorn v2 + LVM) - Backup Button Should NOT Appear


#### Additional documentation or context
