### PR TITLE
fix(upgrade): correct ARM kernel path in bootargs during upgrade

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -81,6 +81,14 @@ clean_up_tmp_files()
     umount $tmp_rootfs_mount || echo "Umount $tmp_rootfs_mount failed with return code: $?"
   fi
   echo "Clean up tmp files..."
+  if [ -n "$tmp_rootfs_dir" ]; then
+    echo "Try to remove $tmp_rootfs_dir..."
+    rm -rf "$tmp_rootfs_dir"
+  fi
+  if [ -n "$tmp_rootfs_mount" ]; then
+    echo "Try to remove $tmp_rootfs_mount..."
+    rm -rf "$tmp_rootfs_mount"
+  fi
   if [ -n "$NEW_OS_SQUASHFS_IMAGE_FILE" ]; then
     echo "Try to remove $NEW_OS_SQUASHFS_IMAGE_FILE..."
     rm -vf "$NEW_OS_SQUASHFS_IMAGE_FILE"
@@ -678,6 +686,18 @@ upgrade_os() {
 
   tmp_rootfs_mount=$(mktemp -d -p $HOST_DIR/tmp)
   mount $tmp_rootfs_squashfs $tmp_rootfs_mount
+  tmp_rootfs_dir=$(mktemp -d -p $HOST_DIR/tmp)
+  cp -a "$tmp_rootfs_mount/." "$tmp_rootfs_dir/"
+
+  case "$(uname -m)" in
+    aarch64|arm64)
+      sed -i 's|kernel=/boot/vmlinuz|kernel=/boot/Image|g' "$tmp_rootfs_dir/etc/cos/bootargs.cfg"
+      if ! grep -q '^set kernel=/boot/Image$' "$tmp_rootfs_dir/etc/cos/bootargs.cfg"; then
+        echo "Failed to patch ARM kernel path in rootfs bootargs.cfg"
+        exit 1
+      fi
+      ;;
+  esac
 
   tmp_elemental_config_dir=$(mktemp -d -p $HOST_DIR/tmp)
   # adjust new active.img size
@@ -717,7 +737,7 @@ EOF
   fi
   chroot $HOST_DIR /tmp/elemental upgrade \
     --logfile "$elemental_upgrade_log" \
-    --directory ${tmp_rootfs_mount#"$HOST_DIR"} \
+    --directory ${tmp_rootfs_dir#"$HOST_DIR"} \
     --config-dir ${tmp_elemental_config_dir#"$HOST_DIR"} \
     --debug || ret=$?
   if [ -n "$glibc_too_old" ]; then
@@ -797,6 +817,10 @@ EOF
   set_nic_names_by_mac_address
 
   umount $tmp_rootfs_mount
+  rm -rf "$tmp_rootfs_mount"
+  rm -rf "$tmp_rootfs_dir"
+  tmp_rootfs_mount=
+  tmp_rootfs_dir=
   rm -rf $tmp_rootfs_squashfs
 
   reboot_if_job_succeed


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
When upgrading an ARM node from v1.7.0 to v1.7.1, the upgrade workflow may remain stuck at `Waiting Reboot`.

The upgrade itself actually completes and the target upgraded image is generated, but the node fails to boot into the upgraded system during reboot. The root cause is that `/etc/cos/bootargs.cfg` inside `active.img` still contains:

`set kernel=/boot/vmlinuz`

On ARM, the correct kernel path should be:

`set kernel=/boot/Image`

As a result, the node cannot find the correct kernel file during reboot, automatically falls back to the previous system, and the overall upgrade workflow remains stuck at `Waiting Reboot`.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
This change fixes the ARM kernel path in `/etc/cos/bootargs.cfg` before the new rootfs is handed over to `elemental upgrade`.

Instead of modifying the mounted rootfs directly, the updated flow:
- copies the mounted rootfs into a temporary writable directory
- rewrites the ARM kernel path in `bootargs.cfg` from `/boot/vmlinuz` to `/boot/Image`
- verifies that the rewritten kernel path is present
- passes the patched temporary rootfs directory to `elemental upgrade`

This ensures that the final upgraded image contains the correct ARM kernel path.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

Fixes #10661

#### Test plan:
<!-- Describe the test plan by steps. -->
- Reproduced the issue on an ARM node when upgrading from v1.7.0 to v1.7.1
- Observed that the upgrade workflow remained stuck at `Waiting Reboot`
- Confirmed that `/etc/os-release` inside `active.img` already showed v1.7.1
- Confirmed that `/etc/cos/bootargs.cfg` inside `active.img` still pointed to `/boot/vmlinuz`
- Verified that the updated script logic rewrites the ARM kernel path in a temporary writable rootfs before passing it to `elemental upgrade`
- 
#### Additional documentation or context

This issue appears to be specific to the upgrade path. A fresh installation of v1.7.1 in the same ARM environment does not hit the missing kernel problem.

AI disclosure: AI tools were used to help draft the issue/PR text and analyze the related code path. I reviewed and verified the final patch myself.