### PR TITLE
Eliminate http superfluous response

### DIFF
--- a/pkg/api/supportbundle/download_handler.go
+++ b/pkg/api/supportbundle/download_handler.go
@@ -96,6 +96,11 @@ func (h *DownloadHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.Response
 		return nil, apierror.NewAPIError(validation.ServerError, msg)
 	}
 
+	// Instruct the framework to skip its automatic response handling to avoid
+	// "superfluous response.WriteHeader" warnings, as this support bundle
+	// download function writes data directly to the ResponseWriter.
+	ctx.SkipAutoResponse()
+
 	rw.Header().Set("Content-Length", fmt.Sprint(sb.Status.Filesize))
 	rw.Header().Set("Content-Disposition", "attachment; filename="+sb.Status.Filename)
 	contentType := resp.Header.Get("Content-Type")
@@ -103,18 +108,24 @@ func (h *DownloadHandler) Do(ctx *harvesterServer.Ctx) (harvesterServer.Response
 		rw.Header().Set("Content-Type", contentType)
 	}
 
+	// Lock in headers and status code before beginning the stream
+	rw.WriteHeader(http.StatusOK)
+
 	if _, err := io.Copy(rw, resp.Body); err != nil {
-		return nil, apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "fail to copy response body to response writer").Error())
+		err := apierror.NewAPIError(validation.ServerError, errors.Wrap(err, "support bundle download failed midway during stream copy").Error())
+		logrus.Warnf("%s", err.Error())
+		return nil, err
 	}
 
 	if retainSb {
+		logrus.Infof("support bundle %s is retained for download reuse", sb.Name)
 		return nil, nil
 	}
 
 	logrus.Infof("delete support bundle %s", sb.Name)
 	err = h.supportBundles.Delete(sb.Namespace, sb.Name, &metav1.DeleteOptions{})
 	if err != nil {
-		logrus.Errorf("fail to delete support bundle %s: %s", sb.Name, err)
+		logrus.Errorf("fail to delete support bundle %s: %s", sb.Name, err.Error())
 	}
 	return nil, nil
 }

--- a/pkg/api/upgradelog/handler.go
+++ b/pkg/api/upgradelog/handler.go
@@ -88,7 +88,7 @@ func (h Handler) Do(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, err
 	vars := util.EncodeVars(mux.Vars(req))
 
 	if req.Method == http.MethodGet {
-		return nil, h.doGet(vars["link"], rw, req)
+		return nil, h.doGet(ctx, vars["link"], rw, req)
 	} else if req.Method == http.MethodPost {
 		return nil, h.doPost(vars["action"], rw, req)
 	}
@@ -96,10 +96,10 @@ func (h Handler) Do(ctx *harvesterServer.Ctx) (harvesterServer.ResponseBody, err
 	return nil, apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported method %s", req.Method))
 }
 
-func (h Handler) doGet(link string, rw http.ResponseWriter, req *http.Request) error {
+func (h Handler) doGet(ctx *harvesterServer.Ctx, link string, rw http.ResponseWriter, req *http.Request) error {
 	switch link {
 	case downloadArchiveLink:
-		return h.downloadArchive(rw, req)
+		return h.downloadArchive(ctx, rw, req)
 	default:
 		return apierror.NewAPIError(validation.InvalidAction, fmt.Sprintf("Unsupported GET action %s", link))
 	}
@@ -114,7 +114,7 @@ func (h Handler) doPost(action string, rw http.ResponseWriter, req *http.Request
 	}
 }
 
-func (h Handler) downloadArchive(rw http.ResponseWriter, req *http.Request) error {
+func (h Handler) downloadArchive(ctx *harvesterServer.Ctx, rw http.ResponseWriter, req *http.Request) error {
 	vars := util.EncodeVars(mux.Vars(req))
 	upgradeLogName := vars["name"]
 	upgradeLogNamespace := vars["namespace"]
@@ -152,6 +152,11 @@ func (h Handler) downloadArchive(rw http.ResponseWriter, req *http.Request) erro
 		return fmt.Errorf("failed with unexpected http status code %d", downloadResp.StatusCode)
 	}
 
+	// Instruct the framework to skip its automatic response handling to avoid
+	// "superfluous response.WriteHeader" warnings, as this upgradelog
+	// download function writes data directly to the ResponseWriter.
+	ctx.SkipAutoResponse()
+
 	// TODO: set Content-Length with archive size
 	rw.Header().Set("Content-Disposition", "attachment; filename="+archiveFileName)
 	contentType := downloadResp.Header.Get("Content-Type")
@@ -159,8 +164,13 @@ func (h Handler) downloadArchive(rw http.ResponseWriter, req *http.Request) erro
 		rw.Header().Set("Content-Type", contentType)
 	}
 
+	// Lock in headers and status code before beginning the stream
+	rw.WriteHeader(http.StatusOK)
+
 	if _, err := io.Copy(rw, downloadResp.Body); err != nil {
-		return fmt.Errorf("failed to copy the downloaded content to the target (%s), err: %w", archiveFileName, err)
+		err := fmt.Errorf("failed to copy the downloaded content to the target (%s), err: %w", archiveFileName, err)
+		logrus.Warnf("%s", err.Error())
+		return err
 	}
 
 	return nil

--- a/pkg/server/http/ctx.go
+++ b/pkg/server/http/ctx.go
@@ -6,6 +6,20 @@ type Ctx struct {
 	statusCode int
 	rw         http.ResponseWriter
 	req        *http.Request
+
+	// skipAutoResponse is explicitly set by the application layer to signal
+	// that it has taken full ownership of the HTTP response lifecycle (e.g.,
+	// manually writing a raw YAML file, streaming binaries, or custom error handling).
+	//
+	// This defaults to false, meaning existing code need not do anything to maintain
+	// current behavior.
+	//
+	// Note: The boundary is absolute with no complex fallback mechanisms. The app layer
+	// either relies entirely on the framework, or handles everything itself. Once this
+	// flag is set to true, the framework completely backs off and does nothing on both
+	// successful and error execution paths, allowing the app layer to safely return
+	// errors (e.g., mid-stream io.Copy failures) without triggering framework response writes.
+	skipAutoResponse bool
 }
 
 func newDefaultHarvesterServerCtx(rw http.ResponseWriter, req *http.Request) *Ctx {
@@ -27,4 +41,15 @@ func (ctx *Ctx) StatusCode() int    { return ctx.statusCode }
 func (ctx *Ctx) Req() *http.Request { return ctx.req }
 func (ctx *Ctx) RespWriter() http.ResponseWriter {
 	return ctx.rw
+}
+
+// SkipAutoResponse signals to the framework that the application layer
+// will handle writing the status code and body directly.
+func (ctx *Ctx) SkipAutoResponse() {
+	ctx.skipAutoResponse = true
+}
+
+// IsAutoResponseSkipped checks if the application layer took over the response.
+func (ctx *Ctx) IsAutoResponseSkipped() bool {
+	return ctx.skipAutoResponse
 }

--- a/pkg/server/http/handler.go
+++ b/pkg/server/http/handler.go
@@ -31,7 +31,14 @@ func NewHandler(httpHandler HarvesterServerHandler) http.Handler {
 func (handler *harvesterServerHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ctx := newDefaultHarvesterServerCtx(rw, req)
 	resp, err := handler.httpHandler.Do(ctx)
+
+	// If the app layer explicitly took over the response, framework doesn't process the return result twice.
+	if ctx.IsAutoResponseSkipped() {
+		return
+	}
+
 	if err != nil {
+
 		status := getHTTPStatusFromError(err)
 		rw.WriteHeader(status)
 		// err.Error() is a server-generated message returned as a plain API error body, not reflected HTML.


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When http handler writes response data directly, the framework still writes response, the causes warning like

```
time="2026-06-16T09:46:58Z" level=info msg="delete support bundle bundle-local-dbed52ea-qsqd1"
2026/06/16 09:46:58 http: superfluous response.WriteHeader call from github.com/harvester/harvester/pkg/server/http.(*harvesterServerHandler).ServeHTTP (handler.go:43)
```

`support bulde, upgrade log, vm image` all have similar warnings.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Allow application to bypass framework auto-response.

2. Fix `support bundle, upgrade log`;  `vm image` code is a bit complex, wont' be fixed on this PR.

https://github.com/harvester/harvester/blob/42c53f2607483a172b921ade2c88799dcff01e16/pkg/api/image/formatter.go#L88-L97

offloaded to issue https://github.com/harvester/harvester/issues/10884

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10878

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Generate SB from Harvester UI
2. Check Harvester pod log
no message like `http: superfluous response.WriteHeader call from github.com/harvester/harvester/pkg/server/http.(*harvesterServerHandler).ServeHTTP` is observed
```
time="2026-06-16T13:24:58Z" level=info msg="deleting support bundle bundle-local-bd04d8b9-ltso6"
```

#### Additional documentation or context

Observed while testing https://github.com/harvester/harvester/pull/10876