### PR TITLE
enhance: refactor auto-rotate-rke2-certs 

### DIFF
--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -329,8 +329,11 @@ data:
     echo "Rotating certificates."
     if ! chroot $HOST_DIR /opt/rke2/bin/rke2 certificate rotate; then
       echo "Error: 'rke2 certificate rotate' failed."
-      chroot $HOST_DIR systemctl start $UNIT || true
-      exit 21
+      if ! chroot $HOST_DIR systemctl start $UNIT; then
+        echo "Error: failed to start $UNIT after rotation failed."
+        exit 21
+      fi
+      exit 22
     fi
     echo "Rotated certificates."
 

--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -246,3 +246,98 @@ data:
     fi
 
     wait_for_label "$NODE_NAME" "$EXPECT_LABEL_VALUE"
+  rke2-cert-check.sh: |-
+    echo "Start rke2 certificate check..."
+    KUBECTL="$HOST_DIR/$(readlink $HOST_DIR/var/lib/rancher/rke2/bin)/kubectl"
+    ANNOTATION_KEY="harvesterhci.io/rke2-cert-info"
+    NODE_NAME="$1"
+
+    TEMP_DIR_HOST=$(mktemp -d -p "$HOST_DIR/tmp" rke2-cert-check.XXXXXX)
+    TEMP_DIR_CHROOT="/tmp/${TEMP_DIR_HOST##*/}"
+    OUTPUT_FILE="annotation_value"
+
+    trap 'rm -rf "$TEMP_DIR_HOST"' EXIT
+
+    chroot $HOST_DIR /bin/sh <<EOF
+      JSON_DATA=\$(/opt/rke2/bin/rke2 certificate check -o json | tee /dev/stderr)
+
+      CLOSEST_EXPIRY=\$(echo "\$JSON_DATA" | jq -r '
+        [ .Certificates[] |
+          select(.Usages | contains(["CertSign"]) | not)
+        ] | sort_by(.ExpiryTime) | .[0].ExpiryTime
+      ')
+
+      jq -n \
+        --arg expiry "\$CLOSEST_EXPIRY" \
+        --arg now "\$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{closestExpiryTime: \$expiry, updatedAt: \$now}' | jq -c . > "$TEMP_DIR_CHROOT/$OUTPUT_FILE"
+    EOF
+
+    ANNOTATION_VALUE=$(cat "$TEMP_DIR_HOST/$OUTPUT_FILE")
+    echo "Annotating $NODE_NAME with $ANNOTATION_KEY=$ANNOTATION_VALUE"
+    $KUBECTL annotate node "$NODE_NAME" "$ANNOTATION_KEY=$ANNOTATION_VALUE" --overwrite
+  rke2-cert-rotate.sh: |-
+    function wait_for_ready() {
+      local unit="$1"
+      local interval=5
+      local timeout=${WAIT_READY_TIMEOUT:-300}
+      local start_time=$(date +%s)
+
+      while true; do
+        local current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+
+        if [ $elapsed -ge $timeout ]; then
+          echo "Error: timeout, elapsed ${elapsed}s"
+          exit 31
+        fi
+
+        if chroot $HOST_DIR curl -fsS -m 5 http://127.0.0.1:10248/healthz >/dev/null 2>&1; then
+          echo "${unit} is ready"
+          return 0
+        fi
+
+        echo "${unit} is not ready yet, wait ${interval}s..."
+        sleep $interval
+      done
+    }
+
+    echo "Start rke2 certificate rotate..."
+    NODE_NAME="$1"
+    ROLE="$2"
+
+    if [ "$ROLE" != "server" ] && [ "$ROLE" != "agent" ]; then
+      echo "Error: ROLE must be 'server' or 'agent', got '$ROLE'"
+      exit 1
+    fi
+
+    UNIT="rke2-${ROLE}"
+    if ! chroot $HOST_DIR systemctl is-active --quiet $UNIT; then
+      echo "Error: $UNIT is not active on this host."
+      exit 2
+    fi
+
+    echo "Stopping $UNIT."
+    if ! chroot $HOST_DIR systemctl stop $UNIT; then
+      echo "Error: failed to stop $UNIT."
+      exit 11
+    fi
+    echo "Stopped $UNIT."
+
+    echo "Rotating certificates."
+    if ! chroot $HOST_DIR /opt/rke2/bin/rke2 certificate rotate; then
+      echo "Error: 'rke2 certificate rotate' failed."
+      chroot $HOST_DIR systemctl start $UNIT || true
+      exit 21
+    fi
+    echo "Rotated certificates."
+
+    echo "Starting $UNIT."
+    if ! chroot $HOST_DIR systemctl start $UNIT; then
+      echo "Error: failed to start $UNIT."
+      exit 12
+    fi
+    echo "Started $UNIT."
+
+    wait_for_ready "$UNIT"
+    echo "End rke2 certificate rotate for $NODE_NAME"

--- a/deploy/charts/harvester/templates/configmap.yaml
+++ b/deploy/charts/harvester/templates/configmap.yaml
@@ -247,6 +247,7 @@ data:
 
     wait_for_label "$NODE_NAME" "$EXPECT_LABEL_VALUE"
   rke2-cert-check.sh: |-
+    set -x
     echo "Start rke2 certificate check..."
     KUBECTL="$HOST_DIR/$(readlink $HOST_DIR/var/lib/rancher/rke2/bin)/kubectl"
     ANNOTATION_KEY="harvesterhci.io/rke2-cert-info"
@@ -277,6 +278,7 @@ data:
     echo "Annotating $NODE_NAME with $ANNOTATION_KEY=$ANNOTATION_VALUE"
     $KUBECTL annotate node "$NODE_NAME" "$ANNOTATION_KEY=$ANNOTATION_VALUE" --overwrite
   rke2-cert-rotate.sh: |-
+    set -x
     function wait_for_ready() {
       local unit="$1"
       local interval=5

--- a/pkg/controller/master/node/cert_check_controller.go
+++ b/pkg/controller/master/node/cert_check_controller.go
@@ -192,7 +192,7 @@ func (h *certCheckNodeHandler) OnJobChanged(_ string, job *batchv1.Job) (*batchv
 }
 
 func (h *certCheckNodeHandler) dispatchCheckJob(node *corev1.Node) (*batchv1.Job, error) {
-	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, util.HarvesterChartReleaseName, []string{"generalJob", "image"})
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, util.HarvesterChartReleaseName, utilHelm.GetKeyNamesGeneralJobImage())
 	if err != nil {
 		return nil, fmt.Errorf("get harvester generalJob image: %w", err)
 	}

--- a/pkg/controller/master/node/cert_check_controller.go
+++ b/pkg/controller/master/node/cert_check_controller.go
@@ -1,0 +1,223 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/condition"
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
+	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+
+	"github.com/harvester/harvester/pkg/config"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/certrotation"
+	utilHelm "github.com/harvester/harvester/pkg/util/helm"
+)
+
+const (
+	certCheckControllerName = "rke2-cert-check-controller"
+
+	certCheckInterval      = 24 * time.Hour
+	certCheckRetryDelay    = 1 * time.Hour
+	certCheckExistingDelay = 2 * time.Minute
+	certCheckJitterMax     = 5
+)
+
+type certCheckNodeHandler struct {
+	nodeController ctlcorev1.NodeController
+	nodeCache      ctlcorev1.NodeCache
+	jobCache       ctlbatchv1.JobCache
+	jobClient      ctlbatchv1.JobClient
+	clientset      kubernetes.Interface
+	namespace      string
+}
+
+func CertCheckRegister(ctx context.Context, management *config.Management, options config.Options) error {
+	jobs := management.BatchFactory.Batch().V1().Job()
+	nodes := management.CoreFactory.Core().V1().Node()
+
+	h := &certCheckNodeHandler{
+		nodeController: nodes,
+		nodeCache:      nodes.Cache(),
+		jobCache:       jobs.Cache(),
+		jobClient:      jobs,
+		clientset:      management.ClientSet,
+		namespace:      options.Namespace,
+	}
+
+	nodes.OnChange(ctx, certCheckControllerName, h.OnNodeChanged)
+	jobs.OnChange(ctx, certCheckControllerName, h.OnJobChanged)
+
+	return nil
+}
+
+func (h *certCheckNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Node, error) {
+	if node == nil || node.DeletionTimestamp != nil {
+		return node, nil
+	}
+
+	logger := logrus.WithFields(logrus.Fields{
+		"controller": certCheckControllerName,
+		"node":       node.Name,
+	})
+
+	delay, err := h.reconcileNode(logger, node)
+	if err != nil {
+		// Re-enqueue with a backoff so transient errors recover without a
+		// tight loop. We do NOT return the error to wrangler because that
+		// would also re-queue
+		logger.WithError(err).Warn("cert-check reconcile failed; will retry")
+		h.nodeController.EnqueueAfter(node.Name, certCheckRetryDelay)
+		return node, nil
+	}
+
+	if delay > 0 {
+		h.nodeController.EnqueueAfter(node.Name, delay)
+	}
+	return node, nil
+}
+
+func (h *certCheckNodeHandler) reconcileNode(logger *logrus.Entry, node *corev1.Node) (time.Duration, error) {
+	running, err := h.runningCheckJobsForNode(node.Name)
+	if err != nil {
+		return 0, fmt.Errorf("list running cert-check jobs: %w", err)
+	}
+	if len(running) > 0 {
+		jobNames := make([]string, 0, len(running))
+		for _, j := range running {
+			jobNames = append(jobNames, j.Name)
+		}
+		logger.WithField("jobs", jobNames).Debug("cert-check Job already in flight; waiting")
+		return certCheckExistingDelay, nil
+	}
+
+	until := h.untilNextCheck(logger, node, time.Now())
+	if until > 0 {
+		logger.WithField("until", until).Debug("cert-check not yet due; rescheduling")
+		return until, nil
+	}
+
+	h.pruneJobs(node.Name)
+
+	job, err := h.dispatchCheckJob(node)
+	if err != nil {
+		return 0, fmt.Errorf("dispatch cert-check job: %w", err)
+	}
+	logger.WithField("job", job.Name).Info("dispatched RKE2 cert-check Job")
+
+	jitter := time.Duration(rand.Intn(certCheckJitterMax)) * time.Second
+	return certCheckInterval + jitter, nil
+}
+
+func (h *certCheckNodeHandler) untilNextCheck(logger *logrus.Entry, node *corev1.Node, now time.Time) time.Duration {
+	info, exists, err := certrotation.LoadCertInfoFromAnnotations(node.Annotations)
+	if err != nil {
+		logger.WithError(err).Warn("malformed rke2-certs annotation; treating as due")
+		return 0
+	}
+	if !exists {
+		return 0
+	}
+
+	jitter := time.Duration(rand.Intn(certCheckJitterMax)) * time.Second
+	last := info.UpdatedAt.Time
+	next := last.Add(certCheckInterval + jitter)
+	if !now.Before(next) {
+		return 0
+	}
+	return next.Sub(now)
+}
+
+func (h *certCheckNodeHandler) runningCheckJobsForNode(nodeName string) ([]*batchv1.Job, error) {
+	all, err := h.jobCache.List(h.namespace, certrotation.CheckJobSelector(nodeName, nil, nil))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*batchv1.Job, 0, len(all))
+	for _, j := range all {
+		if j.DeletionTimestamp != nil {
+			continue
+		}
+		if condition.Cond(batchv1.JobComplete).IsTrue(j) {
+			continue
+		}
+		if condition.Cond(batchv1.JobFailed).IsTrue(j) {
+			continue
+		}
+		out = append(out, j)
+	}
+	return out, nil
+}
+
+func (h *certCheckNodeHandler) OnJobChanged(_ string, job *batchv1.Job) (*batchv1.Job, error) {
+	if job == nil || job.Labels == nil || job.DeletionTimestamp != nil {
+		return job, nil
+	}
+	if action, ok := job.Labels[certrotation.LabelRKE2CertAction]; !ok || action != certrotation.CertActionCheck {
+		return job, nil
+	}
+	if job.Labels[certrotation.LabelRKE2CertCheckPurpose] != string(certrotation.CertCheckPurposeSchedule) {
+		return job, nil
+	}
+
+	nodeName := job.Labels[certrotation.LabelRKE2CertNode]
+	logger := logrus.WithFields(logrus.Fields{
+		"controller": certCheckControllerName,
+		"node":       nodeName,
+		"job":        job.Name,
+	})
+
+	switch {
+	case condition.Cond(batchv1.JobComplete).IsTrue(job):
+		logger.Info("RKE2 cert-check Job completed successfully")
+	case condition.Cond(batchv1.JobFailed).IsTrue(job):
+		logger.Warn("RKE2 cert-check Job failed; will retry on next reconcile (see Job's pod logs)")
+	default:
+		// Not yet terminal.
+		return job, nil
+	}
+
+	h.pruneJobs(nodeName)
+
+	// Wake the node so a new Job is scheduled (or the next interval is set).
+	h.nodeController.Enqueue(nodeName)
+	return job, nil
+}
+
+func (h *certCheckNodeHandler) dispatchCheckJob(node *corev1.Node) (*batchv1.Job, error) {
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, util.HarvesterChartReleaseName, []string{"generalJob", "image"})
+	if err != nil {
+		return nil, fmt.Errorf("get harvester generalJob image: %w", err)
+	}
+
+	job := certrotation.BuildCheckJob(certrotation.CheckJobSpec{
+		Node:                node,
+		Namespace:           h.namespace,
+		Image:               image.ImageName(),
+		HelperConfigMapName: helperConfigMapName,
+		Purpose:             certrotation.CertCheckPurposeSchedule,
+		Generation:          nil,
+	})
+	return h.jobClient.Create(job)
+}
+
+func (h *certCheckNodeHandler) pruneJobs(nodeName string) {
+	logger := logrus.WithFields(logrus.Fields{
+		"controller": certCheckControllerName,
+		"node":       nodeName,
+	})
+	if err := certrotation.PruneJobs(
+		h.jobCache, h.jobClient, h.namespace,
+		certrotation.CheckJobSelector(nodeName, ptr.To(certrotation.CertCheckPurposeSchedule), nil),
+		logger,
+	); err != nil {
+		logger.WithError(err).Warn("prune cert-check jobs failed; will retry on next reconcile")
+	}
+}

--- a/pkg/controller/master/node/cert_check_controller_test.go
+++ b/pkg/controller/master/node/cert_check_controller_test.go
@@ -1,0 +1,293 @@
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util/certrotation"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+const testNamespace = "harvester-system"
+
+func newCertCheckHandlerWithJobs(jobs ...*batchv1.Job) *certCheckNodeHandler {
+	objs := make([]runtime.Object, 0, len(jobs))
+	for _, j := range jobs {
+		objs = append(objs, j)
+	}
+	clientset := fake.NewSimpleClientset(objs...)
+	return &certCheckNodeHandler{
+		jobCache:  fakeclients.JobCache(clientset.BatchV1().Jobs),
+		jobClient: fakeclients.JobClient(clientset.BatchV1().Jobs),
+		namespace: testNamespace,
+	}
+}
+
+func certInfoAnnotation(t *testing.T, info certrotation.CertInfo) map[string]string {
+	t.Helper()
+	raw, err := certrotation.MarshalCertInfo(info)
+	require.NoError(t, err)
+	return map[string]string{certrotation.AnnotationRKE2CertInfo: raw}
+}
+
+func TestDueAt(t *testing.T) {
+	h := &certCheckNodeHandler{}
+	logger := logrus.NewEntry(logrus.New())
+	now := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name             string
+		annotations      map[string]string
+		expectDue        bool
+		expectUntilCheck func(t *testing.T, until time.Duration)
+	}{
+		{
+			name:        "missing annotation -> due now",
+			annotations: nil,
+			expectUntilCheck: func(t *testing.T, until time.Duration) {
+				assert.Equal(t, until, time.Duration(0))
+			},
+		},
+		{
+			name:        "empty annotation value -> due now",
+			annotations: map[string]string{certrotation.AnnotationRKE2CertInfo: ""},
+			expectUntilCheck: func(t *testing.T, until time.Duration) {
+				assert.Equal(t, until, time.Duration(0))
+			},
+		},
+		{
+			name:        "malformed JSON -> due now",
+			annotations: map[string]string{certrotation.AnnotationRKE2CertInfo: "{not json"},
+			expectUntilCheck: func(t *testing.T, until time.Duration) {
+				assert.Equal(t, until, time.Duration(0))
+			},
+		},
+		{
+			name: "checked just now -> not due",
+			annotations: certInfoAnnotation(t, certrotation.CertInfo{
+				ClosestExpiryTime: metav1.Time{Time: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)},
+				UpdatedAt:         metav1.Time{Time: now},
+			}),
+			expectUntilCheck: func(t *testing.T, until time.Duration) {
+				assert.GreaterOrEqual(t, until, certCheckInterval-time.Second)
+				assert.LessOrEqual(t, until, certCheckInterval+certCheckJitterMax*time.Second)
+			},
+		},
+		{
+			name: "checked >24h+jitter ago -> due",
+			annotations: certInfoAnnotation(t, certrotation.CertInfo{
+				ClosestExpiryTime: metav1.Time{Time: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)},
+				UpdatedAt:         metav1.Time{Time: now.Add(-26 * time.Hour)},
+			}),
+			expectUntilCheck: func(t *testing.T, until time.Duration) {
+				assert.Equal(t, until, time.Duration(0))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name:        "n",
+				UID:         types.UID("stable-uid-for-deterministic-jitter"),
+				Annotations: tt.annotations,
+			}}
+			until := h.untilNextCheck(logger, n, now)
+			tt.expectUntilCheck(t, until)
+		})
+	}
+}
+
+func TestRunningCheckJobsForNode(t *testing.T) {
+	mkJob := func(name, nodeName string, complete, failed, deleted bool) *batchv1.Job {
+		j := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					certrotation.LabelRKE2CertAction:       certrotation.CertActionCheck,
+					certrotation.LabelRKE2CertNode:         nodeName,
+					certrotation.LabelRKE2CertCheckPurpose: string(certrotation.CertCheckPurposeSchedule),
+				},
+			},
+		}
+		if complete {
+			j.Status.Conditions = append(j.Status.Conditions, batchv1.JobCondition{
+				Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+			})
+		}
+		if failed {
+			j.Status.Conditions = append(j.Status.Conditions, batchv1.JobCondition{
+				Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+			})
+		}
+		if deleted {
+			now := metav1.Now()
+			j.DeletionTimestamp = &now
+		}
+		return j
+	}
+
+	tests := []struct {
+		name     string
+		jobs     []*batchv1.Job
+		nodeName string
+		want     []string
+	}{
+		{
+			name:     "no jobs",
+			jobs:     nil,
+			nodeName: "n1",
+			want:     nil,
+		},
+		{
+			name:     "running job for n1 returned",
+			jobs:     []*batchv1.Job{mkJob("j1", "n1", false, false, false)},
+			nodeName: "n1",
+			want:     []string{"j1"},
+		},
+		{
+			name:     "completed job excluded",
+			jobs:     []*batchv1.Job{mkJob("j1", "n1", true, false, false)},
+			nodeName: "n1",
+			want:     nil,
+		},
+		{
+			name:     "failed job excluded",
+			jobs:     []*batchv1.Job{mkJob("j1", "n1", false, true, false)},
+			nodeName: "n1",
+			want:     nil,
+		},
+		{
+			name:     "deleting job excluded",
+			jobs:     []*batchv1.Job{mkJob("j1", "n1", false, false, true)},
+			nodeName: "n1",
+			want:     nil,
+		},
+		{
+			name:     "job for other node excluded",
+			jobs:     []*batchv1.Job{mkJob("j1", "n2", false, false, false)},
+			nodeName: "n1",
+			want:     nil,
+		},
+		{
+			name: "mixed: returns only running for n1",
+			jobs: []*batchv1.Job{
+				mkJob("done", "n1", true, false, false),
+				mkJob("running", "n1", false, false, false),
+				mkJob("other", "n2", false, false, false),
+			},
+			nodeName: "n1",
+			want:     []string{"running"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCertCheckHandlerWithJobs(tt.jobs...)
+			got, err := h.runningCheckJobsForNode(tt.nodeName)
+			require.NoError(t, err)
+			gotNames := make([]string, 0, len(got))
+			for _, j := range got {
+				gotNames = append(gotNames, j.Name)
+			}
+			assert.ElementsMatch(t, tt.want, gotNames)
+		})
+	}
+}
+
+func TestRunningCheckJobsForNode_SharedDedupPool(t *testing.T) {
+	mkInflight := func(name, nodeName, purpose string) *batchv1.Job {
+		return &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					certrotation.LabelRKE2CertAction:       certrotation.CertActionCheck,
+					certrotation.LabelRKE2CertNode:         nodeName,
+					certrotation.LabelRKE2CertCheckPurpose: purpose,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		jobs []*batchv1.Job
+		want []string
+	}{
+		{
+			name: "schedule in flight -> returned",
+			jobs: []*batchv1.Job{mkInflight("sched", "n1", string(certrotation.CertCheckPurposeSchedule))},
+			want: []string{"sched"},
+		},
+		{
+			name: "verify in flight -> returned (shared pool)",
+			jobs: []*batchv1.Job{mkInflight("verify", "n1", string(certrotation.CertCheckPurposeVerify))},
+			want: []string{"verify"},
+		},
+		{
+			name: "both in flight -> both returned",
+			jobs: []*batchv1.Job{
+				mkInflight("sched", "n1", string(certrotation.CertCheckPurposeSchedule)),
+				mkInflight("verify", "n1", string(certrotation.CertCheckPurposeVerify)),
+			},
+			want: []string{"sched", "verify"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newCertCheckHandlerWithJobs(tt.jobs...)
+			got, err := h.runningCheckJobsForNode("n1")
+			require.NoError(t, err)
+			gotNames := make([]string, 0, len(got))
+			for _, j := range got {
+				gotNames = append(gotNames, j.Name)
+			}
+			assert.ElementsMatch(t, tt.want, gotNames)
+		})
+	}
+}
+
+func TestOnJobChanged_IgnoresVerifyPurpose(t *testing.T) {
+	mkVerify := func(complete bool) *batchv1.Job {
+		j := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "verify-job",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					certrotation.LabelRKE2CertAction:       certrotation.CertActionCheck,
+					certrotation.LabelRKE2CertNode:         "n1",
+					certrotation.LabelRKE2CertCheckPurpose: string(certrotation.CertCheckPurposeVerify),
+				},
+			},
+		}
+		if complete {
+			j.Status.Conditions = append(j.Status.Conditions, batchv1.JobCondition{
+				Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+			})
+		}
+		return j
+	}
+
+	h := newCertCheckHandlerWithJobs()
+	// nodeController is not wired in this fixture; if OnJobChanged tried
+	// to call h.nodeController.Enqueue for a verify Job, it would NPE.
+	// The test passing without a panic is the assertion: the early
+	// return for verify-purpose Jobs short-circuits before any Enqueue.
+	for _, complete := range []bool{false, true} {
+		_, err := h.OnJobChanged("verify-job", mkVerify(complete))
+		assert.NoError(t, err, "OnJobChanged must not error on verify-purpose Jobs (complete=%v)", complete)
+	}
+}

--- a/pkg/controller/master/node/cpu_manager_controller.go
+++ b/pkg/controller/master/node/cpu_manager_controller.go
@@ -394,7 +394,7 @@ func (h *cpuManagerNodeHandler) getJob(policy CPUManagerPolicy, node *corev1.Nod
 }
 
 func (h *cpuManagerNodeHandler) submitJob(updateStatus *CPUManagerUpdateStatus, node *corev1.Node) (*batchv1.Job, error) {
-	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, releaseAppHarvesterName, []string{"generalJob", "image"})
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, releaseAppHarvesterName, utilHelm.GetKeyNamesGeneralJobImage())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get harvester image (%s): %v", image.ImageName(), err)
 	}

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -411,7 +411,7 @@ func isHarvesterNode(node *corev1.Node) bool {
 }
 
 func (h *PromoteHandler) createPromoteJob(node *corev1.Node) (*batchv1.Job, error) {
-	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, releaseAppHarvesterName, []string{"generalJob", "image"})
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, releaseAppHarvesterName, utilHelm.GetKeyNamesGeneralJobImage())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get harvester image (%s): %v", image.ImageName(), err)
 	}

--- a/pkg/controller/master/schedulevmbackup/svmbackup.go
+++ b/pkg/controller/master/schedulevmbackup/svmbackup.go
@@ -38,7 +38,7 @@ func deleteCronJob(h *svmbackupHandler, svmbackup *harvesterv1.ScheduleVMBackup)
 func createCronJob(h *svmbackupHandler, svmbackup *harvesterv1.ScheduleVMBackup) (*batchv1.CronJob, error) {
 	backoffLimit := int32(cronJobBackoffLimit)
 	jobImage, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace,
-		releaseAppHarvesterName, []string{"generalJob", "image"})
+		releaseAppHarvesterName, utilHelm.GetKeyNamesGeneralJobImage())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get harvester image (%s): %v", jobImage.ImageName(), err)
 	}

--- a/pkg/controller/master/setting/auto_rotate_rke2_certs.go
+++ b/pkg/controller/master/setting/auto_rotate_rke2_certs.go
@@ -481,7 +481,7 @@ func (h *Handler) pruneJobs(nodeName string, isRotateJob bool) {
 }
 
 func (h *Handler) dispatchRotateJob(node *corev1.Node, generation int64, role string) (*batchv1.Job, error) {
-	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, "harvester", []string{"generalJob", "image"})
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, "harvester", utilHelm.GetKeyNamesGeneralJobImage())
 	if err != nil {
 		return nil, fmt.Errorf("get harvester generalJob image: %w", err)
 	}
@@ -518,7 +518,7 @@ func (h *Handler) runningRotationJobsForNode(nodeName string) ([]*batchv1.Job, e
 }
 
 func (h *Handler) dispatchVerifyJob(node *corev1.Node, generation int64) (*batchv1.Job, error) {
-	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, util.HarvesterChartReleaseName, []string{"generalJob", "image"})
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, util.HarvesterChartReleaseName, utilHelm.GetKeyNamesGeneralJobImage())
 	if err != nil {
 		return nil, fmt.Errorf("get harvester generalJob image: %w", err)
 	}

--- a/pkg/controller/master/setting/auto_rotate_rke2_certs.go
+++ b/pkg/controller/master/setting/auto_rotate_rke2_certs.go
@@ -3,170 +3,653 @@ package setting
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
-	provisioningv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
-	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/wrangler/v3/pkg/condition"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/certrotation"
+	utilHelm "github.com/harvester/harvester/pkg/util/helm"
 )
 
 const (
-	defaultReconcilAutoRotateRKE2CertsSettingDuration = time.Hour * 24 // 1 day
+	idleReconcileInterval           = 1 * time.Hour
+	activeReconcileInterval         = 30 * time.Second
+	nodeRotateTimeout               = 15 * time.Minute
+	nodeVerifyTimeout               = 10 * time.Minute
+	rotationStaleThreshold          = nodeRotateTimeout + nodeVerifyTimeout
+	verifyJobMissingRedispatchAfter = activeReconcileInterval
+)
+
+type nodeRole int
+
+const (
+	roleManagement nodeRole = iota // control-plane / etcd / witness
+	roleWorker
 )
 
 func (h *Handler) syncAutoRotateRKE2Certs(setting *harvesterv1.Setting) error {
-	logrus.WithFields(logrus.Fields{
-		"name":  setting.Name,
-		"value": setting.Value,
-	}).Info("Processing setting")
+	logger := logrus.WithField("setting", setting.Name)
 
-	autoRotateRKE2Certs := &settings.AutoRotateRKE2Certs{}
-	if err := json.Unmarshal([]byte(setting.Value), autoRotateRKE2Certs); err != nil {
-		logrus.WithFields(logrus.Fields{
-			"name":  setting.Name,
-			"value": setting.Value,
-		}).WithError(err).Error("failed to unmarshal setting value")
-		return err
-	}
-	if !autoRotateRKE2Certs.Enable {
-		return nil
-	}
-
-	kubernetesIPs, err := util.GetKubernetesIps(h.endpointCache)
-	if err != nil {
-		return err
-	}
-	if len(kubernetesIPs) == 0 {
-		err = fmt.Errorf("cluster ip is empty")
-		logrus.WithFields(logrus.Fields{
-			"name":              setting.Name,
-			"service.namespace": metav1.NamespaceDefault,
-			"service.name":      "kubernetes",
-		}).WithError(err).Error("cluster ip is empty in the endpoints")
-		return err
-	}
-
-	earliestExpiringCert, err := util.GetAddrsEarliestExpiringCert(kubernetesIPs)
-	if err != nil {
-		return err
-	}
-	if earliestExpiringCert == nil {
-		logrus.WithFields(logrus.Fields{
-			"name":              setting.Name,
-			"service.namespace": metav1.NamespaceDefault,
-			"service.name":      "kubernetes",
-			"reconcileAfter":    defaultReconcilAutoRotateRKE2CertsSettingDuration,
-		}).Warn("can't find certificate for cluster ip, reconcile setting again")
-		h.settingController.EnqueueAfter(setting.Name, defaultReconcilAutoRotateRKE2CertsSettingDuration)
-		return nil
-	}
-	logrus.WithField(
-		"earliestExpiringCert", earliestExpiringCert,
-	).Debug("earliest expiring cert for default/kubernetes ClusterIP")
-
-	expiringInHours := time.Duration(autoRotateRKE2Certs.ExpiringInHours) * time.Hour
-	if time.Now().Add(expiringInHours).After(earliestExpiringCert.NotAfter) {
-		reconcileDuration, err := h.rotateRKE2Certs(setting)
-		if err != nil {
+	cfg := &settings.AutoRotateRKE2Certs{}
+	if setting.Value != "" {
+		if err := json.Unmarshal([]byte(setting.Value), cfg); err != nil {
+			logger.WithError(err).WithField("value", setting.Value).
+				Error("failed to unmarshal auto-rotate-rke2-certs value")
 			return err
 		}
-
-		h.settingController.EnqueueAfter(setting.Name, reconcileDuration)
-		return nil
 	}
 
-	reconcileAfter := defaultReconcilAutoRotateRKE2CertsSettingDuration
-	if earliestExpiringCert.NotAfter.Sub(time.Now().Add(expiringInHours)) < reconcileAfter {
-		reconcileAfter = earliestExpiringCert.NotAfter.Sub(time.Now().Add(expiringInHours))
+	state, err := certrotation.LoadClusterStateFromAnnotations(setting.Annotations)
+	if err != nil {
+		now := metav1.Now()
+		logger.WithError(err).Warn("malformed rke2-cert-rotation-state annotation; resetting to idle")
+		state = certrotation.ClusterRotationState{Phase: certrotation.PhaseIdle, StartedAt: now, UpdatedAt: now}
+		if updErr := h.persistClusterState(setting, state); updErr != nil {
+			return updErr
+		}
 	}
-	logrus.WithFields(logrus.Fields{
-		"name":                          setting.Name,
-		"expiringInHours":               expiringInHours,
-		"earliestExpiringCert.notAfter": earliestExpiringCert.NotAfter,
-		"reconcileAfter":                reconcileAfter,
-	}).Info("RKE2 certificate is not expiring, reconcile setting again")
-	h.settingController.EnqueueAfter(setting.Name, reconcileAfter)
+	if state.Phase == "" {
+		state.Phase = certrotation.PhaseIdle
+	}
+
+	logger = logger.WithFields(logrus.Fields{
+		"phase":      state.Phase,
+		"generation": state.Generation,
+	})
+
+	if !cfg.Enable {
+		if !certrotation.IsRotationInProgress(state.Phase) {
+			logger.Debug("auto-rotation disabled and no rotation in progress; nothing to do")
+			return nil
+		}
+		logger.Info("auto-rotation disabled but a rotation is still in progress; continuing to rotate")
+	}
+
+	newState, requeueAfter, err := h.advanceRotation(logger, setting, cfg, state)
+	if err != nil {
+		return err
+	}
+
+	if !certrotation.EqualState(state, newState) {
+		if err := h.persistClusterState(setting, newState); err != nil {
+			return err
+		}
+	}
+
+	if requeueAfter > 0 {
+		h.settingController.EnqueueAfter(setting.Name, requeueAfter)
+	}
 	return nil
 }
 
-func (h *Handler) rotateRKE2Certs(setting *harvesterv1.Setting) (time.Duration, error) {
-	cluster, err := h.clusterCache.Get(util.FleetLocalNamespaceName, util.LocalClusterName)
+func (h *Handler) advanceRotation(
+	logger *logrus.Entry,
+	setting *harvesterv1.Setting,
+	cfg *settings.AutoRotateRKE2Certs,
+	state certrotation.ClusterRotationState,
+) (certrotation.ClusterRotationState, time.Duration, error) {
+	switch state.Phase {
+	case certrotation.PhaseIdle, certrotation.PhaseCompleted:
+		return h.maybeStartRotation(logger, cfg, state)
+
+	case certrotation.PhaseFailed:
+		logger.WithField("lastError", state.LastError).
+			Debug("rotation in failed phase; awaiting operator intervention")
+		return state, 0, nil
+
+	case certrotation.PhaseCPRotation:
+		return h.advancePhase(logger, state, roleManagement, certrotation.PhaseWorkerRotation)
+
+	case certrotation.PhaseWorkerRotation:
+		return h.advancePhase(logger, state, roleWorker, certrotation.PhaseCompleted)
+
+	default:
+		// Unknown phase string: treat as a corruption of the annotation
+		// and return to idle. The next reconcile will re-evaluate.
+		logger.WithField("phase", state.Phase).Warn("unknown rotation phase; resetting to idle")
+		return certrotation.ClusterRotationState{Phase: certrotation.PhaseIdle}, idleReconcileInterval, nil
+	}
+}
+
+func (h *Handler) maybeStartRotation(
+	logger *logrus.Entry,
+	cfg *settings.AutoRotateRKE2Certs,
+	state certrotation.ClusterRotationState,
+) (certrotation.ClusterRotationState, time.Duration, error) {
+	nodes, err := h.nodeCache.List(labels.Everything())
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"cluster.namespace": util.FleetLocalNamespaceName,
-			"cluster.name":      util.LocalClusterName,
-		}).WithError(err).Error("clusterCache.Get")
-		return time.Duration(0), err
+		return state, 0, fmt.Errorf("list nodes: %w", err)
 	}
 
-	rkeControlPlane, err := h.rkeControlPlaneCache.Get(util.FleetLocalNamespaceName, util.LocalClusterName)
-	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"rkeControlPlane.namespace": util.FleetLocalNamespaceName,
-			"rkeControlPlane.name":      util.LocalClusterName,
-		}).WithError(err).Error("rkeControlPlaneCache.Get")
-		return time.Duration(0), err
+	threshold := time.Now().Add(time.Duration(cfg.ExpiringInHours) * time.Hour)
+	earliest, earliestNode := earliestExpiry(nodes)
+	if earliest.IsZero() {
+		logger.Debugf("no node has %s annotation yet; will retry", certrotation.AnnotationRKE2CertInfo)
+		return state, idleReconcileInterval, nil
 	}
 
-	isRKEControlPlaneReady := false
-	for _, cond := range rkeControlPlane.Status.Conditions {
-		if cond.Type == "Ready" && cond.Status == v1.ConditionTrue {
-			isRKEControlPlaneReady = true
-			break
+	if !earliest.Before(threshold) {
+		until := earliest.Sub(threshold)
+		next := idleReconcileInterval
+		if until < next {
+			next = until
+		}
+		logger.WithFields(logrus.Fields{
+			"earliestExpiry":     earliest,
+			"earliestExpiryNode": earliestNode,
+			"threshold":          threshold,
+			"requeueAfter":       next,
+		}).Debug("no expiring certs; reconciling later")
+		return state, next, nil
+	}
+
+	// Start a new rotation.
+	now := metav1.Now()
+	next := certrotation.ClusterRotationState{
+		Generation: state.Generation + 1,
+		Phase:      certrotation.PhaseCPRotation,
+		StartedAt:  now,
+		UpdatedAt:  now,
+	}
+	logger.WithFields(logrus.Fields{
+		"newGeneration":      next.Generation,
+		"earliestExpiry":     earliest,
+		"earliestExpiryNode": earliestNode,
+	}).Info("starting RKE2 cert rotation")
+	return next, activeReconcileInterval, nil
+}
+
+func (h *Handler) advancePhase(
+	logger *logrus.Entry,
+	state certrotation.ClusterRotationState,
+	role nodeRole,
+	nextPhase string,
+) (certrotation.ClusterRotationState, time.Duration, error) {
+	nodes, err := h.nodeCache.List(labels.Everything())
+	if err != nil {
+		return state, 0, fmt.Errorf("list nodes: %w", err)
+	}
+
+	candidates := nodesForRole(nodes, role)
+	node := pickNextNodeForRotation(candidates, state.Generation)
+	now := metav1.Now()
+	if node == nil {
+		// All nodes in this phase are at the current generation; advance.
+		next := state
+		next.Phase = nextPhase
+		next.CurrentNode = ""
+		next.UpdatedAt = now
+		if nextPhase == certrotation.PhaseCompleted {
+			logger.WithField("generation", state.Generation).
+				Info("RKE2 cert rotation completed successfully")
+			return next, idleReconcileInterval, nil
+		}
+		logger.WithFields(logrus.Fields{
+			"fromPhase": state.Phase,
+			"toPhase":   nextPhase,
+		}).Info("phase complete; advancing")
+		return next, activeReconcileInterval, nil
+	}
+
+	nodeState, action, err := h.driveNode(logger.WithField("node", node.Name), node, state.Generation, now)
+	if err != nil {
+		return state, 0, err
+	}
+
+	switch action {
+	case nodeActionWait:
+		next := state
+		next.CurrentNode = node.Name
+		next.UpdatedAt = now
+		return next, activeReconcileInterval, nil
+
+	case nodeActionAdvance:
+		next := state
+		next.CurrentNode = ""
+		next.UpdatedAt = now
+		// pick node in the next prompt reconcile
+		return next, time.Second, nil
+
+	case nodeActionFailed:
+		next := state
+		next.Phase = certrotation.PhaseFailed
+		next.CurrentNode = node.Name
+		next.LastError = nodeState.Reason
+		next.UpdatedAt = now
+		logger.WithFields(logrus.Fields{
+			"node":       node.Name,
+			"generation": state.Generation,
+			"reason":     nodeState.Reason,
+		}).Error("node rotation failed; halting cluster-wide rotation")
+		return next, 0, nil
+
+	default:
+		// unexpected action, keep in the same state
+		return state, activeReconcileInterval, nil
+	}
+}
+
+// nodeAction is the outcome of a single per-node decision pass.
+type nodeAction int
+
+const (
+	nodeActionWait nodeAction = iota
+	nodeActionAdvance
+	nodeActionFailed
+)
+
+func (h *Handler) driveNode(
+	logger *logrus.Entry,
+	node *corev1.Node,
+	generation int64,
+	now metav1.Time,
+) (certrotation.NodeRotationState, nodeAction, error) {
+	current, _, err := certrotation.LoadNodeStateFromAnnotations(node.Annotations)
+	if err != nil {
+		logger.WithError(err).Warnf("malformed %s annotation; resetting", certrotation.AnnotationRKE2CertRotationNodeState)
+	}
+	if err != nil || current.Generation != generation {
+		current = certrotation.NodeRotationState{
+			Generation: generation,
+			Phase:      certrotation.NodePhasePending,
+			StartedAt:  now,
+			UpdatedAt:  now,
+		}
+		if err := h.persistNodeStatus(node, current); err != nil {
+			return current, nodeActionWait, err
 		}
 	}
 
-	quickReconcilDuration := time.Second * 30
-	if !isRKEControlPlaneReady {
-		logrus.WithFields(logrus.Fields{
-			"name":                      setting.Name,
-			"rkeControlPlane.namespace": util.FleetLocalNamespaceName,
-			"rkeControlPlane.name":      util.LocalClusterName,
-			"reconcileAfter":            quickReconcilDuration,
-		}).Info("rkecontrolplane is not ready, reconcile setting again")
-		return quickReconcilDuration, nil
+	// Check for a stuck phase (UpdatedAt too far in the past).
+	if (current.Phase == certrotation.NodePhaseRotating || current.Phase == certrotation.NodePhaseVerifying) && now.Sub(current.UpdatedAt.Time) > rotationStaleThreshold {
+		logger.WithFields(logrus.Fields{
+			"phase":   current.Phase,
+			"stalled": now.Sub(current.UpdatedAt.Time),
+		}).Warn("node rotation appears stuck; marking failed")
+		stuckPhase := current.Phase
+		current.Phase = certrotation.NodePhaseFailed
+		current.Reason = fmt.Sprintf("phase %q stuck for %s without progress", stuckPhase, now.Sub(current.UpdatedAt.Time))
+		current.UpdatedAt = now
+		if err := h.persistNodeStatus(node, current); err != nil {
+			return current, nodeActionWait, err
+		}
+		return current, nodeActionFailed, nil
 	}
 
-	clusterCopy := cluster.DeepCopy()
-	if clusterCopy.Spec.RKEConfig == nil {
-		clusterCopy.Spec.RKEConfig = &provisioningv1.RKEConfig{}
-	}
-	if clusterCopy.Spec.RKEConfig.RotateCertificates == nil {
-		clusterCopy.Spec.RKEConfig.RotateCertificates = &rkev1.RotateCertificates{}
+	role := roleOfNode(node)
+	roleArg := "agent"
+	if role == roleManagement {
+		roleArg = "server"
 	}
 
-	clusterRotateCertificatesGeneration := clusterCopy.Spec.RKEConfig.RotateCertificates.Generation
-	rkeControlPlaneRotateCertificatesGeneration := int64(0)
-	if rkeControlPlane.Spec.RotateCertificates != nil {
-		rkeControlPlaneRotateCertificatesGeneration = rkeControlPlane.Spec.RotateCertificates.Generation
-	}
-	if clusterRotateCertificatesGeneration != rkeControlPlaneRotateCertificatesGeneration ||
-		rkeControlPlaneRotateCertificatesGeneration != rkeControlPlane.Status.CertificateRotationGeneration {
-		logrus.WithFields(logrus.Fields{
-			"name":              setting.Name,
-			"cluster.namespace": util.FleetLocalNamespaceName,
-			"cluster.name":      util.LocalClusterName,
-			"reconcileAfter":    quickReconcilDuration,
-		}).Info("rotateCertificates.Generation is not synced between cluster and rkeControlPlane, reconcile setting again")
-		return quickReconcilDuration, nil
-	}
+	switch current.Phase {
+	case certrotation.NodePhaseCompleted:
+		return current, nodeActionAdvance, nil
 
-	clusterCopy.Spec.RKEConfig.RotateCertificates.Generation++
-	if _, err := h.clusters.Update(clusterCopy); err != nil {
-		logrus.WithFields(logrus.Fields{
-			"namespace": util.FleetLocalNamespaceName,
-			"name":      util.LocalClusterName,
-		}).WithError(err).Error("clusters.Update")
-		return time.Duration(0), err
-	}
+	case certrotation.NodePhaseFailed:
+		return current, nodeActionFailed, nil
 
-	// if users don't udpate the setting, the controller can't be triggered
-	// so we still need to enqueue the setting again to check certs after rotate
-	return defaultReconcilAutoRotateRKE2CertsSettingDuration, nil
+	case certrotation.NodePhasePending, "":
+		// Dedupe: any in-flight rotate Job for this node?
+		running, err := h.runningRotationJobsForNode(node.Name)
+		if err != nil {
+			return current, nodeActionWait, err
+		}
+		if len(running) > 0 {
+			logger.WithField("job", running[0].Name).
+				Debug("rotate Job already in flight; recording state and waiting")
+			current.Phase = certrotation.NodePhaseRotating
+			current.JobName = running[0].Name
+			current.UpdatedAt = now
+			if err := h.persistNodeStatus(node, current); err != nil {
+				return current, nodeActionWait, err
+			}
+			return current, nodeActionWait, nil
+		}
+		h.pruneJobs(node.Name, true)
+		// Dispatch a new rotate Job.
+		job, err := h.dispatchRotateJob(node, generation, roleArg)
+		if err != nil {
+			return current, nodeActionWait, fmt.Errorf("dispatch rotate Job: %w", err)
+		}
+		logger.WithFields(logrus.Fields{
+			"job":  job.Name,
+			"role": roleArg,
+		}).Info("dispatched RKE2 cert-rotate Job")
+		current.Phase = certrotation.NodePhaseRotating
+		current.JobName = job.Name
+		current.UpdatedAt = now
+		if err := h.persistNodeStatus(node, current); err != nil {
+			return current, nodeActionWait, err
+		}
+		return current, nodeActionWait, nil
+
+	case certrotation.NodePhaseRotating:
+		// Wait for the rotate Job to finish.
+		job, err := h.jobCache.Get(h.namespace, current.JobName)
+		if err != nil {
+			return current, nodeActionWait, err
+		}
+		if job == nil {
+			// The Job we dispatched is gone (TTL'd, deleted manually,
+			// etc.) without us ever observing completion. Treat as failed
+			// to avoid silently hanging.
+			logger.Warn("rotate Job disappeared before completion; marking failed")
+			current.Phase = certrotation.NodePhaseFailed
+			current.Reason = "rotate Job disappeared before completion"
+			current.UpdatedAt = now
+			if err := h.persistNodeStatus(node, current); err != nil {
+				return current, nodeActionWait, err
+			}
+			return current, nodeActionFailed, nil
+		}
+		if condition.Cond(batchv1.JobFailed).IsTrue(job) {
+			current.Phase = certrotation.NodePhaseFailed
+			current.Reason = fmt.Sprintf("rotate Job %s failed; see pod logs", job.Name)
+			current.UpdatedAt = now
+			if err := h.persistNodeStatus(node, current); err != nil {
+				return current, nodeActionWait, err
+			}
+			return current, nodeActionFailed, nil
+		}
+		if !condition.Cond(batchv1.JobComplete).IsTrue(job) {
+			return current, nodeActionWait, nil
+		}
+		h.pruneJobs(node.Name, false)
+		verifyJob, err := h.dispatchVerifyJob(node, generation)
+		if err != nil {
+			return current, nodeActionWait, fmt.Errorf("dispatch verify Job: %w", err)
+		}
+		logger.WithField("verifyJob", verifyJob.Name).Info("dispatched RKE2 cert-verify Job")
+		current.Phase = certrotation.NodePhaseVerifying
+		current.VerifyJobName = verifyJob.Name
+		current.UpdatedAt = now
+		if err := h.persistNodeStatus(node, current); err != nil {
+			return current, nodeActionWait, err
+		}
+		return current, nodeActionWait, nil
+
+	case certrotation.NodePhaseVerifying:
+		verifyJob, err := h.jobCache.Get(h.namespace, current.VerifyJobName)
+		if err != nil {
+			return current, nodeActionWait, err
+		}
+		if verifyJob == nil {
+			if now.Sub(current.UpdatedAt.Time) < verifyJobMissingRedispatchAfter {
+				logger.Debug("verify Job not yet visible in cache; waiting")
+				return current, nodeActionWait, nil
+			}
+			logger.Warn("verify Job missing; re-dispatching")
+			redispatched, err := h.dispatchVerifyJob(node, generation)
+			if err != nil {
+				return current, nodeActionWait, fmt.Errorf("re-dispatch verify Job: %w", err)
+			}
+			current.VerifyJobName = redispatched.Name
+			current.UpdatedAt = now
+			if err := h.persistNodeStatus(node, current); err != nil {
+				return current, nodeActionWait, err
+			}
+			return current, nodeActionWait, nil
+		}
+		if condition.Cond(batchv1.JobFailed).IsTrue(verifyJob) {
+			current.Phase = certrotation.NodePhaseFailed
+			current.Reason = fmt.Sprintf("verify Job %s failed; see pod logs", verifyJob.Name)
+			current.UpdatedAt = now
+			if err := h.persistNodeStatus(node, current); err != nil {
+				return current, nodeActionWait, err
+			}
+			return current, nodeActionFailed, nil
+		}
+		if !condition.Cond(batchv1.JobComplete).IsTrue(verifyJob) {
+			return current, nodeActionWait, nil
+		}
+		info, ok, err := certrotation.LoadCertInfoFromAnnotations(node.Annotations)
+		if err != nil || !ok {
+			logger.Debug("verify Job complete but cert annotation not yet observed; waiting")
+			return current, nodeActionWait, nil
+		}
+		latest := info.UpdatedAt.Time
+		floor := current.UpdatedAt.Time
+		if !latest.After(floor) {
+			logger.WithFields(logrus.Fields{
+				"latest": latest,
+				"floor":  floor,
+			}).Debug("cert annotation not yet refreshed past verifying-phase floor; waiting")
+			return current, nodeActionWait, nil
+		}
+		current.Phase = certrotation.NodePhaseCompleted
+		current.UpdatedAt = now
+		if err := h.persistNodeStatus(node, current); err != nil {
+			return current, nodeActionWait, err
+		}
+		closest := info.ClosestExpiryTime.Time
+		logger.WithField("closestExpiry", closest).Info("node rotation verified")
+		return current, nodeActionAdvance, nil
+
+	default:
+		return current, nodeActionWait, nil
+	}
+}
+
+func (h *Handler) rotationJobOnChanged(_ string, job *batchv1.Job) (*batchv1.Job, error) {
+	if job == nil || job.Labels == nil || job.DeletionTimestamp != nil {
+		return job, nil
+	}
+	isRotateJob := job.Labels[certrotation.LabelRKE2CertAction] == certrotation.CertActionRotate
+	isVerifyJob := job.Labels[certrotation.LabelRKE2CertCheckPurpose] == string(certrotation.CertCheckPurposeVerify)
+	if !isRotateJob && !isVerifyJob {
+		return job, nil
+	}
+	if condition.Cond(batchv1.JobComplete).IsTrue(job) || condition.Cond(batchv1.JobFailed).IsTrue(job) {
+		h.settingController.Enqueue(settings.AutoRotateRKE2CertsSettingName)
+		nodeName := job.Labels[certrotation.LabelRKE2CertNode]
+		h.pruneJobs(nodeName, isRotateJob)
+	}
+	return job, nil
+}
+
+func (h *Handler) pruneJobs(nodeName string, isRotateJob bool) {
+	logger := logrus.WithFields(logrus.Fields{
+		"node": nodeName,
+	})
+	if isRotateJob {
+		sel := certrotation.RotateJobSelector(nodeName, nil)
+		if err := certrotation.PruneJobs(
+			h.jobCache, h.jobs, h.namespace, sel, logger,
+		); err != nil {
+			logger.WithError(err).Warn("prune cert-rotate jobs failed; will retry on next reconcile")
+		}
+	} else {
+		sel := certrotation.CheckJobSelector(nodeName, ptr.To(certrotation.CertCheckPurposeVerify), nil)
+		if err := certrotation.PruneJobs(
+			h.jobCache, h.jobs, h.namespace, sel, logger,
+		); err != nil {
+			logger.WithError(err).Warn("prune cert-verify jobs failed; will retry on next reconcile")
+		}
+	}
+}
+
+func (h *Handler) dispatchRotateJob(node *corev1.Node, generation int64, role string) (*batchv1.Job, error) {
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, "harvester", []string{"generalJob", "image"})
+	if err != nil {
+		return nil, fmt.Errorf("get harvester generalJob image: %w", err)
+	}
+	return h.jobs.Create(
+		certrotation.BuildRotateJob(certrotation.RotationJobSpec{
+			Node:       node,
+			Namespace:  h.namespace,
+			Image:      image.ImageName(),
+			Role:       role,
+			Generation: generation,
+		}))
+}
+
+func (h *Handler) runningRotationJobsForNode(nodeName string) ([]*batchv1.Job, error) {
+	s := certrotation.RotateJobSelector(nodeName, nil)
+	all, err := h.jobCache.List(h.namespace, s)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*batchv1.Job, 0, len(all))
+	for _, j := range all {
+		if j.DeletionTimestamp != nil {
+			continue
+		}
+		if condition.Cond(batchv1.JobComplete).IsTrue(j) {
+			continue
+		}
+		if condition.Cond(batchv1.JobFailed).IsTrue(j) {
+			continue
+		}
+		out = append(out, j)
+	}
+	return out, nil
+}
+
+func (h *Handler) dispatchVerifyJob(node *corev1.Node, generation int64) (*batchv1.Job, error) {
+	image, err := utilHelm.FetchImageFromHelmValues(h.clientset, h.namespace, util.HarvesterChartReleaseName, []string{"generalJob", "image"})
+	if err != nil {
+		return nil, fmt.Errorf("get harvester generalJob image: %w", err)
+	}
+	job := certrotation.BuildCheckJob(certrotation.CheckJobSpec{
+		Node:                node,
+		Namespace:           h.namespace,
+		Image:               image.ImageName(),
+		HelperConfigMapName: "harvester-helpers",
+		Purpose:             certrotation.CertCheckPurposeVerify,
+		Generation:          &generation,
+	})
+	return h.jobs.Create(job)
+}
+
+func (h *Handler) persistClusterState(setting *harvesterv1.Setting, state certrotation.ClusterRotationState) error {
+	raw, err := certrotation.MarshalClusterState(state)
+	if err != nil {
+		return fmt.Errorf("marshal cluster rotation state: %w", err)
+	}
+	live, err := h.settings.Get(setting.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get setting %s: %w", setting.Name, err)
+	}
+	toUpdate := live.DeepCopy()
+	if toUpdate.Annotations == nil {
+		toUpdate.Annotations = map[string]string{}
+	}
+	if toUpdate.Annotations[certrotation.AnnotationRKE2CertRotationState] == raw {
+		return nil
+	}
+	toUpdate.Annotations[certrotation.AnnotationRKE2CertRotationState] = raw
+	if _, err := h.settings.Update(toUpdate); err != nil {
+		return fmt.Errorf("update setting %s: %w", setting.Name, err)
+	}
+	return nil
+}
+
+func (h *Handler) persistNodeStatus(node *corev1.Node, status certrotation.NodeRotationState) error {
+	raw, err := certrotation.MarshalNodeState(status)
+	if err != nil {
+		return fmt.Errorf("marshal node rotation status: %w", err)
+	}
+	live, err := h.nodeCache.Get(node.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get node %s: %w", node.Name, err)
+	}
+	toUpdate := live.DeepCopy()
+	if toUpdate.Annotations == nil {
+		toUpdate.Annotations = map[string]string{}
+	}
+	if toUpdate.Annotations[certrotation.AnnotationRKE2CertRotationNodeState] == raw {
+		return nil
+	}
+	toUpdate.Annotations[certrotation.AnnotationRKE2CertRotationNodeState] = raw
+	if _, err := h.nodeClient.Update(toUpdate); err != nil {
+		return fmt.Errorf("update node %s: %w", node.Name, err)
+	}
+	return nil
+}
+
+func earliestExpiry(nodes []*corev1.Node) (time.Time, string) {
+	var earliest time.Time
+	var earliestNode string
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		info, ok, err := certrotation.LoadCertInfoFromAnnotations(n.Annotations)
+		if err != nil || !ok {
+			continue
+		}
+		t := info.ClosestExpiryTime.Time
+		if earliest.IsZero() || t.Before(earliest) {
+			earliest = t
+			earliestNode = n.Name
+		}
+	}
+	return earliest, earliestNode
+}
+
+func roleOfNode(node *corev1.Node) nodeRole {
+	if node == nil {
+		return roleWorker
+	}
+	if isManagementByLabels(node) {
+		return roleManagement
+	}
+	return roleWorker
+}
+
+func isManagementByLabels(node *corev1.Node) bool {
+	for _, key := range []string{
+		"node-role.kubernetes.io/control-plane",
+		"node-role.kubernetes.io/etcd",
+	} {
+		if v, ok := node.Labels[key]; ok && v == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func nodesForRole(nodes []*corev1.Node, role nodeRole) []*corev1.Node {
+	out := make([]*corev1.Node, 0, len(nodes))
+	for _, n := range nodes {
+		if n == nil || n.DeletionTimestamp != nil {
+			continue
+		}
+		if roleOfNode(n) == role {
+			out = append(out, n)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func pickNextNodeForRotation(nodes []*corev1.Node, generation int64) *corev1.Node {
+	for _, n := range nodes {
+		st, ok, err := certrotation.LoadNodeStateFromAnnotations(n.Annotations)
+		if err != nil || !ok {
+			return n
+		}
+		if st.Generation != generation {
+			return n
+		}
+		if st.Phase != certrotation.NodePhaseCompleted {
+			return n
+		}
+	}
+	return nil
 }

--- a/pkg/controller/master/setting/auto_rotate_rke2_certs_test.go
+++ b/pkg/controller/master/setting/auto_rotate_rke2_certs_test.go
@@ -1,0 +1,218 @@
+package setting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/util/certrotation"
+)
+
+func nodeWithLabels(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+}
+
+func certInfoAnnotations(t *testing.T, info certrotation.CertInfo) map[string]string {
+	t.Helper()
+	raw, err := certrotation.MarshalCertInfo(info)
+	require.NoError(t, err)
+	return map[string]string{certrotation.AnnotationRKE2CertInfo: raw}
+}
+
+func nodeStatusAnnotations(t *testing.T, status certrotation.NodeRotationState) map[string]string {
+	t.Helper()
+	raw, err := certrotation.MarshalNodeState(status)
+	require.NoError(t, err)
+	return map[string]string{certrotation.AnnotationRKE2CertRotationNodeState: raw}
+}
+
+func TestRoleOfNode(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   nodeRole
+	}{
+		{
+			name:   "no role labels -> worker",
+			labels: nil,
+			want:   roleWorker,
+		},
+		{
+			name:   "control-plane=true -> management",
+			labels: map[string]string{"node-role.kubernetes.io/control-plane": "true"},
+			want:   roleManagement,
+		},
+		{
+			name:   "etcd=true (witness) -> management",
+			labels: map[string]string{"node-role.kubernetes.io/etcd": "true"},
+			want:   roleManagement,
+		},
+		{
+			name: "control-plane + etcd both -> management (CP ordering)",
+			labels: map[string]string{
+				"node-role.kubernetes.io/control-plane": "true",
+				"node-role.kubernetes.io/etcd":          "true",
+			},
+			want: roleManagement,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := nodeWithLabels("n", tt.labels)
+			assert.Equal(t, tt.want, roleOfNode(n))
+		})
+	}
+
+	t.Run("nil node -> worker (defensive)", func(t *testing.T) {
+		assert.Equal(t, roleWorker, roleOfNode(nil))
+	})
+}
+
+func TestNodesForRole_FiltersAndSorts(t *testing.T) {
+	cp1 := nodeWithLabels("cp-zzz", map[string]string{"node-role.kubernetes.io/control-plane": "true"})
+	cp2 := nodeWithLabels("cp-aaa", map[string]string{"node-role.kubernetes.io/control-plane": "true"})
+	w1 := nodeWithLabels("worker-2", nil)
+	w2 := nodeWithLabels("worker-1", nil)
+	witness := nodeWithLabels("witness", map[string]string{"node-role.kubernetes.io/etcd": "true"})
+	deleting := nodeWithLabels("cp-deleting", map[string]string{"node-role.kubernetes.io/control-plane": "true"})
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+
+	all := []*corev1.Node{cp1, cp2, w1, w2, witness, deleting, nil}
+
+	mgmt := nodesForRole(all, roleManagement)
+	require.Len(t, mgmt, 3)
+	// Sorted by name; deleting and nil are excluded.
+	assert.Equal(t, "cp-aaa", mgmt[0].Name)
+	assert.Equal(t, "cp-zzz", mgmt[1].Name)
+	assert.Equal(t, "witness", mgmt[2].Name)
+
+	workers := nodesForRole(all, roleWorker)
+	require.Len(t, workers, 2)
+	assert.Equal(t, "worker-1", workers[0].Name)
+	assert.Equal(t, "worker-2", workers[1].Name)
+}
+
+func TestEarliestExpiry(t *testing.T) {
+	mkTime := func(s string) time.Time {
+		result, err := time.Parse(time.RFC3339, s)
+		require.Nil(t, err)
+		return result
+	}
+	mk := func(name, expiry string) *corev1.Node {
+		n := nodeWithLabels(name, nil)
+		if expiry != "" {
+			n.Annotations = certInfoAnnotations(t, certrotation.CertInfo{
+				ClosestExpiryTime: metav1.Time{Time: mkTime(expiry)},
+				UpdatedAt:         metav1.Time{Time: mkTime("2026-05-11T10:00:00Z")},
+			})
+		}
+		return n
+	}
+
+	t.Run("no nodes with annotation -> zero", func(t *testing.T) {
+		ts, name := earliestExpiry([]*corev1.Node{mk("a", ""), mk("b", "")})
+		assert.True(t, ts.IsZero())
+		assert.Empty(t, name)
+	})
+
+	t.Run("malformed annotation skipped", func(t *testing.T) {
+		bad := nodeWithLabels("bad", nil)
+		bad.Annotations = map[string]string{certrotation.AnnotationRKE2CertInfo: "{not json"}
+		good := mk("good", "2026-12-01T00:00:00Z")
+		ts, name := earliestExpiry([]*corev1.Node{bad, good})
+		assert.Equal(t, "good", name)
+		assert.Equal(t, "2026-12-01T00:00:00Z", ts.UTC().Format(time.RFC3339))
+	})
+
+	t.Run("returns earliest across nodes", func(t *testing.T) {
+		ts, name := earliestExpiry([]*corev1.Node{
+			mk("late", "2027-01-01T00:00:00Z"),
+			mk("early", "2026-06-01T00:00:00Z"),
+			mk("middle", "2026-09-01T00:00:00Z"),
+		})
+		assert.Equal(t, "early", name)
+		assert.Equal(t, "2026-06-01T00:00:00Z", ts.UTC().Format(time.RFC3339))
+	})
+
+	t.Run("nil node entries skipped", func(t *testing.T) {
+		ts, name := earliestExpiry([]*corev1.Node{nil, mk("only", "2027-01-01T00:00:00Z"), nil})
+		assert.Equal(t, "only", name)
+		assert.False(t, ts.IsZero())
+	})
+}
+
+func TestPickNextNodeForRotation(t *testing.T) {
+	const gen = int64(5)
+
+	completed := nodeWithLabels("done", nil)
+	completed.Annotations = nodeStatusAnnotations(t, certrotation.NodeRotationState{
+		Generation: gen, Phase: certrotation.NodePhaseCompleted,
+	})
+
+	rotating := nodeWithLabels("rotating", nil)
+	rotating.Annotations = nodeStatusAnnotations(t, certrotation.NodeRotationState{
+		Generation: gen, Phase: certrotation.NodePhaseRotating,
+	})
+
+	staleGen := nodeWithLabels("stale", nil)
+	staleGen.Annotations = nodeStatusAnnotations(t, certrotation.NodeRotationState{
+		Generation: gen - 1, Phase: certrotation.NodePhaseCompleted,
+	})
+
+	pristine := nodeWithLabels("pristine", nil)
+
+	tests := []struct {
+		name  string
+		nodes []*corev1.Node
+		want  string // name of the picked node, or "" for nil
+	}{
+		{
+			name:  "empty list -> nil",
+			nodes: nil,
+			want:  "",
+		},
+		{
+			name:  "all completed at current gen -> nil",
+			nodes: []*corev1.Node{completed, completed},
+			want:  "",
+		},
+		{
+			name:  "in-flight at current gen -> picked",
+			nodes: []*corev1.Node{completed, rotating, completed},
+			want:  "rotating",
+		},
+		{
+			name:  "older generation -> picked",
+			nodes: []*corev1.Node{completed, staleGen},
+			want:  "stale",
+		},
+		{
+			name:  "no annotation -> picked",
+			nodes: []*corev1.Node{completed, pristine},
+			want:  "pristine",
+		},
+		{
+			name:  "preserves input order",
+			nodes: []*corev1.Node{rotating, pristine},
+			want:  "rotating",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickNextNodeForRotation(tt.nodes, gen)
+			if tt.want == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.Name)
+		})
+	}
+}

--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -15,9 +15,11 @@ import (
 	ctlrkev1 "github.com/rancher/rancher/pkg/generated/controllers/rke.cattle.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/apply"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps/v1"
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/slice"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
@@ -89,6 +91,9 @@ type Handler struct {
 	kubeVirtConfigCache  kubevirtv1.KubeVirtCache
 	namespaces           ctlcorev1.NamespaceClient
 	namespacesCache      ctlcorev1.NamespaceCache
+	jobs                 ctlbatchv1.JobClient
+	jobCache             ctlbatchv1.JobCache
+	clientset            kubernetes.Interface
 }
 
 func (h *Handler) settingOnChanged(_ string, setting *harvesterv1.Setting) (*harvesterv1.Setting, error) {

--- a/pkg/controller/master/setting/nodeconfig.go
+++ b/pkg/controller/master/setting/nodeconfig.go
@@ -73,10 +73,6 @@ func (h *Handler) nodeOnChanged(_ string, node *corev1.Node) (*corev1.Node, erro
 		return node, nil
 	}
 
-	// Wake the auto-rotate-rke2-certs orchestrator so it can react promptly
-	// to changes in the per-node rke2-certs annotations
-	h.settingController.Enqueue(harvSettings.AutoRotateRKE2CertsSettingName)
-
 	// Get NTP Server settings
 	ntpServersSetting, err := h.settingCache.Get(harvSettings.NTPServersSettingName)
 	if err != nil {

--- a/pkg/controller/master/setting/nodeconfig.go
+++ b/pkg/controller/master/setting/nodeconfig.go
@@ -73,6 +73,10 @@ func (h *Handler) nodeOnChanged(_ string, node *corev1.Node) (*corev1.Node, erro
 		return node, nil
 	}
 
+	// Wake the auto-rotate-rke2-certs orchestrator so it can react promptly
+	// to changes in the per-node rke2-certs annotations
+	h.settingController.Enqueue(harvSettings.AutoRotateRKE2CertsSettingName)
+
 	// Get NTP Server settings
 	ntpServersSetting, err := h.settingCache.Get(harvSettings.NTPServersSettingName)
 	if err != nil {

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -36,6 +36,7 @@ func Register(ctx context.Context, management *config.Management, options config
 	rancherSettings := management.RancherManagementFactory.Management().V3().Setting()
 	kubevirt := management.VirtFactory.Kubevirt().V1().KubeVirt()
 	namespaces := management.CoreFactory.Core().V1().Namespace()
+	jobs := management.BatchFactory.Batch().V1().Job()
 	controller := &Handler{
 		namespace:            options.Namespace,
 		apply:                management.Apply,
@@ -73,6 +74,9 @@ func Register(ctx context.Context, management *config.Management, options config
 		kubeVirtConfigCache:  kubevirt.Cache(),
 		namespaces:           namespaces,
 		namespacesCache:      namespaces.Cache(),
+		jobs:                 jobs,
+		jobCache:             jobs.Cache(),
+		clientset:            management.ClientSet,
 
 		httpClient: http.Client{
 			Timeout: 30 * time.Second,
@@ -112,6 +116,7 @@ func Register(ctx context.Context, management *config.Management, options config
 
 	settings.OnChange(ctx, controllerName, controller.settingOnChanged)
 	node.OnChange(ctx, controllerName, controller.nodeOnChanged)
+	jobs.OnChange(ctx, controllerName, controller.rotationJobOnChanged)
 	relatedresource.WatchClusterScoped(ctx, watchNamespaceChanges, controller.watchNamespaceChanges, settings, namespaces)
 	return nil
 }

--- a/pkg/controller/master/setup.go
+++ b/pkg/controller/master/setup.go
@@ -48,6 +48,7 @@ var registerFuncs = []registerFunc{
 	machine.ControlPlaneRegister,
 	mcmsettings.Register,
 	migration.Register,
+	node.CertCheckRegister,
 	node.CPUManagerRegister,
 	node.CPUModelConfigRegister,
 	node.DownRegister,

--- a/pkg/util/certrotation/jobs.go
+++ b/pkg/util/certrotation/jobs.go
@@ -304,14 +304,20 @@ func PruneJobs(
 
 	// Sort newest-first so we keep the head and prune the tail.
 	sort.Slice(successful, func(i, j int) bool {
-		iCompletionTime := successful[i].Status.CompletionTime.Time
-		jCompletionTime := successful[j].Status.CompletionTime.Time
-		return iCompletionTime.After(jCompletionTime)
+		iTime := successfulJobTime(successful[i])
+		jTime := successfulJobTime(successful[j])
+		if iTime.Equal(jTime) {
+			return failed[i].Name > failed[j].Name // Stable tie-breaker
+		}
+		return iTime.After(jTime)
 	})
 	sort.Slice(failed, func(i, j int) bool {
-		iFailedTime := failedJobTime(failed[i])
-		jFailedTime := failedJobTime(failed[j])
-		return iFailedTime.After(jFailedTime)
+		iTime := failedJobTime(failed[i])
+		jTime := failedJobTime(failed[j])
+		if iTime.Equal(jTime) {
+			return failed[i].Name > failed[j].Name // Stable tie-breaker
+		}
+		return iTime.After(jTime)
 	})
 
 	prune := func(category string, jobs []*batchv1.Job, limit int) {
@@ -351,5 +357,20 @@ func failedJobTime(job *batchv1.Job) time.Time {
 			return c.LastTransitionTime.Time
 		}
 	}
-	return time.Time{}
+	// Fallback to job created time
+	return job.CreationTimestamp.Time
+}
+
+func successfulJobTime(job *batchv1.Job) time.Time {
+	if job.Status.CompletionTime != nil {
+		return job.Status.CompletionTime.Time
+	}
+	// Fallback: If CompletionTime isn't populated yet, look for the condition timestamp
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			return c.LastTransitionTime.Time
+		}
+	}
+	// Fallback to job created time
+	return job.CreationTimestamp.Time
 }

--- a/pkg/util/certrotation/jobs.go
+++ b/pkg/util/certrotation/jobs.go
@@ -1,0 +1,355 @@
+package certrotation
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/condition"
+	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
+	"github.com/rancher/wrangler/v3/pkg/name"
+	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	SuccessfulJobsHistoryPerNodeLimit = 3
+	FailedJobsHistoryPerNodeLimit     = 3
+)
+
+const (
+	certCheckJobPrefix                   = "rke2-cert-check"
+	certCheckScriptMountPath             = "/harvester-helpers"
+	certCheckScriptPath                  = certCheckScriptMountPath + "/rke2-cert-check.sh"
+	certCheckRootMountPath               = "/host"
+	certCheckBackoffLimit          int32 = 5
+	certCheckActiveDeadlineSeconds int64 = 300
+)
+
+type CheckJobSpec struct {
+	Node                *corev1.Node
+	Namespace           string
+	Image               string
+	HelperConfigMapName string
+	Purpose             CertCheckPurpose
+	Generation          *int64
+}
+
+func BuildCheckJob(spec CheckJobSpec) *batchv1.Job {
+	jobLabels := checkJobLabelSet(
+		spec.Node.Name,
+		&spec.Purpose,
+		spec.Generation,
+	)
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: name.SafeConcatName(certCheckJobPrefix, string(spec.Purpose), spec.Node.Name) + "-",
+			Namespace:    spec.Namespace,
+			Labels:       jobLabels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: spec.Node.APIVersion,
+					Kind:       spec.Node.Kind,
+					Name:       spec.Node.Name,
+					UID:        spec.Node.UID,
+				},
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:          ptr.To(certCheckBackoffLimit),
+			ActiveDeadlineSeconds: ptr.To(certCheckActiveDeadlineSeconds),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: jobLabels},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					HostPID:       true,
+					Containers: []corev1.Container{
+						{
+							Name:    "rke2-cert-check",
+							Image:   spec.Image,
+							Command: []string{"sh"},
+							Args:    []string{"-e", certCheckScriptPath, spec.Node.Name},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "host-root", MountPath: certCheckRootMountPath},
+								{Name: "helpers", MountPath: certCheckScriptMountPath},
+							},
+							Env: []corev1.EnvVar{
+								{Name: "HOST_DIR", Value: certCheckRootMountPath},
+							},
+						},
+					},
+					ServiceAccountName: "harvester",
+					// Tolerate everything so cordoned / unschedulable nodes still get checks
+					Tolerations: []corev1.Toleration{
+						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+									MatchExpressions: []corev1.NodeSelectorRequirement{{
+										Key:      corev1.LabelHostname,
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{spec.Node.Name},
+									}},
+								}},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "host-root",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/",
+									Type: ptr.To(corev1.HostPathDirectory),
+								},
+							},
+						},
+						{
+							Name: "helpers",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: spec.HelperConfigMapName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func GenerationLabelValue(generation int64) string {
+	return fmt.Sprintf("%d", generation)
+}
+
+const (
+	rotationRootMountPath             = "/host"
+	rotationScriptMountPath           = "/harvester-helpers"
+	rotationJobPrefix                 = "rke2-cert-rotate"
+	rotationScriptPath                = rotationScriptMountPath + "/rke2-cert-rotate.sh"
+	rotationWaitReadyTimeoutSec int64 = 300
+	rotationJobTimeoutInSec     int64 = rotationWaitReadyTimeoutSec * 2
+)
+
+type RotationJobSpec struct {
+	Node       *corev1.Node
+	Namespace  string
+	Image      string
+	Role       string
+	Generation int64
+}
+
+func BuildRotateJob(spec RotationJobSpec) *batchv1.Job {
+	jobLabels := rotateJobLabelSet(spec.Node.Name, &spec.Generation)
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: name.SafeConcatName(rotationJobPrefix, spec.Node.Name) + "-",
+			Namespace:    spec.Namespace,
+			Labels:       jobLabels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: spec.Node.APIVersion,
+					Kind:       spec.Node.Kind,
+					Name:       spec.Node.Name,
+					UID:        spec.Node.UID,
+				},
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:          ptr.To(int32(0)),
+			ActiveDeadlineSeconds: ptr.To(rotationJobTimeoutInSec),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: jobLabels},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					HostPID:       true,
+					HostNetwork:   true,
+					HostIPC:       true,
+					DNSPolicy:     corev1.DNSClusterFirstWithHostNet,
+					Containers: []corev1.Container{
+						{
+							Name:    "rke2-cert-rotate",
+							Image:   spec.Image,
+							Command: []string{"sh"},
+							Args:    []string{"-e", rotationScriptPath, spec.Node.Name, spec.Role},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "host-root", MountPath: rotationRootMountPath},
+								{Name: "helpers", MountPath: rotationScriptMountPath},
+							},
+							Env: []corev1.EnvVar{
+								{Name: "HOST_DIR", Value: rotationRootMountPath},
+								{Name: "WAIT_READY_TIMEOUT", Value: fmt.Sprintf("%d", rotationWaitReadyTimeoutSec)},
+							},
+						},
+					},
+					ServiceAccountName: "harvester",
+					Tolerations: []corev1.Toleration{
+						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+									MatchExpressions: []corev1.NodeSelectorRequirement{{
+										Key:      corev1.LabelHostname,
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{spec.Node.Name},
+									}},
+								}},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "host-root",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/",
+									Type: ptr.To(corev1.HostPathDirectory),
+								},
+							},
+						},
+						{
+							Name: "helpers",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "harvester-helpers",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func checkJobLabelSet(nodeName string, purpose *CertCheckPurpose, generation *int64) labels.Set {
+	ls := labels.Set{
+		LabelRKE2CertAction: CertActionCheck,
+		LabelRKE2CertNode:   nodeName,
+	}
+	if purpose != nil {
+		ls[LabelRKE2CertCheckPurpose] = string(*purpose)
+	}
+	if generation != nil {
+		ls[LabelRKE2CertGeneration] = GenerationLabelValue(*generation)
+	}
+	return ls
+}
+
+func CheckJobSelector(nodeName string, purpose *CertCheckPurpose, generation *int64) labels.Selector {
+	return labels.SelectorFromSet(checkJobLabelSet(nodeName, purpose, generation))
+}
+
+func rotateJobLabelSet(nodeName string, generation *int64) labels.Set {
+	ls := labels.Set{
+		LabelRKE2CertAction: CertActionRotate,
+		LabelRKE2CertNode:   nodeName,
+	}
+	if generation != nil {
+		ls[LabelRKE2CertGeneration] = GenerationLabelValue(*generation)
+	}
+	return ls
+}
+
+func RotateJobSelector(nodeName string, generation *int64) labels.Selector {
+	return labels.SelectorFromSet(rotateJobLabelSet(nodeName, generation))
+}
+
+func PruneJobs(
+	jobCache ctlbatchv1.JobCache,
+	jobClient ctlbatchv1.JobClient,
+	namespace string,
+	selector labels.Selector,
+	logger *logrus.Entry,
+) error {
+	all, err := jobCache.List(namespace, selector)
+	if err != nil {
+		return fmt.Errorf("list Jobs for pruning (selector=%s): %w", selector, err)
+	}
+
+	var successful, failed []*batchv1.Job
+	for _, j := range all {
+		if j.DeletionTimestamp != nil {
+			continue
+		}
+		switch {
+		case condition.Cond(batchv1.JobComplete).IsTrue(j):
+			successful = append(successful, j)
+		case condition.Cond(batchv1.JobFailed).IsTrue(j):
+			failed = append(failed, j)
+		}
+	}
+
+	// Sort newest-first so we keep the head and prune the tail.
+	sort.Slice(successful, func(i, j int) bool {
+		iCompletionTime := successful[i].Status.CompletionTime.Time
+		jCompletionTime := successful[j].Status.CompletionTime.Time
+		return iCompletionTime.After(jCompletionTime)
+	})
+	sort.Slice(failed, func(i, j int) bool {
+		iFailedTime := failedJobTime(failed[i])
+		jFailedTime := failedJobTime(failed[j])
+		return iFailedTime.After(jFailedTime)
+	})
+
+	prune := func(category string, jobs []*batchv1.Job, limit int) {
+		if len(jobs) <= limit {
+			return
+		}
+		bg := metav1.DeletePropagationBackground
+		for _, j := range jobs[limit:] {
+			err := jobClient.Delete(j.Namespace, j.Name, &metav1.DeleteOptions{
+				PropagationPolicy: &bg,
+			})
+			switch {
+			case err == nil:
+				logger.WithFields(logrus.Fields{
+					"job":      j.Name,
+					"category": category,
+				}).Info("pruned terminal Job (history limit exceeded)")
+			case apierrors.IsNotFound(err):
+				// Already gone; harmless.
+			default:
+				logger.WithFields(logrus.Fields{
+					"job":      j.Name,
+					"category": category,
+				}).WithError(err).Warn("failed to prune terminal Job; will retry next pass")
+			}
+		}
+	}
+
+	prune("successful", successful, SuccessfulJobsHistoryPerNodeLimit)
+	prune("failed", failed, FailedJobsHistoryPerNodeLimit)
+	return nil
+}
+
+func failedJobTime(job *batchv1.Job) time.Time {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return c.LastTransitionTime.Time
+		}
+	}
+	return time.Time{}
+}

--- a/pkg/util/certrotation/jobs_test.go
+++ b/pkg/util/certrotation/jobs_test.go
@@ -1,0 +1,105 @@
+package certrotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+func baseSpec(node *corev1.Node) CheckJobSpec {
+	return CheckJobSpec{
+		Node:                node,
+		Namespace:           "harvester-system",
+		Image:               "registry.example.com/harvester/general:v1",
+		HelperConfigMapName: "harvester-helpers",
+		Purpose:             CertCheckPurposeSchedule,
+		Generation:          nil,
+	}
+}
+
+func TestBuildCheckJob_SchedulePurposeBaseline(t *testing.T) {
+	node := &corev1.Node{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Node"},
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1", UID: types.UID("uid-1")},
+	}
+	job := BuildCheckJob(baseSpec(node))
+
+	// Job-level labels MUST always include the check-node and purpose
+	// labels so dedup queries work regardless of dispatcher.
+	assert.Equal(t, "node-1", job.Labels[LabelRKE2CertNode])
+	assert.Equal(t, string(CertCheckPurposeSchedule), job.Labels[LabelRKE2CertCheckPurpose])
+	// Pod template labels must mirror Job labels so apiserver Job
+	// controller can match pods to Jobs without ambiguity.
+	assert.Equal(t, job.Labels, job.Spec.Template.Labels)
+
+	// Pinned to the node by hostname affinity.
+	require.NotNil(t, job.Spec.Template.Spec.Affinity)
+	require.NotNil(t, job.Spec.Template.Spec.Affinity.NodeAffinity)
+	terms := job.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	require.NotNil(t, terms)
+	require.Len(t, terms.NodeSelectorTerms, 1)
+	require.Len(t, terms.NodeSelectorTerms[0].MatchExpressions, 1)
+	expr := terms.NodeSelectorTerms[0].MatchExpressions[0]
+	assert.Equal(t, corev1.LabelHostname, expr.Key)
+	assert.Equal(t, []string{"node-1"}, expr.Values)
+
+	// Privileged container with host-root + helpers volumes.
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+	c := job.Spec.Template.Spec.Containers[0]
+	require.NotNil(t, c.SecurityContext)
+	require.NotNil(t, c.SecurityContext.Privileged)
+	assert.True(t, *c.SecurityContext.Privileged)
+	assert.Contains(t, c.Args, "/harvester-helpers/rke2-cert-check.sh")
+	assert.Contains(t, c.Args, "node-1")
+	assert.Equal(t, "harvester", job.Spec.Template.Spec.ServiceAccountName)
+
+	// Owner reference points to the node so deleting the node cleans up
+	// the Job.
+	require.Len(t, job.OwnerReferences, 1)
+	assert.Equal(t, "Node", job.OwnerReferences[0].Kind)
+	assert.Equal(t, "node-1", job.OwnerReferences[0].Name)
+	assert.Equal(t, types.UID("uid-1"), job.OwnerReferences[0].UID)
+
+	// Generation label is NOT set for schedule-purpose Jobs by default.
+	_, hasGen := job.Labels[LabelRKE2CertGeneration]
+	assert.False(t, hasGen, "schedule-purpose Jobs should not carry a generation label by default")
+
+	assert.NotNil(t, job.Spec.BackoffLimit)
+	assert.NotNil(t, job.Spec.ActiveDeadlineSeconds)
+	assert.Nil(t, job.Spec.TTLSecondsAfterFinished)
+}
+
+func TestBuildCheckJob_VerifyPurposeWithGenerationLabel(t *testing.T) {
+	node := &corev1.Node{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Node"},
+		ObjectMeta: metav1.ObjectMeta{Name: "node-2", UID: types.UID("uid-2")},
+	}
+	spec := baseSpec(node)
+	spec.Purpose = CertCheckPurposeVerify
+	spec.Generation = ptr.To(int64(7))
+
+	job := BuildCheckJob(spec)
+
+	assert.Equal(t, "node-2", job.Labels[LabelRKE2CertNode])
+	assert.Equal(t, string(CertCheckPurposeVerify), job.Labels[LabelRKE2CertCheckPurpose])
+	assert.Equal(t, "7", job.Labels[LabelRKE2CertGeneration])
+	// Pod template inherits the same labels so kubectl describe-on-pod
+	// shows the full provenance of the Job.
+	assert.Equal(t, "7", job.Spec.Template.Labels[LabelRKE2CertGeneration])
+	assert.Equal(t, string(CertCheckPurposeVerify), job.Spec.Template.Labels[LabelRKE2CertCheckPurpose])
+
+	assert.NotNil(t, job.Spec.BackoffLimit)
+	assert.NotNil(t, job.Spec.ActiveDeadlineSeconds)
+	assert.Nil(t, job.Spec.TTLSecondsAfterFinished)
+}
+
+func TestGenerationLabelValue(t *testing.T) {
+	assert.Equal(t, "0", GenerationLabelValue(0))
+	assert.Equal(t, "1", GenerationLabelValue(1))
+	assert.Equal(t, "12345", GenerationLabelValue(12345))
+}

--- a/pkg/util/certrotation/types.go
+++ b/pkg/util/certrotation/types.go
@@ -1,0 +1,141 @@
+package certrotation
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	AnnotationRKE2CertInfo              = "harvesterhci.io/rke2-cert-info"
+	AnnotationRKE2CertRotationNodeState = "harvesterhci.io/rke2-cert-rotation-node-state"
+
+	AnnotationRKE2CertRotationState = "harvesterhci.io/rke2-cert-rotation-state"
+
+	LabelRKE2CertAction       = "harvesterhci.io/rke2-cert-action"
+	LabelRKE2CertCheckPurpose = "harvesterhci.io/rke2-cert-check-purpose"
+	LabelRKE2CertNode         = "harvesterhci.io/rke2-cert-node"
+	LabelRKE2CertGeneration   = "harvesterhci.io/rke2-cert-generation"
+)
+
+type CertCheckPurpose string
+
+const (
+	CertCheckPurposeSchedule CertCheckPurpose = "schedule"
+	CertCheckPurposeVerify   CertCheckPurpose = "verify"
+)
+
+const (
+	CertActionCheck  = "check"
+	CertActionRotate = "rotate"
+)
+
+// Cluster-wide rotation phases. Stored in ClusterRotationState.Phase.
+const (
+	PhaseIdle           = "idle"
+	PhaseCPRotation     = "cp-rotation"
+	PhaseWorkerRotation = "worker-rotation"
+	PhaseCompleted      = "completed"
+	PhaseFailed         = "failed"
+)
+
+// Per-node rotation phases. Stored in NodeRotationStatus.Phase.
+const (
+	NodePhasePending   = "pending"
+	NodePhaseRotating  = "rotating"
+	NodePhaseVerifying = "verifying"
+	NodePhaseCompleted = "completed"
+	NodePhaseFailed    = "failed"
+)
+
+type ClusterRotationState struct {
+	Generation  int64       `json:"generation"`
+	Phase       string      `json:"phase"`
+	CurrentNode string      `json:"currentNode,omitempty"`
+	StartedAt   metav1.Time `json:"startedAt"`
+	UpdatedAt   metav1.Time `json:"updatedAt"`
+	LastError   string      `json:"lastError,omitempty"`
+}
+
+type NodeRotationState struct {
+	Generation    int64       `json:"generation"`
+	Phase         string      `json:"phase"`
+	JobName       string      `json:"jobName,omitempty"`
+	VerifyJobName string      `json:"verifyJobName,omitempty"`
+	StartedAt     metav1.Time `json:"startedAt"`
+	UpdatedAt     metav1.Time `json:"updatedAt"`
+	Reason        string      `json:"reason,omitempty"`
+}
+
+type CertInfo struct {
+	ClosestExpiryTime metav1.Time `json:"closestExpiryTime"`
+	UpdatedAt         metav1.Time `json:"updatedAt"`
+}
+
+func IsRotationInProgress(phase string) bool {
+	return phase == PhaseCPRotation || phase == PhaseWorkerRotation
+}
+
+func LoadClusterStateFromAnnotations(annotations map[string]string) (ClusterRotationState, error) {
+	raw, ok := annotations[AnnotationRKE2CertRotationState]
+	if !ok || raw == "" {
+		return ClusterRotationState{Phase: PhaseIdle}, nil
+	}
+	var st ClusterRotationState
+	if err := json.Unmarshal([]byte(raw), &st); err != nil {
+		return ClusterRotationState{}, err
+	}
+	return st, nil
+}
+
+func MarshalClusterState(state ClusterRotationState) (string, error) {
+	b, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func EqualState(a, b ClusterRotationState) bool {
+	return a.Generation == b.Generation && a.Phase == b.Phase && a.CurrentNode == b.CurrentNode
+}
+
+func LoadNodeStateFromAnnotations(annotations map[string]string) (NodeRotationState, bool, error) {
+	raw, ok := annotations[AnnotationRKE2CertRotationNodeState]
+	if !ok || raw == "" {
+		return NodeRotationState{}, false, nil
+	}
+	var st NodeRotationState
+	if err := json.Unmarshal([]byte(raw), &st); err != nil {
+		return NodeRotationState{}, false, err
+	}
+	return st, true, nil
+}
+
+func MarshalNodeState(state NodeRotationState) (string, error) {
+	b, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func LoadCertInfoFromAnnotations(annotations map[string]string) (CertInfo, bool, error) {
+	raw, ok := annotations[AnnotationRKE2CertInfo]
+	if !ok || raw == "" {
+		return CertInfo{}, false, nil
+	}
+	var info CertInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return CertInfo{}, false, err
+	}
+	return info, true, nil
+}
+
+func MarshalCertInfo(info CertInfo) (string, error) {
+	b, err := json.Marshal(info)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/pkg/util/certrotation/types_test.go
+++ b/pkg/util/certrotation/types_test.go
@@ -1,0 +1,263 @@
+package certrotation
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsRotationInProgress(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase string
+		want  bool
+	}{
+		{"empty string is not in progress", "", false},
+		{"idle is not in progress", PhaseIdle, false},
+		{"completed is not in progress", PhaseCompleted, false},
+		{"failed is not in progress", PhaseFailed, false},
+		{"cp-rotation is in progress", PhaseCPRotation, true},
+		{"worker-rotation is in progress", PhaseWorkerRotation, true},
+		{"garbage value is not in progress", "garbage", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsRotationInProgress(tt.phase))
+		})
+	}
+}
+
+func TestLoadClusterStateFromAnnotations(t *testing.T) {
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+
+	t.Run("nil annotations map yields PhaseIdle with nil error", func(t *testing.T) {
+		st, err := LoadClusterStateFromAnnotations(nil)
+		require.NoError(t, err)
+		assert.Equal(t, PhaseIdle, st.Phase)
+		assert.Equal(t, int64(0), st.Generation)
+	})
+
+	t.Run("missing annotation yields PhaseIdle with nil error", func(t *testing.T) {
+		st, err := LoadClusterStateFromAnnotations(map[string]string{
+			"unrelated": "value",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, PhaseIdle, st.Phase)
+	})
+
+	t.Run("empty-string annotation yields PhaseIdle with nil error", func(t *testing.T) {
+		st, err := LoadClusterStateFromAnnotations(map[string]string{
+			AnnotationRKE2CertRotationState: "",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, PhaseIdle, st.Phase)
+	})
+
+	t.Run("valid JSON parses correctly", func(t *testing.T) {
+		want := ClusterRotationState{
+			Generation:  3,
+			Phase:       PhaseCPRotation,
+			CurrentNode: "node-1",
+			StartedAt:   now,
+			UpdatedAt:   now,
+		}
+		raw, err := json.Marshal(want)
+		require.NoError(t, err)
+
+		got, err := LoadClusterStateFromAnnotations(map[string]string{
+			AnnotationRKE2CertRotationState: string(raw),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, want.Generation, got.Generation)
+		assert.Equal(t, want.Phase, got.Phase)
+		assert.Equal(t, want.CurrentNode, got.CurrentNode)
+		require.NotNil(t, got.StartedAt)
+		assert.True(t, want.StartedAt.Equal(&got.StartedAt))
+		require.NotNil(t, got.UpdatedAt)
+		assert.True(t, want.UpdatedAt.Equal(&got.UpdatedAt))
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		_, err := LoadClusterStateFromAnnotations(map[string]string{
+			AnnotationRKE2CertRotationState: "{not valid json",
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestMarshalClusterState_RoundTrip(t *testing.T) {
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+	original := ClusterRotationState{
+		Generation:  7,
+		Phase:       PhaseWorkerRotation,
+		CurrentNode: "worker-2",
+		StartedAt:   now,
+		UpdatedAt:   now,
+		LastError:   "",
+	}
+
+	raw, err := MarshalClusterState(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	got, err := LoadClusterStateFromAnnotations(map[string]string{
+		AnnotationRKE2CertRotationState: raw,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, original.Generation, got.Generation)
+	assert.Equal(t, original.Phase, got.Phase)
+	assert.Equal(t, original.CurrentNode, got.CurrentNode)
+	assert.Equal(t, original.LastError, got.LastError)
+	require.NotNil(t, got.StartedAt)
+	assert.True(t, original.StartedAt.Equal(&got.StartedAt))
+	require.NotNil(t, got.UpdatedAt)
+	assert.True(t, original.UpdatedAt.Equal(&got.UpdatedAt))
+}
+
+func TestMarshalClusterState_OmitsEmptyOptionalFields(t *testing.T) {
+	// Sanity check that omitempty tags work, so terminal phases produce a
+	// compact annotation value.
+	state := ClusterRotationState{
+		Generation: 1,
+		Phase:      PhaseIdle,
+	}
+	raw, err := MarshalClusterState(state)
+	require.NoError(t, err)
+	assert.NotContains(t, raw, "currentNode")
+	assert.NotContains(t, raw, "lastError")
+}
+
+func TestLoadNodeStatusFromAnnotations(t *testing.T) {
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+
+	t.Run("nil annotations map", func(t *testing.T) {
+		st, ok, err := LoadNodeStateFromAnnotations(nil)
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Equal(t, NodeRotationState{}, st)
+	})
+
+	t.Run("missing annotation", func(t *testing.T) {
+		st, ok, err := LoadNodeStateFromAnnotations(map[string]string{
+			"other": "thing",
+		})
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Equal(t, NodeRotationState{}, st)
+	})
+
+	t.Run("empty-string annotation", func(t *testing.T) {
+		st, ok, err := LoadNodeStateFromAnnotations(map[string]string{
+			AnnotationRKE2CertRotationNodeState: "",
+		})
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Equal(t, NodeRotationState{}, st)
+	})
+
+	t.Run("valid JSON", func(t *testing.T) {
+		want := NodeRotationState{
+			Generation: 5,
+			Phase:      NodePhaseVerifying,
+			JobName:    "rke2-cert-rotate-node-1-5",
+			StartedAt:  now,
+			UpdatedAt:  now,
+		}
+		raw, err := json.Marshal(want)
+		require.NoError(t, err)
+
+		got, ok, err := LoadNodeStateFromAnnotations(map[string]string{
+			AnnotationRKE2CertRotationNodeState: string(raw),
+		})
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, want.Generation, got.Generation)
+		assert.Equal(t, want.Phase, got.Phase)
+		assert.Equal(t, want.JobName, got.JobName)
+		require.NotNil(t, got.StartedAt)
+		assert.True(t, want.StartedAt.Equal(&got.StartedAt))
+		require.NotNil(t, got.UpdatedAt)
+		assert.True(t, want.UpdatedAt.Equal(&got.UpdatedAt))
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		_, ok, err := LoadNodeStateFromAnnotations(map[string]string{
+			AnnotationRKE2CertRotationNodeState: "}}}",
+		})
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+}
+
+func TestMarshalNodeStatus_RoundTrip(t *testing.T) {
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+	original := NodeRotationState{
+		Generation: 2,
+		Phase:      NodePhaseFailed,
+		JobName:    "rke2-cert-rotate-node-2-2",
+		StartedAt:  now,
+		UpdatedAt:  now,
+		Reason:     "rke2-server failed to come back ready within 5m",
+	}
+
+	raw, err := MarshalNodeState(original)
+	require.NoError(t, err)
+
+	got, ok, err := LoadNodeStateFromAnnotations(map[string]string{
+		AnnotationRKE2CertRotationNodeState: raw,
+	})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, original.Generation, got.Generation)
+	assert.Equal(t, original.Phase, got.Phase)
+	assert.Equal(t, original.JobName, got.JobName)
+	assert.Equal(t, original.Reason, got.Reason)
+	require.NotNil(t, got.StartedAt)
+	assert.True(t, original.StartedAt.Equal(&got.StartedAt))
+	require.NotNil(t, got.UpdatedAt)
+	assert.True(t, original.UpdatedAt.Equal(&got.UpdatedAt))
+}
+
+func TestLoadCertInfoFromAnnotations(t *testing.T) {
+	t.Run("nil annotations map", func(t *testing.T) {
+		info, ok, err := LoadCertInfoFromAnnotations(nil)
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Equal(t, CertInfo{}, info)
+	})
+
+	t.Run("missing annotation", func(t *testing.T) {
+		info, ok, err := LoadCertInfoFromAnnotations(map[string]string{
+			"other": "thing",
+		})
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Equal(t, CertInfo{}, info)
+	})
+
+	t.Run("valid JSON matches helper-script field names", func(t *testing.T) {
+		// This payload mirrors what rke2-cert-check.sh produces. If the
+		// helper-script schema ever changes, this test will fail and remind
+		// the developer to update both sides in lockstep.
+		raw := `{"closestExpiryTime":"2027-05-07T09:38:50Z","updatedAt":"2026-05-11T10:02:14Z"}`
+		info, ok, err := LoadCertInfoFromAnnotations(map[string]string{
+			AnnotationRKE2CertInfo: raw,
+		})
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, "2027-05-07T09:38:50Z", info.ClosestExpiryTime.UTC().Format(time.RFC3339))
+		assert.Equal(t, "2026-05-11T10:02:14Z", info.UpdatedAt.UTC().Format(time.RFC3339))
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		_, ok, err := LoadCertInfoFromAnnotations(map[string]string{
+			AnnotationRKE2CertInfo: "not json",
+		})
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/pkg/util/helm/values.go
+++ b/pkg/util/helm/values.go
@@ -17,6 +17,10 @@ import (
 	"github.com/harvester/harvester/pkg/util"
 )
 
+func GetKeyNamesGeneralJobImage() []string {
+	return []string{"generalJob", "image"}
+}
+
 // FetchImageFromHelmValues fetches image information from helm chart values, the name points to a chart e.g. harvester
 func FetchImageFromHelmValues(clientSet kubernetes.Interface, namespace, name string, keyNames []string) (settings.Image, error) {
 	var image settings.Image

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -58,6 +58,7 @@ import (
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	backuputil "github.com/harvester/harvester/pkg/util/backup"
+	"github.com/harvester/harvester/pkg/util/certrotation"
 	networkutil "github.com/harvester/harvester/pkg/util/network"
 	tlsutil "github.com/harvester/harvester/pkg/util/tls"
 	vmUtil "github.com/harvester/harvester/pkg/util/virtualmachine"
@@ -212,6 +213,8 @@ func NewValidator(
 
 	validateSettingUpdateFuncs[settings.LHIMResourcesSettingName] = validator.validateUpdateLHIMResources
 	validateSettingDeleteFuncs[settings.LHIMResourcesSettingName] = validator.validateDeleteLHIMResources
+
+	validateSettingDeleteFuncs[settings.AutoRotateRKE2CertsSettingName] = validator.validateDeleteAutoRotateRKE2Certs
 
 	return validator
 }
@@ -2080,8 +2083,55 @@ func validateAutoRotateRKE2Certs(setting *v1beta1.Setting) error {
 	return nil
 }
 
-func validateUpdateAutoRotateRKE2Certs(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
-	return validateAutoRotateRKE2Certs(newSetting)
+func validateUpdateAutoRotateRKE2Certs(_ *types.Request, oldSetting *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	if err := validateAutoRotateRKE2Certs(newSetting); err != nil {
+		return err
+	}
+
+	// Allow no-op updates regardless of rotation state. This covers the common
+	// case of updating annotations / labels on the Setting object without
+	// touching the value (e.g. the orchestrator itself stamping the rotation
+	// state annotation).
+	if oldSetting.Value == newSetting.Value {
+		return nil
+	}
+
+	if isRKE2CertRotationInProgress(oldSetting) {
+		return werror.NewBadRequest(rke2CertRotationInProgressMessage(oldSetting))
+	}
+
+	return nil
+}
+
+func (v *settingValidator) validateDeleteAutoRotateRKE2Certs(setting *v1beta1.Setting) error {
+	if isRKE2CertRotationInProgress(setting) {
+		return werror.NewBadRequest(rke2CertRotationInProgressMessage(setting))
+	}
+	return nil
+}
+
+func isRKE2CertRotationInProgress(setting *v1beta1.Setting) bool {
+	state, err := certrotation.LoadClusterStateFromAnnotations(setting.Annotations)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"setting":    setting.Name,
+			"annotation": certrotation.AnnotationRKE2CertRotationState,
+		}).WithError(err).Warn("malformed rke2-cert-rotation-state annotation; treating as not in progress")
+		return false
+	}
+	return certrotation.IsRotationInProgress(state.Phase)
+}
+
+func rke2CertRotationInProgressMessage(setting *v1beta1.Setting) string {
+	state, _ := certrotation.LoadClusterStateFromAnnotations(setting.Annotations)
+	return fmt.Sprintf(
+		"cannot modify or delete setting %q while RKE2 certificate rotation is in progress "+
+			"(phase=%s, generation=%d, currentNode=%q). "+
+			"Wait for rotation to complete, or if it is genuinely stuck, clear the rotation "+
+			"state by running: kubectl annotate setting %s %s-",
+		setting.Name, state.Phase, state.Generation, state.CurrentNode,
+		setting.Name, certrotation.AnnotationRKE2CertRotationState,
+	)
 }
 
 func validateKubeConfigTTLSettingHelper(value string) error {

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/certrotation"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 	networkutil "github.com/harvester/harvester/pkg/util/network"
 	whTypes "github.com/harvester/harvester/pkg/webhook/types"
@@ -2501,6 +2502,219 @@ func Test_checkRWXNetworkRangeValid(t *testing.T) {
 			}
 			err := v.checkRWXNetworkRangeValid(tt.config)
 			assert.Equal(t, tt.expectedErr, err != nil, err)
+		})
+	}
+}
+
+func rotationStateAnnotation(payload string) map[string]string {
+	if payload == "" {
+		return nil
+	}
+	return map[string]string{
+		certrotation.AnnotationRKE2CertRotationState: payload,
+	}
+}
+
+func rotationStateJSON(t *testing.T, phase string, generation int64) string {
+	t.Helper()
+	raw, err := certrotation.MarshalClusterState(certrotation.ClusterRotationState{
+		Generation: generation,
+		Phase:      phase,
+	})
+	assert.NoError(t, err)
+	return raw
+}
+
+func Test_validateUpdateAutoRotateRKE2Certs(t *testing.T) {
+	const (
+		validValue   = `{"enable":true,"expiringInHours":240}`
+		disabledVal  = `{"enable":false,"expiringInHours":240}`
+		differentExp = `{"enable":true,"expiringInHours":120}`
+		invalidVal   = `{"enable":true,"expiringInHours":-1}`
+	)
+
+	tests := []struct {
+		name        string
+		oldAnnots   map[string]string
+		oldValue    string
+		newValue    string
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "no-op update is always allowed (no annotation)",
+			oldAnnots:   nil,
+			oldValue:    validValue,
+			newValue:    validValue,
+			expectError: false,
+		},
+		{
+			name:        "no-op update is allowed even mid-rotation",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseCPRotation, 3)),
+			oldValue:    validValue,
+			newValue:    validValue,
+			expectError: false,
+		},
+		{
+			name:        "disable allowed when annotation absent",
+			oldAnnots:   nil,
+			oldValue:    validValue,
+			newValue:    disabledVal,
+			expectError: false,
+		},
+		{
+			name:        "disable allowed when phase is idle",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseIdle, 0)),
+			oldValue:    validValue,
+			newValue:    disabledVal,
+			expectError: false,
+		},
+		{
+			name:        "disable allowed when phase is completed",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseCompleted, 5)),
+			oldValue:    validValue,
+			newValue:    disabledVal,
+			expectError: false,
+		},
+		{
+			name:        "disable allowed when phase is failed (terminal)",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseFailed, 5)),
+			oldValue:    validValue,
+			newValue:    disabledVal,
+			expectError: false,
+		},
+		{
+			name:        "disable rejected when phase is cp-rotation",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseCPRotation, 3)),
+			oldValue:    validValue,
+			newValue:    disabledVal,
+			expectError: true,
+			errContains: "rotation is in progress",
+		},
+		{
+			name:        "disable rejected when phase is worker-rotation",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseWorkerRotation, 3)),
+			oldValue:    validValue,
+			newValue:    disabledVal,
+			expectError: true,
+			errContains: "rotation is in progress",
+		},
+		{
+			name:        "ExpiringInHours mutation rejected mid-rotation",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseCPRotation, 3)),
+			oldValue:    validValue,
+			newValue:    differentExp,
+			expectError: true,
+			errContains: "rotation is in progress",
+		},
+		{
+			name:        "malformed annotation falls open (does not block)",
+			oldAnnots:   rotationStateAnnotation("{not valid json"),
+			oldValue:    validValue,
+			newValue:    disabledVal,
+			expectError: false,
+		},
+		{
+			name:        "schema validation runs even mid-rotation (rejects invalid value)",
+			oldAnnots:   rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseCPRotation, 3)),
+			oldValue:    validValue,
+			newValue:    invalidVal,
+			expectError: true,
+			errContains: "expiringInHours",
+		},
+	}
+
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSetting := &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        settings.AutoRotateRKE2CertsSettingName,
+					Annotations: tt.oldAnnots,
+				},
+				Value: tt.oldValue,
+			}
+			newSetting := oldSetting.DeepCopy()
+			newSetting.Value = tt.newValue
+
+			err := v.Update(nil, oldSetting, newSetting)
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.ErrorContains(t, err, tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_validateDeleteAutoRotateRKE2Certs(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "delete allowed when annotation absent",
+			annotations: nil,
+			expectError: false,
+		},
+		{
+			name:        "delete allowed when phase is idle",
+			annotations: rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseIdle, 0)),
+			expectError: false,
+		},
+		{
+			name:        "delete allowed when phase is completed",
+			annotations: rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseCompleted, 5)),
+			expectError: false,
+		},
+		{
+			name:        "delete allowed when phase is failed (terminal)",
+			annotations: rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseFailed, 5)),
+			expectError: false,
+		},
+		{
+			name:        "delete rejected when phase is cp-rotation",
+			annotations: rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseCPRotation, 3)),
+			expectError: true,
+			errContains: "rotation is in progress",
+		},
+		{
+			name:        "delete rejected when phase is worker-rotation",
+			annotations: rotationStateAnnotation(rotationStateJSON(t, certrotation.PhaseWorkerRotation, 3)),
+			expectError: true,
+			errContains: "rotation is in progress",
+		},
+		{
+			name:        "malformed annotation falls open (does not block)",
+			annotations: rotationStateAnnotation("garbage"),
+			expectError: false,
+		},
+	}
+
+	v := NewValidator(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSetting := &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        settings.AutoRotateRKE2CertsSettingName,
+					Annotations: tt.annotations,
+				},
+				Value: `{"enable":true,"expiringInHours":240}`,
+			}
+			err := v.Delete(nil, oldSetting)
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.ErrorContains(t, err, tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->


This refactor didn't introduce new user facing settings. The settings of `auto-rotate-rke2-certs` should work as is.


#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

1. To have a robust way to detect rke2 certificate expiration dates
1. To rotate certificates without rancher [provisioningv1 cluster](https://pkg.go.dev/github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1#Cluster).

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Detect the certificate expiration date by running privilege `rke2 certificate check` job on each node periodically and save the date to the annotation `harvesterhci.io/rke2-cert-info` on the node CR
1. Monitor the expiry date annotation on the node and kick off the rotation process (implemented as a state machine) when the date is about to be expired.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10407

#### Test plan:
<!-- Describe the test plan by steps. -->

Create a 4 node cluster (2 management nodes + 1 witness node + 1 worker node)
1. Ensure the `harvesterhci.io/rke2-cert-info` on each node is updated correctly
1. Ensure the auto rotation is halted if the setting is disabled. `{"enable": false, "expiringInHours": 240}`
1. Ensure the auto rotation is working if the setting is enabled. `{"enable": true, "expiringInHours": 8759}`
    1. check the annotation `harvesterhci.io/rke2-cert-rotation-state` on the setting CR (before, in the middle, after)
    1. check the annotation `harvesterhci.io/rke2-cert-rotation-node-state` on each node CR (before, in the middle, after) 


#### Additional documentation or context
