### PR TITLE
Fix package harvester upgrade error and skip Renovate builds

### DIFF
--- a/.github/workflows/build-factory.yml
+++ b/.github/workflows/build-factory.yml
@@ -102,6 +102,7 @@ jobs:
         cp -r ./bin/harvester ./package/
         cp -r ./bin/harvester-webhook ./package/
         cp -r ./bin/upgrade-helper ./package/upgrade/
+        cp -r ./bin/harvester-installer ./package/upgrade/
 
     - name: Download add-ons manifests
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/vagrant-install.yaml
+++ b/.github/workflows/vagrant-install.yaml
@@ -40,6 +40,7 @@ env:
 jobs:
   main:
     name: Build and deploy
+    if: ${{ !(github.actor == 'renovate[bot]' && github.event_name == 'pull_request') }}
     runs-on:
       group: vagrant
     steps:


### PR DESCRIPTION
- Copy installer binary for packaging. This should fix https://github.com/harvester/harvester/actions/runs/28492531142/job/84454117309
- vagrant-install workflow: skip renovate PRs.