### PR TITLE
Enh cloud config generate api

### DIFF
--- a/pkg/api/kubeconfig/generate_handler.go
+++ b/pkg/api/kubeconfig/generate_handler.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -14,7 +15,9 @@ import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	ctlrbacv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/rbac/v1"
+	"github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +35,15 @@ const (
 	defaultTickerInterval = time.Second
 
 	port = "6443"
+
+	csiRole = "harvesterhci.io:csi-driver"
+	hcpRole = "harvesterhci.io:cloudprovider"
+
+	outputFormatYaml = "yaml"
+
+	// cloud-provider cloud-config write-file path
+	legacyPath = "/etc/kubernetes/cloud-config"
+	newPath    = "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 )
 
 type GenerateHandler struct {
@@ -71,6 +83,7 @@ type req struct {
 	ClusterRoleName    string `json:"clusterRoleName"`
 	Namespace          string `json:"namespace"`
 	SaName             string `json:"serviceAccountName"`
+	OutputFormat       string `json:"outputFormat"`
 }
 
 func decodeRequest(r *http.Request) (*req, error) {
@@ -83,17 +96,34 @@ func decodeRequest(r *http.Request) (*req, error) {
 		return nil, err
 	}
 
-	if req.ClusterRoleName == "" || req.Namespace == "" || req.SaName == "" {
-		return nil, fmt.Errorf("invalid request")
+	// only hcpRole is supported
+	if req.ClusterRoleName == "" {
+		req.ClusterRoleName = hcpRole
+	} else if req.ClusterRoleName != hcpRole {
+		return nil, fmt.Errorf("invalid request: clusterRoleName can only be %s", hcpRole)
+	}
+
+	if req.Namespace == "" || req.SaName == "" {
+		return nil, fmt.Errorf("invalid request: namespace and serviceAccountName cannot be empty")
 	}
 
 	return &req, nil
 }
 
 func (h *GenerateHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
+	req := ctx.Req()
+	if req.Method == http.MethodGet {
+		return h.doGet(ctx)
+	} else if req.Method == http.MethodPost {
+		return h.doPost(ctx)
+	}
+
+	return nil, apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported method %s", req.Method))
+}
+
+func (h *GenerateHandler) doPost(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
 	r := ctx.Req()
 
-	// TODO authentication
 	req, err := decodeRequest(r)
 	if err != nil {
 		return nil, apierror.NewAPIError(validation.InvalidBodyContent, errors.Wrap(err, "fail to decode request").Error())
@@ -101,6 +131,11 @@ func (h *GenerateHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.Response
 
 	if _, err := h.clusterRoleCache.Get(req.ClusterRoleName); err != nil {
 		return nil, apierror.NewAPIError(validation.InvalidBodyContent, errors.Wrapf(err, "clusterRole %s is not found", req.ClusterRoleName).Error())
+	}
+
+	serverURL, err := h.getServerURL()
+	if err != nil {
+		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "failed to get server url").Error())
 	}
 
 	sa, secret, err := h.ensureSaAndSecret(req.Namespace, req.SaName)
@@ -116,16 +151,24 @@ func (h *GenerateHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.Response
 		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "fail to create clusterRoleBinding").Error())
 	}
 
-	serverURL, err := h.getServerURL()
-	if err != nil {
-		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "failed to get server url").Error())
-	}
-
-	kubeConfig, err := h.generateKubeConfig(secret, serverURL)
+	kubeConfig, err := h.generateKubeConfig(secret, serverURL, req.OutputFormat)
 	if err != nil {
 		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "fail to generate kubeconfig").Error())
 	}
 
+	logrus.Infof("kubeconfig for service account %s/%s is created", req.Namespace, req.SaName)
+
+	return h.output(ctx, kubeConfig, req.OutputFormat)
+}
+
+func (h *GenerateHandler) output(ctx *harvesterServer.Ctx, kubeConfig, outputFormat string) (harvesterServer.ResponseBody, error) {
+	if outputFormat == outputFormatYaml {
+		//  cloud-init yaml format
+		return h.writeYamlOutput(ctx, kubeConfig)
+	}
+
+	// legacy (empty) or unknown format
+	ctx.SetStatusOK()
 	return kubeConfig, nil
 }
 
@@ -150,8 +193,9 @@ func (h *GenerateHandler) getServerURL() (string, error) {
 
 func (h *GenerateHandler) createRoleBindingIfNotExists(sa *corev1.ServiceAccount) (*rbacv1.RoleBinding, error) {
 	namespace := sa.Namespace
-	name := sa.Namespace + "-" + sa.Name
-	roleBinding, err := h.roleBindingCache.Get(namespace, name)
+	rbName := name.SafeConcatName(sa.Namespace, sa.Name)
+
+	roleBinding, err := h.roleBindingCache.Get(namespace, rbName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
@@ -162,7 +206,7 @@ func (h *GenerateHandler) createRoleBindingIfNotExists(sa *corev1.ServiceAccount
 	return h.roleBindingClient.Create(&rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      name,
+			Name:      rbName,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "v1",
@@ -182,15 +226,15 @@ func (h *GenerateHandler) createRoleBindingIfNotExists(sa *corev1.ServiceAccount
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     "harvesterhci.io:cloudprovider",
+			Name:     hcpRole,
 		},
 	})
 }
 
 func (h *GenerateHandler) createClusterRoleBindingIfNotExists(sa *corev1.ServiceAccount) (*rbacv1.ClusterRoleBinding, error) {
 	namespace := sa.Namespace
-	name := sa.Namespace + "-" + sa.Name
-	clusterRoleBinding, err := h.clusterRoleBindingCache.Get(name)
+	crbName := name.SafeConcatName(sa.Namespace, sa.Name)
+	clusterRoleBinding, err := h.clusterRoleBindingCache.Get(crbName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
@@ -200,7 +244,7 @@ func (h *GenerateHandler) createClusterRoleBindingIfNotExists(sa *corev1.Service
 
 	return h.clusterRoleBindingClient.Create(&rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name: crbName,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "v1",
@@ -220,14 +264,14 @@ func (h *GenerateHandler) createClusterRoleBindingIfNotExists(sa *corev1.Service
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     "harvesterhci.io:csi-driver",
+			Name:     csiRole,
 		},
 	})
 }
 
 // ensureSaAndSecret returns the serviceAccount and the associated secret
-func (h *GenerateHandler) ensureSaAndSecret(namespace, name string) (*corev1.ServiceAccount, *corev1.Secret, error) {
-	sa, err := h.saCache.Get(namespace, name)
+func (h *GenerateHandler) ensureSaAndSecret(namespace, saName string) (*corev1.ServiceAccount, *corev1.Secret, error) {
+	sa, err := h.saCache.Get(namespace, saName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, nil, err
 	}
@@ -235,15 +279,16 @@ func (h *GenerateHandler) ensureSaAndSecret(namespace, name string) (*corev1.Ser
 		sa, err = h.saClient.Create(&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      name,
+				Name:      saName,
 			}})
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
-	secretName := sa.Name + "-token"
+	secretName := name.SafeConcatName(sa.Name, "token")
 	secretNamespace := sa.Namespace
+
 	_, err = h.secretCache.Get(secretNamespace, secretName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, nil, err
@@ -296,7 +341,7 @@ func (h *GenerateHandler) ensureSaAndSecret(namespace, name string) (*corev1.Ser
 	}
 }
 
-func (h *GenerateHandler) generateKubeConfig(secret *corev1.Secret, server string) (string, error) {
+func (h *GenerateHandler) generateKubeConfig(secret *corev1.Secret, server string, outputFormat string) (string, error) {
 	cluster, user, context := "default", "default", "default"
 	ca, token, err := h.getCaAndToken(secret)
 	if err != nil {
@@ -338,4 +383,143 @@ func (h *GenerateHandler) getCaAndToken(secret *corev1.Secret) ([]byte, []byte, 
 	}
 
 	return ca, token, nil
+}
+
+func decodeGetRequest(r *http.Request) (*req, error) {
+	if r == nil {
+		return nil, fmt.Errorf("request can not be nil")
+	}
+
+	req := &req{
+		Namespace:       r.URL.Query().Get("namespace"),
+		SaName:          r.URL.Query().Get("serviceAccountName"),
+		OutputFormat:    r.URL.Query().Get("outputFormat"),
+		ClusterRoleName: hcpRole,
+	}
+	if req.Namespace == "" || req.SaName == "" {
+		return nil, fmt.Errorf("invalid request: namespace and serviceAccountName cannot be empty")
+	}
+
+	return req, nil
+}
+
+func (h *GenerateHandler) doGet(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, error) {
+	r := ctx.Req()
+
+	req, err := decodeGetRequest(r)
+	if err != nil {
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, errors.Wrap(err, "fail to decode request").Error())
+	}
+
+	if _, err := h.clusterRoleCache.Get(req.ClusterRoleName); err != nil {
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, errors.Wrapf(err, "clusterRole %s is not found", req.ClusterRoleName).Error())
+	}
+
+	serverURL, err := h.getServerURL()
+	if err != nil {
+		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "failed to get server url").Error())
+	}
+
+	sa, secret, err := h.getSaAndSecret(req.Namespace, req.SaName)
+	if err != nil {
+		return nil, apierror.NewAPIError(validation.InvalidBodyContent, errors.Wrap(err, "fail to get serviceAccount").Error())
+	}
+
+	if _, err := h.getRoleBinding(sa); err != nil {
+		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "fail to get roleBinding").Error())
+	}
+
+	if _, err := h.getClusterRoleBinding(sa); err != nil {
+		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "fail to get clusterRoleBinding").Error())
+	}
+
+	kubeConfig, err := h.generateKubeConfig(secret, serverURL, req.OutputFormat)
+	if err != nil {
+		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "fail to generate kubeconfig").Error())
+	}
+
+	logrus.Infof("kubeconfig for service account %s/%s is fetched", req.Namespace, req.SaName)
+
+	return h.output(ctx, kubeConfig, req.OutputFormat)
+}
+
+func (h *GenerateHandler) writeYamlOutput(ctx *harvesterServer.Ctx, kubeConfig string) (harvesterServer.ResponseBody, error) {
+	encodedKubeConfig := base64.StdEncoding.EncodeToString([]byte(kubeConfig))
+
+	// Tell the framework don't reply OK again, app has replied directly
+	ctx.SkipAutoResponse()
+
+	rw := ctx.RespWriter()
+	rw.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
+	rw.WriteHeader(http.StatusOK)
+
+	// output both legacy and new cloud-config path
+	yamlOutput := fmt.Sprintf(`########## cloud-init user data ############
+write_files:
+- encoding: b64
+  content: %[1]s
+  owner: root:root
+  path: %[2]s
+  permissions: '0644'
+- encoding: b64
+  content: %[1]s
+  owner: root:root
+  path: %[3]s
+  permissions: '0644'
+`, encodedKubeConfig, legacyPath, newPath)
+
+	if _, err := rw.Write([]byte(yamlOutput)); err != nil {
+		err := fmt.Errorf("failed to write output %s, err: %w", outputFormatYaml, err)
+		logrus.Warnf("%s", err.Error())
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// validateOwner performs a simple structural validation of the owner reference.
+// It checks explicit metadata fields rather than running a complex validation
+// that traces back through the reverse path of the creation process.
+func validateOwner(owner []metav1.OwnerReference, sa *corev1.ServiceAccount) error {
+	if len(owner) != 1 || owner[0].Kind != rbacv1.ServiceAccountKind || owner[0].Name != sa.Name || owner[0].UID != sa.UID {
+		return fmt.Errorf("is not owned by serviceAccount name:%s UID:%s", sa.Name, sa.UID)
+	}
+
+	return nil
+}
+
+func (h *GenerateHandler) getRoleBinding(sa *corev1.ServiceAccount) (*rbacv1.RoleBinding, error) {
+	roleBinding, err := h.roleBindingCache.Get(sa.Namespace, name.SafeConcatName(sa.Namespace, sa.Name))
+	if err != nil {
+		return nil, err
+	}
+	if err := validateOwner(roleBinding.OwnerReferences, sa); err != nil {
+		return nil, fmt.Errorf("rolebinding %s/%s %w, try to delete and recreate", roleBinding.Namespace, roleBinding.Name, err)
+	}
+	return roleBinding, nil
+}
+
+func (h *GenerateHandler) getClusterRoleBinding(sa *corev1.ServiceAccount) (*rbacv1.ClusterRoleBinding, error) {
+	clusterRoleBinding, err := h.clusterRoleBindingCache.Get(name.SafeConcatName(sa.Namespace, sa.Name))
+	if err != nil {
+		return nil, err
+	}
+	if err := validateOwner(clusterRoleBinding.OwnerReferences, sa); err != nil {
+		return nil, fmt.Errorf("clusterrolebinding %s %w, try to delete and recreate", clusterRoleBinding.Name, err)
+	}
+	return clusterRoleBinding, nil
+}
+
+// getSaAndSecret returns the serviceAccount and the associated secret
+func (h *GenerateHandler) getSaAndSecret(namespace, saName string) (*corev1.ServiceAccount, *corev1.Secret, error) {
+	sa, err := h.saCache.Get(namespace, saName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	se, err := h.secretCache.Get(sa.Namespace, name.SafeConcatName(sa.Name, "token"))
+	if err != nil {
+		return nil, nil, err
+	}
+	return sa, se, nil
 }

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -62,6 +62,7 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	// Those routes should be above /v1/harvester/{type}, otherwise, the response status code would be 404
 	kcGenerateHandler := harvesterServer.NewHandler(kubeconfig.NewGenerateHandler(r.scaled, r.options))
 	m.Path("/v1/harvester/kubeconfig").Methods("POST").Handler(verifyAuthMiddleware(kcGenerateHandler))
+	m.Path("/v1/harvester/kubeconfig").Methods("GET").Handler(verifyAuthMiddleware(kcGenerateHandler))
 
 	uiInfoHandler := harvesterServer.NewHandler(uiinfo.NewUIInfoHandler(r.scaled, r.options))
 	m.Path("/v1/harvester/ui-info").Methods("GET").Handler(uiInfoHandler)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Enhance the `/v1/harvester/kubeconfig` endpoint:

1. Ensure the combined name is not exceeding limits
2. Support `Get` operation
3. Support output format `yaml` for `cloud-init`, which is the counter part of below script

https://docs.harvesterhci.io/v1.9/rancher/cloud-provider#manually-deploying-to-the-rke2-cluster
>curl -sfL https://raw.githubusercontent.com/harvester/cloud-provider-harvester/master/deploy/generate_addon.sh | bash -s <serviceaccount name> <namespace>

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10870

#### Test plan:
<!-- Describe the test plan by steps. -->


POST:

>curl -k -X POST -H "Authorization: Bearer token-qxrgr:5wd586vqpblsnk4z5hfvfq4xw5cb99c69b88hxzlpqmkgxbqhnzcsl" "https://192.168.122.141/v1/harvester/kubeconfig" -H "Content-Type: application/json" -d '{"namespace": "gc-test", "serviceAccountName": "gc4"}'

return:

>"apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: ,,,\n    server: https://192.168.122.141:6443\n  name: default\ncontexts:\n- context:\n    cluster: default\n    namespace: gc-test\n    user: default\n  name: default\ncurrent-context: default\nkind: Config\npreferences: {}\nusers:\n- name: default\n  user:\n    token:...\n"

POST, set outputFormat to yaml:

>curl -k -X POST -H "Authorization: Bearer token-qxrgr:5wd586vqpblsnk4z5hfvfq4xw5cb99c69b88hxzlpqmkgxbqhnzcsl" "https://192.168.122.141/v1/harvester/kubeconfig" -H "Content-Type: application/json" -d '{"namespace": "gc-test", "serviceAccountName": "gc4", "outputFormat": "yaml"}'

return:
```
########## cloud-init user data ############
write_files:
- encoding: b64
  content:...
  owner: root:root
  path: /etc/kubernetes/cloud-config
  permissions: '0644'
- encoding: b64
  content: ...
  owner: root:root
  path: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
  permissions: '0644'
```



GET:
>curl -k -X GET -H "Authorization: Bearer token-qxrgr:5wd586vqpblsnk4z5hfvfq4xw5cb99c69b88hxzlpqmkgxbqhnzcsl" "https://192.168.122.141/v1/harvester/kubeconfig?namespace=gc-test&&serviceAccountName=gc4&&outputFormat=file"

return:
>"apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: ...\n    server: https://192.168.122.141:6443\n  name: default\ncontexts:\n- context:\n    cluster: default\n    namespace: gc-test\n    user: default\n  name: default\ncurrent-context: default\nkind: Config\npreferences: {}\nusers:\n- name: default\n  user:\n    token: ...\n"


GET, set outputFormat to yaml:

>curl -k -X GET -H "Authorization: Bearer token-qxrgr:5wd586vqpblsnk4z5hfvfq4xw5cb99c69b88hxzlpqmkgxbqhnzcsl" "https://192.168.122.141/v1/harvester/kubeconfig?namespace=gc-test&&serviceAccountName=gc4&&outputFormat=yaml"

return:
```
########## cloud-init user data ############
write_files:
- encoding: b64
  content:...
  owner: root:root
  path: /etc/kubernetes/cloud-config
  permissions: '0644'
- encoding: b64
  content: ...
  owner: root:root
  path: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
  permissions: '0644'
```

pod log:

```
time="2026-06-16T10:51:59Z" level=info msg="kubeconfig for service account gc-test/gc4 is fetchted"
time="2026-06-16T10:52:06Z" level=info msg="kubeconfig for service account gc-test/gc4 is fetchted"
time="2026-06-16T10:52:09Z" level=info msg="kubeconfig for service account gc-test/gc4 is fetchted"

time="2026-06-16T10:58:46Z" level=info msg="kubeconfig for service account gc-test/gc4 is created"

time="2026-06-16T10:59:26Z" level=info msg="kubeconfig for service account gc-test/gc4 is created"
```


#### Additional documentation or context

This PR includes the framework fix for issue https://github.com/harvester/harvester/issues/10878

via PR https://github.com/harvester/harvester/pull/10881