### PR TITLE
Block registration of new nodes while upgrade is in progress

### DIFF
--- a/pkg/controller/master/node/node_volume_detach_controller.go
+++ b/pkg/controller/master/node/node_volume_detach_controller.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/config"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
@@ -117,7 +116,7 @@ func (c *nodeVolumeDetachController) isInUpgradePreDraining(node *corev1.Node) (
 		return false, err
 	}
 	for _, upgrade := range upgrades {
-		if !harvesterv1.UpgradeCompleted.IsTrue(upgrade) && !harvesterv1.UpgradeCompleted.IsFalse(upgrade) {
+		if util.IsUpgradeInProgress(upgrade) {
 			return true, nil
 		}
 	}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -39,6 +39,7 @@ const (
 	AnnotationLastRefreshTime           = prefix + "/lastRefreshTime"
 	AnnotationMacAddressName            = prefix + "/mac-address"
 	AnnotationEnableCPUAndMemoryHotplug = prefix + "/enableCPUAndMemoryHotplug"
+	AnnotationAllowNodeJoin             = prefix + "/allow-node-join"
 
 	AnnotationSkipRancherLoggingAddonWebhookCheck       = prefix + "/skipRancherLoggingAddonWebhookCheck"
 	AnnotationSkipDeschedulerAddonWebhookCheck          = prefix + "/skipDeschedulerAddonWebhookCheck"

--- a/pkg/util/meta.go
+++ b/pkg/util/meta.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetNamespacedName(obj metav1.Object) string {
+	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+}

--- a/pkg/util/upgrade.go
+++ b/pkg/util/upgrade.go
@@ -22,3 +22,12 @@ func GetUpgradeImage(upgradeImage string, vmImageCache ctlharvesterv1.VirtualMac
 	}
 	return image, nil
 }
+
+// IsUpgradeInProgress reports whether the upgrade is active.
+// An upgrade is considered in progress when UpgradeCompleted is neither True nor False.
+func IsUpgradeInProgress(upgrade *harvesterv1.Upgrade) bool {
+	if upgrade == nil {
+		return false
+	}
+	return !harvesterv1.UpgradeCompleted.IsTrue(upgrade) && !harvesterv1.UpgradeCompleted.IsFalse(upgrade)
+}

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -7,6 +7,7 @@ import (
 
 	ctlbatchv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/batch/v1"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	"github.com/sirupsen/logrus"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -14,7 +15,9 @@ import (
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/virtualmachineinstance"
@@ -22,19 +25,21 @@ import (
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
 
-func NewValidator(nodeCache v1.NodeCache, jobCache ctlbatchv1.JobCache, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) types.Validator {
+func NewValidator(nodeCache v1.NodeCache, jobCache ctlbatchv1.JobCache, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache, upgradeCache ctlharvesterv1.UpgradeCache) types.Validator {
 	return &nodeValidator{
-		nodeCache: nodeCache,
-		jobCache:  jobCache,
-		vmiCache:  vmiCache,
+		nodeCache:    nodeCache,
+		jobCache:     jobCache,
+		vmiCache:     vmiCache,
+		upgradeCache: upgradeCache,
 	}
 }
 
 type nodeValidator struct {
 	types.DefaultValidator
-	nodeCache v1.NodeCache
-	jobCache  ctlbatchv1.JobCache
-	vmiCache  ctlkubevirtv1.VirtualMachineInstanceCache
+	nodeCache    v1.NodeCache
+	jobCache     ctlbatchv1.JobCache
+	vmiCache     ctlkubevirtv1.VirtualMachineInstanceCache
+	upgradeCache ctlharvesterv1.UpgradeCache
 }
 
 func (v *nodeValidator) Resource() types.Resource {
@@ -45,9 +50,66 @@ func (v *nodeValidator) Resource() types.Resource {
 		APIVersion: corev1.SchemeGroupVersion.Version,
 		ObjectType: &corev1.Node{},
 		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Create,
 			admissionregv1.Update,
 		},
 	}
+}
+
+func (v *nodeValidator) Create(req *types.Request, newObj runtime.Object) error {
+	if req.IsFromController() {
+		return nil
+	}
+
+	node := newObj.(*corev1.Node)
+
+	upgrades, err := v.upgradeCache.List(util.HarvesterSystemNamespaceName, labels.NewSelector())
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("failed to list upgrades: %v", err))
+	}
+
+	// Collect all in-progress upgrades first.
+	var inProgressUpgrades []*harvesterv1.Upgrade
+	var inProgressUpgradeNames []string
+	for _, upgrade := range upgrades {
+		if util.IsUpgradeInProgress(upgrade) {
+			inProgressUpgrades = append(inProgressUpgrades, upgrade)
+			inProgressUpgradeNames = append(inProgressUpgradeNames, util.GetNamespacedName(upgrade))
+		}
+	}
+
+	if len(inProgressUpgrades) == 0 {
+		return nil
+	}
+
+	// Log warning if multiple upgrades are running (should not happen in
+	// normal operation).
+	if len(inProgressUpgrades) > 1 {
+		logrus.Warnf("Multiple upgrades in progress: %s", strings.Join(inProgressUpgradeNames, ", "))
+	}
+
+	// Check if ALL in-progress upgrades have the override annotation set to
+	// true. This ensures that when multiple upgrades are running, all must
+	// explicitly allow node join.
+	for _, upgrade := range inProgressUpgrades {
+		value, ok := upgrade.Annotations[util.AnnotationAllowNodeJoin]
+		if !ok {
+			return nodeJoinBlockedByUpgrade(node, upgrade, false)
+		}
+		allow, err := strconv.ParseBool(value)
+		if err != nil {
+			return invalidAllowNodeJoinAnnotation(node, upgrade, value, err)
+		}
+		if !allow {
+			return nodeJoinBlockedByUpgrade(node, upgrade, true)
+		}
+	}
+
+	// All upgrades have the override annotation set to true -> allow with warning.
+	logrus.Warnf("Node %q join allowed during %d active upgrade(s) via override annotation: %s",
+		node.Name, len(inProgressUpgrades), strings.Join(inProgressUpgradeNames, ", "))
+
+	return nil
 }
 
 func (v *nodeValidator) Update(_ *types.Request, oldObj runtime.Object, newObj runtime.Object) error {
@@ -260,4 +322,45 @@ func getCPUManagerRunningJobNamesOnNodes(jobCache ctlbatchv1.JobCache, nodeNames
 		jobNames[i] = job.Name
 	}
 	return jobNames, nil
+}
+
+// invalidAllowNodeJoinAnnotation returns a validation error to indicate that
+// a node join is blocked because the upgrade in progress has an invalid value
+// for the "allow-node-join" annotation.
+func invalidAllowNodeJoinAnnotation(node *corev1.Node, upgrade *harvesterv1.Upgrade, value string, err error) error {
+	upgradeName := util.GetNamespacedName(upgrade)
+	logrus.Warnf("Node %q join blocked: annotation %s has invalid boolean value %q on upgrade %q: %v",
+		node.Name, util.AnnotationAllowNodeJoin, value, upgradeName, err)
+	return werror.NewConflict(fmt.Sprintf(
+		"cannot add node %q to the cluster because the upgrade %q is currently in progress "+
+			"and has an invalid value %q for annotation %s. "+
+			"If you must add this node now, run: %s",
+		node.Name, upgradeName, value, util.AnnotationAllowNodeJoin, getAllowNodeJoinAnnotationCommand(upgrade, false)))
+}
+
+// nodeJoinBlockedByUpgrade returns a validation error to indicate that a node
+// join is blocked because an upgrade is in progress.
+func nodeJoinBlockedByUpgrade(node *corev1.Node, upgrade *harvesterv1.Upgrade, overwrite bool) error {
+	upgradeName := util.GetNamespacedName(upgrade)
+	msg := fmt.Sprintf("Blocked node %q join while upgrade %q is in progress", node.Name, upgradeName)
+	if overwrite {
+		msg += fmt.Sprintf(" (annotation explicitly set to %q)", strconv.FormatBool(false))
+	}
+	logrus.Info(msg)
+	return werror.NewConflict(fmt.Sprintf(
+		"cannot add node %q to the cluster because the upgrade %q is currently in progress. "+
+			"Adding nodes during an upgrade can cause unexpected behavior and is not recommended. "+
+			"If you must add this node now, run: %s",
+		node.Name, upgradeName, getAllowNodeJoinAnnotationCommand(upgrade, overwrite)))
+}
+
+// getAllowNodeJoinAnnotationCommand returns the kubectl command to annotate an
+// upgrade resource to allow node joining.
+func getAllowNodeJoinAnnotationCommand(upgrade *harvesterv1.Upgrade, overwrite bool) string {
+	command := fmt.Sprintf("kubectl annotate upgrade -n %s %s %s=true",
+		upgrade.Namespace, upgrade.Name, util.AnnotationAllowNodeJoin)
+	if overwrite {
+		command += " --overwrite"
+	}
+	return command
 }

--- a/pkg/webhook/resources/node/validator_test.go
+++ b/pkg/webhook/resources/node/validator_test.go
@@ -1,20 +1,32 @@
 package node
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/rancher/wrangler/v3/pkg/webhook"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	batchv1 "k8s.io/api/batch/v1"
 
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
+	"github.com/harvester/harvester/pkg/webhook/types"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/harvester/harvester/pkg/webhook/config"
 )
 
 func TestValidateCordonAndMaintenanceMode(t *testing.T) {
@@ -756,4 +768,530 @@ func Test_validateWitnessRoleChange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
+	type testCase struct {
+		name          string
+		node          *corev1.Node
+		upgrades      []*harvesterv1.Upgrade
+		isController  bool
+		expectedError bool
+		errorContains string
+	}
+
+	testCases := []testCase{
+		{
+			name: "allow node creation when no upgrade is active",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades:      []*harvesterv1.Upgrade{},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when upgrade is completed (True)",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "True",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when upgrade failed (False)",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "False",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "block node creation when upgrade is active (Unknown status)",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: true,
+			errorContains: "because the upgrade \"harvester-system/test-upgrade\" is currently in progress.",
+		},
+		{
+			name: "allow node creation when upgrade is active but override annotation is set",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "true",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when override annotation is set to TRUE (uppercase)",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "TRUE",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when override annotation is set to 1",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "1",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when override annotation is set to t",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "t",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "block node creation when override annotation is set to false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "false",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: true,
+			errorContains: "because the upgrade \"harvester-system/test-upgrade\" is currently in progress.",
+		},
+		{
+			name: "block node creation when override annotation has invalid value",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "invalid",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: true,
+			errorContains: "and has an invalid value \"invalid\" for annotation",
+		},
+		{
+			name: "allow node creation from controller during active upgrade",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  true,
+			expectedError: false,
+		},
+		{
+			name: "block node creation when multiple upgrades active and not all have override",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "upgrade-1",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "true",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "upgrade-2",
+						Namespace: util.HarvesterSystemNamespaceName,
+						// No annotation - should block
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: true,
+			errorContains: "because the upgrade \"harvester-system/upgrade-2\" is currently in progress.",
+		},
+		{
+			name: "allow node creation when multiple upgrades active and all have override",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "upgrade-1",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "true",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "upgrade-2",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "1",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "block node creation when multiple upgrades and one has false override",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "upgrade-1",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "true",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "upgrade-2",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "false",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: true,
+			errorContains: "because the upgrade \"harvester-system/upgrade-2\" is currently in progress.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+
+			for _, upgrade := range tc.upgrades {
+				err := clientset.Tracker().Add(upgrade)
+				assert.Nil(t, err)
+			}
+
+			validator := &nodeValidator{
+				upgradeCache: fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
+			}
+
+			var req *types.Request
+			if tc.isController {
+				req = types.NewRequest(
+					&webhook.Request{
+						AdmissionRequest: admissionv1.AdmissionRequest{
+							UserInfo: authenticationv1.UserInfo{
+								Username: "system:serviceaccount:harvester-system:harvester",
+							},
+						},
+					},
+					&config.Options{
+						HarvesterControllerUsername: "system:serviceaccount:harvester-system:harvester",
+					},
+				)
+			} else {
+				req = &types.Request{
+					Request: &webhook.Request{},
+				}
+			}
+
+			err := validator.Create(req, tc.node)
+
+			if tc.expectedError {
+				assert.NotNil(t, err, "expected error but got nil")
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				var admitErr werror.AdmitError
+				require.ErrorAs(t, err, &admitErr)
+				assert.Equal(t, metav1.StatusReasonConflict, admitErr.AsResult().Reason)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateNodeCreateDuringUpgradeCacheError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	// Simulate an error when listing upgrades.
+	clientset.PrependReactor("list", "upgrades", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("simulated cache error")
+	})
+
+	validator := &nodeValidator{
+		upgradeCache: fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "new-node",
+		},
+	}
+
+	req := &types.Request{
+		Request: &webhook.Request{},
+	}
+
+	err := validator.Create(req, node)
+
+	assert.Error(t, err, "expected error when upgrade cache fails")
+	assert.Contains(t, err.Error(), "failed to list upgrades")
+	assert.Contains(t, err.Error(), "simulated cache error")
+
+	var admitErr werror.AdmitError
+	require.ErrorAs(t, err, &admitErr)
+	assert.Equal(t, metav1.StatusReasonInternalError, admitErr.AsResult().Reason)
 }

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -68,7 +68,8 @@ func Validation(clients *clients.Clients, options *config.Options, crdExists boo
 		node.NewValidator(
 			clients.Core.Node().Cache(),
 			clients.Batch.Job().Cache(),
-			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache()),
+			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
+			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache()),
 		persistentvolumeclaim.NewValidator(
 			clients.Core.PersistentVolumeClaim().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),


### PR DESCRIPTION
#### Problem:
Harvester should block addition of new nodes while an upgrade is in progress.
This can have unwanted side effects if a user adds a node during the upgrade process.

#### Solution:
Add new `Node` validator to prevent node registration during upgrade.

The block can be temporarily bypassed by adding the annotation `harvesterhci.io/allow-node-join=true` to the `upgrade` CR.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7601

#### Test plan:
**Case 1**
- Create an fake upgrade:
```
cat <<EOF | kubectl create -f -
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  name: test-upgrade
  namespace: harvester-system
  labels:
    harvesterhci.io/latestUpgrade: "true"
spec:
  version: "v1.9.1"
  image: "rancher/harvester-upgrade:v1.9.1"
EOF
```
- Try to create a new node:
```
kubectl apply -f - <<EOF
apiVersion: v1
kind: Node
metadata:
  name: test-node
spec:
  podCIDR: 192.168.0.33/32
EOF
```
- The creation should be blocked.
```
# kubectl apply -f - <<EOF
> apiVersion: v1
> kind: Node
> metadata:
>   name: test-node
> spec:
>   podCIDR: 192.168.0.33/32
> EOF
Error from server (Conflict): error when creating "STDIN": admission webhook "validator.harvesterhci.io" denied the request: cannot add node "test-node" to the cluster because the upgrade "harvester-system/test-upgrade" is currently in progress. Adding nodes during an upgrade can cause unexpected behavior and is not recommended. If you must add this node now, run: kubectl annotate upgrade -n harvester-system test-upgrade harvesterhci.io/allow-node-join=true
```

**Case 2**
- Add annotation `harvesterhci.io/allow-node-join`:
```
kubectl annotate upgrade.harvesterhci.io -n harvester-system test-upgrade harvesterhci.io/allow-node-join=true
```
- Try to create a new node:
```
kubectl apply -f - <<EOF
apiVersion: v1
kind: Node
metadata:
  name: test-node
spec:
  podCIDR: 192.168.0.33/32
EOF
```
- The creation should be successful.
```
# kubectl apply -f - <<EOF
apiVersion: v1
kind: Node
metadata:
  name: test-node
spec:
  podCIDR: 192.168.0.33/32
EOF
node/test-node created
```
<img width="1312" height="661" alt="Bildschirmfoto vom 2026-06-16 15-30-40" src="https://github.com/user-attachments/assets/aefb7a55-1ed1-4df7-8a90-2b4163b7bd5b" />

**Cleanup**
```
$ kubectl delete node test-node
$ kubectl delete upgrade.harvesterhci.io test-upgrade -n harvester-system
```