### PR TITLE
enhance: Essential checks upon upgradeLog

### DIFF
--- a/deploy/charts/harvester-crd/templates/harvesterhci.io_upgradelogs.yaml
+++ b/deploy/charts/harvester-crd/templates/harvesterhci.io_upgradelogs.yaml
@@ -43,6 +43,9 @@ spec:
             properties:
               upgradeName:
                 type: string
+                x-kubernetes-validations:
+                - message: spec.upgradeName is immutable
+                  rule: self == oldSelf
             required:
             - upgradeName
             type: object

--- a/pkg/apis/harvesterhci.io/v1beta1/upgradelog.go
+++ b/pkg/apis/harvesterhci.io/v1beta1/upgradelog.go
@@ -28,6 +28,7 @@ type UpgradeLog struct {
 
 type UpgradeLogSpec struct {
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.upgradeName is immutable"
 	UpgradeName string `json:"upgradeName,omitempty"`
 }
 

--- a/pkg/controller/master/upgrade/job_controller.go
+++ b/pkg/controller/master/upgrade/job_controller.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	StateUpgrading               = "Upgrading"
-	StatePreparingLoggingInfra   = "PreparingLoggingInfra"
-	StateLoggingInfraPrepared    = "LoggingInfraPrepared"
+	StatePreparingLoggingInfra   = util.UpgradeStatePreparingLoggingInfra
+	StateLoggingInfraPrepared    = util.UpgradeStateLoggingInfraPrepared
 	StateCreatingUpgradeImage    = "CreatingUpgradeImage"
 	StatePreparingRepo           = "PreparingRepo"
 	StateRepoPrepared            = "RepoPrepared"

--- a/pkg/controller/master/upgrade/upgrade_controller_test.go
+++ b/pkg/controller/master/upgrade/upgrade_controller_test.go
@@ -742,6 +742,15 @@ func TestUpgradeHandler_prepareNodesForUpgrade(t *testing.T) {
 		var actual output
 		actual.upgrade, actual.err = handler.prepareNodesForUpgrade(tc.given.upgrade, "")
 		assert.Equal(t, tc.expected.err, actual.err, "case %q", tc.name)
+
+		// Skip comparing the time in conditions since it's unpredictable.
+		if actual.upgrade != nil {
+			emptyConditionsTime(actual.upgrade.Status.Conditions)
+		}
+		if tc.expected.upgrade != nil {
+			emptyConditionsTime(tc.expected.upgrade.Status.Conditions)
+		}
+
 		assert.Equal(t, tc.expected.upgrade, actual.upgrade, "case %q", tc.name)
 
 		if tc.expected.plan != nil {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -158,9 +158,10 @@ const (
 	CSINodeExpandSecretNameKey       = "csi.storage.k8s.io/node-expand-secret-name"
 	CSINodeExpandSecretNamespaceKey  = "csi.storage.k8s.io/node-expand-secret-namespace"
 
-	LabelUpgradeReadMessage          = prefix + "/read-message"
-	LabelUpgradeState                = prefix + "/upgradeState"
-	UpgradeStateLoggingInfraPrepared = "LoggingInfraPrepared"
+	LabelUpgradeReadMessage           = prefix + "/read-message"
+	LabelUpgradeState                 = prefix + "/upgradeState"
+	UpgradeStatePreparingLoggingInfra = "PreparingLoggingInfra"
+	UpgradeStateLoggingInfraPrepared  = "LoggingInfraPrepared"
 
 	AnnotationArchiveName                 = prefix + "/archiveName"
 	LabelUpgradeLog                       = prefix + "/upgradeLog"

--- a/pkg/webhook/resources/upgradelog/validator.go
+++ b/pkg/webhook/resources/upgradelog/validator.go
@@ -1,0 +1,117 @@
+package upgradelog
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
+	werror "github.com/harvester/harvester/pkg/webhook/error"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+func NewValidator(
+	upgrades ctlharvesterv1.UpgradeCache,
+	upgradeLogs ctlharvesterv1.UpgradeLogCache,
+) types.Validator {
+	return &upgradeLogValidator{
+		upgrades:    upgrades,
+		upgradeLogs: upgradeLogs,
+	}
+}
+
+type upgradeLogValidator struct {
+	types.DefaultValidator
+	upgrades    ctlharvesterv1.UpgradeCache
+	upgradeLogs ctlharvesterv1.UpgradeLogCache
+}
+
+func (v *upgradeLogValidator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{v1beta1.UpgradeLogResourceName},
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   v1beta1.SchemeGroupVersion.Group,
+		APIVersion: v1beta1.SchemeGroupVersion.Version,
+		ObjectType: &v1beta1.UpgradeLog{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (v *upgradeLogValidator) Create(req *types.Request, newObj runtime.Object) error {
+	newUpgradeLog := newObj.(*v1beta1.UpgradeLog)
+	if newUpgradeLog == nil {
+		return nil
+	}
+
+	if req == nil || !req.IsFromController() {
+		return werror.NewBadRequest("upgradelog can only be created by the harvester controller")
+	}
+
+	upgradeName := newUpgradeLog.Spec.UpgradeName
+	logrus.Debugf("Validating UpgradeLog creation for upgrade: %s", upgradeName)
+
+	if upgradeName == "" {
+		return werror.NewBadRequest("upgradeName field is not specified")
+	}
+
+	if newUpgradeLog.Namespace != util.HarvesterSystemNamespaceName {
+		return werror.NewBadRequest(fmt.Sprintf(
+			"UpgradeLog must be created in namespace %s",
+			util.HarvesterSystemNamespaceName))
+	}
+
+	upgrade, err := v.upgrades.Get(util.HarvesterSystemNamespaceName, upgradeName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return werror.NewBadRequest(fmt.Sprintf("referenced upgrade %s not found in namespace %s",
+				upgradeName, util.HarvesterSystemNamespaceName))
+		}
+		return werror.NewInternalError(fmt.Sprintf("failed to get upgrade %s: %v", upgradeName, err))
+	}
+
+	if !upgrade.Spec.LogEnabled {
+		return fmt.Errorf("LogEnabled is false for upgrade %s", upgradeName)
+	}
+
+	if v1beta1.UpgradeCompleted.GetStatus(upgrade) != "" && !v1beta1.LogReady.IsUnknown(upgrade) {
+		return fmt.Errorf("cannot create upgradeLog: upgrade %s is not initializing or waiting for logging infrastructure", upgradeName)
+	}
+
+	existingUpgradeLogs, err := v.upgradeLogs.List(util.HarvesterSystemNamespaceName, labels.Everything())
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("failed to list existing upgradelogs: %v", err))
+	}
+	for _, existingUpgradeLog := range existingUpgradeLogs {
+		if existingUpgradeLog.Name == newUpgradeLog.Name {
+			continue
+		}
+		if existingUpgradeLog.Spec.UpgradeName == upgradeName {
+			return werror.NewBadRequest(fmt.Sprintf(
+				"upgradelog %s already exists for upgrade %s",
+				existingUpgradeLog.Name, upgradeName))
+		}
+	}
+
+	logrus.Debugf("UpgradeLog validation passed for upgrade %s", upgradeName)
+	return nil
+}
+
+func (v *upgradeLogValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
+	oldUpgradeLog := oldObj.(*v1beta1.UpgradeLog)
+	newUpgradeLog := newObj.(*v1beta1.UpgradeLog)
+
+	if oldUpgradeLog.Spec.UpgradeName != newUpgradeLog.Spec.UpgradeName {
+		return werror.NewBadRequest("spec.upgradeName is immutable and cannot be changed")
+	}
+
+	return nil
+}

--- a/pkg/webhook/resources/upgradelog/validator_test.go
+++ b/pkg/webhook/resources/upgradelog/validator_test.go
@@ -1,0 +1,426 @@
+package upgradelog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/webhook"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+	"github.com/harvester/harvester/pkg/webhook/config"
+	"github.com/harvester/harvester/pkg/webhook/types"
+)
+
+const harvesterControllerUsername = "system:serviceaccount:harvester-system:harvester"
+
+func TestCreate(t *testing.T) {
+	type input struct {
+		upgradeLog *v1beta1.UpgradeLog
+		upgrades   []*v1beta1.Upgrade
+		request    *types.Request
+	}
+
+	type output struct {
+		wantErr bool
+		errMsg  string
+	}
+
+	testCases := []struct {
+		name   string
+		input  input
+		output output
+	}{
+		{
+			name: "valid upgradelog with existing upgrade",
+			input: input{
+				upgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				upgrades: []*v1beta1.Upgrade{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-upgrade",
+							Namespace: util.HarvesterSystemNamespaceName,
+						},
+						Spec: v1beta1.UpgradeSpec{
+							LogEnabled: true,
+						},
+					},
+				},
+				request: newControllerRequest(),
+			},
+			output: output{
+				wantErr: false,
+			},
+		},
+		{
+			name: "upgradelog with LogEnabled disabled is rejected",
+			input: input{
+				upgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				upgrades: []*v1beta1.Upgrade{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-upgrade",
+							Namespace: util.HarvesterSystemNamespaceName,
+						},
+					},
+				},
+				request: newControllerRequest(),
+			},
+			output: output{
+				wantErr: true,
+				errMsg:  "LogEnabled is false",
+			},
+		},
+		{
+			name: "upgradelog with non-existent upgrade",
+			input: input{
+				upgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "non-existent-upgrade",
+					},
+				},
+				upgrades: []*v1beta1.Upgrade{},
+				request:  newControllerRequest(),
+			},
+			output: output{
+				wantErr: true,
+				errMsg:  "referenced upgrade non-existent-upgrade not found",
+			},
+		},
+		{
+			name: "upgradelog without upgradeName",
+			input: input{
+				upgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "",
+					},
+				},
+				upgrades: []*v1beta1.Upgrade{},
+				request:  newControllerRequest(),
+			},
+			output: output{
+				wantErr: true,
+				errMsg:  "upgradeName field is not specified",
+			},
+		},
+		{
+			name: "upgradelog outside harvester-system namespace is rejected",
+			input: input{
+				upgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: "default",
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				upgrades: []*v1beta1.Upgrade{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-upgrade",
+							Namespace: util.HarvesterSystemNamespaceName,
+						},
+					},
+				},
+				request: newControllerRequest(),
+			},
+			output: output{
+				wantErr: true,
+				errMsg:  "UpgradeLog must be created in namespace " + util.HarvesterSystemNamespaceName,
+			},
+		},
+		{
+			name: "upgradelog created by non-controller user is rejected",
+			input: input{
+				upgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				upgrades: []*v1beta1.Upgrade{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-upgrade",
+							Namespace: util.HarvesterSystemNamespaceName,
+						},
+						Spec: v1beta1.UpgradeSpec{
+							LogEnabled: true,
+						},
+					},
+				},
+				request: newUserRequest("rancher"),
+			},
+			output: output{
+				wantErr: true,
+				errMsg:  "upgradelog can only be created by the harvester controller",
+			},
+		},
+		{
+			name: "upgradelog created without request is rejected",
+			input: input{
+				upgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				upgrades: []*v1beta1.Upgrade{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-upgrade",
+							Namespace: util.HarvesterSystemNamespaceName,
+						},
+					},
+				},
+				request: nil,
+			},
+			output: output{
+				wantErr: true,
+				errMsg:  "upgradelog can only be created by the harvester controller",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+
+			for _, u := range tc.input.upgrades {
+				_, err := clientset.HarvesterhciV1beta1().Upgrades(u.Namespace).Create(context.Background(), u, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			upgradeCache := fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades)
+			upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
+			validator := NewValidator(upgradeCache, upgradeLogCache)
+
+			err := validator.Create(tc.input.request, tc.input.upgradeLog)
+
+			if tc.output.wantErr {
+				assert.Error(t, err)
+				if tc.output.errMsg != "" {
+					assert.Contains(t, err.Error(), tc.output.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreate_DuplicateUpgradeLog(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	upgrade := &v1beta1.Upgrade{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-upgrade",
+			Namespace: util.HarvesterSystemNamespaceName,
+		},
+		Spec: v1beta1.UpgradeSpec{
+			LogEnabled: true,
+		},
+	}
+
+	existingUpgradeLog := &v1beta1.UpgradeLog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-upgradelog",
+			Namespace: util.HarvesterSystemNamespaceName,
+		},
+		Spec: v1beta1.UpgradeLogSpec{
+			UpgradeName: "test-upgrade",
+		},
+	}
+
+	newUpgradeLog := &v1beta1.UpgradeLog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "new-upgradelog",
+			Namespace: util.HarvesterSystemNamespaceName,
+		},
+		Spec: v1beta1.UpgradeLogSpec{
+			UpgradeName: "test-upgrade",
+		},
+	}
+
+	_, err := clientset.HarvesterhciV1beta1().Upgrades(upgrade.Namespace).Create(context.Background(), upgrade, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	_, err = clientset.HarvesterhciV1beta1().UpgradeLogs(existingUpgradeLog.Namespace).Create(context.Background(), existingUpgradeLog, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	upgradeCache := fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades)
+	upgradeLogCache := fakeclients.UpgradeLogCache(clientset.HarvesterhciV1beta1().UpgradeLogs)
+	validator := NewValidator(upgradeCache, upgradeLogCache)
+
+	err = validator.Create(newControllerRequest(), newUpgradeLog)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists for upgrade")
+	assert.Contains(t, err.Error(), "test-upgrade")
+}
+
+func TestUpdate(t *testing.T) {
+	type input struct {
+		oldUpgradeLog *v1beta1.UpgradeLog
+		newUpgradeLog *v1beta1.UpgradeLog
+	}
+
+	type output struct {
+		wantErr bool
+		errMsg  string
+	}
+
+	testCases := []struct {
+		name   string
+		input  input
+		output output
+	}{
+		{
+			name: "valid update when upgradeName does not change",
+			input: input{
+				oldUpgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				newUpgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+			},
+			output: output{
+				wantErr: false,
+			},
+		},
+		{
+			name: "reject update when upgradeName changes",
+			input: input{
+				oldUpgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				newUpgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "different-upgrade",
+					},
+				},
+			},
+			output: output{
+				wantErr: true,
+				errMsg:  "spec.upgradeName is immutable",
+			},
+		},
+		{
+			name: "allow update when namespace is unchanged outside harvester-system",
+			input: input{
+				oldUpgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: "default",
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+				newUpgradeLog: &v1beta1.UpgradeLog{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgradelog",
+						Namespace: "default",
+					},
+					Spec: v1beta1.UpgradeLogSpec{
+						UpgradeName: "test-upgrade",
+					},
+				},
+			},
+			output: output{
+				wantErr: false,
+			},
+		},
+	}
+
+	validator := NewValidator(nil, nil)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator.Update(nil, tc.input.oldUpgradeLog, tc.input.newUpgradeLog)
+			if tc.output.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.output.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newUserRequest(username string) *types.Request {
+	return types.NewRequest(
+		&webhook.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UserInfo: authenticationv1.UserInfo{Username: username},
+			},
+		},
+		&config.Options{HarvesterControllerUsername: harvesterControllerUsername},
+	)
+}
+
+func newControllerRequest() *types.Request {
+	return newUserRequest(harvesterControllerUsername)
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -31,6 +31,7 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/resources/supportbundle"
 	"github.com/harvester/harvester/pkg/webhook/resources/templateversion"
 	"github.com/harvester/harvester/pkg/webhook/resources/upgrade"
+	"github.com/harvester/harvester/pkg/webhook/resources/upgradelog"
 	"github.com/harvester/harvester/pkg/webhook/resources/version"
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachine"
 	"github.com/harvester/harvester/pkg/webhook/resources/virtualmachinebackup"
@@ -133,6 +134,10 @@ func Validation(clients *clients.Clients, options *config.Options, crdExists boo
 				Timeout:   time.Second * 20,
 			},
 			string(bearToken),
+		),
+		upgradelog.NewValidator(
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().UpgradeLog().Cache(),
 		),
 		virtualmachinebackup.NewValidator(
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->


#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
- upgradeLog can be create manually without checking.
- upgradeLog can be update its upgradeName without checking.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Add CEL in crd to ensure upgradeName in upgradeLog is immutable 
- add validator on create upgradeLog to avoid create the upgradeLog either
  - manually
  - duplicate one
  - upgrade not exist.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
#9573

#### Test plan:
<!-- Describe the test plan by steps. -->
- Ensure the upgradelog exist in ` kubectl get validatingwebhookconfiguration harvester-validator -o yaml | grep upgradelogs`
- create the updatelog, ensure it fails

```yaml
cat > ul.yaml << 'EOF'
apiVersion: harvesterhci.io/v1beta1
kind: UpgradeLog
metadata:
  name: hvst-upgrade-sf594-upgradelog
  namespace: harvester-system
spec:
  upgradeName: hvst-upgrade-sf594
EOF
```
#### Additional documentation or context
