### PR TITLE
fix: add global image registry configuration for Longhorn

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -486,6 +486,9 @@ longhorn:
   ## defaults to "true"
   enabled: true
 
+  global:
+    imageRegistry: "docker.io"
+
   createNamespace: true
 
   ## Specify the namespace to install longhorn.


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->



The `.global.imageRegistry` value has been [changed to an empty string](https://github.com/longhorn/longhorn/pull/13094). Image registry resolution is now handled dynamically via a [Helm helper](https://github.com/longhorn/longhorn/blob/1ae6678e4c58d623f8d824d6ee43dbb19fb3f7d0/chart/templates/_helpers.tpl#L45). While the default resolved registry remains `docker.io`, the [upgrade path still explicitly relies on the values field](https://github.com/harvester/harvester/blob/6e0adc96e854df515e9833c01a2bb1aa405e3beb/package/upgrade/upgrade_manifests.sh#L613) to verify the Longhorn Manager.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Specify the `docker.io` explicitly in the harvester's values file. This is also useful when we publish prime builds that use SUSE Storage charts.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10937



#### Test plan:
<!-- Describe the test plan by steps. -->

- Build ISO
- Cluster bootstrap and Longhorn installation must work.
- Upgrade from v1.8.x to the build ISO must **not** be stuck at checking longhorn-manager, like the following log:
    ```
    hvst-upgrade-dqwjr-apply-manifests-jc748 Waiting for LH settling down...
    hvst-upgrade-dqwjr-apply-manifests-jc748 Waiting for longhorn-manager to be upgraded...
    hvst-upgrade-dqwjr-apply-manifests-jc748 Waiting for longhorn-manager to be upgraded (0/3)...
    hvst-upgrade-dqwjr-apply-manifests-jc748 Waiting for longhorn-manager to be upgraded (0/3)...
    hvst-upgrade-dqwjr-apply-manifests-jc748 Waiting for longhorn-manager to be upgraded (0/3)...
    hvst-upgrade-dqwjr-apply-manifests-jc748 Waiting for longhorn-manager to be upgraded (0/3)...
    ```
#### Additional documentation or context
