### PR TITLE
fix: enhance backup logic for kubevirt workload update methods annotation

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1072,12 +1072,15 @@ disable_kubevirt_workload_live_migration() {
   local methods_json
   methods_json=$(echo "$chart_yaml" | yq e '.spec.values.kubevirt.spec.workloadUpdateStrategy.workloadUpdateMethods | tojson' -)
 
-  # Backup original value to the upgrade annotation (only write once for idempotency)
+  # Backup original value to the upgrade annotation (only write once for idempotency).
+  # Must check key existence rather than the value, because a legitimate backup value of "null"
+  # (meaning the key was absent before the upgrade) is indistinguishable from a missing annotation
+  # when using plain yq value extraction (both produce the string "null").
   local annotation_key="harvesterhci.io/kubevirt-workload-update-methods"
-  local existing_backup
-  existing_backup=$(kubectl get upgrades.harvesterhci.io "$HARVESTER_UPGRADE_NAME" -n harvester-system -o yaml | \
-    yq e ".metadata.annotations[\"$annotation_key\"]" -)
-  if [ "$existing_backup" = "null" ]; then
+  local annotation_exists
+  annotation_exists=$(kubectl get upgrades.harvesterhci.io "$HARVESTER_UPGRADE_NAME" -n harvester-system -o yaml | \
+    yq e "(.metadata.annotations // {}) | has(\"$annotation_key\")" -)
+  if [ "$annotation_exists" != "true" ]; then
     echo "Backing up workloadUpdateMethods value '$methods_json' to upgrade annotation"
     kubectl annotate upgrades.harvesterhci.io "$HARVESTER_UPGRADE_NAME" -n harvester-system \
       "${annotation_key}=${methods_json}"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

`upgrade_manifests.sh` is not reentrant because it could write to the `harvesterhci.io/kubevirt-workload-update-methods` annotation without the `--overwrite` option.


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Check if the annotation is presented. Do not back up again once we have backed up the workload update methods to the annotation.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10938

#### Test plan:
<!-- Describe the test plan by steps. -->

- Build an ISO with the fix.
- Upgrade v1.8.x cluster to the ISO.
- When the upgrade proceeds to the Upgrade System Services stage:
    - First, verify the upgrade CR (harvester-upgrade-xxxx) has the annotation: `harvesterhci.io/kubevirt-workload-update-methods`
    - kill the `hvst-upgrade-xxx-apply-manifests-yyy` pod. Note: kill the **pod**, not **deployment**.
    - The `hvst-upgrade-xxx-apply-manifests-yyy`  should rerun and not error in when manipulating kubevirt workload update methods. Ideally, you can see the following logs:
      
      ```
      ...
      Deleting plan hvst-upgrade-hgc4s-skip-restart-rancher-system-agent...
      plan.upgrade.cattle.io "hvst-upgrade-hgc4s-skip-restart-rancher-system-agent" deleted from cattle-system namespace
      Checking KubeVirt workload live migration settings
      KubeVirt workloadUpdateMethods is already empty. No patching needed.
      Upgrading Rancher
      ...
      ```

#### Additional documentation or context
