### PR TITLE
fix: increase integration test ready condition timeout to 20m

### DIFF
--- a/tests/framework/ready/ready.go
+++ b/tests/framework/ready/ready.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultInterval = 3 * time.Second
-	defaultTimeout  = 10 * time.Minute
+	defaultTimeout  = 45 * time.Minute
 )
 
 var (


### PR DESCRIPTION
The PR https://github.com/harvester/harvester/pull/10774 increased the Ginkgo test timeout from 30m to 60m to fix CI failures, but did not update the defaultTimeout for the ready condition framework. This caused tests to fail with "context deadline exceeded" when ready checks took longer than 10 minutes.

The wait.PollUntilContextTimeout function creates an internal context with the defaultTimeout value. On slower systems (especially with Docker-in-Docker and QEMU emulation), virt-handler DaemonSet startup across multiple nodes can take 30+ minutes. This fix increases the timeout to 45 minutes to accommodate local development environments while staying within the 60-minute overall test timeout.

```
I0610 07:29:00.652987     212 warnings.go:110] "Warning: unrecognized format \"int64\""
  wait for condition virt-handler ready
  wait for condition virt-operator ready
  wait for condition virt-controller ready
  wait for condition virt-api ready
  condition virt-operator ready is ok
  condition virt-api ready is ok
  condition virt-controller ready is ok
  condition virt-handler ready is ok
  [FAILED] in [BeforeSuite] - /go/src/github.com/harvester/harvester/tests/framework/dsl/action.go:44 @ 06/10/26 07:59:00.845
[BeforeSuite] [FAILED] [1861.568 seconds]
[BeforeSuite] 
/go/src/github.com/harvester/harvester/tests/integration/api/suite_test.go:103

  [FAILED] Unexpected error:
      <*fmt.wrapError | 0x17e909cd760>: 
      failed to install harvester chart, context deadline exceeded
      {
          msg: "failed to install harvester chart, context deadline exceeded",
          err: <context.deadlineExceededError>{},
      }
  occurred
  In [BeforeSuite] at: /go/src/github.com/harvester/harvester/tests/framework/dsl/action.go:44 @ 06/10/26 07:59:00.845

  Full Stack Trace
    github.com/harvester/harvester/tests/framework/dsl.MustNotError({0x40e4040?, 0x17e909cd760?})
    	/go/src/github.com/harvester/harvester/tests/framework/dsl/action.go:44 +0x4b
    github.com/harvester/harvester/tests/integration/api_test.init.func5()
    	/go/src/github.com/harvester/harvester/tests/integration/api/suite_test.go:116 +0x1e9
------------------------------
[AfterSuite] 
/go/src/github.com/harvester/harvester/tests/integration/api/suite_test.go:150
  STEP: tearing down test cluster @ 06/10/26 07:59:00.845
  Deleted nodes: ["harvester-worker3" "harvester-worker2" "harvester-control-plane" "harvester-worker"]
  STEP: tearing down harvester server @ 06/10/26 07:59:05.129
[AfterSuite] PASSED [4.283 seconds]
------------------------------

Summarizing 1 Failure:
  [FAIL] [BeforeSuite] 
  /go/src/github.com/harvester/harvester/tests/framework/dsl/action.go:44

Ran 0 of 28 Specs in 1865.851 seconds
FAIL! -- A BeforeSuite node failed so all tests were skipped.
--- FAIL: TestAPI (1865.85s)
FAIL

Ginkgo ran 2 suites in 31m10.451783923s

There were failures detected in the following suites:
  api ./tests/integration/api

Test Suite Failed
```