### PR TITLE
Ensure test-integration is working on current Harvester tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,8 @@ test: gen-version-env
 
 
 # ---- Test integration ----
-test-integration: gen-version-env package-harvester-webhook
+# It ensures the test runs against the current-tag Harvester and Harvester-webhook images
+test-integration: gen-version-env package package-harvester-webhook
 	$(BANNER)
 	$(DOCKER_BUILD) --target test-integration -t $(MK_TEST_INTEGRATION_IMAGE)
 	docker run $(MK_DOCKER_RUN_OPTS_TTY) --rm --privileged --network host \

--- a/scripts/test-integration
+++ b/scripts/test-integration
@@ -7,8 +7,10 @@ source $(dirname $0)/version
 # The root of the harvester directory
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
-export PRELOADING_IMAGES="rancher/harvester-webhook:${TAG}"
+export PRELOADING_IMAGES="rancher/harvester-webhook:${TAG},rancher/harvester:${TAG}"
 export WEBHOOK_IMAGE_NAME="rancher/harvester-webhook:${TAG}"
+
+export HARVESTER_IMAGE_NAME="rancher/harvester:${TAG}"
 
 echo "Running integration tests"
 CGO_ENABLED=0 ginkgo -r -v -trace -tags=test \

--- a/tests/framework/env/env.go
+++ b/tests/framework/env/env.go
@@ -41,6 +41,9 @@ const (
 	// Specify Webhook image name. Use the value in the helm chart if not specified.
 	envWebhookImage = "WEBHOOK_IMAGE_NAME"
 
+	// Specify Harvester image name. Use the value in the helm chart if not specified.
+	envHarvesterImage = "HARVESTER_IMAGE_NAME"
+
 	// In summary, default is:
 	// 1. Create a new local cluster
 	// 2. Deploy runtime
@@ -116,7 +119,17 @@ func GetPreloadingImages() []string {
 
 // GetWebhookImage returns webhook image name and tag
 func GetWebhookImage() (string, string) {
-	image := os.Getenv(envWebhookImage)
+	return GetImageFromEnv(envWebhookImage)
+}
+
+// GetHarvesterImage returns harvester image name and tag
+func GetHarvesterImage() (string, string) {
+	return GetImageFromEnv(envHarvesterImage)
+}
+
+// GetImageFromEnv returns the env based image name and tag
+func GetImageFromEnv(env string) (string, string) {
+	image := os.Getenv(env)
 	if image == "" {
 		return "", ""
 	}

--- a/tests/integration/controllers/fake/jobs_controller.go
+++ b/tests/integration/controllers/fake/jobs_controller.go
@@ -40,6 +40,8 @@ func RegisterFakeControllers(ctx context.Context, management *config.Management,
 		helm: hc,
 	}
 
+	logrus.Infof("fake helmchart-controller is registered")
+
 	hc.OnChange(ctx, "fake-helmchart-controller", h.OnHelmChartChange)
 	hc.OnRemove(ctx, "fake-helmchart-controller-deletion", h.OnHelmChartDelete)
 	return nil
@@ -75,7 +77,7 @@ func (h *handler) OnHelmChartChange(_ string, hc *helmv1.HelmChart) (*helmv1.Hel
 		return hc, nil
 	}
 
-	logrus.Infof("Linking job %s to helmChart %s/%s with hash %s", jobName, hcCopy.Namespace, hcCopy.Name, currentHash)
+	logrus.Infof("Linking job %s to helmChart %s/%s with hash %s, hash changed: %v", jobName, hcCopy.Namespace, hcCopy.Name, currentHash, changed)
 	hcCopy.Status.JobName = jobName
 	return h.helm.Update(hcCopy)
 }
@@ -196,7 +198,7 @@ func (h *handler) createJobIfNotFound(namespace, name, hash string, override boo
 		},
 	}
 	_, err = h.job.Create(job)
-	logrus.Infof("new job %s is created with result %+v", job.Name, err)
+	logrus.Infof("new job %s is created, error result: %+v", job.Name, err)
 	return err
 }
 

--- a/tests/integration/controllers/fake/jobs_controller.go
+++ b/tests/integration/controllers/fake/jobs_controller.go
@@ -1,11 +1,15 @@
 package fake
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
+
+	"github.com/sirupsen/logrus"
 
 	helmv1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
 	ctlhelmv1 "github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io/v1"
@@ -46,30 +50,32 @@ func (h *handler) OnHelmChartChange(_ string, hc *helmv1.HelmChart) (*helmv1.Hel
 		return hc, nil
 	}
 
+	// 1. Generate the expected hash for this specific state
 	hcCopy := hc.DeepCopy()
-	hcCopy, updated, err := h.checkAndGenerateHash(hcCopy)
-
+	hcCopy, currentHash, changed, err := h.checkAndGenerateHash(hcCopy)
 	if err != nil {
-		return hcCopy, err
+		return hc, err
 	}
 
-	if hcCopy.Status.JobName != "" && !updated {
+	// 2. Evaluate annotations for failure testing overrides
+	var override bool
+	if val, ok := hcCopy.Annotations[OverrideToFail]; ok && val == "true" {
+		override = true
+	}
+
+	// 3. Reconcile the cluster state (Ensures matching Job exists)
+	jobName := fmt.Sprintf("helm-install-%s", hc.Name)
+	if err := h.createJobIfNotFound(hcCopy.Namespace, jobName, currentHash, override); err != nil {
+		return hc, err
+	}
+
+	// 4. Skip to update the HelmChart Status, if job name && hash are both matched
+	// for a running addon, the spec could change, but the job name is still `helm-install-...`
+	if hcCopy.Status.JobName == jobName && !changed {
 		return hc, nil
 	}
 
-	var override bool
-	if hcCopy.Annotations != nil {
-		val, ok := hcCopy.Annotations[OverrideToFail]
-		if ok && val == "true" {
-			override = true
-		}
-	}
-
-	jobName := fmt.Sprintf("helm-install-%s", hc.Name)
-	if err := h.createJobIfNotFound(hcCopy.Namespace, jobName, override); err != nil {
-		return hcCopy, err
-	}
-
+	logrus.Infof("Linking job %s to helmChart %s/%s with hash %s", jobName, hcCopy.Namespace, hcCopy.Name, currentHash)
 	hcCopy.Status.JobName = jobName
 	return h.helm.Update(hcCopy)
 }
@@ -79,60 +85,92 @@ func (h *handler) OnHelmChartDelete(_ string, hc *helmv1.HelmChart) (*helmv1.Hel
 		return nil, nil
 	}
 
+	deleteJobName := fmt.Sprintf("helm-delete-%s", hc.Name)
+
+	// 1. CONFIDENCE GUARD: If status is already locked onto this deletion task, hand-off is complete.
+	if hc.Status.JobName == deleteJobName {
+		return hc, nil
+	}
+
+	// 2. Calculate the target hash of the spec being torn down
+	currentHash, err := calculateSpecHash(hc.Spec)
+	if err != nil {
+		return hc, err
+	}
+
+	// 3. Evaluate failure overrides from metadata
 	var override bool
-	if hc.Annotations != nil {
-		val, ok := hc.Annotations[OverrideToFail]
-		if ok && val == "true" {
-			override = true
-		}
-	}
-	if err := h.job.Delete(hc.Namespace, fmt.Sprintf("helm-install-%s", hc.Name), &metav1.DeleteOptions{}); err != nil {
-		return hc, err
+	if val, ok := hc.Annotations[OverrideToFail]; ok && val == "true" {
+		override = true
 	}
 
-	jobName := fmt.Sprintf("helm-delete-%s", hc.Name)
-	if err := h.createJobIfNotFound(hc.Namespace, jobName, override); err != nil {
-		return hc, err
+	// 4. Delegate everything to our smart helper!
+	// It will fetch, inspect, purge if stale, or create a brand new job if missing.
+	if err := h.createJobIfNotFound(hc.Namespace, deleteJobName, currentHash, override); err != nil {
+		return hc, err // Safely bubbles up re-queues if a stale job was just deleted
 	}
 
-	if hc.Status.JobName == jobName {
-		_, err := h.helm.Update(hc)
-		if err != nil {
-			return hc, err
-		}
-	}
+	// 5. Seal the status link to transfer ownership to the monitoring controller
+	hcCopy := hc.DeepCopy()
+	hcCopy.Status.JobName = deleteJobName
 
-	// wait for job to complete
-	for h.waitForJobCompletion(hc.Namespace, jobName) == nil {
-		time.Sleep(5 * time.Second)
-	}
-
-	return hc, nil
+	logrus.Infof("Uninstallation job %s established for helmChart %s/%s with hash %s", deleteJobName, hc.Namespace, hc.Name, currentHash)
+	return h.helm.Update(hcCopy)
 }
 
-func (h *handler) createJobIfNotFound(namespace string, name string, override bool) error {
-	foundJob, err := h.job.Cache().Get(namespace, name)
-	if err != nil && !apierrors.IsNotFound(err) {
+func (h *handler) createJobIfNotFound(namespace, name, hash string, override bool) error {
+	// 1. Try to fetch the existing job
+	existingJob, err := h.job.Cache().Get(namespace, name)
+	if err == nil {
+		// Check if the old job is currently in the middle of being deleted
+		if existingJob.DeletionTimestamp != nil {
+			return fmt.Errorf("waiting for outdated job %s to finish deleting before recreating", name)
+		}
+
+		// Job exists and is active! Check if the configuration matches
+		existingHash := existingJob.Annotations[LastAppliedHash]
+		if existingHash == hash {
+			// Perfect match. No action needed.
+			return nil
+		}
+
+		// Hash mismatch! The HelmChart changed while this job was tracking old config.
+		// We must delete the outdated job so a fresh one can be spun up.
+		propPolicy := metav1.DeletePropagationBackground
+		deleteOpts := metav1.DeleteOptions{PropagationPolicy: &propPolicy}
+		if err := h.job.Delete(namespace, name, &deleteOpts); err != nil {
+			return fmt.Errorf("failed to delete outdated job %s: %w", name, err)
+		}
+
+		// CRITICAL: Return an error to stop execution and trigger a quick retry.
+		// This gives Kubernetes time to gracefully delete the old job and pods.
+		return fmt.Errorf("outdated job %s deleted; retrying on next sync to allow cleanup", name)
+
+	} else if !apierrors.IsNotFound(err) {
 		return err
 	}
 
-	if foundJob != nil {
-		err = h.job.Delete(namespace, name, &metav1.DeleteOptions{})
-		if err != nil {
-			return err
-		}
+	args := []string{}
+	// The loop prints progress 5 times, sleeping 1 second between each step
+	// Avoid the job to be done too fast, the real helm-job takes time to finish all the tasks
+	loopScript := "for i in 1 2 3 4 5; do echo \"Current iteration: $i/5\"; sleep 1; done; "
+
+	if strings.Contains(name, "fail") || override {
+		// Appends the loop first, then terminates with a failure exit code
+		args = append(args, loopScript+"echo \"Failure condition met, exiting with 1\"; exit 1")
+	} else {
+		// Appends the loop first, then terminates with a success exit code
+		args = append(args, loopScript+"echo \"Success condition met, exiting with 0\"; exit 0")
 	}
 
-	args := []string{}
-	if strings.Contains(name, "fail") || override {
-		args = append(args, "exit 1")
-	} else {
-		args = append(args, "exit 0")
-	}
-	j := &batchv1.Job{
+	// 2. Construct the new Job object if not found (or just deleted above)
+	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				LastAppliedHash: hash, // Pair with helmchart
+			},
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &[]int32{1}[0],
@@ -157,39 +195,49 @@ func (h *handler) createJobIfNotFound(namespace string, name string, override bo
 			},
 		},
 	}
-
-	_, err = h.job.Create(j)
+	_, err = h.job.Create(job)
+	logrus.Infof("new job %s is created with result %+v", job.Name, err)
 	return err
 }
 
-func (h *handler) waitForJobCompletion(namespace string, name string) error {
-	j, err := h.job.Cache().Get(namespace, name)
+// the `bool` return param is to indicate if the hash has changed
+func (h *handler) checkAndGenerateHash(hc *helmv1.HelmChart) (*helmv1.HelmChart, string, bool, error) {
+	// 1. Calculate the real hash using the pure utility function
+	currentHashVal, err := calculateSpecHash(hc.Spec)
 	if err != nil {
-		return err
+		return hc, "", false, err
 	}
 
-	if j.Status.CompletionTime == nil {
-		return fmt.Errorf("waiting for job to complete")
-	}
-
-	return nil
-}
-
-func (h *handler) checkAndGenerateHash(hc *helmv1.HelmChart) (*helmv1.HelmChart, bool, error) {
-	hcByte, err := json.Marshal(hc.Spec)
-	if err != nil {
-		return hc, false, err
-	}
-
+	// 2. Safely initialize metadata maps if needed
 	if hc.Annotations == nil {
 		hc.Annotations = make(map[string]string)
 	}
 
 	lastAppliedHashVal := hc.Annotations[LastAppliedHash]
-	if string(hcByte) != lastAppliedHashVal {
-		hc.Annotations[LastAppliedHash] = string(hcByte)
-		return hc, true, nil
+
+	// 3. Track if adjustments were introduced
+	if currentHashVal != lastAppliedHashVal {
+		hc.Annotations[LastAppliedHash] = currentHashVal
+		return hc, currentHashVal, true, nil
 	}
 
-	return hc, false, nil
+	return hc, currentHashVal, false, nil
+}
+
+// calculateSpecHash generates a stable, deterministic SHA-256 hex string
+// from a given specification structure.
+func calculateSpecHash(spec interface{}) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+
+	// Prevent character escaping and ensure uniform formatting
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(spec); err != nil {
+		return "", err
+	}
+
+	// Compute the cryptographic checksum directly from the buffer bytes
+	hashBytes := sha256.Sum256(buf.Bytes())
+	return hex.EncodeToString(hashBytes[:]), nil
 }

--- a/tests/integration/controllers/manifest/helm-crd.yaml
+++ b/tests/integration/controllers/manifest/helm-crd.yaml
@@ -56,6 +56,10 @@ spec:
                 jobImage:
                   nullable: true
                   type: string
+                backOffLimit:
+                  nullable: true
+                  type: integer
+                  format: int32
                 repo:
                   nullable: true
                   type: string
@@ -90,7 +94,6 @@ spec:
           type: object
       served: true
       storage: true
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/tests/integration/controllers/suite_test.go
+++ b/tests/integration/controllers/suite_test.go
@@ -87,6 +87,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	err = applyObj(crds)
 	dsl.MustNotError(err)
 
+	ginkgo.By("wait 5 seconds for crds to be applied")
+	time.Sleep(time.Second * 5)
+
 	err = helmv1.AddToScheme(scheme)
 	dsl.MustNotError(err)
 

--- a/tests/integration/runtime/construct.go
+++ b/tests/integration/runtime/construct.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	restclient "k8s.io/client-go/rest"
 
 	"github.com/harvester/harvester/tests/framework/client"
@@ -60,6 +62,15 @@ func installHarvesterChart(ctx context.Context, kubeConfig *restclient.Config) e
 		patches["webhook.debug"] = true
 	}
 
+	// if not aligned with local image tag, it is always `master-head` of main repo
+	// not testing the locally developed image
+	repo, tag = env.GetHarvesterImage()
+	if repo != "" {
+		patches["containers.apiserver.image.repository"] = repo
+		patches["containers.apiserver.image.tag"] = tag
+		patches["containers.apiserver.image.imagePullPolicy"] = "IfNotPresent"
+	}
+
 	if !env.IsE2ETestsEnabled() {
 		patches["longhorn.enabled"] = "false"
 	}
@@ -67,6 +78,13 @@ func installHarvesterChart(ctx context.Context, kubeConfig *restclient.Config) e
 	if env.IsUsingEmulation() {
 		patches["kubevirt.spec.configuration.developerConfiguration.useEmulation"] = "true"
 	}
+
+	logrus.WithFields(logrus.Fields{
+		"release":   testChartReleaseName,
+		"namespace": testHarvesterNamespace,
+		"chartDir":  testChartDir,
+		"patches":   patches,
+	}).Info("Preparing to install Harvester chart for test")
 
 	// install crd chart
 	_, err := helm.InstallChart(testCRDChartReleaseName, testHarvesterNamespace, testCRDChartDir, nil)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

`make test-integration` is working on `master-head` Harvester by default, it is not the expectation on PR based actions.

There are also error cases which are very easy to encounter:
```
addon and helm chart deletion verify helm deletion tasks
/go/src/github.com/harvester/harvester/tests/integration/controllers/addons_test.go:218
  STEP: create addon @ 05/21/26 19:57:49.26
  STEP: check helm chart object is created @ 05/21/26 19:57:49.264
time="2026-05-21T19:57:49Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:57:49Z" level=info msg="new job helm-install-demo-addon-deleted is created with result <nil>"
time="2026-05-21T19:57:49Z" level=info msg="Linking job helm-install-demo-addon-deleted to helmChart default/demo-addon-deleted"
time="2026-05-21T19:57:49Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:57:49Z" level=info msg="Linking job helm-install-demo-addon-deleted to helmChart default/demo-addon-deleted"
time="2026-05-21T19:57:50Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:57:50Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:57:50Z" level=info msg="Linking job helm-install-demo-addon-deleted to helmChart default/demo-addon-deleted"
time="2026-05-21T19:57:50Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:57:51Z" level=info msg="Linking job helm-install-demo-addon-deleted to helmChart default/demo-addon-deleted"
time="2026-05-21T19:57:51Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:57:51Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:57:52Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
  STEP: check addon status is successful @ 05/21/26 19:57:54.269
time="2026-05-21T19:57:57Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:58:07Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
time="2026-05-21T19:58:28Z" level=error msg="error syncing 'default/demo-addon-deleted': handler monitor-addon-per-status: waiting for job to be populated on helmchart demo-addon-deleted, requeuing"
  [FAILED] in [It] - /go/src/github.com/harvester/harvester/tests/integration/controllers/addons_test.go:261 @ 05/21/26 19:58:54.27
• [FAILED] [65.010 seconds]
addon and helm chart deletion [It] verify helm deletion tasks
/go/src/github.com/harvester/harvester/tests/integration/controllers/addons_test.go:218

  [FAILED] Timed out after 60.001s.
  Unexpected error:
      <*errors.errorString | 0xc001249280>: 
      addon demo-addon-deleted is not deployed successfully, status AddonEnabling
      {
          s: "addon demo-addon-deleted is not deployed successfully, status AddonEnabling",
      }
  occurred
  In [It] at: /go/src/github.com/harvester/harvester/tests/integration/controllers/addons_test.go:261 @ 05/21/26 19:58:54.27

  Full Stack Trace
    github.com/harvester/harvester/tests/integration/controllers.init.func2.1.3()
    	/go/src/github.com/harvester/harvester/tests/integration/controllers/addons_test.go:261 +0xdf
    github.com/harvester/harvester/tests/integration/controllers.init.func2.1()
    	/go/src/github.com/harvester/harvester/tests/integration/controllers/addons_test.go:251 +0x145

```


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Build and pre-load the image tags for kind.

2. Refactor the fake job-controller to handle addon test effectively.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10644

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

before the fix:
example
https://github.com/harvester/harvester/actions/runs/26135741014/job/76887529829#step:5:2416
the log:
```
...
  Loading image rancher/harvester-webhook:7aa1fc1c-amd64...
  Image: "rancher/harvester-webhook:7aa1fc1c-amd64" with ID "sha256:db43fcd2b08d1a2b78c32867ea6824397d57823e6b276e12aba203d5b96d61f1" not yet present on node "harvester-worker2", loading...
  Image: "rancher/harvester-webhook:7aa1fc1c-amd64" with ID "sha256:db43fcd2b08d1a2b78c32867ea6824397d57823e6b276e12aba203d5b96d61f1" not yet present on node "harvester-worker3", loading...
  Image: "rancher/harvester-webhook:7aa1fc1c-amd64" with ID "sha256:db43fcd2b08d1a2b78c32867ea6824397d57823e6b276e12aba203d5b96d61f1" not yet present on node "harvester-control-plane", loading...
  Image: "rancher/harvester-webhook:7aa1fc1c-amd64" with ID "sha256:db43fcd2b08d1a2b78c32867ea6824397d57823e6b276e12aba203d5b96d61f1" not yet present on node "harvester-worker", loading...
  STEP: construct harvester runtime @ 05/20/26 04:55:31.552
time="2026-05-20T04:55:31Z" level=info msg="Applying CRD helmchartconfigs.helm.cattle.io"
time="2026-05-20T04:55:31Z" level=info msg="Applying CRD network-attachment-definitions.k8s.cni.cncf.io"
time="2026-05-20T04:55:31Z" level=info msg="Applying CRD managedcharts.management.cattle.io"
time="2026-05-20T04:55:31Z" level=info msg="Applying CRD apps.catalog.cattle.io"
time="2026-05-20T04:55:31Z" level=info msg="Applying CRD plans.upgrade.cattle.io"
time="2026-05-20T04:55:31Z" level=info msg="Applying CRD helmcharts.helm.cattle.io"
```


after the fix

```
...
  • Waiting ≤ 10m0s for control-plane = Ready ⏳  ...
   ✓ Waiting ≤ 10m0s for control-plane = Ready ⏳
   • Ready after 11s 💚
  Loading image rancher/harvester-webhook:ffbd59b5-amd64...
  Image: "rancher/harvester-webhook:ffbd59b5-amd64" with ID "sha256:b1205c63a936491b09a80608ea144c67ea08ea27282d4141c51442379a7b42d5" not yet present on node "harvester-worker", loading...
  Image: "rancher/harvester-webhook:ffbd59b5-amd64" with ID "sha256:b1205c63a936491b09a80608ea144c67ea08ea27282d4141c51442379a7b42d5" not yet present on node "harvester-control-plane", loading...
  Image: "rancher/harvester-webhook:ffbd59b5-amd64" with ID "sha256:b1205c63a936491b09a80608ea144c67ea08ea27282d4141c51442379a7b42d5" not yet present on node "harvester-worker2", loading...
  Image: "rancher/harvester-webhook:ffbd59b5-amd64" with ID "sha256:b1205c63a936491b09a80608ea144c67ea08ea27282d4141c51442379a7b42d5" not yet present on node "harvester-worker3", loading...
  Loading image rancher/harvester:ffbd59b5-amd64...
  Image: "rancher/harvester:ffbd59b5-amd64" with ID "sha256:b2754b795bd3b159b1dd1dbd602f225d09c657f311b041c6cc06635c102898cb" not yet present on node "harvester-worker", loading...
  Image: "rancher/harvester:ffbd59b5-amd64" with ID "sha256:b2754b795bd3b159b1dd1dbd602f225d09c657f311b041c6cc06635c102898cb" not yet present on node "harvester-control-plane", loading...
  Image: "rancher/harvester:ffbd59b5-amd64" with ID "sha256:b2754b795bd3b159b1dd1dbd602f225d09c657f311b041c6cc06635c102898cb" not yet present on node "harvester-worker2", loading...
  Image: "rancher/harvester:ffbd59b5-amd64" with ID "sha256:b2754b795bd3b159b1dd1dbd602f225d09c657f311b041c6cc06635c102898cb" not yet present on node "harvester-worker3", loading...
  STEP: construct harvester runtime @ 05/21/26 11:47:53.615
time="2026-05-21T11:47:53Z" level=info msg="Applying CRD helmchartconfigs.helm.cattle.io"
time="2026-05-21T11:47:53Z" level=info msg="Applying CRD network-attachment-definitions.k8s.cni.cncf.io"
time="2026-05-21T11:47:53Z" level=info msg="Applying CRD managedcharts.management.cattle.io"
time="2026-05-21T11:47:53Z" level=info msg="Applying CRD apps.catalog.cattle.io"
time="2026-05-21T11:47:53Z" level=info msg="Applying CRD plans.upgrade.cattle.io"
time="2026-05-21T11:47:53Z" level=info msg="Applying CRD helmcharts.helm.cattle.io"
time="2026-05-21T11:47:54Z" level=info msg="Applying CRD nodes.longhorn.io"
time="2026-05-21T11:47:54Z" level=info msg="Applying CRD volumes.longhorn.io"
time="2026-05-21T11:47:54Z" level=info msg="Applying CRD replicas.longhorn.io"
time="2026-05-21T11:47:55Z" level=info msg="Applying CRD clusterrepos.catalog.cattle.io"
time="2026-05-21T11:47:55Z" level=info msg="Waiting for CRD clusterrepos.catalog.cattle.io to become available"
time="2026-05-21T11:47:56Z" level=info msg="Done waiting for CRD clusterrepos.catalog.cattle.io to become available"
time="2026-05-21T11:47:56Z" level=info msg="Prepare to installing Harvester chart for test" chartDir=../../../deploy/charts/harvester namespace=harvester-system patches="map[containers.apiserver.image.repository:rancher/harvester containers.apiserver.image.tag:ffbd59b5-amd64 harvester-network-controller.enabled:true kubevirt.spec.configuration.developerConfiguration.useEmulation:true longhorn.enabled:false replicas:0 webhook.controllerUser:kubernetes-admin webhook.debug:true webhook.image.imagePullPolicy:Never webhook.image.repository:rancher/harvester-webhook webhook.image.tag:ffbd59b5-amd64]" release=harvester
  getting history for release harvester-crd
  creating 1 resource(s)
  creating 25 resource(s)
I0521 11:47:56.767830     244 warnings.go:110] "Warning: unrecognized format \"int64\""
...
```

addon test logs after fix:
```
verify helm chart redeploy reconcile helm chart recreation
/go/src/github.com/harvester/harvester/tests/integration/controllers/addons_test.go:316
  STEP: fetch helm chart and verify its spec @ 05/21/26 21:09:55.18
time="2026-05-21T21:09:55Z" level=info msg="new job helm-delete-demo-addon-fail is created with result <nil>"
time="2026-05-21T21:09:55Z" level=info msg="Uninstallation job helm-delete-demo-addon-fail established for helmChart default/demo-addon-fail with hash f5c4cecaa5a82b55427e37e74023f127ad4b47c7583de0822003f5a43c1a4732"
I0521 21:09:55.191559     239 warnings.go:110] "Warning: unknown field \"spec.backOffLimit\""
time="2026-05-21T21:09:55Z" level=info msg="new job helm-install-demo-addon-redeploy is created with result <nil>"
time="2026-05-21T21:09:55Z" level=info msg="Linking job helm-install-demo-addon-redeploy to helmChart default/demo-addon-redeploy with hash f5c4cecaa5a82b55427e37e74023f127ad4b47c7583de0822003f5a43c1a4732"
time="2026-05-21T21:09:56Z" level=error msg="error syncing 'default/demo-addon-fail': handler fake-helmchart-controller-deletion: helmcharts.helm.cattle.io \"demo-addon-fail\" not found, requeuing"
  STEP: check addon status is successful @ 05/21/26 21:10:00.184
  STEP: delete helm chart object @ 05/21/26 21:10:15.195
  STEP: verify helm chart is recreated @ 05/21/26 21:10:15.206
time="2026-05-21T21:10:15Z" level=info msg="new job helm-delete-demo-addon-redeploy is created with result <nil>"
time="2026-05-21T21:10:15Z" level=info msg="Uninstallation job helm-delete-demo-addon-redeploy established for helmChart default/demo-addon-redeploy with hash f5c4cecaa5a82b55427e37e74023f127ad4b47c7583de0822003f5a43c1a4732"
• [20.038 seconds]
```