### PR TITLE
fix(backend): reduce dashboard load delay in air-gapped environments

### DIFF
--- a/pkg/server/ui/ui.go
+++ b/pkg/server/ui/ui.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	responsewriter "github.com/rancher/apiserver/pkg/middleware"
 	"github.com/sirupsen/logrus"
@@ -17,6 +18,7 @@ import (
 
 var (
 	insecureClient = &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
@@ -70,7 +72,7 @@ func (u *handler) canDownload(url string) bool {
 		if err := serveIndex(io.Discard, url); err == nil {
 			u.downloadSuccess = true
 		} else {
-			logrus.Errorf("Failed to download %s, falling back to packaged UI", url)
+			logrus.Errorf("Failed to download %s (error: %v), falling back to packaged UI", url, err)
 		}
 	})
 	return u.downloadSuccess
@@ -113,7 +115,10 @@ func (u *handler) IndexFileOnNotFound() http.Handler {
 func (u *handler) IndexFile() http.Handler {
 	return u.indexMiddleware(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if path, isURL := u.path(); isURL {
-			_ = serveIndex(rw, path)
+			err := serveIndex(rw, path)
+			if err != nil {
+				logrus.Errorf("Failed to serve index from %s (error: %v)", path, err)
+			}
 		} else {
 			http.ServeFile(rw, req, filepath.Join(path, "index.html"))
 		}


### PR DESCRIPTION

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Deploy harvester non-formal releases in an air-gapped environment, we can't load the dashboard immidately after the deploy is finished.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add a timeout
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10540

#### Test plan:
<!-- Describe the test plan by steps. -->

* Deploy the harvester in an air-gapped environment; one node is OK.
  * You can configure nodes with a DNS server that can still be reached. But ensure the nodes can't reach the outside world with IP.
* After the cluster is ready, open the dashboard, and it should work.

#### Additional documentation or context

In non-formal releases (e.g., master or local builds), the backend defaults to fetching the external UI index before falling back to local assets.
In certain air-gapped environments—specifically those with functioning DNS but no external routing—this request can hang for up to 10 minutes before timing out.
This PR introduces a 30-second timeout to the external index request to ensure a faster fallback to bundled assets when the network is restricted.
