### PR TITLE
fix(upgrade): wait_capi_cluster no longer requires a generation bump

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -532,31 +532,46 @@ EOF
 }
 
 wait_capi_cluster() {
-  # Wait for cluster to settle down
+  # Wait for the CAPI cluster to be Provisioned and fully reconciled
+  # (status.observedGeneration == metadata.generation), held stable for
+  # several consecutive observations to allow controllers like Rancher
+  # Turtles to complete a takeover/reconcile burst
   namespace=$1
   name=$2
-  generation=$3
+
+  local required_stable=6   # ~30s of stability at 5s poll interval
+  local stable=0
 
   while [ true ]; do
     unset localcluster
     local localcluster=$(kubectl get clusters.cluster.x-k8s.io $name -n $namespace -o yaml)
     if [[ -z ${localcluster} ]]; then
       echo "failed to get CAPI cluster $namespace/$name, retry..."
+      stable=0
       sleep 5
       continue
     fi
 
-    current_generation=$(echo "$localcluster" | yq e '.status.observedGeneration' -)
-    current_phase=$(echo "$localcluster" | yq e '.status.phase' -)
+    local current_metadata_generation=$(echo "$localcluster" | yq e '.metadata.generation' -)
+    local current_observed_generation=$(echo "$localcluster" | yq e '.status.observedGeneration' -)
+    local current_phase=$(echo "$localcluster" | yq e '.status.phase' -)
 
-    if [ "$current_generation" -gt "$generation" ]; then
-      if [ "$current_phase" = "Provisioned" ]; then
-        echo "CAPI cluster $namespace/$name is provisioned (current generation: $current_generation)."
+    if [ "$current_observed_generation" = "$current_metadata_generation" ] && [ "$current_phase" = "Provisioned" ]; then
+      stable=$((stable + 1))
+      if [ "$stable" -ge "$required_stable" ]; then
+        echo "CAPI cluster $namespace/$name is provisioned and stable (current generation: $current_metadata_generation)."
         break
       fi
+      echo "CAPI cluster $namespace/$name appears ready (phase=$current_phase, generation=$current_metadata_generation), stability $stable/$required_stable..."
+    else
+      if [ "$stable" -ne 0 ]; then
+        echo "CAPI cluster $namespace/$name reconcile in progress (phase=$current_phase, observed=$current_observed_generation, metadata=$current_metadata_generation), resetting stability counter."
+      else
+        echo "Waiting for CAPI cluster $namespace/$name to be provisioned (phase=$current_phase, observed=$current_observed_generation, metadata=$current_metadata_generation)..."
+      fi
+      stable=0
     fi
 
-    echo "Waiting for CAPI cluster $namespace/$name to be provisioned (current phase: $current_phase, current generation: $current_generation)..."
     sleep 5
   done
 }
@@ -765,8 +780,7 @@ upgrade_rancher() {
   fi
 
   # Wait for Rancher to settle down before start upgrading, just in case
-  wait_capi_cluster fleet-local local 0
-  pre_generation=$(kubectl get clusters.cluster.x-k8s.io local -n fleet-local -o=jsonpath="{.status.observedGeneration}")
+  wait_capi_cluster fleet-local local
 
   # XXX Workaround for https://github.com/rancher/rancher/issues/36914
   # Delete all rancher's clusterrepos so they will be updated by the new version rancher pods
@@ -830,7 +844,7 @@ upgrade_rancher() {
   # v0.10.1: https://github.com/rancher/fleet/blob/62de718a20e1377d5a8702876077762ed9a37f27/internal/cmd/controller/agentmanagement/agent/manifest.go#L152-L161
   wait_rollout_with_loop cattle-fleet-local-system deployment fleet-agent
   echo "Wait for cluster settling down..."
-  wait_capi_cluster fleet-local local $pre_generation
+  wait_capi_cluster fleet-local local
 
   # Following patch is not enough
   wait_rollout_with_loop cattle-fleet-local-system deployment fleet-agent

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -539,15 +539,15 @@ wait_capi_cluster() {
   namespace=$1
   name=$2
 
-  local required_stable=6   # ~30s of stability at 5s poll interval
-  local stable=0
+  local required_stable_seconds=30
+  local stable_since=""
 
   while [ true ]; do
     unset localcluster
     local localcluster=$(kubectl get clusters.cluster.x-k8s.io $name -n $namespace -o yaml)
     if [[ -z ${localcluster} ]]; then
       echo "failed to get CAPI cluster $namespace/$name, retry..."
-      stable=0
+      stable_since=""
       sleep 5
       continue
     fi
@@ -557,19 +557,22 @@ wait_capi_cluster() {
     local current_phase=$(echo "$localcluster" | yq e '.status.phase' -)
 
     if [ "$current_observed_generation" = "$current_metadata_generation" ] && [ "$current_phase" = "Provisioned" ]; then
-      stable=$((stable + 1))
-      if [ "$stable" -ge "$required_stable" ]; then
-        echo "CAPI cluster $namespace/$name is provisioned and stable (current generation: $current_metadata_generation)."
+      if [ -z "$stable_since" ]; then
+        stable_since=$(date +%s)
+      fi
+      local elapsed=$(( $(date +%s) - stable_since ))
+      if [ "$elapsed" -ge "$required_stable_seconds" ]; then
+        echo "CAPI cluster $namespace/$name is provisioned and stable for ${elapsed}s (current generation: $current_metadata_generation)."
         break
       fi
-      echo "CAPI cluster $namespace/$name appears ready (phase=$current_phase, generation=$current_metadata_generation), stability $stable/$required_stable..."
+      echo "CAPI cluster $namespace/$name appears ready (phase=$current_phase, generation=$current_metadata_generation), stability ${elapsed}s/${required_stable_seconds}s..."
     else
-      if [ "$stable" -ne 0 ]; then
-        echo "CAPI cluster $namespace/$name reconcile in progress (phase=$current_phase, observed=$current_observed_generation, metadata=$current_metadata_generation), resetting stability counter."
+      if [ -n "$stable_since" ]; then
+        echo "CAPI cluster $namespace/$name reconcile in progress (phase=$current_phase, observed=$current_observed_generation, metadata=$current_metadata_generation), resetting stability timer."
       else
         echo "Waiting for CAPI cluster $namespace/$name to be provisioned (phase=$current_phase, observed=$current_observed_generation, metadata=$current_metadata_generation)..."
       fi
-      stable=0
+      stable_since=""
     fi
 
     sleep 5

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -543,7 +543,6 @@ wait_capi_cluster() {
   local stable_since=""
 
   while [ true ]; do
-    unset localcluster
     local localcluster=$(kubectl get clusters.cluster.x-k8s.io $name -n $namespace -o yaml)
     if [[ -z ${localcluster} ]]; then
       echo "failed to get CAPI cluster $namespace/$name, retry..."


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

To address this issue found in https://github.com/harvester/harvester-installer/pull/1278#issuecomment-4543749866

From v1.8.0, embedded CAPI is replaced by Rancher Turtles https://github.com/harvester/harvester-installer/pull/1205.  Empirically, we noticed that a v1.8.x → v1.8.x (v1.9.x could also have the same issue) Rancher upgrade legitimately does not mutate the CAPI cluster `kubectl get clusters.cluster.x-k8s.io -n fleet-local local`. The generation never advances and apply-manifests hangs forever at "Wait for CAPI cluster settling down...".


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Relax `wait_capi_cluster` to consider stable while status.observedGeneration == metadata.generation and status.phase == "Provisioned" for 30s

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10566
https://github.com/harvester/harvester/issues/10719

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Upgrade from v1.8.0 to `v1.8-head + changes in this PR`

```
# kubectl logs hvst-upgrade-h9jcp-apply-manifests-pcmxp -n harvester-system --timestamps
...
2026-05-27T06:07:12.563066009Z Wait for cluster settling down...
2026-05-27T06:07:12.624679931Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=2), stability 0s/30s...
2026-05-27T06:07:17.696727198Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=2), stability 5s/30s...
2026-05-27T06:07:22.768652446Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=2), stability 10s/30s...
2026-05-27T06:07:27.836623929Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=2), stability 15s/30s...
2026-05-27T06:07:32.919247644Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=2), stability 20s/30s...
2026-05-27T06:07:37.983560316Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=2), stability 25s/30s...
2026-05-27T06:07:43.053946859Z CAPI cluster fleet-local/local is provisioned and stable for 31s (current generation: 2).
...
```

2. Upgrade from v1.7.1 to `v1.8-head + changes in this PR`

```
# kubectl logs hvst-upgrade-48q7h-apply-manifests-l7qd5 -n harvester-system --timestamps
...
2026-05-27T06:58:05.863026246Z Wait for cluster settling down...
2026-05-27T06:58:05.953773159Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=42), stability 0s/30s...
2026-05-27T06:58:11.140147748Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=42), stability 6s/30s...
2026-05-27T06:58:16.213878547Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=42), stability 11s/30s...
2026-05-27T06:58:21.302739598Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=42), stability 16s/30s...
2026-05-27T06:58:26.927482019Z Error from server: conversion webhook for cluster.x-k8s.io/v1beta1, Kind=Cluster failed: Post "https://capi-webhook-service.cattle-capi-system.svc:443/convert?timeout=30s": no endpoints available for service "capi-webhook-service"
2026-05-27T06:58:26.932016741Z failed to get CAPI cluster fleet-local/local, retry...
2026-05-27T06:58:32.131643997Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=44), stability 0s/30s...
2026-05-27T06:58:37.211901710Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=44), stability 5s/30s...
2026-05-27T06:58:42.287649550Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=44), stability 10s/30s...
2026-05-27T06:58:47.355149246Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=44), stability 15s/30s...
2026-05-27T06:58:52.445172794Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=44), stability 20s/30s...
2026-05-27T06:58:57.583062317Z CAPI cluster fleet-local/local appears ready (phase=Provisioned, generation=44), stability 25s/30s...
2026-05-27T06:59:02.666463526Z CAPI cluster fleet-local/local is provisioned and stable for 30s (current generation: 44).
...
```

#### Additional documentation or context
