### PR TITLE
integration with forklift inventory service

### DIFF
--- a/pkg/api/forkliftproxy/forklift.go
+++ b/pkg/api/forkliftproxy/forklift.go
@@ -1,0 +1,139 @@
+package forkliftproxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	satoken                      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	OriginHeader                 = "Origin"
+	forkliftInventoryServiceName = "forklift-inventory"
+	forkliftInventoryNamespace   = "forklift"
+)
+
+var (
+	forkliftInventoryEndpoint = fmt.Sprintf("%s.%s:8443", forkliftInventoryServiceName, forkliftInventoryNamespace)
+)
+
+type ForkliftProxyHandler struct {
+	config *rest.Config
+}
+
+func NewForkliftProxyHandler(config *rest.Config) *ForkliftProxyHandler {
+	return &ForkliftProxyHandler{
+		config: config,
+	}
+}
+
+func (f *ForkliftProxyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Extract the path variables map from the request
+	vars := mux.Vars(req)
+	providerId := vars["providerId"]
+	object := vars["object"]
+
+	// on successful auth rancher sets the header Impersonate-Extra-Username
+	// we can use this logic to identify if user is not yet authenticated and return 401
+	extraUserName := req.Header.Get("Impersonate-Extra-Username")
+	if extraUserName == "" {
+		http.Error(rw, "Unauthorized: missing authentication headers", http.StatusUnauthorized)
+		return
+	}
+	//validate object to ensure it is one of datastores, networks or vms
+	if object != "datastores" && object != "networks" && object != "vms" {
+		http.Error(rw, "Invalid object type", http.StatusBadRequest)
+		return
+	}
+
+	err := f.checkServiceAccess(req)
+	if err != nil {
+		logrus.Errorf("failed to fetch service with user impersonation: %v", err)
+		http.Error(rw, "error verifying access to service: "+err.Error(), http.StatusForbidden)
+		return
+	}
+
+	director := func(r *http.Request) {
+		r.URL.Scheme = "https"
+		r.URL.Host = forkliftInventoryEndpoint
+		r.URL.Path = fmt.Sprintf("/providers/vsphere/%s/%s", providerId, object)
+		r.Header.Set(OriginHeader, fmt.Sprintf("%s://%s", GetOriginScheme(r.URL.Scheme), r.Host))
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	httpProxy := &httputil.ReverseProxy{
+		Director:  director,
+		Transport: transport,
+	}
+
+	token, err := getToken()
+	if err != nil {
+		http.Error(rw, "Failed to get token for forklift inventory", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	httpProxy.ServeHTTP(rw, req)
+}
+
+func getToken() (string, error) {
+	tokenBytes, err := os.ReadFile(satoken)
+	if err != nil {
+		return "", err
+	}
+	return string(tokenBytes), nil
+}
+
+func GetOriginScheme(scheme string) string {
+	switch scheme {
+	case "ws":
+		return "http"
+	case "wss":
+		return "https"
+	default:
+		return scheme
+	}
+}
+
+// checkServiceAccess checks if the user can access the forklift inventory service by attempting to get the service resource in Kubernetes using the user's credentials.
+// users will need access to `forklift-inventory` service in `forklift` namespace to pass this check and be able to use the proxy api.
+func (f *ForkliftProxyHandler) checkServiceAccess(req *http.Request) error {
+	userConfig, err := userImpersonationConfig(f.config, req)
+	if err != nil {
+		return fmt.Errorf("failed to generate user kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(userConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes clientset: %w", err)
+	}
+
+	_, err = clientset.CoreV1().Services(forkliftInventoryNamespace).Get(req.Context(), forkliftInventoryServiceName, metav1.GetOptions{})
+	return err
+}
+
+func userImpersonationConfig(restConfig *rest.Config, req *http.Request) (*rest.Config, error) {
+	userConfig := rest.CopyConfig(restConfig)
+	userName := req.Header.Get("Impersonate-User")
+	groups := req.Header.Values("Impersonate-Extra-Groups")
+	logrus.Debugf("Impersonate-User: %s, Impersonate-Extra-Groups: %v", userName, groups)
+	if userName == "" {
+		return nil, fmt.Errorf("missing required authentication headers")
+	}
+
+	logrus.Debugf("Impersonating user for api call: %s, groups: %s", userName, groups)
+	userConfig.Impersonate = rest.ImpersonationConfig{
+		UserName: userName,
+		Groups:   groups,
+	}
+	return userConfig, nil
+}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/harvester/harvester/pkg/api/backuptarget"
+	"github.com/harvester/harvester/pkg/api/forkliftproxy"
 	"github.com/harvester/harvester/pkg/api/kubeconfig"
 	"github.com/harvester/harvester/pkg/api/proxy"
 	"github.com/harvester/harvester/pkg/api/readyz"
@@ -58,6 +59,10 @@ func (r *Router) Routes(h router.Handlers) http.Handler {
 	m.Path("/").HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		http.Redirect(rw, req, "/dashboard/", http.StatusFound)
 	})
+
+	// add a prefix based handler for forklift
+	forkliftProxyHandler := forkliftproxy.NewForkliftProxyHandler(r.restConfig)
+	m.Path("/v1/harvester/providers/vsphere/{providerId}/{object}").Methods("GET").Handler(forkliftProxyHandler)
 
 	// Those routes should be above /v1/harvester/{type}, otherwise, the response status code would be 404
 	kcGenerateHandler := harvesterServer.NewHandler(kubeconfig.NewGenerateHandler(r.scaled, r.options))


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
For Harvester UI integration with forklift we need an api to allow access to the forklift inventory service data

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces a new forklift proxy service which leverages harvester steve federation.

It allows users with access to `GET` `forklift-inventory` service in `forklift` namespace to access the forklift proxy service.

The service allows access to 3 proxied endpoints

* https://VIP/v1/harvester/providers/vsphere/${providerUUID}/datastores
* https://VIP/v1/harvester/providers/vsphere/${providerUUID}/vms
* https://VIP/v1/harvester/providers/vsphere/${providerUUID}/networks

When access via rancher the endpoint can also be accessed via

* https://${RANCHERENDPOINT}/k8s/clusters/${HARVESTERCLUSTERID}/v1/harvester/providers/vsphere/${providerUUID}/datastores
* https://${RANCHERENDPOINT}/k8s/clusters/${HARVESTERCLUSTERID}/v1/harvester/providers/vsphere/${providerUUID}/vms
* https://${RANCHERENDPOINT}/k8s/clusters/${HARVESTERCLUSTERID}/v1/harvester/providers/vsphere/${providerUUID}/networks

Non admin users need to be able to `view services` in the `System` project on the downstream harvester cluster to consume the api

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10606
#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
