### PR TITLE
fix(upgrade): retry transient cluster update via reconcile loop

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -727,7 +727,7 @@ func (h *upgradeHandler) resetLatestUpgradeLabel(latestUpgradeName string) error
 func (h *upgradeHandler) upgradeKubernetes(kubernetesVersion string) error {
 	cluster, err := h.clusterCache.Get("fleet-local", "local")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get fleet-local/local cluster from cache: %w", err)
 	}
 
 	toUpdate := cluster.DeepCopy()
@@ -754,8 +754,10 @@ func (h *upgradeHandler) upgradeKubernetes(kubernetesVersion string) error {
 	updateDrainHooks(&toUpdate.Spec.RKEConfig.UpgradeStrategy.WorkerDrainOptions.PreDrainHooks, preDrainAnnotation)
 	updateDrainHooks(&toUpdate.Spec.RKEConfig.UpgradeStrategy.WorkerDrainOptions.PostDrainHooks, postDrainAnnotation)
 
-	_, err = h.clusterClient.Update(toUpdate)
-	return err
+	if _, err := h.clusterClient.Update(toUpdate); err != nil {
+		return fmt.Errorf("failed to update fleet-local/local cluster to kubernetes version %s: %w", kubernetesVersion, err)
+	}
+	return nil
 }
 
 func updateDrainHooks(hooks *[]rkev1.DrainHook, annotation string) {

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -449,11 +449,21 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 				return nil, err
 			}
 
+			// Persist the in-memory annotations set above (replica-replenishment-wait-interval
+			// and reenable-descheduler-addon) before attempting upgradeKubernetes. Both are
+			// read later during cleanup; if upgradeKubernetes fails and we returned without
+			// persisting, the next reconcile would skip the save block (the live values are
+			// already mutated) and lose the original state we need to restore.
+			persisted, err := h.upgradeClient.Update(toUpdate)
+			if err != nil {
+				return nil, err
+			}
+			toUpdate = persisted.DeepCopy()
+
 			// go with RKE2 pre-drain/post-drain hooks
 			logrus.Infof("Start upgrading Kubernetes runtime to %s", info.Release.Kubernetes)
 			if err := h.upgradeKubernetes(info.Release.Kubernetes); err != nil {
-				setUpgradeCompletedCondition(toUpdate, StateFailed, corev1.ConditionFalse, err.Error(), "")
-				return h.upgradeClient.Update(toUpdate)
+				return upgrade, err
 			}
 		}
 

--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -387,8 +387,7 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 		}
 
 		if _, err := h.jobClient.Create(applyManifestsJob(upgrade, repoInfo)); err != nil && !apierrors.IsAlreadyExists(err) {
-			setUpgradeCompletedCondition(toUpdate, StateFailed, corev1.ConditionFalse, err.Error(), "")
-			return h.upgradeClient.Update(toUpdate)
+			return upgrade, fmt.Errorf("failed to create apply-manifests job: %w", err)
 		}
 		toUpdate.Labels[upgradeStateLabel] = StateUpgradingSystemServices
 		setHelmChartUpgradeStatus(toUpdate, corev1.ConditionUnknown, "", "")
@@ -422,8 +421,7 @@ func (h *upgradeHandler) OnChanged(_ string, upgrade *harvesterv1.Upgrade) (*har
 
 			logrus.Info("Start single node upgrade job")
 			if _, err = h.jobClient.Create(applyNodeJob(upgrade, info, singleNodeName, upgradeJobTypeSingleNodeUpgrade)); err != nil && !apierrors.IsAlreadyExists(err) {
-				setUpgradeCompletedCondition(toUpdate, StateFailed, corev1.ConditionFalse, err.Error(), "")
-				return h.upgradeClient.Update(toUpdate)
+				return upgrade, fmt.Errorf("failed to create single-node upgrade job for node %s: %w", singleNodeName, err)
 			}
 		} else {
 			if waiting, err := h.ensureSkipManifestPlanCompleted(upgrade, true); err != nil || waiting {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When the rancher-webhook pod is momentarily unavailable, the apiserver rejects the provisioning Cluster CR update with an "Internal error occurred: failed calling webhook ..." error. The upgrade controller previously treated this as a permanent failure and required users to restart the upgrade from scratch.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Return the error from upgradeKubernetes so the wrangler controller framework re-queues and retries the reconcile until the webhook recovers. Before the cluster update, persist the in-memory replica-replenishment-wait-interval and reenable-descheduler-addon annotations on the Upgrade CR; otherwise a return-without-persist would discard them and the next reconcile would skip the save block (the live values are already mutated), leaving cleanup unable to restore the original Longhorn setting and re-enable the descheduler.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#10529

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Prepare a multi-node v1.8.0 Harvester cluster
2. Upgrade the cluster using a master-head build ISO image
3. Keep an eye on the upgrade progress; When the apply-manifest job is about to complete, scale the `rancher-webhook` deployment down to 0 to mimic the webhook unavailablility
4. The upgarde should stall and never enters the node upgrade phase
5. Observe the log from the harvester pod, the `Start upgrading Kubernetes runtime...` messages should appear multiple times
6. Scale the `rancher-webhook` deployment up to the original replica count
7. The upgrade should be unblocked and eventually completes

#### Additional documentation or context
