### PR TITLE
build: always pull referenced images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ MK_ADDONS_IMAGE           := harvester-addons:$(MK_REPO_ID)
 MK_ISO_BUILDER_IMAGE      := harvester-iso-builder:$(MK_REPO_ID)
 MK_TEST_INTEGRATION_IMAGE := harvester-test-integration:$(MK_REPO_ID)
 MK_DOCKER_PROGRESS        ?= plain
+MK_DOCKER_PULL            ?= --pull
 
 # Legacy dapper env variables
 CODECOV_TOKEN             ?=
@@ -52,7 +53,7 @@ PUSH                      ?=
 DRONE_BRANCH              ?=
 DRONE_TAG                 ?=
 
-export MK_DOCKER_PROGRESS MK_REPO_ID MK_ADDONS_IMAGE MK_ISO_BUILDER_IMAGE
+export MK_DOCKER_PROGRESS MK_DOCKER_PULL MK_REPO_ID MK_ADDONS_IMAGE MK_ISO_BUILDER_IMAGE
 export HARVESTER_UI_VERSION HARVESTER_UI_PLUGIN_BUNDLED_VERSION
 export HARVESTER_INSTALLER_REPO HARVESTER_INSTALLER_REF RKE2_IMAGE_REPO USE_LOCAL_IMAGES REPO PUSH DRONE_BRANCH DRONE_TAG
 export CODECOV_TOKEN HARVESTER_ADDONS_VERSION
@@ -60,7 +61,7 @@ export CODECOV_TOKEN HARVESTER_ADDONS_VERSION
 MK_HOST_ARCH := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 export MK_HOST_ARCH
 
-DOCKER_BUILD = docker build \
+DOCKER_BUILD = docker build $(MK_DOCKER_PULL) \
 	--progress=$(MK_DOCKER_PROGRESS) \
 	--build-arg MK_REPO_ID \
 	--build-arg MK_HOST_ARCH \


### PR DESCRIPTION

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Image like `golang:1.26-bookworm` might be updated in the registry when its patch version changes. Without the --pull option, docker might build the code with cached images.

For example, the change in https://github.com/harvester/harvester/pull/10735 might not be picked up because cached image is used.

Note that this mostly affects developer local builds or some self-hosted runners. CI runners in the repo are always started with a clean state.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add --pull option to docker build commands. Developers can disable it by overriding the `MK_DOCKER_PULL` option.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
