### PR TITLE
hep: benchmark policy

### DIFF
--- a/enhancements/20260424-harvester-benchmark-policy.md
+++ b/enhancements/20260424-harvester-benchmark-policy.md
@@ -59,32 +59,43 @@ N/A
 
 ### Implementation Overview
 
-The benchmark policy is organized into four categories. Each defines scope, tooling, topology, methodology, and key metrics.
+The benchmark policy is organized into three categories. Each defines scope, tooling, topology, methodology, and key metrics.
 
 #### Category 1: Resource Footprint
 
-- **Scope**: CPU and memory consumption of each Harvester component (pods) at idle and under VMs load.
+- **Scope**: CPU and memory consumption of each Harvester component at idle and under maximum VM density.
 - **Tooling**:
-  - `kubectl top pods`, know the pod cpu, memory usages
-  - `grep -E 'MemTotal|MemFree|MemAvailable|SReclaimable' /proc/meminfo`, host memory allocation.
-  - `kubectl describe node | grep -A5 'Allocated resources'`, know the scheduler cpu/memory resource allocation.
+  - `kubectl top pods` — per-pod CPU/memory usage.
+  - `ps -C containerd,kubelet,rke2 -o rss=` — host-level process RSS.
+  - `grep -E 'MemTotal|MemFree|MemAvailable|SReclaimable' /proc/meminfo` — host memory allocation.
+  - `kubectl describe node | grep -A5 'Allocated resources'` — scheduler CPU/memory resource allocation.
+  - `etcdctl endpoint status` — etcd db size.
 - **Topology**:
   - Single-node: 1 control-plane node, no worker nodes.
   - Multi-node: 3-node cluster (1 control-plane, 2 workers).
 - **Methodology**:
   - [Harvester Resource Footprint gist](https://gist.github.com/Vicente-Cheng/ae8d5ce743f94c0c9a333574813bc777).
-  - Capture component-level CPU/memory at rest, then with increasing VM counts (e.g., 10 VMs, 20 VMs) to understand how resource consumption scales.
+  - Phase 1: Measure at idle (0 VMs running) to establish the platform baseline.
+  - Phase 2: Create VMs until the scheduler rejects — record the maximum VM count and which resource (CPU, memory, or other) is the bottleneck.
+  - Capture per-namespace breakdown (kube-system, harvester-system, longhorn-system, cattle-system) at each phase.
+  - Compare single-node vs multi-node to understand how platform overhead scales with node count.
 - **Key metrics**:
-  - CPU (millicores), memory RSS (MiB), per pod, per VM count.
-  - VMs can be created in a given environment before a component becomes the bottleneck.
+  - Platform idle cost: total CPU (millicores) and memory (MiB) with 0 VMs.
+  - Maximum VM count before scheduler rejects, and the bottleneck resource.
+  - Scheduler-reserved vs actual physical consumption ratio.
+  - etcd db size (MiB).
 
-#### Category 2: Performance Benchmark (I/O)
+#### Category 2: Performance Benchmark
+
+##### 2a: Storage and Network I/O
 
 - **Scope**: Storage throughput/latency and network throughput.
 - **Tooling**:
   - Storage: `fio` (sequential and random read/write, 4K and 128K block sizes)
   - Network: `iperf3` (TCP throughput, UDP jitter)
-- **Topology**: Multi-node cluster.
+- **Topology**:
+  - Single-node: 1 control-plane node, no worker nodes.
+  - Multi-node: 3-node cluster (1 control-plane, 2 workers).
 - **Methodology**: [Harvester Performance wiki](https://github.com/harvester/harvester/wiki/Harvester-Performance-Result).
   - Raw Device measure - fio / iperf3
   - VMs on Longhorn volumes for storage tests.
@@ -92,21 +103,51 @@ The benchmark policy is organized into four categories. Each defines scope, tool
     - Windows VM - fio
 - **Key metrics**: IOPS, throughput (MB/s), latency (ms), bandwidth (Gbps).
 
-#### Category 3: KubeVirt Scaling Comparison
+##### 2b: etcd
 
-- **Scope**: Measure the additional overhead Harvester introduce on top of vanilla KubeVirt.
+- **Scope**: etcd get, put, and watch latency and throughput at idle (0 VMs), to establish baseline performance for a given hardware configuration.
 - **Tooling**:
-  - `kubectl top pods` — per-component CPU/memory during and after VM creation.
+  - etcd [benchmark](https://github.com/etcd-io/etcd/tree/main/tools/benchmark) tool — build from `etcd/tools/benchmark` in the etcd repository.
 - **Topology**:
   - Single-node: 1 control-plane node, no worker nodes.
-  - Multi-node: 3-node cluster, from [kubevirt-presubmits-1.8.yaml](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml).
+  - Multi-node: 3-node cluster (1 control-plane, 2 workers).
 - **Methodology**:
-  - Follow [KubeVirt perf-scale-benchmarks](https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md).
-  - Create 100 VMs with 100ms interval, wait for all to reach Running state.
-  - Compare results between vanilla KubeVirt and Harvester on the same hardware, similar to Category 1: Resource Footprint
+  - Run at idle (0 VMs) to establish baseline.
+  - For each operation, run a single-client and a concurrent workload:
+    - **Put**:
+      - Single: 1 connection, 1 client, 10,000 requests, 256-byte value.
+      - Concurrent: 100 connections, 1,000 clients, 100,000 requests, 256-byte value.
+    - **Get** (seed keys before benchmarking):
+      - Single: 1 connection, 1 client, 10,000 requests.
+      - Concurrent: 100 connections, 1,000 clients, 100,000 requests.
+    - **Watch**:
+      - Single: 1 connection, 1 client, 10,000 watch events.
+      - Concurrent: 100 connections, 1,000 clients, 100,000 watch events.
 - **Key metrics**:
-  - vmiCreationToRunningSeconds P50/P95
-  - CPU/memory of virt-controller, harvester-controller during batch creation
+  - Requests per second (throughput).
+  - Latency: average, P50, P99.
+
+#### Category 3: KubeVirt Scaling Comparison
+
+- **Scope**: Measure the additional overhead Harvester introduces on top of vanilla KubeVirt, using the KubeVirt version bundled with the Harvester release under test.
+- **Tooling**:
+  - Prometheus (built-in to Harvester) — query KubeVirt metrics via PromQL.
+  - KubeVirt [perfscale-audit](https://github.com/kubevirt/kubevirt/tree/main/tools/perfscale-audit) tool — connects to Prometheus, runs predefined queries, dumps results to JSON.
+- **Topology**:
+  - Single-node: 1 control-plane node, no worker nodes.
+  - Multi-node: 3-node cluster (1 control-plane, 2 workers).
+- **Methodology**:
+  - Adopt measurement methodology from [KubeVirt perf-scale-benchmarks](https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md), not their cluster topology.
+  - Use local-path storage for VM volumes to isolate KubeVirt overhead from storage backend variance.
+  - Create 100 VMs with 100ms interval (minimal spec: Cirros, 100m CPU, 90Mi memory), wait for all to reach Running state.
+  - Collect metrics via Prometheus after waiting for scrape interval (30s default).
+  - Run the same test on vanilla KubeVirt (same version as bundled in Harvester) and Harvester on the same hardware.
+  - Ensure workloads are evenly distributed among workers to avoid skewed results.
+- **Phase 1 — Baseline** (establish the performance gap):
+  - vmiCreationToRunningSeconds P50/P95 (boot time tail latency).
+  - Total time for 100 VMs to reach Running (batch throughput).
+- **Phase 2 — Profiling** (identify where the gap comes from):
+  - **API operation counts**: PATCH-pods-count, PATCH-virtualmachineinstances-count, UPDATE-virtualmachineinstances-count per component — identifies the most expensive calls from the Harvester stack.
 
 ### Test plan
 
@@ -118,4 +159,7 @@ N/A
 
 ## Note [optional]
 
-- Future work: benchmark automation (scheduled runs, result diffing, automatic regression issue filing).  
+- Future work:
+  - Benchmark automation (scheduled runs, result diffing, automatic regression issue filing).
+  - etcd benchmark under VM load — run during VM creation to capture peak write pressure, and compare with steady-state after VMs are running.
+  - Disk topology comparison — measure etcd performance when etcd shares the root disk (e.g., LVM) vs. a dedicated disk, to quantify I/O contention impact on etcd latency.

--- a/enhancements/20260424-harvester-benchmark-policy.md
+++ b/enhancements/20260424-harvester-benchmark-policy.md
@@ -94,13 +94,17 @@ The benchmark policy is organized into three categories. Each defines scope, too
   - Storage: `fio` (sequential and random read/write, 4K and 128K block sizes)
   - Network: `iperf3` (TCP throughput, UDP jitter)
 - **Topology**:
-  - Single-node: 1 control-plane node, no worker nodes.
   - Multi-node: 3-node cluster (1 control-plane, 2 workers).
+  - **Storage network**: 10GbE dedicated NIC for Longhorn replication traffic, isolated from management and VM networks.
+  - **Inter-node bandwidth**: Measured via iperf3 before benchmark runs to confirm line rate (record actual observed bandwidth).
 - **Methodology**: [Harvester Performance wiki](https://github.com/harvester/harvester/wiki/Harvester-Performance-Result).
-  - Raw Device measure - fio / iperf3
-  - VMs on Longhorn volumes for storage tests.
-    - Linux VM - fio
-    - Windows VM - fio
+  - **Storage overhead**:
+    - Layer 0 (Raw Device): fio directly on host block device
+    - Layer 1 (Longhorn volume, host): fio on Longhorn PVC mounted to a pod on the host
+    - Layer 2 (guest VM): fio inside Linux/Windows VM backed by Longhorn volume
+  - **Network overhead**:
+    - Layer 0 (Raw Device): confirm inter-node line rate via iperf3
+    - VM network: iperf3 between two VMs to measure guest network throughput.
 - **Key metrics**: IOPS, throughput (MB/s), latency (ms), bandwidth (Gbps).
 
 ##### 2b: etcd

--- a/enhancements/20260424-harvester-benchmark-policy.md
+++ b/enhancements/20260424-harvester-benchmark-policy.md
@@ -42,7 +42,7 @@ I want profiling data so that I can identify bottlenecks, catch potential OOMs b
 - **Per-component resource profiling**: CPU/memory consumption of each pod as VM count grows, to understand which component becomes the bottleneck first (e.g., instance-manager at ~20 GiB per pod with 149 volumes).
 - **Memory pressure analysis**: Identify components at risk of OOM — comparing scheduler-reserved memory vs actual RSS, and flagging components where actual consumption grows disproportionately with VM count.
 - **Upgrade per-phase timing**: Break down upgrade duration into pre-drain, node drain, post-drain, and total, so we can pinpoint which phase is slow and whether optimizations reduce it (see [#10421](https://github.com/harvester/harvester/issues/10421)).
-- **VM migration profiling**: Duration and resource cost of live migration under varying VM sizes and storage backends, since migration involves both network and storage I/O.
+- **VM migration profiling**: Duration and resource cost of live migration under varying VM sizes and storage backends, since migration involves both network and storage I/O. Include VMs using overlay network (Kube-OVN) to measure the additional encapsulation overhead during migration.
 - **CSI driver throughput under load**: Whether the Harvester CSI driver can keep up during rapid guest node shutdown/recreation before Longhorn times out.
 
 ### User Experience In Detail
@@ -84,12 +84,13 @@ The benchmark policy is organized into two categories. Each defines scope, tooli
 
 - **Scope**: CPU and memory consumption of each Harvester component at idle and under maximum VM density, including VM creation latency metrics.
 - **Tooling**:
-  - `kubectl top pods` — per-pod CPU/memory usage.
-  - `ps -C containerd,kubelet,rke2 -o rss=` — host-level process RSS.
-  - `grep -E 'MemTotal|MemFree|MemAvailable|SReclaimable' /proc/meminfo` — host memory allocation.
-  - `kubectl describe node | grep -A5 'Allocated resources'` — scheduler CPU/memory resource allocation.
+  - Prometheus (enabled via monitoring stack) — primary source for time-series CPU/memory metrics during the entire benchmark run.
+    - Pod CPU usage: `sum(rate(container_cpu_usage_seconds_total{container!="", container!="POD"}[5m])) by (namespace, pod)`
+    - Pod memory working set: `sum(container_memory_working_set_bytes{container!="", container!="POD"}) by (namespace, pod)`
+    - CPU usage vs limit ratio: `sum(rate(container_cpu_usage_seconds_total{container!="", container!="POD"}[5m])) by (namespace, pod) / sum(kube_pod_container_resource_limits{resource="cpu"}) by (namespace, pod) * 100`
+    - Memory usage vs limit ratio: `sum(container_memory_working_set_bytes{container!="", container!="POD"}) by (namespace, pod) / sum(kube_pod_container_resource_limits{resource="memory"}) by (namespace, pod) * 100`
+  - Prometheus / kube-state-metrics — resource requests and limits per pod/namespace for reserved-vs-actual comparisons.
   - `etcdctl endpoint status` — etcd db size.
-  - Prometheus (enabled via monitoring stack) — query `kubevirt_vmi_phase_transition_time_from_creation_seconds` and component metrics.
   - KubeVirt [perfscale-audit](https://github.com/kubevirt/kubevirt/tree/main/tools/perfscale-audit) tool — connects to Prometheus for VM creation latency queries.
 - **Topology**:
   - Single-node: 1 control-plane node, no worker nodes.
@@ -99,24 +100,26 @@ The benchmark policy is organized into two categories. Each defines scope, tooli
   - Adopt VM creation latency measurement from [KubeVirt perf-scale-benchmarks](https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md) (PromQL queries).
   - **Phase 1: Idle baseline**
     - Ensure monitoring stack is running and all pods are Ready.
-    - Measure resource consumption with 0 VMs to establish platform baseline.
-    - Capture per-namespace breakdown: `kube-system`, `harvester-system`, `longhorn-system`, `cattle-system`, `cattle-monitoring-system`.
+    - Record Prometheus time-series for CPU and memory with 0 VMs to establish platform baseline; report min/avg/max over the observation window rather than a single point-in-time snapshot.
+    - Capture per-namespace and per-pod breakdown: `kube-system`, `harvester-system`, `longhorn-system`, `cattle-system`, `cattle-monitoring-system`.
   - **Phase 2: VM creation and scaling**
     - Create VMs incrementally with 100ms interval (minimal spec: Cirros or Alpine, 100m CPU, 128Mi memory) until the scheduler rejects new VMs.
-    - **During VM creation**, capture VM creation latency via Prometheus:
+    - **During VM creation**, capture VM creation latency and component resource usage via Prometheus:
       - `kubevirt_vmi_phase_transition_time_from_creation_seconds` (histogram) — P50, P95, P99.
+      - Per-pod CPU and memory time-series to identify transient spikes and bottlenecks during the run.
       - Total time from first VM creation to last VM reaching Running (batch throughput).
     - Record the maximum VM count and identify the bottleneck resource (CPU, memory).
-    - Capture per-component resource consumption at max VM density (same metrics as Phase 1).
+    - Capture per-component resource consumption at max VM density using the same Prometheus metrics as Phase 1, and report peak as well as average usage.
     - Ensure workloads are evenly distributed among workers to avoid skewed results.
   - Compare single-node vs multi-node to understand how platform overhead scales with node count.
   - **User-reproducible script**: Provide a standalone script with VM manifest templates and PromQL queries so users can run in their own environment to validate expected resource footprint and VM creation performance.
 - **Key metrics**:
   - **Resource consumption**:
-    - Platform idle cost: total CPU (millicores) and memory (MiB) with 0 VMs, broken down by namespace.
+    - Platform idle cost: total CPU (millicores) and memory (MiB) with 0 VMs, reported as min/avg/max and broken down by namespace.
     - Monitoring stack overhead: CPU/memory of `cattle-monitoring-system`, Prometheus TSDB size (MiB).
     - Maximum VM count before scheduler rejects, and the bottleneck resource.
-    - Scheduler-reserved vs actual physical consumption ratio.
+    - Scheduler-reserved vs actual consumption ratio.
+    - Peak per-pod CPU and memory working set during the scaling run.
     - etcd db size (MiB).
   - **VM creation latency** (captured during Phase 2):
     - P50, P95, P99 (seconds from VMI creation to Running state).
@@ -143,7 +146,7 @@ The benchmark policy is organized into two categories. Each defines scope, tooli
     - **Kube-OVN enabled**: Test with Kube-OVN networking to measure its impact on VM network performance (compare against default Canal/Multus).
     - **Longhorn storage profiles**:
       - **Local-single-replica**: Set Longhorn volume replicas to 1 and place the workload on the node hosting that replica to measure stack overhead without Longhorn replication traffic.
-      - **Replicated**: Set Longhorn volume replicas to 2 to measure replication overhead on storage throughput.
+      - **Replicated**: Set Longhorn volume replicas to 3 to measure replication overhead on storage throughput.
   - **Inter-node bandwidth**: Measured via iperf3 before benchmark runs to confirm line rate (record actual observed bandwidth).
 - **Methodology**: [Harvester Performance wiki](https://github.com/harvester/harvester/wiki/Harvester-Performance-Result).
   - **Storage overhead (layered testing)**:
@@ -153,6 +156,9 @@ The benchmark policy is organized into two categories. Each defines scope, tooli
   - **Network overhead (layered testing)**:
     - **Layer 0 (Raw Device)**: Confirm inter-node line rate via iperf3 between bare metal nodes or host pods.
     - **Layer 1 (VM network)**: iperf3 between two VMs on different nodes to measure guest network throughput.
+    - **Jumbo frames**: Test with MTU 9000 to verify fragmentation/reassembly overhead compared to standard MTU 1500.
+    - **Bond modes**: Benchmark different NIC bonding configurations (active-backup vs 802.3ad LACP) to measure throughput differences.
+    - **Hardware variation**: Test across different NIC vendors (BCM, Dell, etc.) where lab hardware is available, as driver performance can vary.
   - **Prometheus monitoring during tests**:
     - Capture time-series data during the entire fio/iperf3 run.
     - Track node-level metrics to identify bottlenecks (see Prometheus metrics section).

--- a/enhancements/20260424-harvester-benchmark-policy.md
+++ b/enhancements/20260424-harvester-benchmark-policy.md
@@ -1,0 +1,121 @@
+# Harvester Benchmark Policy
+
+## Summary
+
+This HEP defines the benchmarking policy for Harvester — what categories we test, how we run them, and what follow-up actions we take on the results. The goal is to establish a repeatable, release-gated process so performance regressions are caught before shipping and improvements can be tracked across releases.
+
+Currently, benchmark runs are ad-hoc: different engineers use different tools, results are not captured consistently, and there is no agreed baseline to compare against. This makes it difficult to reason about performance trends or give users reliable sizing guidance.
+
+### Related Issues
+
+- <https://github.com/harvester/harvester/issues/9777>
+- <https://github.com/harvester/harvester/issues/10421>
+
+## Motivation
+
+### Goals
+
+- **Define Benchmark Categories**: Establish canonical categories covering Harvester's performance surface — Resource Footprint, I/O Performance, and KubeVirt Scaling.
+- **Standardize Tooling and Methodology**: Specify tools and procedures for each category so results are reproducible by any team member.
+- **Maintain a Shared Baseline**: Publish benchmark results to the Harvester wiki each release and compare against the previous baseline.
+
+### Non-goals
+
+- Full automation of benchmark execution.
+- Profiling and root-cause analysis (a follow-up action triggered by benchmark results, not part of the benchmark itself).
+- Define Regression Criteria: Set thresholds for flagging regressions and a process for acting on them before release.
+
+## Proposal
+
+### User Stories
+
+**Story 1: As a field engineer/PM presenting Harvester to a customer**
+I want per-release benchmark results so that I can give concrete sizing guidance instead of guessing. Specifically:
+
+- **Resource footprint**: How much CPU/memory does Harvester itself consume at idle? How much headroom is left for VMs?
+- **VM capacity**: What is the maximum number of VMs a given hardware configuration can support before hitting a bottleneck?
+- **Storage/network throughput**: What IOPS, bandwidth, and latency can VMs expect under realistic workloads?
+
+**Story 2: As a Harvester software engineer improving performance**
+I want profiling data so that I can identify bottlenecks, catch potential OOMs before they hit production, and prove my optimizations work. Specifically:
+
+- **Per-component resource profiling**: CPU/memory consumption of each pod as VM count grows, to understand which component becomes the bottleneck first (e.g., instance-manager at ~20 GiB per pod with 149 volumes).
+- **Memory pressure analysis**: Identify components at risk of OOM — comparing scheduler-reserved memory vs actual RSS, and flagging components where actual consumption grows disproportionately with VM count.
+- **Upgrade per-phase timing**: Break down upgrade duration into pre-drain, node drain, post-drain, and total, so we can pinpoint which phase is slow and whether optimizations reduce it (see [#10421](https://github.com/harvester/harvester/issues/10421)).
+- **VM migration profiling**: Duration and resource cost of live migration under varying VM sizes and storage backends, since migration involves both network and storage I/O.
+- **CSI driver throughput under load**: Whether the Harvester CSI driver can keep up during rapid guest node shutdown/recreation before Longhorn times out.
+
+### User Experience In Detail
+
+1. At each release, run the benchmark suite against a clean cluster matching the defined topology.
+2. Record results in the wiki under the release version.
+3. Compare against the previous release baseline and publish in release notes.
+
+### API changes
+
+N/A
+
+## Design
+
+### Implementation Overview
+
+The benchmark policy is organized into four categories. Each defines scope, tooling, topology, methodology, and key metrics.
+
+#### Category 1: Resource Footprint
+
+- **Scope**: CPU and memory consumption of each Harvester component (pods) at idle and under VMs load.
+- **Tooling**:
+  - `kubectl top pods`, know the pod cpu, memory usages
+  - `grep -E 'MemTotal|MemFree|MemAvailable|SReclaimable' /proc/meminfo`, host memory allocation.
+  - `kubectl describe node | grep -A5 'Allocated resources'`, know the scheduler cpu/memory resource allocation.
+- **Topology**:
+  - Single-node: 1 control-plane node, no worker nodes.
+  - Multi-node: 3-node cluster (1 control-plane, 2 workers).
+- **Methodology**:
+  - [Harvester Resource Footprint gist](https://gist.github.com/Vicente-Cheng/ae8d5ce743f94c0c9a333574813bc777).
+  - Capture component-level CPU/memory at rest, then with increasing VM counts (e.g., 10 VMs, 20 VMs) to understand how resource consumption scales.
+- **Key metrics**:
+  - CPU (millicores), memory RSS (MiB), per pod, per VM count.
+  - VMs can be created in a given environment before a component becomes the bottleneck.
+
+#### Category 2: Performance Benchmark (I/O)
+
+- **Scope**: Storage throughput/latency and network throughput.
+- **Tooling**:
+  - Storage: `fio` (sequential and random read/write, 4K and 128K block sizes)
+  - Network: `iperf3` (TCP throughput, UDP jitter)
+- **Topology**: Multi-node cluster.
+- **Methodology**: [Harvester Performance wiki](https://github.com/harvester/harvester/wiki/Harvester-Performance-Result).
+  - Raw Device measure - fio / iperf3
+  - VMs on Longhorn volumes for storage tests.
+    - Linux VM - fio
+    - Windows VM - fio
+- **Key metrics**: IOPS, throughput (MB/s), latency (ms), bandwidth (Gbps).
+
+#### Category 3: KubeVirt Scaling Comparison
+
+- **Scope**: Measure the additional overhead Harvester introduce on top of vanilla KubeVirt.
+- **Tooling**:
+  - `kubectl top pods` — per-component CPU/memory during and after VM creation.
+- **Topology**:
+  - Single-node: 1 control-plane node, no worker nodes.
+  - Multi-node: 3-node cluster, from [kubevirt-presubmits-1.8.yaml](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml).
+- **Methodology**:
+  - Follow [KubeVirt perf-scale-benchmarks](https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md).
+  - Create 100 VMs with 100ms interval, wait for all to reach Running state.
+  - Compare results between vanilla KubeVirt and Harvester on the same hardware, similar to Category 1: Resource Footprint
+- **Key metrics**:
+  - vmiCreationToRunningSeconds P50/P95
+  - CPU/memory of virt-controller, harvester-controller during batch creation
+
+### Test plan
+
+N/A
+
+### Upgrade strategy
+
+N/A
+
+## Note [optional]
+
+- Future work: benchmark automation (scheduled runs, result diffing, automatic regression issue filing).  

--- a/enhancements/20260424-harvester-benchmark-policy.md
+++ b/enhancements/20260424-harvester-benchmark-policy.md
@@ -141,7 +141,9 @@ The benchmark policy is organized into two categories. Each defines scope, tooli
     - All three nodes: 1 control-plane, 2 workers.
     - **Storage network**: 10GbE dedicated NIC for Longhorn replication traffic, isolated from management and VM networks.
     - **Kube-OVN enabled**: Test with Kube-OVN networking to measure its impact on VM network performance (compare against default Canal/Multus).
-    - **Longhorn replica count > 1**: Set Longhorn volume replicas to 2 or 3 to measure replication overhead on storage throughput.
+    - **Longhorn storage profiles**:
+      - **Local-single-replica**: Set Longhorn volume replicas to 1 and place the workload on the node hosting that replica to measure stack overhead without Longhorn replication traffic.
+      - **Replicated**: Set Longhorn volume replicas to 2 to measure replication overhead on storage throughput.
   - **Inter-node bandwidth**: Measured via iperf3 before benchmark runs to confirm line rate (record actual observed bandwidth).
 - **Methodology**: [Harvester Performance wiki](https://github.com/harvester/harvester/wiki/Harvester-Performance-Result).
   - **Storage overhead (layered testing)**:

--- a/enhancements/20260424-harvester-benchmark-policy.md
+++ b/enhancements/20260424-harvester-benchmark-policy.md
@@ -15,8 +15,8 @@ Currently, benchmark runs are ad-hoc: different engineers use different tools, r
 
 ### Goals
 
-- **Define Benchmark Categories**: Establish canonical categories covering Harvester's performance surface — Resource Footprint, I/O Performance, and KubeVirt Scaling.
-- **Standardize Tooling and Methodology**: Specify tools and procedures for each category so results are reproducible by any team member.
+- **Define Benchmark Categories**: Establish canonical categories covering Harvester's performance surface — Resource Footprint (including VM creation latency) and I/O Performance.
+- **Standardize Tooling and Methodology**: Specify tools and procedures for each category so results are reproducible by any team member and users can run benchmarks in their own environments.
 - **Maintain a Shared Baseline**: Publish benchmark results to the Harvester wiki each release and compare against the previous baseline.
 
 ### Non-goals
@@ -59,99 +59,145 @@ N/A
 
 ### Implementation Overview
 
-The benchmark policy is organized into three categories. Each defines scope, tooling, topology, methodology, and key metrics.
+The benchmark policy is organized into two categories. Each defines scope, tooling, topology, methodology, and key metrics.
+
+#### Prerequisites
+
+##### Infrastructure Configuration Consistency
+
+**Standardize configurations** to ensure results are comparable across releases:
+- **Hardware**: Document CPU model, RAM, disk type (SSD/NVMe/HDD), network interfaces. Use same hardware across releases or annotate changes.
+- **Network**: Kube-OVN is enabled.
+- **Storage**: Specify Longhorn replica count, LVM config, disk partitioning, filesystem type.
+- **Harvester config**: Document non-default settings (kernel params, resource reservations, addons).
+
+##### Monitoring Stack Setup
+
+**All benchmark categories require the Harvester monitoring stack to be enabled** to collect detailed metrics during test execution.
+
+- **Installation**: Enable the `rancher-monitoring` chart in Harvester settings before running any benchmark.
+- **Purpose**: 
+  - Collect component-level metrics (CPU, memory, API latency) via Prometheus during benchmark runs, rather than just a peak value
+  - Capture P50/P99/tail latency metrics for VM creation.
 
 #### Category 1: Resource Footprint
 
-- **Scope**: CPU and memory consumption of each Harvester component at idle and under maximum VM density.
+- **Scope**: CPU and memory consumption of each Harvester component at idle and under maximum VM density, including VM creation latency metrics.
 - **Tooling**:
   - `kubectl top pods` — per-pod CPU/memory usage.
   - `ps -C containerd,kubelet,rke2 -o rss=` — host-level process RSS.
   - `grep -E 'MemTotal|MemFree|MemAvailable|SReclaimable' /proc/meminfo` — host memory allocation.
   - `kubectl describe node | grep -A5 'Allocated resources'` — scheduler CPU/memory resource allocation.
   - `etcdctl endpoint status` — etcd db size.
+  - Prometheus (enabled via monitoring stack) — query `kubevirt_vmi_phase_transition_time_from_creation_seconds` and component metrics.
+  - KubeVirt [perfscale-audit](https://github.com/kubevirt/kubevirt/tree/main/tools/perfscale-audit) tool — connects to Prometheus for VM creation latency queries.
 - **Topology**:
   - Single-node: 1 control-plane node, no worker nodes.
   - Multi-node: 3-node cluster (1 control-plane, 2 workers).
 - **Methodology**:
   - [Harvester Resource Footprint gist](https://gist.github.com/Vicente-Cheng/ae8d5ce743f94c0c9a333574813bc777).
-  - Phase 1: Measure at idle (0 VMs running) to establish the platform baseline.
-  - Phase 2: Create VMs until the scheduler rejects — record the maximum VM count and which resource (CPU, memory, or other) is the bottleneck.
-  - Capture per-namespace breakdown (kube-system, harvester-system, longhorn-system, cattle-system) at each phase.
+  - Adopt VM creation latency measurement from [KubeVirt perf-scale-benchmarks](https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md) (PromQL queries).
+  - **Phase 1: Idle baseline**
+    - Ensure monitoring stack is running and all pods are Ready.
+    - Measure resource consumption with 0 VMs to establish platform baseline.
+    - Capture per-namespace breakdown: `kube-system`, `harvester-system`, `longhorn-system`, `cattle-system`, `cattle-monitoring-system`.
+  - **Phase 2: VM creation and scaling**
+    - Create VMs incrementally with 100ms interval (minimal spec: Cirros or Alpine, 100m CPU, 128Mi memory) until the scheduler rejects new VMs.
+    - **During VM creation**, capture VM creation latency via Prometheus:
+      - `kubevirt_vmi_phase_transition_time_from_creation_seconds` (histogram) — P50, P95, P99.
+      - Total time from first VM creation to last VM reaching Running (batch throughput).
+    - Record the maximum VM count and identify the bottleneck resource (CPU, memory).
+    - Capture per-component resource consumption at max VM density (same metrics as Phase 1).
+    - Ensure workloads are evenly distributed among workers to avoid skewed results.
   - Compare single-node vs multi-node to understand how platform overhead scales with node count.
+  - **User-reproducible script**: Provide a standalone script with VM manifest templates and PromQL queries so users can run in their own environment to validate expected resource footprint and VM creation performance.
 - **Key metrics**:
-  - Platform idle cost: total CPU (millicores) and memory (MiB) with 0 VMs.
-  - Maximum VM count before scheduler rejects, and the bottleneck resource.
-  - Scheduler-reserved vs actual physical consumption ratio.
-  - etcd db size (MiB).
-
+  - **Resource consumption**:
+    - Platform idle cost: total CPU (millicores) and memory (MiB) with 0 VMs, broken down by namespace.
+    - Monitoring stack overhead: CPU/memory of `cattle-monitoring-system`, Prometheus TSDB size (MiB).
+    - Maximum VM count before scheduler rejects, and the bottleneck resource.
+    - Scheduler-reserved vs actual physical consumption ratio.
+    - etcd db size (MiB).
+  - **VM creation latency** (captured during Phase 2):
+    - P50, P95, P99 (seconds from VMI creation to Running state).
+    - Tail latency: max creation time in the batch.
+    - Batch throughput: total time for all VMs to reach Running.
 #### Category 2: Performance Benchmark
 
 ##### 2a: Storage and Network I/O
 
-- **Scope**: Storage throughput/latency and network throughput.
+- **Scope**: Storage throughput/latency and network throughput, with Prometheus monitoring of system-level resource impact during I/O tests.
 - **Tooling**:
-  - Storage: `fio` (sequential and random read/write, 4K and 128K block sizes)
-  - Network: `iperf3` (TCP throughput, UDP jitter)
+  - **Storage**: 
+    - `fio` (sequential and random read/write, 4K and 128K block sizes)
+    - **Version pinning**: Use the same fio version across all Harvester releases for result consistency (e.g., fio-3.36 from official container image or built into test VM image).
+  - **Network**: 
+    - `iperf3` (TCP throughput, UDP jitter)
+    - **Packaged image**: Provide a pre-built container image with iperf3 for reproducibility (e.g., `harbor.example.com/harvester/iperf3:3.15`).
+  - **Monitoring**:
+    - Prometheus (enabled via monitoring stack) — track node-level disk I/O, network bandwidth, and CPU iowait during tests.
 - **Topology**:
-  - Multi-node: 3-node cluster (1 control-plane, 2 workers).
-  - **Storage network**: 10GbE dedicated NIC for Longhorn replication traffic, isolated from management and VM networks.
+  - **Multi-node (3-node cluster)**: For cluster-level storage/network tests.
+    - All three nodes: 1 control-plane, 2 workers.
+    - **Storage network**: 10GbE dedicated NIC for Longhorn replication traffic, isolated from management and VM networks.
+    - **Kube-OVN enabled**: Test with Kube-OVN networking to measure its impact on VM network performance (compare against default Canal/Multus).
+    - **Longhorn replica count > 1**: Set Longhorn volume replicas to 2 or 3 to measure replication overhead on storage throughput.
   - **Inter-node bandwidth**: Measured via iperf3 before benchmark runs to confirm line rate (record actual observed bandwidth).
 - **Methodology**: [Harvester Performance wiki](https://github.com/harvester/harvester/wiki/Harvester-Performance-Result).
-  - **Storage overhead**:
-    - Layer 0 (Raw Device): fio directly on host block device
-    - Layer 1 (Longhorn volume, host): fio on Longhorn PVC mounted to a pod on the host
-    - Layer 2 (guest VM): fio inside Linux/Windows VM backed by Longhorn volume
-  - **Network overhead**:
-    - Layer 0 (Raw Device): confirm inter-node line rate via iperf3
-    - VM network: iperf3 between two VMs to measure guest network throughput.
-- **Key metrics**: IOPS, throughput (MB/s), latency (ms), bandwidth (Gbps).
+  - **Storage overhead (layered testing)**:
+    - **Layer 0 (Raw Device)**: fio directly on host block device (multi-node host controller node).
+    - **Layer 1 (Longhorn volume, host)**: fio on Longhorn PVC mounted to a pod on the host (multi-node, with replica count ≥ 2).
+    - **Layer 2 (guest VM)**: fio inside Linux/Windows VM backed by Longhorn volume (multi-node, with Kube-OVN enabled/disabled comparison).
+  - **Network overhead (layered testing)**:
+    - **Layer 0 (Raw Device)**: Confirm inter-node line rate via iperf3 between bare metal nodes or host pods.
+    - **Layer 1 (VM network)**: iperf3 between two VMs on different nodes to measure guest network throughput.
+  - **Prometheus monitoring during tests**:
+    - Capture time-series data during the entire fio/iperf3 run.
+    - Track node-level metrics to identify bottlenecks (see Prometheus metrics section).
+  - **User-reproducible script**: Provide a standalone script with:
+    - Pre-built fio/iperf3 container images.
+    - VM manifest templates with fio/iperf3 pre-installed.
+    - PromQL queries to validate results.
+- **Key metrics**:
+  - **Storage**:
+    - IOPS (4K random read/write).
+    - Throughput (MB/s, 128K sequential read/write).
+    - Latency (ms, P50/P95/P99).
+  - **Network**:
+    - Bandwidth (Gbps, TCP throughput).
+    - Latency (ms, UDP jitter).
 
 ##### 2b: etcd
 
-- **Scope**: etcd get, put, and watch latency and throughput at idle (0 VMs), to establish baseline performance for a given hardware configuration.
+- **Scope**: etcd get, put, and watch latency and throughput at idle (0 VMs), with Prometheus monitoring to identify disk-level bottlenecks.
 - **Tooling**:
-  - etcd [benchmark](https://github.com/etcd-io/etcd/tree/main/tools/benchmark) tool — build from `etcd/tools/benchmark` in the etcd repository.
+  - **etcd benchmark**: etcd [benchmark](https://github.com/etcd-io/etcd/tree/main/tools/benchmark) tool — build from `etcd/tools/benchmark` in the etcd repository.
+  - **Prometheus metrics**: Monitor etcd disk performance via `etcd_disk_wal_fsync_duration_seconds` and `etcd_disk_backend_commit_duration_seconds`, [reference](https://etcd.io/docs/v3.6/metrics/).
 - **Topology**:
   - Single-node: 1 control-plane node, no worker nodes.
   - Multi-node: 3-node cluster (1 control-plane, 2 workers).
 - **Methodology**:
   - Run at idle (0 VMs) to establish baseline.
-  - For each operation, run a single-client and a concurrent workload:
-    - **Put**:
-      - Single: 1 connection, 1 client, 10,000 requests, 256-byte value.
-      - Concurrent: 100 connections, 1,000 clients, 100,000 requests, 256-byte value.
-    - **Get** (seed keys before benchmarking):
-      - Single: 1 connection, 1 client, 10,000 requests.
-      - Concurrent: 100 connections, 1,000 clients, 100,000 requests.
-    - **Watch**:
-      - Single: 1 connection, 1 client, 10,000 watch events.
-      - Concurrent: 100 connections, 1,000 clients, 100,000 watch events.
+  - **etcd API benchmark**:
+    - For each operation, run a single-client and a concurrent workload:
+      - **Put**:
+        - Single: 1 connection, 1 client, 10,000 requests, 256-byte value.
+        - Concurrent: 100 connections, 1,000 clients, 100,000 requests, 256-byte value.
+      - **Get** (seed keys before benchmarking):
+        - Single: 1 connection, 1 client, 10,000 requests.
+        - Concurrent: 100 connections, 1,000 clients, 100,000 requests.
+      - **Watch**:
+        - Single: 1 connection, 1 client, 10,000 watch events.
+        - Concurrent: 100 connections, 1,000 clients, 100,000 watch events.
+
 - **Key metrics**:
-  - Requests per second (throughput).
-  - Latency: average, P50, P99.
-
-#### Category 3: KubeVirt Scaling Comparison
-
-- **Scope**: Measure the additional overhead Harvester introduces on top of vanilla KubeVirt, using the KubeVirt version bundled with the Harvester release under test.
-- **Tooling**:
-  - Prometheus (built-in to Harvester) — query KubeVirt metrics via PromQL.
-  - KubeVirt [perfscale-audit](https://github.com/kubevirt/kubevirt/tree/main/tools/perfscale-audit) tool — connects to Prometheus, runs predefined queries, dumps results to JSON.
-- **Topology**:
-  - Single-node: 1 control-plane node, no worker nodes.
-  - Multi-node: 3-node cluster (1 control-plane, 2 workers).
-- **Methodology**:
-  - Adopt measurement methodology from [KubeVirt perf-scale-benchmarks](https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md), not their cluster topology.
-  - Use local-path storage for VM volumes to isolate KubeVirt overhead from storage backend variance.
-  - Create 100 VMs with 100ms interval (minimal spec: Cirros, 100m CPU, 90Mi memory), wait for all to reach Running state.
-  - Collect metrics via Prometheus after waiting for scrape interval (30s default).
-  - Run the same test on vanilla KubeVirt (same version as bundled in Harvester) and Harvester on the same hardware.
-  - Ensure workloads are evenly distributed among workers to avoid skewed results.
-- **Phase 1 — Baseline** (establish the performance gap):
-  - vmiCreationToRunningSeconds P50/P95 (boot time tail latency).
-  - Total time for 100 VMs to reach Running (batch throughput).
-- **Phase 2 — Profiling** (identify where the gap comes from):
-  - **API operation counts**: PATCH-pods-count, PATCH-virtualmachineinstances-count, UPDATE-virtualmachineinstances-count per component — identifies the most expensive calls from the Harvester stack.
+  - **etcd API performance (from etcd benchmark)**:
+    - Requests per second (throughput).
+    - Latency: average, P50, P99.
+  - **Prometheus monitoring during tests**:
+    - Capture etcd disk performance metrics during the benchmark:
+      - `etcd_disk_wal_fsync_duration_seconds` — WAL (Write-Ahead Log) fsync latency (how long it takes to persist each write to disk).
+      - `etcd_disk_backend_commit_duration_seconds` — boltdb snapshot commit latency (how long it takes to commit batched changes to disk).
 
 ### Test plan
 
@@ -163,7 +209,15 @@ N/A
 
 ## Note [optional]
 
-- Future work:
-  - Benchmark automation (scheduled runs, result diffing, automatic regression issue filing).
-  - etcd benchmark under VM load — run during VM creation to capture peak write pressure, and compare with steady-state after VMs are running.
-  - Disk topology comparison — measure etcd performance when etcd shares the root disk (e.g., LVM) vs. a dedicated disk, to quantify I/O contention impact on etcd latency.
+### User-Reproducible Benchmark Scripts
+
+All benchmark categories will include standalone scripts that users can run in their own Harvester environments to:
+- Validate that their hardware meets expected performance baselines.
+- Debug performance issues by comparing local results against published benchmarks.
+- Reproduce benchmark results for support cases.
+
+### Future Work
+
+- Benchmark automation (scheduled runs, result diffing, automatic regression issue filing).
+- etcd benchmark under VM load — run during VM creation to capture peak write pressure, and compare with steady-state after VMs are running.
+- Disk topology comparison — measure etcd performance when etcd shares the root disk (e.g., LVM) vs. a dedicated disk, to quantify I/O contention impact on etcd latency.


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
#9777

#### Solution:
HEP for #9777

#### Related Issue(s):
HEP for #9777

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Open Question
1. **Cluster topology**: Does Harvester support the same 4-node setup used by KubeVirt's SIG-scale presubmit (1 control-plane + 3 workers, see
   [kubevirt-presubmits-1.8.yaml](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml)?

   I want to keep the reproduction close to the https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md.
   If not, should we re-run the benchmark ourselves with a Harvester-supported topology to keep the comparison fair (1 control-plane + 2 worker node) ?

2. **KubeVirt version baseline**: Which KubeVirt version should we compare
   against — the one bundled with the Harvester release under test (e.g. Harvester 1.8.0 vs its embedded KubeVirt version), or a fixed upstream version (e.g. Harvester 1.8.0 vs vanilla KubeVirt 1.8.0)?