### PR TITLE
fix(controller): skip node taint cleanup during UpgradePlan upgrades

### DIFF
--- a/pkg/controller/master/node/node_down_controller.go
+++ b/pkg/controller/master/node/node_down_controller.go
@@ -10,9 +10,14 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/dynamic"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"github.com/harvester/harvester/pkg/config"
@@ -24,7 +29,24 @@ import (
 
 const (
 	nodeDownControllerName = "node-down-controller"
+
+	// Terminal phase strings for the upgrade-toolkit (Upgrade V2) UpgradePlan
+	// CRD. Mirrored from
+	// https://github.com/harvester/upgrade-toolkit/blob/main/api/v1beta1/upgradeplan_types.go
+	// (UpgradePlanPhaseSucceeded / UpgradePlanPhaseFailed). These are part of
+	// the public CRD contract; keep in sync if upgrade-toolkit changes them.
+	upgradePlanPhaseSucceeded = "Succeeded"
+	upgradePlanPhaseFailed    = "Failed"
 )
+
+// upgradePlanGVR is the GVR for upgrade-toolkit's cluster-scoped UpgradePlan
+// resource. Used via the dynamic client so harvester does not need to import
+// upgrade-toolkit (which would create a circular module dependency).
+var upgradePlanGVR = schema.GroupVersionResource{
+	Group:    "management.harvesterhci.io",
+	Version:  "v1beta1",
+	Resource: "upgradeplans",
+}
 
 // kubevirtDrainTaint is used to trigger migration
 var kubevirtDrainTaint = corev1.Taint{
@@ -50,17 +72,23 @@ type nodeDownHandler struct {
 	nodes     ctlcorev1.NodeController
 	nodeCache ctlcorev1.NodeCache
 
-	upgrades ctlharvesterv1.UpgradeClient
+	upgrades      ctlharvesterv1.UpgradeClient
+	dynamicClient dynamic.Interface
 }
 
 // DownRegister registers a controller to delete VMI when node is down
 func DownRegister(ctx context.Context, management *config.Management, _ config.Options) error {
 	nodes := management.CoreFactory.Core().V1().Node()
 	upgrades := management.HarvesterFactory.Harvesterhci().V1beta1().Upgrade()
+	dynamicClient, err := dynamic.NewForConfig(management.RestConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client for node-down controller: %w", err)
+	}
 	nodeDownHandler := &nodeDownHandler{
-		nodes:     nodes,
-		nodeCache: nodes.Cache(),
-		upgrades:  upgrades,
+		nodes:         nodes,
+		nodeCache:     nodes.Cache(),
+		upgrades:      upgrades,
+		dynamicClient: dynamicClient,
 	}
 
 	nodes.OnChange(ctx, nodeDownControllerName, nodeDownHandler.OnNodeChanged)
@@ -94,7 +122,7 @@ func (h *nodeDownHandler) checkNodeReady(node *corev1.Node) error {
 		return fmt.Errorf("can't find %s condition in node %s", corev1.NodeReady, node.Name)
 	}
 
-	if isOnUpgrade(h.upgrades) {
+	if isOnUpgrade(h.upgrades, h.dynamicClient) {
 		logrus.Debugf("Node %s is on upgrade, skipping checking node readiness", node.Name)
 		// skip processing during upgrade
 		return nil
@@ -301,7 +329,16 @@ func getNodeTaint(taints []corev1.Taint, taintKey string) *corev1.Taint {
 	return taint
 }
 
-func isOnUpgrade(upgrades ctlharvesterv1.UpgradeClient) bool {
+func isOnUpgrade(upgrades ctlharvesterv1.UpgradeClient, dynamicClient dynamic.Interface) bool {
+	if isOnUpgradeV1(upgrades) {
+		return true
+	}
+	return isOnUpgradeV2(dynamicClient)
+}
+
+// isOnUpgradeV1 checks for in-progress harvesterhci.io/v1beta1 Upgrade CRs
+// created by the legacy (in-tree) upgrade controller.
+func isOnUpgradeV1(upgrades ctlharvesterv1.UpgradeClient) bool {
 	req, err := labels.NewRequirement(util.LabelHarvesterUpgradeState, selection.NotIn, []string{upgrade.StateSucceeded, upgrade.StateFailed})
 	if err != nil {
 		logrus.Warnf("Failed to create label requirement for %s: %v", util.LabelHarvesterUpgradeState, err)
@@ -317,6 +354,42 @@ func isOnUpgrade(upgrades ctlharvesterv1.UpgradeClient) bool {
 	}
 	if len(upgradesItems.Items) > 0 {
 		logrus.Debugf("There are ongoing upgrades: %v.", upgradesItems.Items[0].Name)
+		return true
+	}
+	return false
+}
+
+// isOnUpgradeV2 checks for in-progress management.harvesterhci.io/v1beta1
+// UpgradePlan CRs managed by upgrade-toolkit. An UpgradePlan is considered
+// in-progress when its status.currentPhase is anything other than Succeeded
+// or Failed (including the empty string, which means the plan has just been
+// created and the controller has not yet set a phase).
+//
+// The CRD may not be installed on every cluster (e.g. clusters not using
+// upgrade-toolkit). NotFound / NoMatchError responses are treated as "no
+// active upgrade" so the controller continues to function as before. Any
+// other transient error also falls through to false to match the behavior of
+// isOnUpgradeV1.
+func isOnUpgradeV2(dynamicClient dynamic.Interface) bool {
+	if dynamicClient == nil {
+		return false
+	}
+	upgradePlans, err := dynamicClient.Resource(upgradePlanGVR).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			logrus.Debugf("UpgradePlan CRD not present; skipping Upgrade V2 check: %v", err)
+			return false
+		}
+		logrus.Warnf("Failed to list UpgradePlans: %v", err)
+		return false
+	}
+	for i := range upgradePlans.Items {
+		plan := &upgradePlans.Items[i]
+		phase, _, _ := unstructured.NestedString(plan.Object, "status", "currentPhase")
+		if phase == upgradePlanPhaseSucceeded || phase == upgradePlanPhaseFailed {
+			continue
+		}
+		logrus.Debugf("There are ongoing UpgradePlans: %s (currentPhase=%q).", plan.GetName(), phase)
 		return true
 	}
 	return false

--- a/pkg/controller/master/node/node_down_controller_test.go
+++ b/pkg/controller/master/node/node_down_controller_test.go
@@ -1,0 +1,165 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newUpgradePlan returns a minimal unstructured UpgradePlan with the given
+// name and status.currentPhase. An empty phase mimics a freshly created plan
+// whose status has not yet been reconciled.
+func newUpgradePlan(name, phase string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   upgradePlanGVR.Group,
+		Version: upgradePlanGVR.Version,
+		Kind:    "UpgradePlan",
+	})
+	u.SetName(name)
+	if phase != "" {
+		_ = unstructured.SetNestedField(u.Object, phase, "status", "currentPhase")
+	}
+	return u
+}
+
+func newFakeDynamicClientWithPlans(plans ...*unstructured.Unstructured) *fakedynamic.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		upgradePlanGVR: "UpgradePlanList",
+	}
+	objs := make([]runtime.Object, 0, len(plans))
+	for _, p := range plans {
+		objs = append(objs, p)
+	}
+	return fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
+}
+
+func TestIsOnUpgradeV2(t *testing.T) {
+	tests := []struct {
+		name   string
+		client func() dynamic.Interface
+		want   bool
+	}{
+		{
+			name:   "nil dynamic client returns false",
+			client: func() dynamic.Interface { return nil },
+			want:   false,
+		},
+		{
+			name:   "no UpgradePlan exists returns false",
+			client: func() dynamic.Interface { return newFakeDynamicClientWithPlans() },
+			want:   false,
+		},
+		{
+			name: "UpgradePlan in non-terminal phase returns true",
+			client: func() dynamic.Interface {
+				return newFakeDynamicClientWithPlans(newUpgradePlan("test-plan", "NodeUpgrading"))
+			},
+			want: true,
+		},
+		{
+			name: "UpgradePlan with empty currentPhase (just created) returns true",
+			client: func() dynamic.Interface {
+				return newFakeDynamicClientWithPlans(newUpgradePlan("test-plan", ""))
+			},
+			want: true,
+		},
+		{
+			name: "UpgradePlan with currentPhase=Succeeded returns false",
+			client: func() dynamic.Interface {
+				return newFakeDynamicClientWithPlans(newUpgradePlan("test-plan", upgradePlanPhaseSucceeded))
+			},
+			want: false,
+		},
+		{
+			name: "UpgradePlan with currentPhase=Failed returns false",
+			client: func() dynamic.Interface {
+				return newFakeDynamicClientWithPlans(newUpgradePlan("test-plan", upgradePlanPhaseFailed))
+			},
+			want: false,
+		},
+		{
+			name: "mix of terminal and non-terminal UpgradePlans returns true",
+			client: func() dynamic.Interface {
+				return newFakeDynamicClientWithPlans(
+					newUpgradePlan("old-plan", upgradePlanPhaseSucceeded),
+					newUpgradePlan("new-plan", "ImagePreloading"),
+				)
+			},
+			want: true,
+		},
+		{
+			name: "all UpgradePlans terminal returns false",
+			client: func() dynamic.Interface {
+				return newFakeDynamicClientWithPlans(
+					newUpgradePlan("a", upgradePlanPhaseSucceeded),
+					newUpgradePlan("b", upgradePlanPhaseFailed),
+				)
+			},
+			want: false,
+		},
+		{
+			name: "UpgradePlan CRD not registered (NoKindMatchError) returns false",
+			client: func() dynamic.Interface {
+				c := newFakeDynamicClientWithPlans()
+				c.PrependReactor("list", "upgradeplans", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, &meta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: upgradePlanGVR.Group, Kind: "UpgradePlan"},
+						SearchedVersions: []string{upgradePlanGVR.Version},
+					}
+				})
+				return c
+			},
+			want: false,
+		},
+		{
+			name: "UpgradePlan list returns NotFound returns false",
+			client: func() dynamic.Interface {
+				c := newFakeDynamicClientWithPlans()
+				c.PrependReactor("list", "upgradeplans", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewNotFound(upgradePlanGVR.GroupResource(), "")
+				})
+				return c
+			},
+			want: false,
+		},
+		{
+			name: "UpgradePlan list returns transient error returns false (fail-open)",
+			client: func() dynamic.Interface {
+				c := newFakeDynamicClientWithPlans()
+				c.PrependReactor("list", "upgradeplans", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewServiceUnavailable("temporary glitch")
+				})
+				return c
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isOnUpgradeV2(tt.client())
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIsOnUpgradeV2DoesNotPanicOnEmptyList ensures the fake's required
+// list-kind registration is wired correctly and List succeeds even when no
+// UpgradePlans exist.
+func TestIsOnUpgradeV2DoesNotPanicOnEmptyList(t *testing.T) {
+	c := newFakeDynamicClientWithPlans()
+	assert.NotPanics(t, func() {
+		_, err := c.Resource(upgradePlanGVR).List(t.Context(), metav1.ListOptions{})
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION


<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

During the node upgrade phase, Harvester's node controller will temporarily skip the logic to remove the taint from the node that is under upgrade. The node controller checks for the Upgrade CR to determine whether there is any upgrade ongoing. However, that's a V1 stuff; Upgrade V2 uses another CRD, UpgradePlan. As a result, people using Upgrade V2 to upgrade their clusters will run into issues—the node controller still removes the taint.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Extend isOnUpgrade() to also detect active management.harvesterhci.io UpgradePlan resources via a dynamic client. Previously only the legacy harvesterhci.io Upgrade CRD was checked, so the node-down controller could wipe the kubevirt.io/drain taint placed by upgrade-toolkit's pre-drain step and stall VM evacuation.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#10714

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Prepare a 3-node cluster in v1.8.0
2. Install and enable the harvester-upgrade-manager add-on
3. Trigger upgrade to master-head
4. During the node upgrade phase, the node under upgrade should have the kubevirt taint
5. The upgrade should complete successfully eventually

#### Additional documentation or context
