### PR TITLE
Fix older buildx doesn't support env in secret mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,8 @@ ARG MK_REPO_ID
 
 RUN --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-${MK_REPO_ID} \
     --mount=type=cache,target=/go/src/github.com/harvester/harvester/.cache/go-build,id=harvester-go-build-${MK_REPO_ID} \
-    --mount=type=secret,id=codecov_token_${MK_REPO_ID},env=CODECOV_TOKEN \
+    --mount=type=secret,id=codecov_token_${MK_REPO_ID} \
+    CODECOV_TOKEN=$(cat /run/secrets/codecov_token_${MK_REPO_ID} 2>/dev/null || true) \
     ./scripts/test
 
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

On some systems, the `make test` build fails with:
```
#5 DONE 0.2s
Dockerfile:144
--------------------
 143 |
 144 | >>> RUN --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-${MK_REPO_ID} \
 145 | >>>     --mount=type=cache,target=/go/src/github.com/harvester/harvester/.cache/go-build,id=harvester-go-build-${MK_REPO_ID} \
 146 | >>>     --mount=type=secret,id=codecov_token_${MK_REPO_ID},env=CODECOV_TOKEN \
 147 | >>>     ./scripts/test
 148 |
--------------------
ERROR: failed to build: failed to solve: unexpected key 'env' in 'env=CODECOV_TOKEN'
make: *** [Makefile:96: test] Error 1
```
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
manually pass the secret variable. do not rely on the env argument in a secret mount.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10478

#### Test plan:
<!-- Describe the test plan by steps. -->
Make sure `make test` works.

#### Additional documentation or context
