### PR TITLE
Additional updates to new builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,12 +143,26 @@ ARG MK_REPO_ID
 
 RUN --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-${MK_REPO_ID} \
     --mount=type=cache,target=/go/src/github.com/harvester/harvester/.cache/go-build,id=harvester-go-build-${MK_REPO_ID} \
-    --mount=type=secret,id=codecov_token_${MK_REPO_ID},env=CODECOV_TOKEN \
+    --mount=type=secret,id=codecov_token_${MK_REPO_ID} \
+    CODECOV_TOKEN=$(cat /run/secrets/codecov_token_${MK_REPO_ID} 2>/dev/null || true) \
     ./scripts/test
 
 
 # ---- test-integration ----
 FROM base AS test-integration
+
+
+# ---- generate-stage ----
+FROM base AS generate-stage
+# Bind mount the host's git directory from our custom named context
+RUN --mount=type=bind,from=git-dir,target=.git,rw ./scripts/generate
+
+
+# ---- generate-output ----
+FROM scratch AS generate-output
+# Export only the core API definitions and their generated code assets
+COPY --from=generate-stage /go/src/github.com/harvester/harvester/pkg/apis/      /apis/
+COPY --from=generate-stage /go/src/github.com/harvester/harvester/pkg/generated/ /generated/
 
 
 # ---- generate-manifest ----

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,39 +152,68 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-${MK_REPO_ID} \
 FROM base AS test-integration
 
 
-# ---- generate-stage ----
-FROM base AS generate-stage
-# Bind mount the host's git directory from our custom named context
-RUN --mount=type=bind,from=git-dir,target=.git,rw ./scripts/generate
+# ---- git-setup-stage ----
+# Handles caching and dynamically configures the Git environment for both local and CI builds.
+# Worktree-aware: Mirrors both worktree-specific configurations and shared common object directories.
+FROM base AS git-setup-stage
+ARG MK_REPO_ID
+RUN --mount=type=bind,from=git-dir,target=/tmp/host-git \
+--mount=type=bind,from=git-common,target=/tmp/host-git-common \
+--mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-${MK_REPO_ID} \
+--mount=type=cache,target=/go/src/github.com/harvester/harvester/.cache/go-build,id=harvester-go-build-${MK_REPO_ID} \
+if [ -d /tmp/host-git/objects ]; then \
+    echo "✅ Authentic Git repository detected from host. Mirroring configurations..."; \
+    mkdir -p /go/src/github.com/harvester/harvester/.git; \
+    cp -r /tmp/host-git/* /go/src/github.com/harvester/harvester/.git/ 2>/dev/null || true; \
+elif [ -d /tmp/host-git-common/objects ]; then \
+    echo "✅ Git worktree workspace detected. Mirroring configs and linking shared core objects..."; \
+    mkdir -p /go/src/github.com/harvester/harvester/.git; \
+    cp -r /tmp/host-git/* /go/src/github.com/harvester/harvester/.git/ 2>/dev/null || true; \
+    rm -rf /go/src/github.com/harvester/harvester/.git/objects; \
+    ln -s /tmp/host-git-common/objects /go/src/github.com/harvester/harvester/.git/objects; \
+else \
+    echo "⚠️ No host Git data found (Fresh CI Environment). Initializing self-healing fake Git layer..."; \
+    git config --global user.email "ci@example.com" && \
+    git config --global user.name "ci" && \
+    git init 2>/dev/null && \
+    git add . && \
+    git commit -q -m "automated commit for validate-ci"; \
+fi
 
-
-# ---- generate-output ----
-FROM scratch AS generate-output
-# Export only the core API definitions and their generated code assets
-COPY --from=generate-stage /go/src/github.com/harvester/harvester/pkg/apis/      /apis/
-COPY --from=generate-stage /go/src/github.com/harvester/harvester/pkg/generated/ /generated/
+# ---- generate-stage (`go generate`) ----
+# Runs full go generate (which automatically triggers manifests and openapi via go:generate directives)
+FROM git-setup-stage AS generate-stage
+RUN ./scripts/generate
 
 
 # ---- generate-manifest ----
-FROM base AS generate-manifest
+# Standalone target branch: Runs only manifest generation from a clean git environment
+FROM git-setup-stage AS generate-manifest
 RUN ./scripts/generate-manifest
-
-FROM scratch AS generate-manifest-output
-COPY --from=generate-manifest /go/src/github.com/harvester/harvester/deploy/charts/harvester-crd/templates/ /templates/
 
 
 # ---- generate-openapi ----
-FROM base AS generate-openapi
-ARG MK_REPO_ID
+# Standalone target branch: Runs only openapi generation from a clean git environment
+FROM git-setup-stage AS generate-openapi
+RUN ./scripts/generate-openapi
 
-RUN git config --global user.email "ci@example.com" && \
-    git config --global user.name "ci" && \
-    git init 2>/dev/null && git add . && git commit -q -m "commit for validate-ci"
 
-RUN --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-${MK_REPO_ID} \
-    --mount=type=cache,target=/go/src/github.com/harvester/harvester/.cache/go-build,id=harvester-go-build-${MK_REPO_ID} \
-    ./scripts/generate-openapi
+# ---- generate-output ----
+# Since generate-stage already ran EVERYTHING via go generate, we pull all assets straight from it!
+FROM scratch AS generate-output
+COPY --from=generate-stage /go/src/github.com/harvester/harvester/pkg/apis/ /pkg/apis/
+COPY --from=generate-stage /go/src/github.com/harvester/harvester/pkg/generated/ /pkg/generated/
+COPY --from=generate-stage /go/src/github.com/harvester/harvester/deploy/charts/harvester-crd/templates/ /deploy/charts/harvester-crd/templates/
+COPY --from=generate-stage /go/src/github.com/harvester/harvester/api/openapi-spec/swagger.json /api/openapi-spec/swagger.json
+COPY --from=generate-stage /go/src/github.com/harvester/harvester/scripts/known-api-rule-violations.txt /scripts/known-api-rule-violations.txt
 
+
+# ---- generate-manifest-output ----
+FROM scratch AS generate-manifest-output
+COPY --from=generate-manifest /go/src/github.com/harvester/harvester/deploy/charts/harvester-crd/templates/ /deploy/charts/harvester-crd/templates/
+
+
+# ---- generate-openapi-output ----
 FROM scratch AS generate-openapi-output
 COPY --from=generate-openapi /go/src/github.com/harvester/harvester/api/openapi-spec/swagger.json /api/openapi-spec/swagger.json
 COPY --from=generate-openapi /go/src/github.com/harvester/harvester/scripts/known-api-rule-violations.txt /scripts/known-api-rule-violations.txt

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,22 @@ BANNER = @printf "$(BOLD)$(CYAN)[target: $@]$(RESET)\n"
 MK_DOCKER_RUN_OPTS_TTY := $(if $(CI),,-it)
 export MK_DOCKER_RUN_OPTS_TTY
 
+# Safely detect a unique system identifier into a variable
+MK_SYSTEM_ID := $(strip $(shell \
+    if [ -s /etc/machine-id ]; then \
+        cat /etc/machine-id 2>/dev/null; \
+    elif command -v hostname >/dev/null 2>&1; then \
+        hostname 2>/dev/null; \
+    else \
+        echo -n "unknown"; \
+    fi))
+
 # User might have several repos in a host. Distinguish each by using the abs path of the repo
-MK_REPO_ID               := $(shell echo -n "$(ROOT)$$(cat /etc/machine-id 2>/dev/null)" | sha256sum | cut -c1-8)
-MK_ADDONS_IMAGE          := harvester-addons:$(MK_REPO_ID)
-MK_ISO_BUILDER_IMAGE     := harvester-iso-builder:$(MK_REPO_ID)
-MK_TEST_INTEGRATION_IMAGE       := harvester-test-integration:$(MK_REPO_ID)
-MK_DOCKER_PROGRESS       ?= plain
+MK_REPO_ID                := $(shell echo -n "$(ROOT)$(MK_SYSTEM_ID)" | sha256sum | cut -c1-8)
+MK_ADDONS_IMAGE           := harvester-addons:$(MK_REPO_ID)
+MK_ISO_BUILDER_IMAGE      := harvester-iso-builder:$(MK_REPO_ID)
+MK_TEST_INTEGRATION_IMAGE := harvester-test-integration:$(MK_REPO_ID)
+MK_DOCKER_PROGRESS        ?= plain
 
 # Legacy dapper env variables
 CODECOV_TOKEN             ?=
@@ -56,7 +66,7 @@ DOCKER_BUILD = docker build \
 
 .PHONY: build validate validate-ci test test-integration build-iso \
 	package-all package package-harvester-webhook package-harvester-upgrade \
-	generate-manifest generate-openapi prepare-addons ci arm clean clean-all default \
+	generate generate-manifest generate-openapi prepare-addons ci arm clean clean-all default \
 	gen-version-env
 
 
@@ -81,19 +91,19 @@ build: gen-version-env | $(ROOT)/bin
 # ---- Validate ----
 validate: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) --target validate
+	$(DOCKER_BUILD) --target validate -t harvester-image-builder-validate-cache:$(MK_REPO_ID)
 
 
 # ---- Validate CI (dirty check after go generate + go mod tidy) ----
 validate-ci: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) --target validate-ci
+	$(DOCKER_BUILD) --target validate-ci -t harvester-image-builder-validate-ci-cache:$(MK_REPO_ID)
 
 
 # ---- Test ----
 test: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) $(if $(CODECOV_TOKEN),--secret id=codecov_token_$(MK_REPO_ID)$(comma)env=CODECOV_TOKEN --no-cache-filter=test) --target test
+	$(DOCKER_BUILD) $(if $(CODECOV_TOKEN),--secret id=codecov_token_$(MK_REPO_ID)$(comma)env=CODECOV_TOKEN --no-cache-filter=test) --target test -t harvester-image-builder-test-cache:$(MK_REPO_ID)
 
 
 # ---- Test integration ----
@@ -127,6 +137,38 @@ package-harvester-upgrade: build prepare-addons
 
 # ---- Package all images ----
 package-all: package package-harvester-webhook package-harvester-upgrade
+
+
+# ---- Generate Go Code & APIs ----
+# Runs code generation identical to a local 'go generate', but inside a
+# container to guarantee the Go compiler version matches project expectations.
+# The fresh api/ and generated/ definitions are exported back to the host.
+#
+# NOTE ON SAFETY CHECKS:
+# Unlike normal build targets, 'make generate' runs internal scripts (like
+# scripts/generate-openapi) that execute destructive commands ('git checkout --').
+# Because the host .git folder is bind-mounted read-write into the container,
+# any uncommitted modifications on the host could be silently deleted by the
+# container. We strictly require a clean tracked working tree to prevent data loss.
+generate: gen-version-env
+	$(BANNER)
+	@if ! command -v git >/dev/null 2>&1; then \
+		echo "❌ ERROR: 'git' command not found. Please install git first."; \
+		exit 1; \
+	fi
+	@if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+		echo "❌ ERROR: This directory is not a git repository."; \
+		exit 1; \
+	fi
+	@if [ -n "$$(git status --porcelain --untracked-files=no)" ]; then \
+		echo "❌ ERROR: Your working directory has uncommitted changes to tracked files."; \
+		echo "Please commit, stash, or discard them before running 'make generate' to protect your work."; \
+		exit 1; \
+	fi
+	$(eval REAL_GIT_DIR=$(shell git rev-parse --absolute-git-dir))
+	$(DOCKER_BUILD) --build-context git-dir=$(REAL_GIT_DIR) \
+					--target generate-output \
+					--output type=local,dest=$(ROOT)/pkg/
 
 
 # ---- Generate CRD manifests ----

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,43 @@ export CODECOV_TOKEN HARVESTER_ADDONS_VERSION
 MK_HOST_ARCH := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 export MK_HOST_ARCH
 
+# Helpers for make generate, make generate-openapi and make generate-manifest
+#
+# Check if we are running inside an actual functional Git workspace on the host
+IS_GIT_REPO := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
+
+ifeq ($(IS_GIT_REPO),true)
+    REAL_GIT_DIR := $(shell git rev-parse --absolute-git-dir)
+
+    # ---- Git Workspace Context Resolution ----
+    # Read from environment override, otherwise default to a standard .git path layout.
+    # 
+    # MULTI-WORKSPACE / GIT WORKTREE NOTE:
+    # If you are working out of a secondary Git worktree workspace, the local '.git'
+    # file is just a pointer text file and does not contain the actual Git databases.
+    # This will cause build-time tracking scripts inside the container to fail.
+    #
+    # To fix this, locate your primary repository storage folder (usually found under
+    # <main-repo-dir>/.git/worktrees/<this-worktree-name>/) or point directly to the
+    # central object database directory. You can override this variable at runtime:
+    #   REAL_GIT_COMMON=/path/to/main-harvester-repo/.git make generate
+    REAL_GIT_COMMON ?= $(ROOT)/.git
+else
+    # Fallback placeholders if the host has no Git tracking data (e.g., bare CI runner)
+    REAL_GIT_DIR    := $(ROOT)
+    REAL_GIT_COMMON := $(ROOT)
+endif
+
+define assert_clean_workspace
+	@if [ "$(IS_GIT_REPO)" = "true" ]; then \
+		if [ -n "$$(git status --porcelain --untracked-files=no)" ]; then \
+			echo "❌ ERROR: Your working directory has uncommitted changes to tracked files."; \
+			echo "Please commit or stash them before running this target to prevent data loss."; \
+			exit 1; \
+		fi \
+	fi
+endef
+
 DOCKER_BUILD = docker build \
 	--progress=$(MK_DOCKER_PROGRESS) \
 	--build-arg MK_REPO_ID \
@@ -139,48 +176,34 @@ package-harvester-upgrade: build prepare-addons
 package-all: package package-harvester-webhook package-harvester-upgrade
 
 
-# ---- Generate Go Code & APIs ----
-# Runs code generation identical to a local 'go generate', but inside a
-# container to guarantee the Go compiler version matches project expectations.
-# The fresh api/ and generated/ definitions are exported back to the host.
-#
-# NOTE ON SAFETY CHECKS:
-# Unlike normal build targets, 'make generate' runs internal scripts (like
-# scripts/generate-openapi) that execute destructive commands ('git checkout --').
-# Because the host .git folder is bind-mounted read-write into the container,
-# any uncommitted modifications on the host could be silently deleted by the
-# container. We strictly require a clean tracked working tree to prevent data loss.
+# ---- Generate All Assets (Go Code, APIs, CRD Manifests, and OpenAPI Specs) ----
 generate: gen-version-env
 	$(BANNER)
-	@if ! command -v git >/dev/null 2>&1; then \
-		echo "❌ ERROR: 'git' command not found. Please install git first."; \
-		exit 1; \
-	fi
-	@if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
-		echo "❌ ERROR: This directory is not a git repository."; \
-		exit 1; \
-	fi
-	@if [ -n "$$(git status --porcelain --untracked-files=no)" ]; then \
-		echo "❌ ERROR: Your working directory has uncommitted changes to tracked files."; \
-		echo "Please commit, stash, or discard them before running 'make generate' to protect your work."; \
-		exit 1; \
-	fi
-	$(eval REAL_GIT_DIR=$(shell git rev-parse --absolute-git-dir))
+	$(call assert_clean_workspace)
 	$(DOCKER_BUILD) --build-context git-dir=$(REAL_GIT_DIR) \
-					--target generate-output \
-					--output type=local,dest=$(ROOT)/pkg/
+	                --build-context git-common=$(REAL_GIT_COMMON) \
+	                --target generate-output \
+	                --output type=local,dest=$(ROOT)/
 
 
 # ---- Generate CRD manifests ----
 generate-manifest: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) --target generate-manifest-output --output type=local,dest=$(ROOT)/deploy/charts/harvester-crd/
+	$(call assert_clean_workspace)
+	$(DOCKER_BUILD) --build-context git-dir=$(REAL_GIT_DIR) \
+	                --build-context git-common=$(REAL_GIT_COMMON) \
+	                --target generate-manifest-output \
+	                --output type=local,dest=$(ROOT)/
 
 
 # ---- Generate OpenAPI/Swagger spec ----
 generate-openapi: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) --target generate-openapi-output --output type=local,dest=$(ROOT)
+	$(call assert_clean_workspace)
+	$(DOCKER_BUILD) --build-context git-dir=$(REAL_GIT_DIR) \
+	                --build-context git-common=$(REAL_GIT_COMMON) \
+	                --target generate-openapi-output \
+	                --output type=local,dest=$(ROOT)/
 
 
 # ---- Cache addons repo and generate addons manifests ---

--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,12 @@ BANNER = @printf "$(BOLD)$(CYAN)[target: $@]$(RESET)\n"
 MK_DOCKER_RUN_OPTS_TTY := $(if $(CI),,-it)
 export MK_DOCKER_RUN_OPTS_TTY
 
-# Safely detect a unique system identifier into a variable
-MK_SYSTEM_ID := $(strip $(shell \
-    if [ -s /etc/machine-id ]; then \
-        cat /etc/machine-id 2>/dev/null; \
-    elif command -v hostname >/dev/null 2>&1; then \
-        hostname 2>/dev/null; \
-    else \
-        echo -n "unknown"; \
-    fi))
-
 # User might have several repos in a host. Distinguish each by using the abs path of the repo
-MK_REPO_ID                := $(shell echo -n "$(ROOT)$(MK_SYSTEM_ID)" | sha256sum | cut -c1-8)
-MK_ADDONS_IMAGE           := harvester-addons:$(MK_REPO_ID)
-MK_ISO_BUILDER_IMAGE      := harvester-iso-builder:$(MK_REPO_ID)
-MK_TEST_INTEGRATION_IMAGE := harvester-test-integration:$(MK_REPO_ID)
-MK_DOCKER_PROGRESS        ?= plain
+MK_REPO_ID               := $(shell echo -n "$(ROOT)$$(cat /etc/machine-id 2>/dev/null)" | sha256sum | cut -c1-8)
+MK_ADDONS_IMAGE          := harvester-addons:$(MK_REPO_ID)
+MK_ISO_BUILDER_IMAGE     := harvester-iso-builder:$(MK_REPO_ID)
+MK_TEST_INTEGRATION_IMAGE       := harvester-test-integration:$(MK_REPO_ID)
+MK_DOCKER_PROGRESS       ?= plain
 
 # Legacy dapper env variables
 CODECOV_TOKEN             ?=
@@ -128,19 +118,19 @@ build: gen-version-env | $(ROOT)/bin
 # ---- Validate ----
 validate: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) --target validate -t harvester-image-builder-validate-cache:$(MK_REPO_ID)
+	$(DOCKER_BUILD) --target validate
 
 
 # ---- Validate CI (dirty check after go generate + go mod tidy) ----
 validate-ci: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) --target validate-ci -t harvester-image-builder-validate-ci-cache:$(MK_REPO_ID)
+	$(DOCKER_BUILD) --target validate-ci
 
 
 # ---- Test ----
 test: gen-version-env
 	$(BANNER)
-	$(DOCKER_BUILD) $(if $(CODECOV_TOKEN),--secret id=codecov_token_$(MK_REPO_ID)$(comma)env=CODECOV_TOKEN --no-cache-filter=test) --target test -t harvester-image-builder-test-cache:$(MK_REPO_ID)
+	$(DOCKER_BUILD) $(if $(CODECOV_TOKEN),--secret id=codecov_token_$(MK_REPO_ID)$(comma)env=CODECOV_TOKEN --no-cache-filter=test) --target test
 
 
 # ---- Test integration ----
@@ -233,6 +223,7 @@ clean-all: clean
 	$(BANNER)
 	@docker rmi -f $(MK_ADDONS_IMAGE) || true
 	@docker rmi -f $(MK_ISO_BUILDER_IMAGE) $(MK_TEST_INTEGRATION_IMAGE) || true
+
 
 .DEFAULT_GOAL := default
 

--- a/scripts/generate
+++ b/scripts/generate
@@ -1,0 +1,7 @@
+#!/bin/bash
+# DESC: Runs `go generate`
+set -e
+
+cd $(dirname $0)/..
+
+go generate

--- a/scripts/generate
+++ b/scripts/generate
@@ -2,6 +2,7 @@
 # DESC: Runs `go generate`
 set -e
 
-cd $(dirname $0)/..
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
 
 go generate


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

## Summary
This PR addresses two key gaps in our new builder environment: restoring the missing `make generate` target and establishing a robust strategy for handling Git metadata during code generation.

## 1. Restoring `make generate`
*   Ported the `make generate` command into the new builder environment.

## 2. Local Development Strategy: Reusing Local `.git`
For daily development workflows, we evaluated two paths for handling Git context during generation: faking a lightweight git state via `git init/commit`, or reusing the host's local `.git` directory. 

We have chosen to **reuse the local `.git` directory** based on the following engineering rationales:

*   **Pre-flight Cleanliness Validation:** If the local working directory is "dirty" (contains uncommitted changes), the `make generate` process will intentionally block execution. This ensures that all code generation occurs on top of a stable, known baseline.
*   **Correctness Over Speed:** While passing the full `.git` history makes the context slightly heavier, **historical and metadata correctness outranks daily speed here**. Because `make generate` is an intentional, intermittent action rather than a high-frequency loop, the security of accurate metadata and strict validation outweighs the minor performance trade-off.

## Verification / Testing Done
- [ ] Verified `make generate` executes successfully within the new builder container.
- [ ] Confirmed the process correctly blocks when uncommitted local files are present.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. add back `make generate`
3. embed the PR https://github.com/harvester/harvester/pull/10605 to let it work
4. support both real git repo and fake one on the CI env, to run `make generate` smoothly, also allow insert ENV  to get `GIT WORKTREE` mode working.

other changes are moved away:
1. use tag for those leftover/reusable images, instead of ghost <none><none> image (split to https://github.com/harvester/harvester/pull/10633)
2. a robust way to fetch system_id  (split to https://github.com/harvester/harvester/pull/10632)


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

`make generate`

will show if it is from an real git repo (from developer) or CI env (faked git)

```
$ make generate
[target: gen-version-env]
[target: generate]
docker build --progress=plain --build-arg MK_REPO_ID --build-arg MK_HOST_ARCH -f /go/src/github.com/harvester/harvester/Dockerfile /go/src/github.com/harvester/harvester --build-context git-dir=/go/src/github.com/harvester/harvester/.git --target generate-output --output type=local,dest=/go/src/github.com/harvester/harvester/pkg/apis/
#0 building with "default" instance using docker driver


#30 [generate-stage 1/1] RUN --mount=type=bind,from=git-dir,target=/tmp/host-git --mount=type=cache,target=/go/pkg/mod,id=harvester-go-mod-d13d488b --mount=type=cache,target=/go/src/github.com/harvester/harvester/.cache/go-build,id=harvester-go-build-d13d488b if [ -d /tmp/host-git/objects ]; then     echo "✅ Authentic Git repository detected from host. Mirroring real git history...";     cp -r /tmp/host-git /go/src/github.com/harvester/harvester/.git; else     echo "⚠️ No host Git data found (Fresh CI Environment). Initializing self-healing fake Git layer...";     git config --global user.email "ci@example.com" &&     git config --global user.name "ci" &&     git init 2>/dev/null &&     git add . &&     git commit -q -m "automated commit for validate-ci";     fi && ./scripts/generate


#30 0.213 ✅ Authentic Git repository detected from host. Mirroring real git history...  // from real env
#30 1.103 ./pkg/apis
#30 1.103 pkg/apis/harvesterhci.io
#30 1.103 pkg/apis/harvesterhci.io/v1beta1


...
....
#30 3.536 pkg/apis/harvesterhci.io/v1beta1/zz_generated_register.go
#30 3.536 Removing pkg/apis/harvesterhci.io/v1beta1/zz_generated_register.go
#30 3.536 pkg/apis/harvesterhci.io/zz_generated_register.go
...
#30 49.80 E0519 10:58:04.664551   10498 openapi.go:589] k8s.io/api/core/v1.AzureSharedBlobDisk, k8s.io/api/core/v1
#30 DONE 53.9s

#31 [generate-output 1/1] COPY --from=generate-stage /go/src/github.com/harvester/harvester/pkg/apis/ /
#31 DONE 0.0s

#32 exporting to client directory
#32 copying files 1.99MB done
#32 DONE 0.0s
```


#### Additional documentation or context
