### PR TITLE
fix: perform rbac check on cpu manager ui actions

### DIFF
--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -64,12 +64,13 @@ func Formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.AddAction(request, listUnhealthyVM)
 	resource.AddAction(request, maintenancePossible)
 	resource.AddAction(request, powerActionPossible)
-	resource.AddAction(request, enableCPUManager)
-	resource.AddAction(request, disableCPUManager)
 
 	if request.AccessControl.CanUpdate(request, resource.APIObject, resource.Schema) != nil {
 		return
 	}
+
+	resource.AddAction(request, enableCPUManager)
+	resource.AddAction(request, disableCPUManager)
 
 	if resource.APIObject.Data().String("metadata", "annotations", ctlnode.MaintainStatusAnnotationKey) != "" {
 		resource.AddAction(request, disableMaintenanceModeAction)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When the Rancher RBAC integration is enabled, a Rancher user with the read-only virtualization role is able to enable/disable CPU manager on every host. The expectation is that this user can only perform read-only virtualization operations, but not operations like enabling/disabling CPU manager that would alter the hosts' state and configuration.

This happens because the backend node API formatter bypasses the Rancher API server's access control check and always returns the `enableCPUManager` and `disableCPUManager` actions to the UI,

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Enable the `enableCPUManager` and `disableCPUManager` actions only after the Rancher API server's access control check.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10241

#### Test plan:
<!-- Describe the test plan by steps. -->

##### Test Case 1 - Without Rancher Integration

* Log in to the Harvester console as the Harvester admin
* Navigate to the "Hosts" page
* Expect that the user can use the "Enable/Disable CPU Manager" option on all hosts

For the remaining Rancher integration test cases,

* Import Harvester into Rancher
* Install the "Harvester Rancher RBAC" Helm chart per instructions [here](https://docs.harvesterhci.io/v1.8/rancher/rancher-rbac#installation)

##### Test Case 2 - With Rancher Integration (Read-Only Role)

* Create a new Rancher user
* On the "Virtualization Management" page, assigns the new user to the imported Harvester cluster with the "View Virtualization Resources" cluster role
* Navigate to the Harvester console
* On the "Hosts" page, expect the user to not see the "Enable/Disable CPU Manager" options on all hosts

##### Test Case 3 - With Rancher Integration (Read-Write Role)

* Create a new Rancher user
* On the "Virtualization Management" page, assigns the new user to the imported Harvester cluster with the "Manage Virtualization Resources" cluster role
* Navigate to the Harvester console
* On the "Hosts" page, expect the user can see and use the "Enable/Disable CPU Manager" options on all hosts

##### Test Case 4 - With Rancher Integration (Cluster Owner Role)

* Create a new Rancher user
* On the "Virtualization Management" page, assigns the new user to the imported Harvester cluster with the "Cluster Owner" cluster role
* Navigate to the Harvester console
* On the "Hosts" page, expect the user can see and use the "Enable/Disable CPU Manager" options on all hosts

#### Additional documentation or context

See initial diagnosis at https://github.com/harvester/harvester/issues/10241#issuecomment-4376958910.F