### PR TITLE
enhancement: Add node expansion secret as optional and reduce duplicated code

### DIFF
--- a/pkg/image/common/mutator.go
+++ b/pkg/image/common/mutator.go
@@ -40,14 +40,16 @@ func mergeStorageClassParams(vmi *harvesterv1.VirtualMachineImage, sc *storagev1
 	} else if vmi.Spec.StorageClassParameters != nil {
 		mergeParams = vmi.Spec.StorageClassParameters
 	}
-	var allowPatchParams = []string{
+	baseParams := []string{
 		longhorntypes.OptionNodeSelector, longhorntypes.OptionDiskSelector,
 		longhorntypes.OptionNumberOfReplicas, longhorntypes.OptionStaleReplicaTimeout,
 		util.LonghornDataLocality,
 		util.LonghornOptionEncrypted,
-		util.CSIProvisionerSecretNameKey, util.CSIProvisionerSecretNamespaceKey,
-		util.CSINodeStageSecretNameKey, util.CSINodeStageSecretNamespaceKey,
-		util.CSINodePublishSecretNameKey, util.CSINodePublishSecretNamespaceKey,
+	}
+	allowPatchParams := make([]string, 0, len(baseParams)+2*len(util.CSIEncryptionSecretKeyPairs))
+	allowPatchParams = append(allowPatchParams, baseParams...)
+	for _, p := range util.CSIEncryptionSecretKeyPairs {
+		allowPatchParams = append(allowPatchParams, p.NameKey, p.NamespaceKey)
 	}
 
 	for k, v := range mergeParams {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -149,6 +149,8 @@ const (
 	CSINodePublishSecretNamespaceKey = "csi.storage.k8s.io/node-publish-secret-namespace"
 	CSINodeStageSecretNameKey        = "csi.storage.k8s.io/node-stage-secret-name"
 	CSINodeStageSecretNamespaceKey   = "csi.storage.k8s.io/node-stage-secret-namespace"
+	CSINodeExpandSecretNameKey       = "csi.storage.k8s.io/node-expand-secret-name"
+	CSINodeExpandSecretNamespaceKey  = "csi.storage.k8s.io/node-expand-secret-namespace"
 
 	LabelUpgradeReadMessage          = prefix + "/read-message"
 	LabelUpgradeState                = prefix + "/upgradeState"
@@ -309,3 +311,18 @@ const (
 
 	GoArchArm64 = "arm64"
 )
+
+// CSISecretKeyPair groups a CSI secret-name parameter key with its matching namespace key.
+type CSISecretKeyPair struct {
+	NameKey      string
+	NamespaceKey string
+}
+
+// CSIEncryptionSecretKeyPairs lists the CSI parameter key pairs used to reference
+// the encryption secret for a StorageClass, in the order CSI expects them.
+var CSIEncryptionSecretKeyPairs = []CSISecretKeyPair{
+	{CSIProvisionerSecretNameKey, CSIProvisionerSecretNamespaceKey},
+	{CSINodeStageSecretNameKey, CSINodeStageSecretNamespaceKey},
+	{CSINodePublishSecretNameKey, CSINodePublishSecretNamespaceKey},
+	{CSINodeExpandSecretNameKey, CSINodeExpandSecretNamespaceKey},
+}

--- a/pkg/webhook/resources/storageclass/validator.go
+++ b/pkg/webhook/resources/storageclass/validator.go
@@ -33,20 +33,38 @@ const (
 	errorMessageReservedStorageClass = "storage class %s is reserved by Harvester and can't be deleted"
 )
 
+type secretPair struct {
+	nameKey, namespaceKey string
+	required              bool
+}
+
+// optionalEncryptionSecretKeys are CSI key pairs whose absence is tolerated by the validator.
+var optionalEncryptionSecretKeys = map[string]bool{
+	util.CSINodeExpandSecretNameKey: true,
+}
+
 var (
 	availableCiphers  = []string{"aes-xts-plain", "aes-xts-plain64", "aes-cbc-plain", "aes-cbc-plain64", "aes-cbc-essiv:sha256"}
 	availablePBKDFs   = []string{"argon2i", "argon2id", "pbkdf2"}
 	availableHash     = []string{"sha256", "sha384", "sha512"}
 	availableKeySizes = []string{"256", "384", "512"}
 
-	pairs = [][2]string{
-		{util.CSIProvisionerSecretNameKey, util.CSIProvisionerSecretNamespaceKey},
-		{util.CSINodeStageSecretNameKey, util.CSINodeStageSecretNamespaceKey},
-		{util.CSINodePublishSecretNameKey, util.CSINodePublishSecretNamespaceKey},
-	}
+	encryptionPairs = buildEncryptionPairs()
 
 	allCDICloneStrategies = []string{string(cdiv1.CloneStrategyHostAssisted), string(cdiv1.CloneStrategySnapshot), string(cdiv1.CloneStrategyCsiClone)}
 )
+
+func buildEncryptionPairs() []secretPair {
+	pairs := make([]secretPair, 0, len(util.CSIEncryptionSecretKeyPairs))
+	for _, p := range util.CSIEncryptionSecretKeyPairs {
+		pairs = append(pairs, secretPair{
+			nameKey:      p.NameKey,
+			namespaceKey: p.NamespaceKey,
+			required:     !optionalEncryptionSecretKeys[p.NameKey],
+		})
+	}
+	return pairs
+}
 
 func NewValidator(
 	storageClassCache ctlstoragev1.StorageClassCache,
@@ -207,18 +225,16 @@ func (v *storageClassValidator) validateEncryption(newObj runtime.Object) error 
 		return nil
 	}
 
-	err = v.validateEncryptionParams(newSC)
+	secretName, secretNamespace, err := v.validateEncryptionParams(newSC)
 	if err != nil {
 		return err
 	}
 
-	secretName, secretNamespace := newSC.Parameters[pairs[0][0]], newSC.Parameters[pairs[0][1]]
-
 	secret, err := v.secretCache.Get(secretNamespace, secretName)
+	if errors.IsNotFound(err) {
+		return werror.NewInvalidError(fmt.Sprintf("secret %s/%s not found", secretNamespace, secretName), "")
+	}
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return werror.NewInvalidError(fmt.Sprintf("secret %s/%s not found", secretNamespace, secretName), "")
-		}
 		return werror.NewInvalidError(err.Error(), "")
 	}
 
@@ -269,49 +285,49 @@ func (v *storageClassValidator) validateEncryptionSecret(secret *corev1.Secret, 
 	return nil
 }
 
-func (v *storageClassValidator) validateEncryptionParams(newSC *storagev1.StorageClass) error {
-	var (
-		secretName      string
-		secretNamespace string
-		missingParams   []string
-	)
+func (v *storageClassValidator) validateEncryptionParams(newSC *storagev1.StorageClass) (string, string, error) {
+	var wantName, wantNS string
+	var missing []string
 
-	for _, pair := range pairs {
-		name, nameExists := newSC.Parameters[pair[0]]
-		namespace, namespaceExists := newSC.Parameters[pair[1]]
+	for _, p := range encryptionPairs {
+		name, hasName := newSC.Parameters[p.nameKey]
+		ns, hasNS := newSC.Parameters[p.namespaceKey]
 
-		if !nameExists {
-			missingParams = append(missingParams, pair[0])
+		if !hasName && !hasNS {
+			if p.required {
+				missing = append(missing, p.nameKey, p.namespaceKey)
+			}
+			continue
 		}
-
-		if !namespaceExists {
-			missingParams = append(missingParams, pair[1])
+		if !hasName {
+			missing = append(missing, p.nameKey)
+			continue
 		}
-
-		if !nameExists || !namespaceExists {
+		if !hasNS {
+			missing = append(missing, p.namespaceKey)
 			continue
 		}
 
-		if secretName == "" && secretNamespace == "" {
-			secretName = name
-			secretNamespace = namespace
+		if wantName == "" {
+			wantName, wantNS = name, ns
 			continue
 		}
-
-		if secretName != name || secretNamespace != namespace {
-			return werror.NewInvalidError(fmt.Sprintf("secret names and namespaces in %s and %s are different from others", pair[0], pair[1]), "")
+		if name != wantName || ns != wantNS {
+			return "", "", werror.NewInvalidError(
+				fmt.Sprintf("secret names and namespaces in %s and %s are different from others",
+					p.nameKey, p.namespaceKey), "")
 		}
 	}
 
-	if len(missingParams) != 0 {
-		return werror.NewInvalidError(fmt.Sprintf("storage class must contain %s", strings.Join(missingParams, ", ")), "spec.parameters")
+	if len(missing) > 0 {
+		return "", "", werror.NewInvalidError(
+			fmt.Sprintf("storage class must contain %s", strings.Join(missing, ", ")),
+			"spec.parameters")
 	}
-
-	if secretName == "" || secretNamespace == "" {
-		return werror.NewInvalidError("storage class must contain secret name and namespace", "spec.parameters")
+	if wantName == "" {
+		return "", "", werror.NewInvalidError("storage class must contain secret name and namespace", "spec.parameters")
 	}
-
-	return nil
+	return wantName, wantNS, nil
 }
 
 func (v *storageClassValidator) validateVMImageUsage(sc *storagev1.StorageClass) error {

--- a/pkg/webhook/resources/storageclass/validator_test.go
+++ b/pkg/webhook/resources/storageclass/validator_test.go
@@ -37,6 +37,8 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 			util.CSINodeStageSecretNamespaceKey:   "default",
 			util.CSINodePublishSecretNameKey:      "test-secret",
 			util.CSINodePublishSecretNamespaceKey: "default",
+			util.CSINodeExpandSecretNameKey:       "test-secret",
+			util.CSINodeExpandSecretNamespaceKey:  "default",
 		},
 	}
 	emptySecretSc := storagev1.StorageClass{
@@ -51,6 +53,8 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 			util.CSINodeStageSecretNamespaceKey:   "",
 			util.CSINodePublishSecretNameKey:      "",
 			util.CSINodePublishSecretNamespaceKey: "",
+			util.CSINodeExpandSecretNameKey:       "",
+			util.CSINodeExpandSecretNamespaceKey:  "",
 		},
 	}
 
@@ -334,6 +338,8 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 					util.CSINodeStageSecretNamespaceKey:   "default",
 					util.CSINodePublishSecretNameKey:      "non-existent-secret",
 					util.CSINodePublishSecretNamespaceKey: "default",
+					util.CSINodeExpandSecretNameKey:       "non-existent-secret",
+					util.CSINodeExpandSecretNamespaceKey:  "default",
 				},
 			},
 			expectError: true,
@@ -371,6 +377,92 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 				Parameters: map[string]string{
 					util.LonghornOptionEncrypted:     "true",
 					util.CSIProvisionerSecretNameKey: "non-existent-secret",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "optional node-expand secret omitted is allowed",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					lhtypes.CryptoKeyHash:     []byte(lhcrypto.CryptoKeyDefaultHash),
+					lhtypes.CryptoKeyCipher:   []byte(lhcrypto.CryptoKeyDefaultCipher),
+					lhtypes.CryptoKeySize:     []byte(lhcrypto.CryptoKeyDefaultSize),
+					lhtypes.CryptoPBKDF:       []byte(lhcrypto.CryptoDefaultPBKDF),
+					lhtypes.CryptoKeyProvider: []byte("secret"),
+					lhtypes.CryptoKeyValue:    []byte("test-value"),
+				},
+			},
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sc6",
+				},
+				Parameters: map[string]string{
+					util.LonghornOptionEncrypted:          "true",
+					util.CSIProvisionerSecretNameKey:      "test-secret",
+					util.CSIProvisionerSecretNamespaceKey: "default",
+					util.CSINodeStageSecretNameKey:        "test-secret",
+					util.CSINodeStageSecretNamespaceKey:   "default",
+					util.CSINodePublishSecretNameKey:      "test-secret",
+					util.CSINodePublishSecretNamespaceKey: "default",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "optional node-expand secret partially set is rejected",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sc7",
+				},
+				Parameters: map[string]string{
+					util.LonghornOptionEncrypted:          "true",
+					util.CSIProvisionerSecretNameKey:      "test-secret",
+					util.CSIProvisionerSecretNamespaceKey: "default",
+					util.CSINodeStageSecretNameKey:        "test-secret",
+					util.CSINodeStageSecretNamespaceKey:   "default",
+					util.CSINodePublishSecretNameKey:      "test-secret",
+					util.CSINodePublishSecretNamespaceKey: "default",
+					util.CSINodeExpandSecretNameKey:       "test-secret",
+					// namespace deliberately omitted
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "optional node-expand secret pointing to a different secret is rejected",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					lhtypes.CryptoKeyHash:     []byte(lhcrypto.CryptoKeyDefaultHash),
+					lhtypes.CryptoKeyCipher:   []byte(lhcrypto.CryptoKeyDefaultCipher),
+					lhtypes.CryptoKeySize:     []byte(lhcrypto.CryptoKeyDefaultSize),
+					lhtypes.CryptoPBKDF:       []byte(lhcrypto.CryptoDefaultPBKDF),
+					lhtypes.CryptoKeyProvider: []byte("secret"),
+					lhtypes.CryptoKeyValue:    []byte("test-value"),
+				},
+			},
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sc8",
+				},
+				Parameters: map[string]string{
+					util.LonghornOptionEncrypted:          "true",
+					util.CSIProvisionerSecretNameKey:      "test-secret",
+					util.CSIProvisionerSecretNamespaceKey: "default",
+					util.CSINodeStageSecretNameKey:        "test-secret",
+					util.CSINodeStageSecretNamespaceKey:   "default",
+					util.CSINodePublishSecretNameKey:      "test-secret",
+					util.CSINodePublishSecretNamespaceKey: "default",
+					util.CSINodeExpandSecretNameKey:       "other-secret",
+					util.CSINodeExpandSecretNamespaceKey:  "other-ns",
 				},
 			},
 			expectError: true,


### PR DESCRIPTION
#### Problem:
https://github.com/harvester/harvester/issues/9775

#### Solution:
Add node expansion secret support as optional to allow encrypted volume expansion.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9775

#### Test plan:
* Prepare a Harvester `v1.8.0` cluster with LH `v1.11.1`.
* Boot a VM with an encrypted LH volume as the root disk.
* Check the related storage size on the cluster node. The related block device is 16 MB smaller than expected.
  ```
  hp-155-tink-system:/home/rancher # lsblk /dev/sdb
  NAME                                       MAJ:MIN RM SIZE RO TYPE  MOUNTPOINTS
  sdb                                          8:16   0   6G  0 disk  
  └─pvc-0a0d064c-1803-4c3e-8dc9-84a1b1743670 254:0    0   6G  0 crypt 
  hp-155-tink-system:/home/rancher # blockdev --getsize64 /dev/sdb
  6442450944
  hp-155-tink-system:/home/rancher # blockdev --getsize64 /dev/mapper/pvc-0a0d064c-1803-4c3e-8dc9-84a1b1743670 
  6425673728
  ```
* Update the LH deployments with the following manifests:
  * [crds.yaml](https://github.com/WebberHuang1118/longhorn/blob/v1.12.0-rc1-direct-apply/chart/templates/crds.yaml)
  * [daemonset-sa.yaml](https://github.com/WebberHuang1118/longhorn/blob/v1.12.0-rc1-direct-apply/chart/templates/daemonset-sa.yaml)
  * [clusterrole.yaml](https://github.com/WebberHuang1118/longhorn/blob/v1.12.0-rc1-direct-apply/chart/templates/clusterrole.yaml)
  * [deployment-driver.yaml](https://github.com/WebberHuang1118/longhorn/blob/v1.12.0-rc1-direct-apply/chart/templates/deployment-driver.yaml)
* After the LH engine live-upgrades to v1.12, check the related storage size on the cluster node. The related block device have the correct size.
  ```
  p-155-tink-system:/home/rancher # lsblk /dev/sdb
  NAME                                       MAJ:MIN RM SIZE RO TYPE  MOUNTPOINTS
  sdb                                          8:16   0   6G  0 disk  
  └─pvc-0a0d064c-1803-4c3e-8dc9-84a1b1743670 254:0    0   6G  0 crypt 
  hp-155-tink-system:/home/rancher # blockdev --getsize64 /dev/sdb
  6459228160
  hp-155-tink-system:/home/rancher # blockdev --getsize64 /dev/mapper/pvc-0a0d064c-1803-4c3e-8dc9-84a1b1743670 
  6442450944
  ```
* Trigger VM live migration. The related block device should also migrate to another node. Then check the related storage size on the target cluster node.
  ```
  hp-107-tink-system:/home/rancher # lsblk /dev/sdd
  NAME                                       MAJ:MIN RM SIZE RO TYPE  MOUNTPOINTS
  sdd                                          8:48   0   6G  0 disk  
  └─pvc-0a0d064c-1803-4c3e-8dc9-84a1b1743670 254:0    0   6G  0 crypt 
  hp-107-tink-system:/home/rancher # blockdev --getsize64 /dev/sdd
  6459228160
  hp-107-tink-system:/home/rancher # blockdev --getsize64 /dev/mapper/pvc-0a0d064c-1803-4c3e-8dc9-84a1b1743670 
  6442450944
  ```
* Trigger volume online expansion. Then check the related storage size on the target cluster node and inside the guest VM.

#### Additional documentation or context
