### PR TITLE
hep: LB IP on non management network interface for guest cluster[skip ci]

### DIFF
--- a/enhancements/20260515-lb-on-non-management-interface.md
+++ b/enhancements/20260515-lb-on-non-management-interface.md
@@ -1,0 +1,182 @@
+# Support Load Balancers on Non-Management Interfaces for Guest Clusters
+
+## Summary
+
+When a guest cluster has multiple network interfaces, all `LoadBalancer` Service VIPs are bound to the management interface regardless of which network the IP pool or DHCP server belongs to. This enhancement fixes the binding by allowing users to select a NAD name from the UI; the cloud provider resolves it to the correct Linux interface via a shared ConfigMap and sets `kube-vip.io/serviceInterface` on the Service.
+
+### Related Issues
+
+https://github.com/harvester/harvester/issues/5486
+
+## Motivation
+
+kube-vip defaults to the management interface when no interface hint is provided, defeating network isolation for workload-network IP pools or DHCP servers.
+
+### Goals
+
+- **IP pool mode**: VIPs are automatically bound to the interface matching the IP pool's subnet.
+- **DHCP mode**: Users can select the correct network interface from the UI.
+
+### Non-goals
+
+- Deal with asymmetric network topology where nodes have different interface configurations, e.g.:
+
+```
+Management Node:  enp1s0 → net-mgmt (192.168.100.0/24)
+Worker Node:      enp1s0 → net-mgmt (192.168.100.0/24)
+                  enp2s0 → net-101  (192.168.101.0/24)
+```
+
+## Introduction
+
+`harvester-cloud-provider` runs in the guest cluster and connects to both the guest cluster (to manage Services) and the Harvester cluster (to manage `LoadBalancer` CRs and query VMI resources).
+
+When a `LoadBalancer` Service is created:
+
+1. The CCM service controller calls `EnsureLoadBalancer()`.
+2. The cloud provider creates a `LoadBalancer` CR on Harvester.
+3. Harvester allocates an IP from the matching pool.
+4. The cloud provider writes the IP to `kube-vip.io/loadbalancerIPs`.
+5. kube-vip binds the VIP to an interface — defaulting to management.
+
+**IP pool mode — broken state:**
+
+```
+enp1s0 → net-mgmt (192.168.100.0/24)
+enp2s0 → net-101  (192.168.101.0/24)
+```
+
+```shell
+$ ip addr show enp1s0
+    inet 192.168.101.57/32 scope global enp1s0   ← VIP on wrong interface
+```
+
+**DHCP mode — broken state:**
+
+In DHCP mode `kube-vip.io/loadbalancerIPs` is set to `0.0.0.0`. kube-vip creates a macvlan sub-interface and sends a DHCP request using the macvlan's unique MAC. `serviceInterface: auto` cannot work here — it finds interfaces by subnet match, and `0.0.0.0` matches nothing — so kube-vip falls back to the management interface and is not able to use non-management network.
+
+## Proposal
+
+### IP Pool Mode
+
+**Network selection**: The frontend reads the NAD keys from the `harvester-nad-mapping` ConfigMap (in `kube-system`) and shows them as a dropdown — e.g. `default/net123`. The user's selection sets `cloudprovider.harvesterhci.io/network: default/net123` on the Service. The cloud provider resolves the NAD name to a Linux interface via the ConfigMap and writes `kube-vip.io/serviceInterface` accordingly; the load-balancer controller picks the matching IPPool.
+
+### DHCP Mode
+
+Both DHCP and IP pool modes use the same unified approach: the frontend selects a NAD name and the cloud provider resolves it to a Linux interface via the ConfigMap.
+
+**Interface mapping ConfigMap**
+
+Using `VirtualMachineInstance.spec.networks` (nic name → NAD name) joined with `VirtualMachineInstance.status.interfaces` (nic name → Linux interface name, from the KubeVirt guest agent), the cloud provider syncs a ConfigMap in `kube-system`:
+
+```yaml
+apiVersion: v1
+data:
+  interface-nad-mapping: '{"default/mgmt-vlan1":"enp1s0","default/net123":"enp2s0"}'
+kind: ConfigMap
+metadata:
+  name: harvester-nad-mapping
+  namespace: kube-system
+```
+
+Interfaces without a multus `name` (calico, kube-vip macvlan, etc.) are excluded automatically. Only NADs consistently present on the same interface across all nodes are included.
+
+**Frontend interface selection**
+
+The frontend reads the `harvester-nad-mapping` ConfigMap and shows a dropdown when a specific network is needed:
+
+```
+default/mgmt-vlan1
+default/net123      ← user selects this
+```
+
+The frontend sets only:
+
+```yaml
+cloudprovider.harvesterhci.io/ipam: dhcp
+cloudprovider.harvesterhci.io/network: default/net123
+```
+
+**Cloud provider resolves the interface**
+
+For both DHCP and IP pool modes, when `cloudprovider.harvesterhci.io/network` is present, the cloud provider looks up the corresponding Linux interface name in the `harvester-nad-mapping` ConfigMap and writes it to `kube-vip.io/serviceInterface`. If no network is specified, the interface annotation is left unset and kube-vip falls back to its default behavior.
+
+```shell
+4: vip-3fa2c1d8@enp2s0: ...   ← macvlan on correct interface
+    inet 192.168.101.82/32 ...
+```
+
+### User Stories
+
+#### Story 1
+
+I want an app exposed on `net-101`. The UI shows the NAD names from the `harvester-nad-mapping` ConfigMap. I select `default/net-101`; the frontend sets `cloudprovider.harvesterhci.io/network: default/net-101` on the Service. The cloud provider allocates an IP from the matching pool; kube-vip automatically places the VIP on `enp2s0`.
+
+#### Story 2
+
+I want to expose an app via a DHCP `LoadBalancer` on my workload network. The UI shows `default/mgmt-vlan1` and `default/net123`. I select `default/net123`; the frontend sets `cloudprovider.harvesterhci.io/network: default/net123`. The cloud provider resolves this to `enp2s0` via the ConfigMap and sets `kube-vip.io/serviceInterface: enp2s0`; kube-vip creates the macvlan on `enp2s0`, gets a DHCP address from the workload subnet, and binds the VIP there.
+
+### API Changes
+
+```go
+// pkg/cloud-controller-manager/annotation.go
+KeyKubevipServiceInterface = "kube-vip.io/serviceInterface"
+
+// pkg/utils/consts.go
+ConfigMapNADMapping    = "harvester-nad-mapping"    // ConfigMap name in kube-system
+ConfigMapKeyNADMapping = "interface-nad-mapping"    // data key inside the ConfigMap
+```
+
+No new CRDs, no changes to the `LoadBalancer` CR schema. RBAC for `harvester-cloud-provider` must be extended to allow read/write on `ConfigMap` in `kube-system`.
+
+Also, [`svc_election`](https://kube-vip.io/docs/usage/kubernetes-services/#load-balancing-load-balancers-when-using-arp-mode-yes-you-read-that-correctly-kube-vip-v050) can be enabled for per-Service leader election instead of a single global leader.
+
+## Design
+
+### Implementation Overview
+
+**Both modes (unified)**: When `cloudprovider.harvesterhci.io/network` is present on a Service, the cloud provider looks up the Linux interface name in the `harvester-nad-mapping` ConfigMap and writes `kube-vip.io/serviceInterface` accordingly. If no network is specified, the annotation is left unset.
+
+**ConfigMap sync**: In a VMI controller, build the NAD → interface mapping from VMI spec/status (intersection across all qualifying VMIs) and sync it to the `harvester-nad-mapping` ConfigMap in `kube-system`.
+
+### Test Plan
+
+#### IP Pool Mode
+
+1. Create a VM Network `net123` and IPPool with `selector.network: default/net123` scoped to the guest cluster.
+2. Provision a guest cluster with nodes on both networks.
+3. Verify the ConfigMap is written:
+   ```shell
+   kubectl get configmap -n kube-system harvester-nad-mapping -o jsonpath='{.data.interface-nad-mapping}' | jq .
+   ```
+4. Confirm the NAD keys (e.g. `default/net123`) appear in the UI network dropdown for pool mode; select `default/net123` and confirm `cloudprovider.harvesterhci.io/network: default/net123` is set on the Service.
+5. Verify the VIP is bound to `enp2s0` and connectivity from the workload subnet works.
+
+#### DHCP Mode
+
+1. Create a VM Network with a DHCP server.
+2. Verify the ConfigMap is written:
+   ```shell
+   kubectl get configmap -n kube-system harvester-nad-mapping -o jsonpath='{.data.interface-nad-mapping}' | jq .
+   ```
+3. Create a `LoadBalancer` Service in DHCP mode, select `default/net123 (enp2s0)` from the UI dropdown.
+4. Confirm `kube-vip.io/serviceInterface: enp2s0` is set on the Service.
+5. Verify the macvlan is created on `enp2s0`:
+   ```shell
+   ip addr show   # Expected: vip-xxxxxxxx@enp2s0
+   ```
+6. Confirm connectivity from a client on the workload subnet.
+
+### Upgrade Strategy
+
+After upgrading `harvester-cloud-provider`, existing Services that already have `cloudprovider.harvesterhci.io/network` will have `kube-vip.io/serviceInterface` resolved and written by the reconciler. Services without a network annotation are not affected. A one-time kube-vip restart may be required for the new annotation to take effect:
+
+```shell
+kubectl rollout restart daemonset kube-vip -n kube-system
+```
+
+New Services created post-upgrade receive the annotation automatically.
+
+## Note
+
+None.

--- a/enhancements/20260515-lb-on-non-management-interface.md
+++ b/enhancements/20260515-lb-on-non-management-interface.md
@@ -1,0 +1,195 @@
+# Support Load Balancers on Non-Management Interfaces for Guest Clusters
+
+## Summary
+
+When a guest cluster has multiple network interfaces, all `LoadBalancer` Service VIPs are bound to the management interface regardless of which network the IP pool or DHCP server belongs to. This enhancement fixes the binding for both IP pool mode (via `serviceInterface: auto`) and DHCP mode (via user-selected interface exposed through a Node annotation).
+
+### Related Issues
+
+https://github.com/harvester/harvester/issues/5486
+
+## Motivation
+
+kube-vip defaults to the management interface when no interface hint is provided, defeating network isolation for workload-network IP pools or DHCP servers.
+
+### Goals
+
+- **IP pool mode**: VIPs are automatically bound to the interface matching the IP pool's subnet.
+- **DHCP mode**: Users can select the correct network interface from the UI.
+
+### Non-goals
+
+- Deal with asymmetric network topology where nodes have different interface configurations, e.g.:
+
+```
+Management Node:  enp1s0 → net-mgmt (192.168.100.0/24)
+Worker Node:      enp1s0 → net-mgmt (192.168.100.0/24)
+                  enp2s0 → net-101  (192.168.101.0/24)
+```
+
+## Introduction
+
+`harvester-cloud-provider` runs in the guest cluster and connects to both the guest cluster (to manage Services) and the Harvester cluster (to manage `LoadBalancer` CRs and query VMI resources).
+
+When a `LoadBalancer` Service is created:
+
+1. The CCM service controller calls `EnsureLoadBalancer()`.
+2. The cloud provider creates a `LoadBalancer` CR on Harvester.
+3. Harvester allocates an IP from the matching pool.
+4. The cloud provider writes the IP to `kube-vip.io/loadbalancerIPs`.
+5. kube-vip binds the VIP to an interface — defaulting to management.
+
+**IP pool mode — broken state:**
+
+```
+enp1s0 → net-mgmt (192.168.100.0/24)
+enp2s0 → net-101  (192.168.101.0/24)
+```
+
+```shell
+$ ip addr show enp1s0
+    inet 192.168.101.57/32 scope global enp1s0   ← VIP on wrong interface
+```
+
+**DHCP mode — broken state:**
+
+In DHCP mode `kube-vip.io/loadbalancerIPs` is set to `0.0.0.0`. kube-vip creates a macvlan sub-interface and sends a DHCP request using the macvlan's unique MAC. `serviceInterface: auto` cannot work here — it finds interfaces by subnet match, and `0.0.0.0` matches nothing — so kube-vip falls back to the management interface and is not able to use non-management network.
+
+## Proposal
+
+### IP Pool Mode
+
+**Interface binding**: Set `kube-vip.io/serviceInterface: auto` alongside `kube-vip.io/loadbalancerIPs`. kube-vip's `autoFindInterface()` locates the interface whose subnet contains the VIP.
+
+**Network selection**: The cloud provider annotates each Node with `cloudprovider.harvesterhci.io/ippool-network-mapping`, a JSON map of IPPool name → VM network (`spec.selector.network`) for pools scoped to this guest cluster — e.g. `{"n123":"default/net123"}`. The frontend shows a dropdown like `n123 (default/net123)`; the user's selection sets `cloudprovider.harvesterhci.io/network: default/net123` on the Service. The cloud provider copies this to the LoadBalancer CR, and the load-balancer controller picks the matching IPPool.
+
+### DHCP Mode
+
+Since `auto` cannot work with `0.0.0.0`, an explicit interface name is needed. Raw Linux names (`enp1s0`, `enp2s0`) are meaningless to users, so the cloud provider builds and exposes a mapping.
+
+**Interface mapping on Nodes**
+
+Using `VirtualMachineInstance.spec.networks` (nic name → NAD name) joined with `VirtualMachineInstance.status.interfaces` (nic name → Linux interface name, from the KubeVirt guest agent), it writes:
+
+```
+cloudprovider.harvesterhci.io/interface-nad-mapping: '{"enp1s0":"default/mgmt-vlan1","enp2s0":"default/net123"}'
+```
+
+Interfaces without a multus `name` (calico, kube-vip macvlan, etc.) are excluded automatically.
+
+**Frontend interface selection**
+
+The frontend reads the annotation from any Node and shows a dropdown when DHCP mode is selected:
+
+```
+enp1s0  (default/mgmt-vlan1)
+enp2s0  (default/net123)       ← user selects this
+```
+
+The frontend sets:
+
+```yaml
+cloudprovider.harvesterhci.io/ipam: dhcp
+kube-vip.io/loadbalancerIPs: 0.0.0.0
+kube-vip.io/serviceInterface: enp2s0
+```
+
+**Cloud provider preserves the choice**
+
+For DHCP mode, the cloud provider must not overwrite `kube-vip.io/serviceInterface` with `"auto"`. The `expectedServiceInterface()` helper returns `"auto"` for pool mode and preserves the existing annotation value for DHCP mode.
+
+```shell
+4: vip-3fa2c1d8@enp2s0: ...   ← macvlan on correct interface
+    inet 192.168.101.82/32 ...
+```
+
+### User Stories
+
+#### Story 1
+
+I want an app exposed on `net-101`. The UI shows the available pool networks scoped to my guest cluster. I select `default/net-101`; the frontend sets `cloudprovider.harvesterhci.io/network: default/net-101` on the Service. The cloud provider allocates an IP from the matching pool; kube-vip automatically places the VIP on `enp2s0`.
+
+#### Story 2
+
+I want to expose an app via a DHCP `LoadBalancer` on my workload network. The UI shows `enp1s0 (default/mgmt-vlan1)` and `enp2s0 (default/net123)`. I select `enp2s0`. kube-vip creates the macvlan on `enp2s0`, gets a DHCP address from the workload subnet, and binds the VIP there.
+
+### API Changes
+
+```go
+// pkg/cloud-controller-manager/annotation.go
+KeyKubevipServiceInterface = "kube-vip.io/serviceInterface"
+KeyInterfaceNADMapping     = "cloudprovider.harvesterhci.io/interface-nad-mapping"
+KeyIPPoolNetworkMapping    = "cloudprovider.harvesterhci.io/ippool-network-mapping"
+```
+
+No new CRDs, no changes to the `LoadBalancer` CR schema.
+
+**RBAC**: The `harvesterhci.io:cloudprovider` ClusterRole must grant `get/list/watch` on `ippools`. Updated in `deploy/charts/harvester/templates/rbac.yaml`.
+
+The cloud provider's service account (e.g. `default:test`) is currently bound via a namespace-scoped **RoleBinding**, which cannot grant access to cluster-scoped resources like IPPool. The binding in `pkg/api/kubeconfig/generate_handler.go` must be changed from RoleBinding to **ClusterRoleBinding** so the cloud provider can list IPPools at cluster scope.
+
+Also, [`svc_election`](https://kube-vip.io/docs/usage/kubernetes-services/#load-balancing-load-balancers-when-using-arp-mode-yes-you-read-that-correctly-kube-vip-v050) can be enabled for per-Service leader election instead of a single global leader.
+
+## Design
+
+### Implementation Overview
+
+**IP pool mode**: When writing `kube-vip.io/loadbalancerIPs`, also write `kube-vip.io/serviceInterface: auto`.
+
+**DHCP mode**:
+- In `InstanceMetadata()`, build the interface → NAD mapping from VMI spec/status and write it as a Node annotation.
+- Add `expectedServiceInterface()` to `loadbalancer.go`: returns `"auto"` for pool mode, returns the existing `kube-vip.io/serviceInterface` value for DHCP mode.
+
+Action Items:
+
+- [ ] Add `KeyKubevipServiceInterface`, `KeyInterfaceNADMapping`, `KeyIPPoolNetworkMapping` to `annotation.go`.
+- [ ] Set `kube-vip.io/serviceInterface: auto` for primary and secondary Services in `loadbalancer.go`.
+- [ ] Add `expectedServiceInterface()` helper to `loadbalancer.go`.
+- [ ] Add `nodeClient`, `ipPoolClient`, `clusterName` to `instanceManager`; implement `getInterfaceToNADMapping()`, `annotateNodeWithInterfaceMapping()`, `getAvailableIPPoolNetworks()`, `annotateNodeWithIPPoolNetworks()` in `instance.go`.
+- [ ] In `main.go`, call `SetClusterName()` from `cloudInitializer` to propagate `--cluster-name`.
+- [ ] Update unit tests in `loadbalancer_test.go`.
+- [ ] Add `ippools` get/list/watch to `harvesterhci.io:cloudprovider` ClusterRole in `deploy/charts/harvester/templates/rbac.yaml`.
+- [ ] Change the `harvesterhci.io:cloudprovider` binding in `pkg/api/kubeconfig/generate_handler.go` from RoleBinding to ClusterRoleBinding.
+- [ ] Update the Harvester frontend to read `KeyIPPoolNetworkMapping` for pool mode network dropdown and `KeyInterfaceNADMapping` for DHCP mode interface dropdown.
+
+### Test Plan
+
+#### IP Pool Mode
+
+1. Create a VM Network `net123` and IPPool with `selector.network: default/net123` scoped to the guest cluster.
+2. Provision a guest cluster with nodes on both networks.
+3. Verify the Node annotation is written:
+   ```shell
+   kubectl get node <node> -o jsonpath='{.metadata.annotations.cloudprovider\.harvesterhci\.io/ippool-network-mapping}' | jq .
+   ```
+4. From the UI dropdown, select `default/net123`; confirm `cloudprovider.harvesterhci.io/network: default/net123` is set on the Service.
+5. Verify the VIP is bound to `enp2s0` and connectivity from the workload subnet works.
+
+#### DHCP Mode
+
+1. Create a VM Network with a DHCP server; confirm nodes show `AgentConnected: True`.
+2. Verify the Node annotation is written:
+   ```shell
+   kubectl get node <node> -o jsonpath='{.metadata.annotations.cloudprovider\.harvesterhci\.io/interface-nad-mapping}' | jq .
+   ```
+3. Create a `LoadBalancer` Service in DHCP mode, select `enp2s0 (default/net123)` from the UI dropdown.
+4. Confirm `kube-vip.io/serviceInterface: enp2s0` is set on the Service.
+5. Verify the macvlan is created on `enp2s0`:
+   ```shell
+   ip addr show   # Expected: vip-xxxxxxxx@enp2s0
+   ```
+6. Confirm connectivity from a client on the workload subnet.
+
+### Upgrade Strategy
+
+After upgrading `harvester-cloud-provider`, the reconciler patches existing Services with `kube-vip.io/serviceInterface: auto`. A one-time kube-vip restart is required for the new annotation to take effect:
+
+```shell
+kubectl rollout restart daemonset kube-vip -n kube-system
+```
+
+New Services created post-upgrade receive the annotation automatically.
+
+## Note
+
+None.


### PR DESCRIPTION
#### Problem:
https://github.com/harvester/harvester/issues/5486

#### Solution:


Write common nad-to-interface mapping config map data:

```yaml
apiVersion: v1
data:
  interface-nad-mapping: '{"default/mgmt-vlan1":"enp1s0","default/net123":"enp2s0"}'
kind: ConfigMap
metadata:
  name: harvester-nad-mapping
  namespace: kube-system
```

For ippool & DHCP mode:

1). Frontend reads the config map and display NADs to users
2). Frontend passes `"cloudprovider.harvesterhci.io/network":"{VM Network selected from users}"`
3). Backend converts the VM network to linux interface and put it into `kube-vip.io/serviceInterface: {interface}`. Then kube-vip can bind ip to the correct interface.

Then, for DHCP mode:

4). Remove the `cloudprovider.harvesterhci.io/network` annotation


#### Related Issue(s):
https://github.com/harvester/harvester/issues/5486

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

cloud-provider: https://github.com/harvester/cloud-provider-harvester/pull/75
frontend: https://github.com/rancher/dashboard/pull/17885
load-balancer: https://github.com/harvester/load-balancer-harvester/pull/110
