### PR TITLE
Block PVC expansion with Longhorn V2 encryption until upstreamissue is resolved

### DIFF
--- a/pkg/webhook/util/volume.go
+++ b/pkg/webhook/util/volume.go
@@ -3,9 +3,11 @@ package util
 import (
 	"fmt"
 	"slices"
+	"strconv"
 
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kvirtfeatures "kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
@@ -74,11 +76,64 @@ func isKubevirtExpandEnabled(kubevirt *kubevirtv1.KubeVirt) bool {
 	return slices.Contains(featureGates, kvirtfeatures.ExpandDisksGate)
 }
 
+func checkLonghornV2EncryptedExpand(
+	pvc *corev1.PersistentVolumeClaim,
+	scCache ctlstoragev1.StorageClassCache) error {
+
+	sc, err := getStorageClassForPVC(pvc, scCache)
+	if err != nil {
+		return err
+	}
+	if sc == nil || sc.Provisioner != util.CSIProvisionerLonghorn {
+		return nil
+	}
+
+	encrypted, err := strconv.ParseBool(sc.Parameters[util.LonghornOptionEncrypted])
+	if err != nil && sc.Parameters[util.LonghornOptionEncrypted] != "" {
+		return fmt.Errorf("failed to parse storage class %s parameter %q: %w", sc.Name, util.LonghornOptionEncrypted, err)
+	}
+
+	if sc.Parameters[util.ParamDataEngine] == "v2" && encrypted {
+		return werror.NewInvalidError(
+			fmt.Sprintf(
+				util.PVCExpandErrorPrefix+": expansion of Longhorn V2 encrypted PVC %s/%s is temporarily not supported",
+				pvc.Namespace,
+				pvc.Name,
+			),
+			"",
+		)
+	}
+
+	return nil
+}
+
+func getStorageClassForPVC(pvc *corev1.PersistentVolumeClaim, scCache ctlstoragev1.StorageClassCache) (*storagev1.StorageClass, error) {
+	if pvc.Spec.StorageClassName == nil {
+		return util.GetDefaultSC(scCache), nil
+	}
+	// An explicit empty storageClassName opts out of default StorageClass assignment and requests a PV with no class.
+	if *pvc.Spec.StorageClassName == "" {
+		return nil, nil
+	}
+
+	sc, err := scCache.Get(*pvc.Spec.StorageClassName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get storage class %s for PVC %s/%s: %w", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name, err)
+	}
+	return sc, nil
+}
+
 func CheckExpand(pvc *corev1.PersistentVolumeClaim,
 	vmCache ctlkv1.VirtualMachineCache,
 	kubevirtCache ctlkv1.KubeVirtCache,
 	scCache ctlstoragev1.StorageClassCache,
 	settingCache ctlharvesterv1.SettingCache) error {
+
+	// Longhorn V2 encrypted PVC expansion is temporarily blocked.
+	// See https://github.com/harvester/harvester/issues/10715 for details.
+	if err := checkLonghornV2EncryptedExpand(pvc, scCache); err != nil {
+		return err
+	}
 
 	// Check if online expand is needed first
 	onlineExpand, err := isOnlineExpandNeeded(pvc, vmCache)

--- a/pkg/webhook/util/volume_test.go
+++ b/pkg/webhook/util/volume_test.go
@@ -1,0 +1,137 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	harvesterutil "github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestCheckLonghornV2EncryptedExpand(t *testing.T) {
+	tests := []struct {
+		name          string
+		pvc           *corev1.PersistentVolumeClaim
+		sc            *storagev1.StorageClass
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "blocks Longhorn V2 encrypted PVC",
+			pvc:           newTestPVC("test-pvc", "longhorn-v2-encrypted"),
+			sc:            newTestStorageClass("longhorn-v2-encrypted", harvesterutil.CSIProvisionerLonghorn, map[string]string{harvesterutil.ParamDataEngine: "v2", harvesterutil.LonghornOptionEncrypted: "true"}),
+			expectError:   true,
+			errorContains: "expansion of Longhorn V2 encrypted PVC default/test-pvc is temporarily not supported",
+		},
+		{
+			name: "allows Longhorn V2 unencrypted PVC",
+			pvc:  newTestPVC("test-pvc", "longhorn-v2"),
+			sc:   newTestStorageClass("longhorn-v2", harvesterutil.CSIProvisionerLonghorn, map[string]string{harvesterutil.ParamDataEngine: "v2", harvesterutil.LonghornOptionEncrypted: "false"}),
+		},
+		{
+			name: "allows Longhorn V1 encrypted PVC",
+			pvc:  newTestPVC("test-pvc", "longhorn-v1-encrypted"),
+			sc:   newTestStorageClass("longhorn-v1-encrypted", harvesterutil.CSIProvisionerLonghorn, map[string]string{harvesterutil.ParamDataEngine: "v1", harvesterutil.LonghornOptionEncrypted: "true"}),
+		},
+		{
+			name: "allows non-Longhorn PVC",
+			pvc:  newTestPVC("test-pvc", "standard"),
+			sc:   newTestStorageClass("standard", "rancher.io/local-path", map[string]string{harvesterutil.ParamDataEngine: "v2", harvesterutil.LonghornOptionEncrypted: "true"}),
+		},
+		{
+			name:          "blocks PVC without storage class when default is Longhorn V2 encrypted",
+			pvc:           newTestPVCWithoutStorageClass("test-pvc"),
+			sc:            newDefaultTestStorageClass("longhorn-v2-encrypted", harvesterutil.CSIProvisionerLonghorn, map[string]string{harvesterutil.ParamDataEngine: "v2", harvesterutil.LonghornOptionEncrypted: "true"}),
+			expectError:   true,
+			errorContains: "expansion of Longhorn V2 encrypted PVC default/test-pvc is temporarily not supported",
+		},
+		{
+			name: "allows PVC with explicit empty storage class",
+			pvc:  newTestPVCWithEmptyStorageClass("test-pvc"),
+			sc:   newDefaultTestStorageClass("longhorn-v2-encrypted", harvesterutil.CSIProvisionerLonghorn, map[string]string{harvesterutil.ParamDataEngine: "v2", harvesterutil.LonghornOptionEncrypted: "true"}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			if tc.sc != nil {
+				assert.NoError(t, clientset.Tracker().Add(tc.sc))
+			}
+
+			err := checkLonghornV2EncryptedExpand(
+				tc.pvc,
+				fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+			)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorContains)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			err = CheckExpand(
+				tc.pvc,
+				fakeclients.VirtualMachineCache(clientset.KubevirtV1().VirtualMachines),
+				nil,
+				fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+				nil,
+			)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorContains)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func newTestPVC(name, storageClassName string) *corev1.PersistentVolumeClaim {
+	return newTestPVCWithStorageClassName(name, &storageClassName)
+}
+
+func newTestPVCWithoutStorageClass(name string) *corev1.PersistentVolumeClaim {
+	return newTestPVCWithStorageClassName(name, nil)
+}
+
+func newTestPVCWithEmptyStorageClass(name string) *corev1.PersistentVolumeClaim {
+	storageClassName := ""
+	return newTestPVCWithStorageClassName(name, &storageClassName)
+}
+
+func newTestPVCWithStorageClassName(name string, storageClassName *string) *corev1.PersistentVolumeClaim {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+	pvc.Spec.StorageClassName = storageClassName
+	return pvc
+}
+
+func newTestStorageClass(name, provisioner string, parameters map[string]string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: provisioner,
+		Parameters:  parameters,
+	}
+}
+
+func newDefaultTestStorageClass(name, provisioner string, parameters map[string]string) *storagev1.StorageClass {
+	sc := newTestStorageClass(name, provisioner, parameters)
+	sc.Annotations = map[string]string{
+		harvesterutil.AnnotationIsDefaultStorageClassName: "true",
+	}
+	return sc
+}


### PR DESCRIPTION
#### Problem:
https://github.com/harvester/harvester/issues/10715

#### Solution:
Block PVC online expansion with Longhorn V2 encryption until upstreamissue is resolved

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10715

#### Test plan:

**Watch this first 👇**

**WARNING: If the harvester cluster include this https://github.com/harvester/harvester/pull/10961 patch. You will be unable to create an lhv2 encrypted storage class. Therefore, testing this PR requires a v1.8.0 environment that already has an lhv2 encrypted volume created and upgrade to the harvester version with this patch.**

1. Enable lhv2
1. create secret
    ```
    kubectl apply -f - << 'EOF'
    apiVersion: v1
    kind: Secret
    metadata:
      name: qa-encryption
      namespace: default
    type: Opaque
    stringData:
      CRYPTO_KEY_CIPHER: "aes-xts-plain64"
      CRYPTO_KEY_HASH: "sha256"
      CRYPTO_KEY_PROVIDER: "secret"
      CRYPTO_KEY_SIZE: "256"
      CRYPTO_KEY_VALUE: "qa-test-encryption-key"
      CRYPTO_PBKDF: "argon2i"
    EOF
    ```
1. create lhv2 storage class
    ```
    kubectl apply -f - << 'EOF'
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
    metadata:
      name: qa-lhv2-encrypted
    provisioner: driver.longhorn.io
    allowVolumeExpansion: true
    parameters:
      dataEngine: v2
      encrypted: "true"
      migratable: "true"
      csi.storage.k8s.io/provisioner-secret-name: qa-encryption
      csi.storage.k8s.io/provisioner-secret-namespace: default
      csi.storage.k8s.io/node-stage-secret-name: qa-encryption
      csi.storage.k8s.io/node-stage-secret-namespace: default
      csi.storage.k8s.io/node-publish-secret-name: qa-encryption
      csi.storage.k8s.io/node-publish-secret-namespace: default
    EOF
    ```
1. create volume <img width="3530" height="1370" alt="image" src="https://github.com/user-attachments/assets/3862c55a-dd71-4689-ac55-268306d4508d" />
1. Expand the volume, and you'll see validator raise error block lhv2 encrypted volume expansion <img width="1766" height="710" alt="Screenshot 2026-07-01 at 8 57 55 PM" src="https://github.com/user-attachments/assets/4be6059f-11ba-4a5e-999d-b0f455628d6d" />


#### Additional documentation or context

- Currently vmimage creation using the lhv2 encrypted storage class fails due to a volume size mismatch (it is 16MB short). This occurs because the CDI enforces a PVC size check.
- please hold off merging this pr, if https://github.com/longhorn/longhorn/issues/13365 is fixed, and harvester v1.9.0 bump longhorn to v1.12.1, then we don't this patch anymore.