### PR TITLE
Builder: add command to show the generated envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ DOCKER_BUILD = docker build \
 .PHONY: build validate validate-ci test test-integration build-iso \
 	package-all package package-harvester-webhook package-harvester-upgrade \
 	generate-manifest generate-openapi prepare-addons ci arm clean clean-all default \
-	gen-version-env
+	gen-version-env gen-version-env-debug
 
 
 # ---- Directories ----
@@ -70,6 +70,12 @@ $(ROOT)/bin:
 gen-version-env:
 	$(BANNER)
 	@bash $(ROOT)/scripts/version > /dev/null
+
+
+# ---- Generate and show the version env for debugging ----
+gen-version-env-debug:
+	$(BANNER)
+	bash $(ROOT)/scripts/version debug
 
 
 # ---- Compile harvester binaries ----

--- a/scripts/version
+++ b/scripts/version
@@ -13,8 +13,14 @@ if ! git -C "${TOP_DIR}" rev-parse HEAD &>/dev/null 2>&1; then
     if [[ -f "${_VERSION_ENV}" ]]; then
         # shellcheck source=/dev/null
         source "${_VERSION_ENV}"
+        if [ "$1" = "debug" ]; then
+            echo "The envs from the pre-generated file:"
+            echo ""
+            tail -n +3 "${_VERSION_ENV}" || echo "ERROR: failed to run tail" >&2
+        fi
         return 0 2>/dev/null || true
     fi
+
     echo "ERROR: git is unavailable and no pre-generated scripts/.version_env was found." >&2
     echo "Run 'scripts/version' (or 'make gen-version-env') on a host with git access first." >&2
     return 1 2>/dev/null || exit 1
@@ -22,6 +28,7 @@ fi
 
 unset DIRTY
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    echo "Warning: there are uncommitted files; the build result might not be as expected" >&2
     DIRTY="-dirty"
 fi
 
@@ -30,11 +37,11 @@ COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 COMMIT_BRANCH_FORMATTED=$(echo "${COMMIT_BRANCH}" | sed -E 's/[^a-zA-Z0-9.]+/-/g')
 GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
 if [[ "$GIT_TAG" == *"-dev-"* ]]; then
-  SPRINT_RELEASE="-dev-"
+    SPRINT_RELEASE="-dev-"
 fi
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" && -z "$SPRINT_RELEASE" ]]; then
-    echo "Checking minimum upgradable version, if no minimum upgradeable version, will fail with `Error: no matches found`"
+    echo "Checking minimum upgradable version, if no minimum upgradeable version, will fail with \`Error: no matches found\`"
     VERSION=$GIT_TAG
     # Search for minimum upgradable version.
     # If the release does not come with a corresponding minimum upgradable version, the build will error out.
@@ -81,16 +88,6 @@ if echo $TAG | grep -q dirty; then
     TAG=dev
 fi
 
-echo "ARCH: $ARCH"
-echo "VERSION: $VERSION"
-echo "CHART_VERSION: $CHART_VERSION"
-echo "APP_VERSION: $APP_VERSION"
-echo "SUFFIX: $SUFFIX"
-echo "REPO: $REPO"
-echo "TAG: $TAG"
-echo "IMAGE_PUSH_TAG: $IMAGE_PUSH_TAG"
-echo "MIN_UPGRADABLE_VERSION: $MIN_UPGRADABLE_VERSION"
-
 # Write a snapshot of all version variables so that container builds (and git worktree
 # checkouts) can source this file instead of running git commands.  The file is regenerated
 # every time this script runs on a host that has a live git tree.
@@ -113,3 +110,9 @@ SUFFIX="${SUFFIX}"
 TAG="${TAG}"
 REPO="${REPO}"
 __EOF__
+
+if [ "$1" = "debug" ]; then
+    echo "The newly generated envs:"
+    echo ""
+    tail -n +3 "${_VERSION_ENV}" || echo "ERROR: failed to run tail" >&2
+fi


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

1. The `ENV` echo and the final generated env file are not aligned

2. When migrating the builder system to other repos, the ENV needs to be tailered as other repo doesn't have so many envs, need a way to check the output quickly.

3. Add a warning message when the git repo is dirty.

4. Align the indent on version file

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Previously, the version script used standalone `echo` statements to print variables for debugging, which frequently went out of sync with the actual variables being written to the environment snapshot file.

To fix this alignment issue, the script has been refactored to treat the generated env file as the single source of truth:

*   **Eliminated Redundant Echos:** Removed the loosely tracked `echo` statements at the top of the script.
*   **Unified Debug Output:** The script now dynamically prints the exact payload being written to `${_VERSION_ENV}` (e.g., using `cat` or mirroring the `__EOF__` block). 
*   **Impact:** This ensures that what you see in the CI/CD build logs during debugging perfectly matches the version snapshot sourced by subsequent container builds and Git worktree checkouts, preventing silent variable mismatch bugs.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

with uncommitted files:
```
$ make gen-version-env-debug
[target: gen-version-env-debug]
bash /go/src/github.com/harvester/harvester/scripts/version debug
Warning: there are uncommitted files; the build result might not be as expected
The generated envs:

ARCH="amd64"
DIRTY="-dirty"
COMMIT="aa621022"
COMMIT_BRANCH="builder-show-env"
COMMIT_BRANCH_FORMATTED="builder-show-env"
GIT_TAG=""
SPRINT_RELEASE=""
VERSION="aa621022-dirty"
MIN_UPGRADABLE_VERSION=""
IMAGE_PUSH_TAG="builder-show-env-head"
APP_VERSION="builder-show-env-aa621022-dirty"
CHART_VERSION="0.0.0-builder-show-env-aa621022-dirty"
SUFFIX="-amd64"
TAG="dev"
REPO="rancher"

```

clean commit:
```
$ make gen-version-env-debug
[target: gen-version-env-debug]
bash /go/src/github.com/harvester/harvester/scripts/version debug
the generated envs

ARCH="amd64"
DIRTY=""
COMMIT="aa621022"
COMMIT_BRANCH="builder-show-env"
COMMIT_BRANCH_FORMATTED="builder-show-env"
GIT_TAG=""
SPRINT_RELEASE=""
VERSION="aa621022"
MIN_UPGRADABLE_VERSION=""
IMAGE_PUSH_TAG="builder-show-env-head"
APP_VERSION="builder-show-env-aa621022"
CHART_VERSION="0.0.0-builder-show-env-aa621022"
SUFFIX="-amd64"
TAG="aa621022-amd64"
REPO="rancher"
```



#### Additional documentation or context
