### PR TITLE
fix: increase cdi utility pod memory limit

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -171,6 +171,9 @@ cdi:
     config:
       featureGates:
         - HonorWaitForFirstConsumer
+      podResourceRequirements:
+        limits:
+          memory: 2G
     imagePullPolicy: "IfNotPresent"
     infra:
       nodeSelector:


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
The default utility pod memory limit (600M) is too conservative. When priming volumes on a slower storage, the conversion buffer might easily reach the limit, and the pod is oom-killed.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Increase the limit to 2G.


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10056


#### Test plan:
<!-- Describe the test plan by steps. -->

**Check utility pod limit**
* Build an ISO, and check cdiconfig. The `status.defaultPodResourceRequirements.limits.memory` value should be 2G.
```
kubectl get cdiconfig config  -o yaml

...
status:
  defaultPodResourceRequirements:
    limits:
      cpu: 750m
      memory: 2G
```

**Upgrade should work**
* Provision a cluster with an ISO with this change.
* Upgrade the cluster to the next master ISO. The upgrade should not fail at the stage of downloading the upgrade ISO. (See issue https://github.com/harvester/harvester/issues/10056). It's especially easier to repro the issue in a virtualization cluster.



#### Additional documentation or context

Note this is a workaround. To 100% fix the issue https://github.com/harvester/harvester/issues/10056, we'll need to clean stale file in the scratch volume that attached to prime pods.