### PR TITLE
Block PVC provisioning with Longhorn V2 encryption until upstream issue is resolved

### DIFF
--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -2,8 +2,10 @@ package persistentvolumeclaim
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
+	longhornv1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
@@ -144,7 +146,42 @@ func (v *pvcValidator) Update(_ *types.Request, oldObj runtime.Object, newObj ru
 
 func (v *pvcValidator) Create(request *types.Request, newObj runtime.Object) error {
 	newPVC := newObj.(*corev1.PersistentVolumeClaim)
-	return v.validateInternalUsage(newPVC)
+	if err := v.validateInternalUsage(newPVC); err != nil {
+		return err
+	}
+
+	return v.validateLonghornV2Encryption(newPVC)
+}
+
+// Encrypted V2 volumes are supported, but their actual size is currently smaller than requested.
+// See https://github.com/longhorn/longhorn/issues/13163.
+func (v *pvcValidator) validateLonghornV2Encryption(pvc *corev1.PersistentVolumeClaim) error {
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName == "" {
+		return nil
+	}
+
+	scName := *pvc.Spec.StorageClassName
+	sc, err := v.scCache.Get(scName)
+	if err != nil {
+		// A PVC is allowed to reference a StorageClass that does not exist yet.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return werror.NewInternalError(fmt.Sprintf("failed to get storage class %s: %v", scName, err))
+	}
+
+	if sc.Provisioner != util.CSIProvisionerLonghorn ||
+		util.GetLonghornDataEngineType(sc) != longhornv1.DataEngineTypeV2 {
+		return nil
+	}
+
+	encrypted, err := strconv.ParseBool(sc.Parameters[util.LonghornOptionEncrypted])
+	if err != nil || !encrypted {
+		return nil
+	}
+
+	message := fmt.Sprintf("can not create volume with Longhorn V2 encrypted storage class %s", scName)
+	return werror.NewInvalidError(message, "spec.storageClassName")
 }
 
 func (v *pvcValidator) checkGoldenImageAnno(pvc *corev1.PersistentVolumeClaim) error {

--- a/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
@@ -3,9 +3,12 @@ package persistentvolumeclaim
 import (
 	"testing"
 
+	longhornv1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -187,6 +190,60 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	const (
+		longhornV1EncryptedStorageClass = "longhorn-v1-encrypted"
+		longhornV2StorageClass          = "longhorn-v2"
+		longhornV2EncryptedStorageClass = "longhorn-v2-encrypted"
+		longhornV2EncryptedAltBoolClass = "longhorn-v2-encrypted-alt-bool"
+		nonLonghornV2EncryptedClass     = "non-longhorn-v2-encrypted"
+	)
+
+	storageClasses := []runtime.Object{
+		&storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: util.StorageClassHarvesterLonghorn},
+			Provisioner: util.CSIProvisionerLonghorn,
+		},
+		&storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: longhornV1EncryptedStorageClass},
+			Provisioner: util.CSIProvisionerLonghorn,
+			Parameters: map[string]string{
+				util.ParamDataEngine:         string(longhornv1.DataEngineTypeV1),
+				util.LonghornOptionEncrypted: "true",
+			},
+		},
+		&storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: longhornV2StorageClass},
+			Provisioner: util.CSIProvisionerLonghorn,
+			Parameters: map[string]string{
+				util.ParamDataEngine: string(longhornv1.DataEngineTypeV2),
+			},
+		},
+		&storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: longhornV2EncryptedStorageClass},
+			Provisioner: util.CSIProvisionerLonghorn,
+			Parameters: map[string]string{
+				util.ParamDataEngine:         string(longhornv1.DataEngineTypeV2),
+				util.LonghornOptionEncrypted: "true",
+			},
+		},
+		&storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: longhornV2EncryptedAltBoolClass},
+			Provisioner: util.CSIProvisionerLonghorn,
+			Parameters: map[string]string{
+				util.ParamDataEngine:         string(longhornv1.DataEngineTypeV2),
+				util.LonghornOptionEncrypted: "TRUE",
+			},
+		},
+		&storagev1.StorageClass{
+			ObjectMeta:  metav1.ObjectMeta{Name: nonLonghornV2EncryptedClass},
+			Provisioner: "example.csi.io",
+			Parameters: map[string]string{
+				util.ParamDataEngine:         string(longhornv1.DataEngineTypeV2),
+				util.LonghornOptionEncrypted: "true",
+			},
+		},
+	}
+
 	tests := []struct {
 		name          string
 		pvc           *corev1.PersistentVolumeClaim
@@ -214,6 +271,62 @@ func TestCreate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{},
+			},
+			expectError: false,
+		},
+		{
+			name: "create PVC with encrypted Longhorn V1 storage class",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(longhornV1EncryptedStorageClass),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "create PVC with unencrypted Longhorn V2 storage class",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(longhornV2StorageClass),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "create PVC with encrypted Longhorn V2 storage class",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(longhornV2EncryptedStorageClass),
+				},
+			},
+			expectError:   true,
+			errorContains: "Longhorn V2 encrypted storage class",
+		},
+		{
+			name: "create PVC with encrypted Longhorn V2 storage class using alternative boolean value",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(longhornV2EncryptedAltBoolClass),
+				},
+			},
+			expectError:   true,
+			errorContains: "Longhorn V2 encrypted storage class",
+		},
+		{
+			name: "create PVC with non-Longhorn encrypted V2 storage class",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(nonLonghornV2EncryptedClass),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "create PVC with storage class that does not exist yet",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To("not-found"),
+				},
 			},
 			expectError: false,
 		},
@@ -315,7 +428,10 @@ func TestCreate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			validator := &pvcValidator{}
+			clientset := fake.NewSimpleClientset(storageClasses...)
+			validator := &pvcValidator{
+				scCache: fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+			}
 
 			err := validator.Create(nil, tc.pvc)
 

--- a/pkg/webhook/resources/storageclass/validator.go
+++ b/pkg/webhook/resources/storageclass/validator.go
@@ -225,6 +225,13 @@ func (v *storageClassValidator) validateEncryption(newObj runtime.Object) error 
 		return nil
 	}
 
+	if newSC.Provisioner == util.CSIProvisionerLonghorn &&
+		util.GetLonghornDataEngineType(newSC) == longhorn.DataEngineTypeV2 {
+		// Encrypted V2 volumes are supported, but their actual size is currently smaller than requested.
+		// See https://github.com/longhorn/longhorn/issues/13163.
+		return werror.NewInvalidError("encrypted Longhorn V2 volumes are temporarily disabled due to a known volume size issue", "parameters.encrypted")
+	}
+
 	secretName, secretNamespace, err := v.validateEncryptionParams(newSC)
 	if err != nil {
 		return err

--- a/pkg/webhook/resources/storageclass/validator.go
+++ b/pkg/webhook/resources/storageclass/validator.go
@@ -329,10 +329,10 @@ func (v *storageClassValidator) validateEncryptionParams(newSC *storagev1.Storag
 	if len(missing) > 0 {
 		return "", "", werror.NewInvalidError(
 			fmt.Sprintf("storage class must contain %s", strings.Join(missing, ", ")),
-			"spec.parameters")
+			"parameters.encrypted")
 	}
 	if wantName == "" {
-		return "", "", werror.NewInvalidError("storage class must contain secret name and namespace", "spec.parameters")
+		return "", "", werror.NewInvalidError("storage class must contain secret name and namespace", "parameters.encrypted")
 	}
 	return wantName, wantNS, nil
 }

--- a/pkg/webhook/resources/storageclass/validator_test.go
+++ b/pkg/webhook/resources/storageclass/validator_test.go
@@ -59,10 +59,11 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		secret       *corev1.Secret
-		storageClass *storagev1.StorageClass
-		expectError  bool
+		name          string
+		secret        *corev1.Secret
+		storageClass  *storagev1.StorageClass
+		expectError   bool
+		errorContains string
 	}{
 		{
 			name: "valid encryption parameters",
@@ -345,6 +346,21 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "Longhorn V2 encryption is temporarily disabled",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "longhorn-v2-encrypted",
+				},
+				Provisioner: util.CSIProvisionerLonghorn,
+				Parameters: map[string]string{
+					util.ParamDataEngine:         string(longhornv1.DataEngineTypeV2),
+					util.LonghornOptionEncrypted: "true",
+				},
+			},
+			expectError:   true,
+			errorContains: "temporarily disabled due to a known volume size issue",
+		},
+		{
 			name: "encryption disabled",
 			storageClass: &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
@@ -486,6 +502,9 @@ func Test_storageClassValidator_validateEncryption(t *testing.T) {
 			err := validator.validateEncryption(tc.storageClass)
 			if tc.expectError {
 				assert.NotNil(t, err, tc.name)
+				if tc.errorContains != "" {
+					assert.ErrorContains(t, err, tc.errorContains)
+				}
 			} else {
 				assert.Nil(t, err, tc.name)
 			}


### PR DESCRIPTION
#### Problem:

see https://github.com/harvester/harvester/issues/10641

#### Solution:

Block 
- Storage class creation with Longhorn v2 encryption until upstream issue is resolved
- PVC provisioning with Longhorn V2 encryption until upstream issue is resolved

#### Related Issue(s):

https://github.com/harvester/harvester/issues/10641

#### Test plan:

1. Validate the creation of lhv2 storage class with encryption enabled block by webhook, the error message should be: `The request is invalid: parameters.encrypted: encrypted Longhorn V2 volumes are temporarily disabled due to a known volume size issue
`
```
kubectl apply -f - << 'EOF'
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: qa-lhv2-encrypted
provisioner: driver.longhorn.io
allowVolumeExpansion: true
parameters:
  dataEngine: v2
  encrypted: "true"
  migratable: "true"
EOF
```

2. Validate PVC cannot be created with lhv2 + encryption storage class
  a. prepare a harvester v1.8.0 cluster
  b. create secret
    ```
    kubectl apply -f - << 'EOF'
    apiVersion: v1
    kind: Secret
    metadata:
      name: qa-encryption
      namespace: default
    type: Opaque
    stringData:
      CRYPTO_KEY_CIPHER: "aes-xts-plain64"
      CRYPTO_KEY_HASH: "sha256"
      CRYPTO_KEY_PROVIDER: "secret"
      CRYPTO_KEY_SIZE: "256"
      CRYPTO_KEY_VALUE: "qa-test-encryption-key"
      CRYPTO_PBKDF: "argon2i"
    EOF
    ```
  c. create storage class
```
kubectl apply -f - << 'EOF'
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: qa-lhv2-encrypted
provisioner: driver.longhorn.io
allowVolumeExpansion: true
parameters:
  dataEngine: v2
  encrypted: "true"
  migratable: "true"
  csi.storage.k8s.io/provisioner-secret-name: qa-encryption
  csi.storage.k8s.io/provisioner-secret-namespace: default
  csi.storage.k8s.io/node-stage-secret-name: qa-encryption
  csi.storage.k8s.io/node-stage-secret-namespace: default
  csi.storage.k8s.io/node-publish-secret-name: qa-encryption
  csi.storage.k8s.io/node-publish-secret-namespace: default
EOF
```

  d. create pvc, webhook raise error `can not create volume with Longhorn V2 encrypted storage class qa-future-lhv2-encrypted`
```
kubectl apply -f - << 'EOF'
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: qa-future-encrypted-volume
  namespace: default
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Block
  storageClassName: qa-future-lhv2-encrypted
  resources:
    requests:
      storage: 1Gi
EOF
```

#### Additional documentation or context

please hold off merging this pr, if https://github.com/longhorn/longhorn/issues/13365 is fixed, and harvester v1.9.0 bump longhorn to v1.12.1, then we don't this patch anymore.
