### PR TITLE
Allow user to customize snapshot/backup filesystem freeze deadline

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8849,6 +8849,9 @@
           "source"
         ],
         "properties": {
+          "fsFreezeDeadline": {
+            "$ref": "#/components/schemas/k8s.io.v1.Duration"
+          },
           "source": {
             "default": {},
             "allOf": [
@@ -9809,6 +9812,9 @@
             "$ref": "#/components/schemas/k8s.io.v1.ResourceFieldSelector"
           }
         }
+      },
+      "k8s.io.v1.Duration": {
+        "type": "string"
       },
       "k8s.io.v1.ExecAction": {
         "type": "object",

--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_schedulevmbackups.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_schedulevmbackups.yaml
@@ -78,6 +78,12 @@ spec:
                 type: boolean
               vmbackup:
                 properties:
+                  fsFreezeDeadline:
+                    description: |-
+                      FsFreezeDeadline specifies how long the guest filesystem may remain frozen
+                      before it is automatically unfrozen during snapshot or backup creation.
+                      A value of 0 means there is no deadline.
+                    type: string
                   source:
                     description: |-
                       TypedLocalObjectReference contains enough information to let you locate the

--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinebackups.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_virtualmachinebackups.yaml
@@ -59,6 +59,12 @@ spec:
             type: object
           spec:
             properties:
+              fsFreezeDeadline:
+                description: |-
+                  FsFreezeDeadline specifies how long the guest filesystem may remain frozen
+                  before it is automatically unfrozen during snapshot or backup creation.
+                  A value of 0 means there is no deadline.
+                type: string
               source:
                 description: |-
                   TypedLocalObjectReference contains enough information to let you locate the

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -166,7 +166,10 @@ func (h *vmActionHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.Response
 		}
 
 		if input.Name == "" {
-			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter backup name is required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `name` is required")
+		}
+		if input.FsFreezeDeadline != nil && input.FsFreezeDeadline.Duration < 0 {
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `fsFreezeDeadline` must not be negative")
 		}
 
 		if err := h.checkBackupTargetConfigured(); err != nil {
@@ -869,12 +872,15 @@ func (h *vmActionHandler) createVMBackup(vmName, vmNamespace string, input Backu
 				Kind:     kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 				Name:     vmName,
 			},
-			Type: harvesterv1.Backup,
+			Type:             harvesterv1.Backup,
+			FsFreezeDeadline: input.FsFreezeDeadline,
 		},
 	}
+
 	if _, err := h.backupClient.Create(backup); err != nil {
 		return fmt.Errorf("failed to create VM backup, error: %s", err.Error())
 	}
+
 	return nil
 }
 

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -160,7 +160,10 @@ func (h *vmActionHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.Response
 		}
 
 		if input.Name == "" {
-			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter backup name is required")
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `name` is required")
+		}
+		if input.FsFreezeDeadline != nil && input.FsFreezeDeadline.Duration < 0 {
+			return nil, apierror.NewAPIError(validation.InvalidBodyContent, "Parameter `fsFreezeDeadline` must not be negative")
 		}
 
 		if err := h.checkBackupTargetConfigured(); err != nil {
@@ -863,12 +866,15 @@ func (h *vmActionHandler) createVMBackup(vmName, vmNamespace string, input Backu
 				Kind:     kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 				Name:     vmName,
 			},
-			Type: harvesterv1.Backup,
+			Type:             harvesterv1.Backup,
+			FsFreezeDeadline: input.FsFreezeDeadline,
 		},
 	}
+
 	if _, err := h.backupClient.Create(backup); err != nil {
 		return fmt.Errorf("failed to create VM backup, error: %s", err.Error())
 	}
+
 	return nil
 }
 

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -1759,3 +1759,54 @@ func TestDetermineCloneAction(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateVMBackup(t *testing.T) {
+	vmName := "vm1"
+	vmNamespace := "default"
+
+	testCases := []struct {
+		name  string
+		input BackupInput
+	}{
+		{
+			name: "Create VM backup w/ FsFreezeDeadline (Infinite)",
+			input: BackupInput{
+				Name:             "backup1",
+				FsFreezeDeadline: ptr.To(metav1.Duration{Duration: 0 * time.Second}),
+			},
+		},
+		{
+			name: "Create VM backup w/ FsFreezeDeadline (5m)",
+			input: BackupInput{
+				Name:             "backup2",
+				FsFreezeDeadline: ptr.To(metav1.Duration{Duration: 5 * time.Minute}),
+			},
+		},
+		{
+			name: "Create VM backup w/o FsFreezeDeadline",
+			input: BackupInput{
+				Name: "backup3",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			handler := &vmActionHandler{
+				backupClient: fakeclients.VMBackupClient(clientset.HarvesterhciV1beta1().VirtualMachineBackups),
+			}
+
+			err := handler.createVMBackup(vmName, vmNamespace, tc.input)
+			assert.NoError(t, err)
+
+			backup, err := clientset.HarvesterhciV1beta1().VirtualMachineBackups(vmNamespace).Get(context.TODO(), tc.input.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.input.Name, backup.Name)
+			assert.Equal(t, vmNamespace, backup.Namespace)
+			assert.Equal(t, vmName, backup.Spec.Source.Name)
+			assert.Equal(t, harvesterv1.Backup, backup.Spec.Type)
+			assert.Equal(t, tc.input.FsFreezeDeadline, backup.Spec.FsFreezeDeadline)
+		})
+	}
+}

--- a/pkg/api/vm/handler_test.go
+++ b/pkg/api/vm/handler_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kubevirtutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 
@@ -1629,6 +1630,57 @@ func TestBuildVirtualMachineRestore(t *testing.T) {
 			assert.Equal(t, tt.input.BackupName, got.Spec.VirtualMachineBackupName)
 			assert.Equal(t, tt.input.KeepMacAddress, got.Spec.KeepMacAddress)
 			assert.Equal(t, tt.input.HaltAfterRestore, got.Spec.HaltAfterRestore)
+		})
+	}
+}
+
+func TestCreateVMBackup(t *testing.T) {
+	vmName := "vm1"
+	vmNamespace := "default"
+
+	testCases := []struct {
+		name  string
+		input BackupInput
+	}{
+		{
+			name: "Create VM backup w/ FsFreezeDeadline (Infinite)",
+			input: BackupInput{
+				Name:             "backup1",
+				FsFreezeDeadline: ptr.To(metav1.Duration{Duration: 0 * time.Second}),
+			},
+		},
+		{
+			name: "Create VM backup w/ FsFreezeDeadline (5m)",
+			input: BackupInput{
+				Name:             "backup2",
+				FsFreezeDeadline: ptr.To(metav1.Duration{Duration: 5 * time.Minute}),
+			},
+		},
+		{
+			name: "Create VM backup w/o FsFreezeDeadline",
+			input: BackupInput{
+				Name: "backup3",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			handler := &vmActionHandler{
+				backupClient: fakeclients.VMBackupClient(clientset.HarvesterhciV1beta1().VirtualMachineBackups),
+			}
+
+			err := handler.createVMBackup(vmName, vmNamespace, tc.input)
+			assert.NoError(t, err)
+
+			backup, err := clientset.HarvesterhciV1beta1().VirtualMachineBackups(vmNamespace).Get(context.TODO(), tc.input.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.input.Name, backup.Name)
+			assert.Equal(t, vmNamespace, backup.Namespace)
+			assert.Equal(t, vmName, backup.Spec.Source.Name)
+			assert.Equal(t, harvesterv1.Backup, backup.Spec.Type)
+			assert.Equal(t, tc.input.FsFreezeDeadline, backup.Spec.FsFreezeDeadline)
 		})
 	}
 }

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -1,6 +1,10 @@
 package vm
 
-import "github.com/rancher/wrangler/v3/pkg/condition"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/wrangler/v3/pkg/condition"
+)
 
 var (
 	vmiPaused condition.Cond = "Paused"
@@ -16,7 +20,8 @@ type EjectCdRomVolumeActionInput struct {
 }
 
 type BackupInput struct {
-	Name string `json:"name"`
+	Name             string           `json:"name"`
+	FsFreezeDeadline *metav1.Duration `json:"fsFreezeDeadline,omitempty"`
 }
 
 type RestoreInput struct {

--- a/pkg/apis/harvesterhci.io/v1beta1/backup.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/backup.go
@@ -95,6 +95,12 @@ type VirtualMachineBackupSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.type is immutable"
 	Type BackupType `json:"type,omitempty" default:"backup"`
+
+	// +optional
+	// FsFreezeDeadline specifies how long the guest filesystem may remain frozen
+	// before it is automatically unfrozen during snapshot or backup creation.
+	// A value of 0 means there is no deadline.
+	FsFreezeDeadline *metav1.Duration `json:"fsFreezeDeadline,omitempty"`
 }
 
 // VirtualMachineBackupStatus is the status for a VirtualMachineBackup resource

--- a/pkg/apis/harvesterhci.io/v1beta1/backup.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/backup.go
@@ -66,6 +66,12 @@ type VirtualMachineBackupSpec struct {
 	// +kubebuilder:validation:Enum=backup;snapshot
 	// +kubebuilder:validation:Optional
 	Type BackupType `json:"type,omitempty" default:"backup"`
+
+	// +optional
+	// FsFreezeDeadline specifies how long the guest filesystem may remain frozen
+	// before it is automatically unfrozen during snapshot or backup creation.
+	// A value of 0 means there is no deadline.
+	FsFreezeDeadline *metav1.Duration `json:"fsFreezeDeadline,omitempty"`
 }
 
 // VirtualMachineBackupStatus is the status for a VirtualMachineBackup resource

--- a/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/openapi_generated.go
@@ -3856,12 +3856,18 @@ func schema_pkg_apis_harvesterhciio_v1beta1_VirtualMachineBackupSpec(ref common.
 							Format: "",
 						},
 					},
+					"fsFreezeDeadline": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FsFreezeDeadline specifies how long the guest filesystem may remain frozen before it is automatically unfrozen during snapshot or backup creation. A value of 0 means there is no deadline.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 				Required: []string{"source"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.TypedLocalObjectReference"},
+			"k8s.io/api/core/v1.TypedLocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 

--- a/pkg/apis/harvesterhci.io/v1beta1/zz_generated_deepcopy.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/zz_generated_deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -1286,6 +1287,11 @@ func (in *VirtualMachineBackupList) DeepCopyObject() runtime.Object {
 func (in *VirtualMachineBackupSpec) DeepCopyInto(out *VirtualMachineBackupSpec) {
 	*out = *in
 	in.Source.DeepCopyInto(&out.Source)
+	if in.FsFreezeDeadline != nil {
+		in, out := &in.FsFreezeDeadline, &out.FsFreezeDeadline
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/backup/common/operator.go
+++ b/pkg/backup/common/operator.go
@@ -33,7 +33,7 @@ const (
 	backupBucketNameAnnotation   = "backup.harvesterhci.io/bucket-name"
 	backupBucketRegionAnnotation = "backup.harvesterhci.io/bucket-region"
 	volumeBackupNameFormat       = "%s-volume-%s"
-	defaultFreezeDuration        = 1 * time.Second
+	defaultFsFreezeDeadline      = 1 * time.Second
 	changeToNonReadyMessage      = "Change back to non-ready"
 	errVolumeBackupNil           = "volume backup is nil"
 	errVolumeBackupNameNil       = "volume backup name is nil"
@@ -158,6 +158,7 @@ type VMBackupReader interface {
 	GetCSIDriverVSCNames(vmb *harvesterv1.VirtualMachineBackup) map[string]string
 	GetType(vmb *harvesterv1.VirtualMachineBackup) harvesterv1.BackupType
 	GetBackupTarget(vmb *harvesterv1.VirtualMachineBackup) *harvesterv1.BackupTarget
+	GetFsFreezeDeadline(vmb *harvesterv1.VirtualMachineBackup) *metav1.Duration
 }
 
 type vmbackupReader struct{}
@@ -407,6 +408,13 @@ func (a *vmbackupReader) GetType(vmb *harvesterv1.VirtualMachineBackup) harveste
 
 func (a *vmbackupReader) GetBackupTarget(vmb *harvesterv1.VirtualMachineBackup) *harvesterv1.BackupTarget {
 	return vmb.Status.BackupTarget
+}
+
+func (a *vmbackupReader) GetFsFreezeDeadline(vmb *harvesterv1.VirtualMachineBackup) *metav1.Duration {
+	if vmb == nil {
+		return nil
+	}
+	return vmb.Spec.FsFreezeDeadline
 }
 
 type vmbackupOperator struct {
@@ -1287,7 +1295,12 @@ func (vmbo *vmbackupOperator) TryFreezeFS(ctx context.Context, vmb *harvesterv1.
 		return nil
 	}
 
-	if err := vmbo.freezeFS(ctx, sourceVMI, defaultFreezeDuration); err != nil {
+	timeout := defaultFsFreezeDeadline
+	if updatedVMb.Spec.FsFreezeDeadline != nil {
+		timeout = updatedVMb.Spec.FsFreezeDeadline.Duration
+	}
+
+	if err := vmbo.freezeFS(ctx, sourceVMI, timeout); err != nil {
 		return fmt.Errorf("qemu-guest-agent failed to freeze filesystem for VM %s/%s: %w",
 			sourceVMI.Namespace, sourceVMI.Name, err)
 	}

--- a/pkg/controller/master/backup/backup.go
+++ b/pkg/controller/master/backup/backup.go
@@ -58,8 +58,8 @@ const (
 	backupBucketNameAnnotation   = "backup.harvesterhci.io/bucket-name"
 	backupBucketRegionAnnotation = "backup.harvesterhci.io/bucket-region"
 
-	defaultFreezeDuration = 1 * time.Second
-	snapRevise            = "-snap-revise"
+	defaultFsFreezeDeadline = 1 * time.Second
+	snapRevise              = "-snap-revise"
 )
 
 var vmBackupKind = harvesterv1.SchemeGroupVersion.WithKind(vmBackupKindName)
@@ -278,7 +278,11 @@ func (h *Handler) tryFreezeFS(backup *harvesterv1.VirtualMachineBackup) error {
 		return err
 	}
 
-	err = h.freezeFS(context.Background(), sourceVMI, defaultFreezeDuration)
+	timeout := defaultFsFreezeDeadline
+	if backup.Spec.FsFreezeDeadline != nil {
+		timeout = backup.Spec.FsFreezeDeadline.Duration
+	}
+	err = h.freezeFS(context.Background(), sourceVMI, timeout)
 	if err != nil {
 		logrus.WithError(err).Warn("qemu-guest-agent fs-freeze")
 		return errors.New("failed to freeze file system")

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	fieldSourceName = "spec.source.name"
-	fieldTypeName   = "spec.type"
+	fieldSourceName       = "spec.source.name"
+	fieldTypeName         = "spec.type"
+	fieldFsFreezeDeadline = "spec.fsFreezeDeadline"
 )
 
 func NewValidator(
@@ -83,6 +84,10 @@ func (v *virtualMachineBackupValidator) Create(_ *types.Request, newObj runtime.
 
 	if newVMBackup.Spec.Source.Name == "" {
 		return werror.NewInvalidError("source VM name is empty", fieldSourceName)
+	}
+
+	if newVMBackup.Spec.FsFreezeDeadline != nil && newVMBackup.Spec.FsFreezeDeadline.Duration < 0 {
+		return werror.NewInvalidError("must not be negative", fieldFsFreezeDeadline)
 	}
 
 	validateFunc := v.validateStandardBackup
@@ -185,6 +190,12 @@ func (v *virtualMachineBackupValidator) checkBackupTarget() error {
 func (v *virtualMachineBackupValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	newVMBackup := newObj.(*v1beta1.VirtualMachineBackup)
 	oldVMBackup := oldObj.(*v1beta1.VirtualMachineBackup)
+
+	// It's actually pretty useless, since this value is only used during
+	// creation, but for the sake of consistency, we'll check it here anyway.
+	if newVMBackup.Spec.FsFreezeDeadline != nil && newVMBackup.Spec.FsFreezeDeadline.Duration < 0 {
+		return werror.NewInvalidError("must not be negative", fieldFsFreezeDeadline)
+	}
 
 	oldAnnotations := oldVMBackup.GetAnnotations()
 	newAnnotations := newVMBackup.GetAnnotations()

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	fieldSourceName = "spec.source.name"
-	fieldTypeName   = "spec.type"
+	fieldSourceName       = "spec.source.name"
+	fieldTypeName         = "spec.type"
+	fieldFsFreezeDeadline = "spec.fsFreezeDeadline"
 )
 
 func NewValidator(
@@ -89,6 +90,10 @@ func (v *virtualMachineBackupValidator) Create(_ *types.Request, newObj runtime.
 	sourceName := v.vmbr.GetSourceName(newVMBackup)
 	if sourceName == "" {
 		return werror.NewInvalidError("source VM name is empty", fieldSourceName)
+	}
+
+	if fsFreezeDeadline := v.vmbr.GetFsFreezeDeadline(newVMBackup); fsFreezeDeadline != nil && fsFreezeDeadline.Duration < 0 {
+		return werror.NewInvalidError("must not be negative", fieldFsFreezeDeadline)
 	}
 
 	validateFunc := v.validateStandardBackup
@@ -191,6 +196,12 @@ func (v *virtualMachineBackupValidator) checkBackupTarget() error {
 func (v *virtualMachineBackupValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
 	newVMBackup := newObj.(*v1beta1.VirtualMachineBackup)
 	oldVMBackup := oldObj.(*v1beta1.VirtualMachineBackup)
+
+	// It's actually pretty useless, since this value is only used during
+	// creation, but for the sake of consistency, we'll check it here anyway.
+	if fsFreezeDeadline := v.vmbr.GetFsFreezeDeadline(newVMBackup); fsFreezeDeadline != nil && fsFreezeDeadline.Duration < 0 {
+		return werror.NewInvalidError("must not be negative", fieldFsFreezeDeadline)
+	}
 
 	oldAnnotations := oldVMBackup.GetAnnotations()
 	newAnnotations := newVMBackup.GetAnnotations()


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Since https://github.com/harvester/harvester/commit/bcacb1b0145dd1ee15db1f438a52ae091c70c78c: during a snapshot or backup, Harvester will check if the VM is running the QEMU Guest Agent, and if it is, it will instruct the guest agent to freeze the guest file systems and flush pending I/O. That PR uses a very conservative timeout value of 1 second, which is probably fine for CPU bound VMs but most likely not sufficient for a VM running a ton of I/O.

As a result, Harvester can support perfectly consistent snapshots for some VMs but not all VMs. Ideally, Harvester can be positioned to provide consistent snapshots for all workloads.

#### Solution:
Add a field to `VirtualMachineBackup` CR that allows the user to specify the filesystem freeze deadline value to be used.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/4098

#### Test plan:
These test cases do NOT verify whether the configured `UnfreezeTimeout` parameter is applied when the [freeze REST-API endpoint](https://github.com/kubevirt/kubevirt/blob/4e3d95f6053b21ba0fe22ed748b69af1d242c847/pkg/virt-launcher/virtwrap/storage/fsfreeze.go#L36) is called.

***Case 1***
- Run this:
```
$ cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineBackup
metadata:
  name: back01
  namespace: default
spec:
  fsFreezeDeadline: "-1m"
  source:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test01
  type: backup
EOF
```
The output must look like this:
```
The request is invalid: spec.fsFreezeDeadline: must not be negative
```

***Case 2***
- Create a VM called `test01`.
- Run this:
```
$ cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineBackup
metadata:
  name: back01
  namespace: default
spec:
  fsFreezeDeadline: "30s"
  source:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test01
  type: backup
EOF
```
- A backup called `back01` should be created.
<img width="1207" height="449" alt="grafik" src="https://github.com/user-attachments/assets/7890cff2-0140-4230-a21f-950cb9d8c4af" />

- Edit the YAML. The `fsFreezeDeadline` should look like:
<img width="1207" height="548" alt="grafik" src="https://github.com/user-attachments/assets/6f988f07-ad54-41e0-b1aa-6f1bc60202da" />

***Case 3***
- Create a VM called `test01`.
- Run this:
```
$ cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: VirtualMachineBackup
metadata:
  name: snap01
  namespace: default
spec:
  fsFreezeDeadline: "0"
  source:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test01
  type: snapshot
EOF
```
- A snapshot called `snap01` should be created.
<img width="1207" height="449" alt="grafik" src="https://github.com/user-attachments/assets/40308845-1f73-4a04-802b-2bdd22a2a25c" />

- Edit the YAML. The `fsFreezeDeadline` should look like:
<img width="1207" height="548" alt="grafik" src="https://github.com/user-attachments/assets/2cb1972a-28bf-432a-9dcc-1fbd39bffc87" />

***Case 4***
- Edit one of the previous backup/snapshot in YAML. Change the `fsFreezeDeadline` to `"-20s"`. Press `Save`.
- The following error message must appear:
<img width="1207" height="548" alt="Bildschirmfoto vom 2026-05-13 08-31-21" src="https://github.com/user-attachments/assets/d4fe26ba-a149-447f-95b7-7f7a0089918a" />

#### Additional documentation or context
