### PR TITLE
webhook mutation for supporting static ip allocation via kubeovn

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,5 +1,7 @@
 package util
 
+import "fmt"
+
 const (
 	prefix                              = "harvesterhci.io"
 	RemovedPVCsAnnotationKey            = prefix + "/removedPersistentVolumeClaims"
@@ -225,6 +227,7 @@ const (
 	MaintainModeStrategyDefault                        = MaintainModeStrategyMigrate
 	HarvesterReportedConditionKey                      = prefix + "/condition"
 	HarvesterReportedConditionMessageKey               = prefix + "/condition-message"
+	ManagedTapBindingName                              = "managedtap"
 )
 
 var (
@@ -242,6 +245,8 @@ var (
 	}
 
 	DefaultHarvesterNamespaceWhiteList = []string{"calico-apiserver", "calico-system", "cattle-alerting", "cattle-csp-adapter-system", "cattle-elemental-system", "cattle-epinio-system", "cattle-externalip-system", "cattle-fleet-local-system", "cattle-fleet-system", "cattle-gatekeeper-system", "cattle-global-data", "cattle-global-nt", "cattle-impersonation-system", "cattle-istio", "cattle-istio-system", "cattle-logging", "cattle-logging-system", "cattle-monitoring-system", "cattle-neuvector-system", "cattle-prometheus", "cattle-provisioning-capi-system", "cattle-resources-system", "cattle-sriov-system", "cattle-system", "cattle-ui-plugin-system", "cattle-windows-gmsa-system", "cert-manager", "cis-operator-system", "fleet-default", "ingress-nginx", "istio-system", "kube-node-lease", "kube-public", "kube-system", "longhorn-system", "rancher-alerting-drivers", "security-scan", "tigera-operator", "harvester-system", "harvester-public", "rancher-vcluster", "cattle-dashboards", "fleet-local", "local", "forklift"}
+
+	StaticIPAnnotationKeyPrefix = fmt.Sprintf("static-ip.%s", prefix)
 )
 
 const (

--- a/pkg/webhook/resources/virtualmachineinstance/mutator.go
+++ b/pkg/webhook/resources/virtualmachineinstance/mutator.go
@@ -5,13 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
 
+	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -19,15 +23,18 @@ import (
 
 func NewMutator(
 	vm ctlkubevirtv1.VirtualMachineCache,
+	nadCache ctlcniv1.NetworkAttachmentDefinitionCache,
 ) types.Mutator {
 	return &vmiMutator{
-		vm: vm,
+		vm:       vm,
+		nadCache: nadCache,
 	}
 }
 
 type vmiMutator struct {
 	types.DefaultMutator
-	vm ctlkubevirtv1.VirtualMachineCache
+	vm       ctlkubevirtv1.VirtualMachineCache
+	nadCache ctlcniv1.NetworkAttachmentDefinitionCache
 }
 
 func (m *vmiMutator) Resource() types.Resource {
@@ -69,6 +76,12 @@ func (m *vmiMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patc
 		patchOps = append(patchOps, devicesPatch...)
 	}
 
+	// generate static ip annotation patch for kubeovn if applicable
+	kubeOVNPatch, err := generateKubeOVNStaticIPPatch(vm, vmi, m.nadCache)
+	if err != nil {
+		return nil, fmt.Errorf("error generating kubeovn static ip patch for vmi %s/%s: %w", vmi.Namespace, vmi.Name, err)
+	}
+	patchOps = append(patchOps, kubeOVNPatch...)
 	return patchOps, nil
 }
 
@@ -127,4 +140,96 @@ func patchDeviceName(vmi *kubevirtv1.VirtualMachineInstance) (types.PatchOps, er
 		}
 	}
 	return patchOps, nil
+}
+
+func generateKubeOVNStaticIPPatch(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance, nadCache ctlcniv1.NetworkAttachmentDefinitionCache) (types.PatchOps, error) {
+	patchOps := types.PatchOps{}
+	extraAnnotations, err := generateKubeOVNAnnotations(vm, vmi, nadCache)
+	if err != nil {
+		return nil, err
+	}
+	// if no field is present for annotations in metadata and we have annotations to add, we need to add the annotations field before adding any annotations
+	if vmi.ObjectMeta.Annotations == nil && len(extraAnnotations) > 0 {
+		patchOps = append(patchOps, `{"op": "add", "path": "/metadata/annotations", "value": {}}`)
+	}
+
+	for key, val := range extraAnnotations {
+		patchOps = append(patchOps, fmt.Sprintf(`{"op": "add", "path": "/metadata/annotations/%s", "value": "%s"}`, patch.EscapeJSONPointer(key), val))
+	}
+	return patchOps, nil
+}
+
+func generateKubeOVNAnnotations(vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance, nadCache ctlcniv1.NetworkAttachmentDefinitionCache) (map[string]string, error) {
+	extraAnnotations := make(map[string]string)
+	// generate a map of annotation keys for each network in vmi.Spec.Networks for kubeovn
+	// for kubeovn to allocation static ip, each vmi object will need annotations of the form
+	// vm-network.default.ovn.net1.kubernetes.io/logical_switch: vm-network
+	// vm-network.default.kubernetes.io/ip_address.net1: 192.168.0.12
+	// this needs to be repeated for each network interface that may be needing a static address
+
+	// kubeovnNetworkMap will contain the prefix value for both switch and static ip annotation
+	// eg
+	// networks:
+	// - multus:
+	//     networkName: default/vm-network
+	//   name: default
+	// gets mapped to
+	// default: vm-network.default in the kubeovnNetworkMap and used to generate switch and static ip annotations
+	kubeovnNetworkMap := make(map[string]string)
+	for _, network := range vmi.Spec.Networks {
+		if network.Multus == nil {
+			continue
+
+		}
+		elements := strings.Split(network.Multus.NetworkName, "/")
+		var networkName, networkNamespace string
+		if len(elements) == 1 {
+			// no namespace provided for multus net-attach-def, so we use the namespace of vmi object
+			networkName = elements[0]
+			networkNamespace = vmi.Namespace
+		} else if len(elements) == 2 {
+			networkNamespace = elements[0]
+			networkName = elements[1]
+		} else {
+			return nil, fmt.Errorf("invalid network name %s for network interface %s in vmi %s/%s", network.Multus.NetworkName, network.Name, vmi.Namespace, vmi.Name)
+		}
+		// verify if vm network is overlay, if not skip it as we will not be generating annotations for non-overlay network
+		nad, err := nadCache.Get(networkNamespace, networkName)
+		if err != nil {
+			return nil, fmt.Errorf("error getting nad %s/%s for vmi %s/%s: %w", networkNamespace, networkName, vmi.Namespace, vmi.Name, err)
+		}
+		if !util.IsNetworkTypeOverlay(nad) {
+			// net-attach-def is not of type overlay, skipping as this cannot be used for annotation generation
+			continue
+		}
+
+		kubeovnNetworkMap[network.Name] = fmt.Sprintf("%s.%s", networkName, networkNamespace)
+	}
+
+	hashedNetworkNameMap := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
+	// for each interface in the vmi, check if a static ip allocation annotation exists
+	// on vm object and use the same to generate kubeovn annotations for each interface
+	for _, interfaceObj := range vmi.Spec.Domain.Devices.Interfaces {
+		// check if interface is even using overlay network as kubeovnNetworkMap only contains networks of type overlay, if interface is not using overlay network, skip it as we will not be generating annotations for non-overlay network
+		if _, ok := kubeovnNetworkMap[interfaceObj.Name]; !ok {
+			continue
+		}
+		// check static ip annotations, else skip and move to next interface as static ip annotation is required for generating kubeovn annotations
+		staticIPAnnotationKey := fmt.Sprintf("%s/%s", util.StaticIPAnnotationKeyPrefix, interfaceObj.Name)
+		val, ok := vm.Annotations[staticIPAnnotationKey]
+		// no annotation found, nothing needs to be done for this interface
+		if !ok {
+			continue
+		}
+		// annotation found, generate ip annotation string
+		podIfName := hashedNetworkNameMap[interfaceObj.Name]
+		kubeovnPrefix := kubeovnNetworkMap[interfaceObj.Name]
+		ipAnnotationKey := fmt.Sprintf("%s.kubernetes.io/ip_address.%s", kubeovnPrefix, podIfName)
+		switchName := strings.Split(kubeovnPrefix, ".")[0]
+		switchAnnotationKey := fmt.Sprintf("%s.ovn.%s.kubernetes.io/logical_switch", kubeovnPrefix, podIfName)
+		extraAnnotations[ipAnnotationKey] = val
+		extraAnnotations[switchAnnotationKey] = switchName
+
+	}
+	return extraAnnotations, nil
 }

--- a/pkg/webhook/resources/virtualmachineinstance/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachineinstance/mutator_test.go
@@ -6,14 +6,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rancher/wrangler/v3/pkg/patch"
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubevirtv1 "kubevirt.io/api/core/v1"
-
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 	"github.com/harvester/harvester/pkg/webhook/types"
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/rancher/wrangler/v3/pkg/patch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 func TestPatchMacAddress(t *testing.T) {
@@ -226,7 +229,7 @@ func TestPatchMacAddress(t *testing.T) {
 
 	for _, tc := range tests {
 		clientSet := fake.NewSimpleClientset()
-		mutator := NewMutator(fakeclients.VirtualMachineCache(clientSet.KubevirtV1().VirtualMachines))
+		mutator := NewMutator(fakeclients.VirtualMachineCache(clientSet.KubevirtV1().VirtualMachines), nil)
 		patchOps, err := mutator.(*vmiMutator).patchMacAddress(tc.vm, tc.vmi)
 		assert.Nil(t, err, tc.name)
 		assert.Equal(t, tc.patches, patchOps, tc.name)
@@ -249,7 +252,7 @@ func TestCreateWithoutVM(t *testing.T) {
 	}
 	req := &types.Request{}
 	clientSet := fake.NewSimpleClientset()
-	mutator := NewMutator(fakeclients.VirtualMachineCache(clientSet.KubevirtV1().VirtualMachines))
+	mutator := NewMutator(fakeclients.VirtualMachineCache(clientSet.KubevirtV1().VirtualMachines), nil)
 	patchOps, err := mutator.Create(req, vmi)
 	assert.Nil(t, err)
 	assert.Nil(t, patchOps)
@@ -799,4 +802,347 @@ func generateVMI(input []byte) (*kubevirtv1.VirtualMachineInstance, error) {
 	vmi := &kubevirtv1.VirtualMachineInstance{}
 	err := json.Unmarshal(input, vmi)
 	return vmi, err
+}
+
+func Test_kubeovnStaticIPAnnotations(t *testing.T) {
+	workloadNetwork := &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workload",
+			Namespace: "default",
+			Labels: map[string]string{
+				util.KeyNetworkType: util.OverlayNetwork,
+			},
+		},
+	}
+
+	workloadNetwork2 := &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workload2",
+			Namespace: "default",
+			Labels: map[string]string{
+				util.KeyNetworkType: util.OverlayNetwork,
+			},
+		},
+	}
+
+	vmNetwork := &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm-network",
+			Namespace: "default",
+		},
+	}
+
+	clientSet := fake.NewSimpleClientset()
+	nadGvr := schema.GroupVersionResource{
+		Group:    "k8s.cni.cncf.io",
+		Version:  "v1",
+		Resource: "network-attachment-definitions",
+	}
+	if err := clientSet.Tracker().Create(nadGvr, workloadNetwork, workloadNetwork.Namespace); err != nil {
+		t.Fatalf("failed to add net1 %+v", workloadNetwork)
+	}
+	if err := clientSet.Tracker().Create(nadGvr, workloadNetwork2, workloadNetwork2.Namespace); err != nil {
+		t.Fatalf("failed to add net2 %+v", workloadNetwork2)
+	}
+	if err := clientSet.Tracker().Create(nadGvr, vmNetwork, vmNetwork.Namespace); err != nil {
+		t.Fatalf("failed to add vmNetwork %+v", vmNetwork)
+	}
+
+	nadCache := fakeclients.NetworkAttachmentDefinitionCache(clientSet.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
+
+	var testCases = []struct {
+		Name          string
+		VMI           *kubevirtv1.VirtualMachineInstance
+		VM            *kubevirtv1.VirtualMachine
+		ErrorExpected bool
+		PatchExpected bool
+		PatchLength   int
+	}{
+		{
+			Name: "static ip annotation with single interface and overlay network",
+			VM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vm",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"static-ip.harvesterhci.io/default": "192.168.0.12",
+					},
+				},
+			},
+			VMI: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vmi",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+									Binding: &kubevirtv1.PluginBinding{
+										Name: util.ManagedTapBindingName,
+									},
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "default",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/workload",
+								}},
+						},
+					},
+				},
+			},
+			ErrorExpected: false,
+			PatchExpected: true,
+			PatchLength:   3, // 1 for annotation itself and 2 for static ip patch for interface
+		},
+		{
+			Name: "static ip annotation with multiple interface and overlay network",
+			VM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vm",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"static-ip.harvesterhci.io/default": "192.168.0.12",
+						"static-ip.harvesterhci.io/nic-1":   "192.168.0.13",
+					},
+				},
+			},
+			VMI: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vmi",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+									Binding: &kubevirtv1.PluginBinding{
+										Name: util.ManagedTapBindingName,
+									},
+								},
+								{
+									Name: "nic-1",
+									Binding: &kubevirtv1.PluginBinding{
+										Name: util.ManagedTapBindingName,
+									},
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "default",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/workload",
+								}},
+						},
+						{
+							Name: "nic-1",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/workload",
+								}},
+						},
+					},
+				},
+			},
+			ErrorExpected: false,
+			PatchExpected: true,
+			PatchLength:   5, // 1 for annotation itself and 2 for static ip patch for each interface
+		},
+		{
+			Name: "static ip annotation with multiple interface from different overlay networks",
+			VM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vm",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"static-ip.harvesterhci.io/default": "192.168.0.12",
+						"static-ip.harvesterhci.io/nic-1":   "172.19.0.10",
+					},
+				},
+			},
+			VMI: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vmi",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+									Binding: &kubevirtv1.PluginBinding{
+										Name: util.ManagedTapBindingName,
+									},
+								},
+								{
+									Name: "nic-1",
+									Binding: &kubevirtv1.PluginBinding{
+										Name: util.ManagedTapBindingName,
+									},
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "default",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/workload",
+								}},
+						},
+						{
+							Name: "nic-1",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/workload2",
+								}},
+						},
+					},
+				},
+			},
+			ErrorExpected: false,
+			PatchExpected: true,
+			PatchLength:   5, // 1 for annotation itself and 2 for static ip patch for each interface
+		},
+		{
+			Name: "static ip annotation with bridge interfaces and overlay network",
+			VM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vm",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"static-ip.harvesterhci.io/default": "192.168.0.12",
+						"static-ip.harvesterhci.io/nic-1":   "172.19.0.10",
+					},
+				},
+			},
+			VMI: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-ovn-vmi",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Bridge: &kubevirtv1.InterfaceBridge{},
+									},
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "default",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/workload",
+								}},
+						},
+					},
+				},
+			},
+			ErrorExpected: false,
+			PatchExpected: true,
+			PatchLength:   3,
+		},
+		{
+			Name: "static ip annotation with bridge interfaces and vm network",
+			VM: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-vm-vm",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"static-ip.harvesterhci.io/default": "192.168.0.12",
+						"static-ip.harvesterhci.io/nic-1":   "172.19.0.10",
+					},
+				},
+			},
+			VMI: &kubevirtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-ip-vm-vmi",
+					Namespace: "default",
+				},
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Interfaces: []kubevirtv1.Interface{
+								{
+									Name: "default",
+									InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+										Bridge: &kubevirtv1.InterfaceBridge{},
+									},
+								},
+							},
+						},
+					},
+					Networks: []kubevirtv1.Network{
+						{
+							Name: "default",
+							NetworkSource: kubevirtv1.NetworkSource{
+								Multus: &kubevirtv1.MultusNetwork{
+									NetworkName: "default/vm-network",
+								}},
+						},
+					},
+				},
+			},
+			ErrorExpected: false,
+			PatchExpected: false,
+			PatchLength:   0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert := require.New(t)
+			annotations, err := generateKubeOVNAnnotations(tc.VM, tc.VMI, nadCache)
+			if tc.ErrorExpected {
+				assert.Error(err, "expected error but got none")
+			} else {
+				assert.NoError(err, "unexpected error")
+			}
+			patchOps, _ := generateKubeOVNStaticIPPatch(tc.VM, tc.VMI, nadCache)
+			if tc.PatchExpected {
+				assert.NotEmpty(patchOps, "expected patch operations but got none")
+			} else {
+				assert.Empty(patchOps, "expected no patch operations but got some")
+			}
+
+			assert.Len(patchOps, tc.PatchLength, "expected patch operations length to be %d but got %d", tc.PatchLength, len(patchOps))
+			// patch VMI with generated patchOps and validate annotations are added correctly
+			vmiJson, err := json.Marshal(tc.VMI)
+			assert.NoError(err, "should marshal vmi object without error")
+			patchData := fmt.Sprintf("[%s]", strings.Join(patchOps, ","))
+			patchedVMIBytes, err := patch.Apply(vmiJson, []byte(patchData))
+			assert.NoError(err, "should apply patch without error")
+			patchedVMI := &kubevirtv1.VirtualMachineInstance{}
+			err = json.Unmarshal(patchedVMIBytes, patchedVMI)
+			assert.NoError(err, "should unmarshal patched vmi without error")
+
+			// verify expected annotations are found on vm object
+			for key, value := range annotations {
+				patchedValue, exists := patchedVMI.Annotations[key]
+				assert.True(exists, "expected annotation key %s not found on patched VMI", key)
+				assert.Equal(value, patchedValue, "expected annotation value for key %s to be %s but got %s", key, value, patchedValue)
+			}
+		})
+
+	}
 }

--- a/pkg/webhook/server/mutation.go
+++ b/pkg/webhook/server/mutation.go
@@ -42,7 +42,7 @@ func Mutation(clients *clients.Clients, options *config.Options, crdExists bool)
 		templateversion.NewMutator(),
 		upgrade.NewMutator(nodeCache, settingCache),
 		virtualmachine.NewMutator(settingCache, nadCache, kubevirtCache, kubeovnSubnetCache),
-		virtualmachineinstance.NewMutator(vmCache),
+		virtualmachineinstance.NewMutator(vmCache, nadCache),
 		virtualmachineimage.NewMutator(storageClassCache),
 		virtualmachinebackup.NewMutator(vmBackupCache),
 		storageclass.NewMutator(),


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Users need to be able to provide static ip addresses for VM's when using kubeovn

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR adds an additional `virtualmachineinstance` webhook mutator which reads the static ip annotations from VM object and generates kubeovn specific static ip annotations. Example is available in kubeovn docs

https://kubeovn.github.io/docs/v1.16.x/en/guide/static-ip-mac/

Users simply need to provide an annotation on the VM object for their interfaces
<img width="1898" height="137" alt="image" src="https://github.com/user-attachments/assets/e00d3853-2e58-497c-a0f7-941d5da73a0a" />

The annotation format is `static-ip.harvesterhci.io/$interfaceName` and needs to match interface name provide in network page

<img width="1910" height="594" alt="image" src="https://github.com/user-attachments/assets/e8c0ea57-01aa-4887-88b2-83397d17f7e4" />

The mutator checks if interface is using an overlay network and if a static ip annotation exists for the interface.

If found, the mutator generates the `pod` interface name associated with that vm interface, and applies kubeovn annotations to the VMI.

Kubevirt applies all VMI annotations to virt-launcher pod, which is subsequently picked by kubeovn to perform ipam.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8844

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
