### PR TITLE
Kubelet enters NotReady state after RKE2 upgrade due to failed node registration

### DIFF
--- a/pkg/controller/master/upgrade/upgrade_controller.go
+++ b/pkg/controller/master/upgrade/upgrade_controller.go
@@ -54,7 +54,7 @@ const (
 	harvesterSystemNamespace       = util.HarvesterSystemNamespaceName
 	harvesterUpgradeLabel          = util.LabelHarvesterUpgrade
 	harvesterManagedLabel          = util.HarvesterManagedNodeLabelKey
-	harvesterLatestUpgradeLabel    = "harvesterhci.io/latestUpgrade"
+	harvesterLatestUpgradeLabel    = util.LabelHarvesterLatestUpgrade
 	harvesterUpgradeComponentLabel = util.LabelHarvesterUpgradeComponent
 	harvesterNodeLabel             = "harvesterhci.io/node"
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -35,6 +35,7 @@ const (
 	LabelHarvesterUpgrade               = prefix + "/upgrade"
 	LabelHarvesterUpgradeState          = prefix + "/upgradeState"
 	LabelHarvesterUpgradeComponent      = prefix + "/upgradeComponent"
+	LabelHarvesterLatestUpgrade         = prefix + "/latestUpgrade"
 	AnnotationStorageClassName          = prefix + "/storageClassName"
 	AnnotationStorageProvisioner        = prefix + "/storageProvisioner"
 	AnnotationIsDefaultStorageClassName = "storageclass.kubernetes.io/is-default-class"

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -63,51 +63,47 @@ func (v *nodeValidator) Create(req *types.Request, newObj runtime.Object) error 
 
 	node := newObj.(*corev1.Node)
 
-	upgrades, err := v.upgradeCache.List(util.HarvesterSystemNamespaceName, labels.NewSelector())
-	if err != nil {
-		return werror.NewInternalError(fmt.Sprintf("failed to list upgrades: %v", err))
-	}
-
-	// Collect all in-progress upgrades first.
-	var inProgressUpgrades []*harvesterv1.Upgrade
-	var inProgressUpgradeNames []string
-	for _, upgrade := range upgrades {
-		if util.IsUpgradeInProgress(upgrade) {
-			inProgressUpgrades = append(inProgressUpgrades, upgrade)
-			inProgressUpgradeNames = append(inProgressUpgradeNames, util.GetNamespacedName(upgrade))
-		}
-	}
-
-	if len(inProgressUpgrades) == 0 {
+	// Allow idempotent create attempts for already-registered nodes. During
+	// upgrades, components may call `Create` first (receive `AlreadyExists`)
+	// and then reconcile updates.
+	existingNode, err := v.nodeCache.Get(node.Name)
+	if err == nil && existingNode != nil {
 		return nil
 	}
 
-	// Log warning if multiple upgrades are running (should not happen in
-	// normal operation).
-	if len(inProgressUpgrades) > 1 {
-		logrus.Warnf("Multiple upgrades in progress: %s", strings.Join(inProgressUpgradeNames, ", "))
+	upgrades, err := v.upgradeCache.List(util.HarvesterSystemNamespaceName, labels.SelectorFromSet(labels.Set{
+		util.LabelHarvesterLatestUpgrade: "true",
+	}))
+	if err != nil {
+		return werror.NewInternalError(fmt.Sprintf("failed to list upgrades: %v", err))
+	}
+	if len(upgrades) == 0 {
+		return nil
 	}
 
-	// Check if ALL in-progress upgrades have the override annotation set to
-	// true. This ensures that when multiple upgrades are running, all must
-	// explicitly allow node join.
-	for _, upgrade := range inProgressUpgrades {
-		value, ok := upgrade.Annotations[util.AnnotationAllowNodeJoin]
-		if !ok {
-			return nodeJoinBlockedByUpgrade(node, upgrade, false)
-		}
-		allow, err := strconv.ParseBool(value)
-		if err != nil {
-			return invalidAllowNodeJoinAnnotation(node, upgrade, value, err)
-		}
-		if !allow {
-			return nodeJoinBlockedByUpgrade(node, upgrade, true)
-		}
+	// Intentionally evaluate only the first latest-labeled upgrade.
+	// The upgrade controller keeps at most one valid "latest" upgrade; if multiple
+	// exist, that is an upstream inconsistency and this webhook stays scoped to the
+	// expected single-latest path.
+	latestUpgrade := upgrades[0]
+	if !util.IsUpgradeInProgress(latestUpgrade) {
+		return nil
 	}
 
-	// All upgrades have the override annotation set to true -> allow with warning.
-	logrus.Warnf("Node %q join allowed during %d active upgrade(s) via override annotation: %s",
-		node.Name, len(inProgressUpgrades), strings.Join(inProgressUpgradeNames, ", "))
+	value, ok := latestUpgrade.Annotations[util.AnnotationAllowNodeJoin]
+	if !ok {
+		return nodeJoinBlockedByUpgrade(node, latestUpgrade, false)
+	}
+	allow, err := strconv.ParseBool(value)
+	if err != nil {
+		return invalidAllowNodeJoinAnnotation(node, latestUpgrade, value, err)
+	}
+	if !allow {
+		return nodeJoinBlockedByUpgrade(node, latestUpgrade, true)
+	}
+
+	logrus.Warnf("Node %q join allowed during active upgrade %q via override annotation",
+		node.Name, util.GetNamespacedName(latestUpgrade))
 
 	return nil
 }

--- a/pkg/webhook/resources/node/validator_test.go
+++ b/pkg/webhook/resources/node/validator_test.go
@@ -774,6 +774,7 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 	type testCase struct {
 		name          string
 		node          *corev1.Node
+		existingNodes []*corev1.Node
 		upgrades      []*harvesterv1.Upgrade
 		isController  bool
 		expectedError bool
@@ -781,6 +782,107 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 	}
 
 	testCases := []testCase{
+		{
+			name: "allow node creation when in-progress upgrade has no latest label",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when in-progress upgrade latest label is false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "false",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when latest upgrade override is true and non-latest has no override",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-node",
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "latest-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
+						Annotations: map[string]string{
+							util.AnnotationAllowNodeJoin: "true",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
 		{
 			name: "allow node creation when no upgrade is active",
 			node: &corev1.Node{
@@ -804,6 +906,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 					},
 					Status: harvesterv1.UpgradeStatus{
 						Conditions: []harvesterv1.Condition{
@@ -856,6 +961,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 					},
 					Status: harvesterv1.UpgradeStatus{
 						Conditions: []harvesterv1.Condition{
@@ -883,6 +991,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "true",
 						},
@@ -912,6 +1023,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "TRUE",
 						},
@@ -941,6 +1055,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "1",
 						},
@@ -970,6 +1087,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "t",
 						},
@@ -999,6 +1119,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "false",
 						},
@@ -1029,6 +1152,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "invalid",
 						},
@@ -1059,6 +1185,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-upgrade",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 					},
 					Status: harvesterv1.UpgradeStatus{
 						Conditions: []harvesterv1.Condition{
@@ -1074,7 +1203,43 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "block node creation when multiple upgrades active and not all have override",
+			name: "allow create on already-registered node during active upgrade",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existing-node",
+				},
+			},
+			existingNodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+				},
+			},
+			upgrades: []*harvesterv1.Upgrade{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-upgrade",
+						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
+					},
+					Status: harvesterv1.UpgradeStatus{
+						Conditions: []harvesterv1.Condition{
+							{
+								Type:   "Completed",
+								Status: "Unknown",
+							},
+						},
+					},
+				},
+			},
+			isController:  false,
+			expectedError: false,
+		},
+		{
+			name: "allow node creation when multiple latest upgrades exist and first allows override",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "new-node",
@@ -1085,6 +1250,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-1",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "true",
 						},
@@ -1115,11 +1283,10 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 				},
 			},
 			isController:  false,
-			expectedError: true,
-			errorContains: "because the upgrade \"harvester-system/upgrade-2\" is currently in progress.",
+			expectedError: false,
 		},
 		{
-			name: "allow node creation when multiple upgrades active and all have override",
+			name: "allow node creation when multiple upgrades active and first has allow override",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "new-node",
@@ -1130,6 +1297,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-1",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "true",
 						},
@@ -1147,6 +1317,9 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-2",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
 							util.AnnotationAllowNodeJoin: "1",
 						},
@@ -1165,7 +1338,7 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "block node creation when multiple upgrades and one has false override",
+			name: "block node creation when multiple latest upgrades exist and first denies override",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "new-node",
@@ -1176,8 +1349,11 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-1",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
-							util.AnnotationAllowNodeJoin: "true",
+							util.AnnotationAllowNodeJoin: "false",
 						},
 					},
 					Status: harvesterv1.UpgradeStatus{
@@ -1193,8 +1369,11 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "upgrade-2",
 						Namespace: util.HarvesterSystemNamespaceName,
+						Labels: map[string]string{
+							util.LabelHarvesterLatestUpgrade: "true",
+						},
 						Annotations: map[string]string{
-							util.AnnotationAllowNodeJoin: "false",
+							util.AnnotationAllowNodeJoin: "true",
 						},
 					},
 					Status: harvesterv1.UpgradeStatus{
@@ -1209,7 +1388,7 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 			},
 			isController:  false,
 			expectedError: true,
-			errorContains: "because the upgrade \"harvester-system/upgrade-2\" is currently in progress.",
+			errorContains: "because the upgrade \"harvester-system/upgrade-1\" is currently in progress.",
 		},
 	}
 
@@ -1217,12 +1396,18 @@ func TestValidateNodeCreateDuringUpgrade(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			clientset := fake.NewSimpleClientset()
 
+			for _, node := range tc.existingNodes {
+				err := clientset.Tracker().Add(node)
+				assert.Nil(t, err)
+			}
+
 			for _, upgrade := range tc.upgrades {
 				err := clientset.Tracker().Add(upgrade)
 				assert.Nil(t, err)
 			}
 
 			validator := &nodeValidator{
+				nodeCache:    fakeclients.NodeCache(clientset.CoreV1().Nodes),
 				upgradeCache: fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
 			}
 
@@ -1272,6 +1457,7 @@ func TestValidateNodeCreateDuringUpgradeCacheError(t *testing.T) {
 	})
 
 	validator := &nodeValidator{
+		nodeCache:    fakeclients.NodeCache(clientset.CoreV1().Nodes),
 		upgradeCache: fakeclients.UpgradeCache(clientset.HarvesterhciV1beta1().Upgrades),
 	}
 


### PR DESCRIPTION
#### Problem:
The upgrade became stuck indefinitely after RKE2 was upgraded on the first node.
Apparently, [kubelet tries to register the node](https://github.com/kubernetes/kubernetes/blob/6b88c9134c504ce1596368f9fe6e79e2174cad4e/pkg/kubelet/kubelet_node_status.go#L92-L110) to the cluster periodically. But during the upgrade, such Create calls are blocked by our validator, which was introduced in https://github.com/harvester/harvester/pull/10723.

#### Solution:
Allow idempotent create attempts for already-registered nodes. During upgrades, components may call `Create` first (receive `AlreadyExists`) and then reconcile updates.

#### Related Issue(s):
- https://github.com/harvester/harvester/issues/11011
- https://github.com/harvester/harvester/issues/7601

#### Test plan:
***Case 1***
- Install a 1.8.0 3-node cluster. 
- Upload the 1.9.0 ISO image under the `server-version` setting.
- Start the upgrade.
- The upgrade should succeed.

<img width="1269" height="890" alt="grafik" src="https://github.com/user-attachments/assets/1b1cc102-eacb-4ec2-a074-2517641426ec" />

***Case 2***
- Install a 1.9.0 1-node cluster.
- Scale down the `harvester` deployment.
```
kubectl scale deployment harvester -n harvester-system --replicas=0
```
- Create an fake upgrade:
```
cat <<EOF | kubectl create -f -
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  name: test-upgrade
  namespace: harvester-system
  labels:
    harvesterhci.io/latestUpgrade: "true"
spec:
  version: "v1.9.1"
  image: "rancher/harvester-upgrade:v1.9.1"
EOF
```
- Patch the status of the `Upgrade`.
```
kubectl patch upgrades.harvesterhci.io test-upgrade -n harvester-system --type=merge -p '{"status": {"conditions": [{"type": "Completed", "status": "Unknown", "reason": "InProgress", "message": "Upgrade in progress"}]}}'
```
- Don't take too long to execute the following commands, because the `Upgrade` CR won't remain in the patched state indefinitely.
- Try to create a new node:
```
kubectl apply -f - <<EOF
apiVersion: v1
kind: Node
metadata:
  name: test-node
spec:
  podCIDR: 192.168.0.33/32
EOF
```
- The creation should be blocked. The output should look like:
```
$ kubectl apply -f - <<EOF
apiVersion: v1
kind: Node
metadata:
  name: test-node
spec:
  podCIDR: 192.168.0.33/32
EOF
Error from server (Conflict): error when creating "STDIN": admission webhook "validator.harvesterhci.io" denied the request: cannot add node "test-node" to the cluster because the upgrade "harvester-system/test-upgrade" is currently in progress. Adding nodes during an upgrade can cause unexpected behavior and is not recommended. If you must add this node now, run: kubectl annotate upgrade -n harvester-system test-upgrade harvesterhci.io/allow-node-join=true
```
- Cleanup
```
kubectl delete upgrades.harvesterhci.io test-upgrade -n harvester-system
kubectl scale deployment harvester -n harvester-system --replicas=1
```

***Case 3***
- Install a 1.9.0 1-node cluster.
- Scale down the `harvester` deployment.
```
kubectl scale deployment harvester -n harvester-system --replicas=0
```
- Create an fake upgrade:
```
cat <<EOF | kubectl create -f -
apiVersion: harvesterhci.io/v1beta1
kind: Upgrade
metadata:
  name: test-upgrade
  namespace: harvester-system
  annotations:
    harvesterhci.io/allow-node-join: "true"
  labels:
    harvesterhci.io/latestUpgrade: "true"
spec:
  version: "v1.9.1"
  image: "rancher/harvester-upgrade:v1.9.1"
EOF
```
- Patch the status of the `Upgrade`.
```
kubectl patch upgrades.harvesterhci.io test-upgrade -n harvester-system --type=merge -p '{"status": {"conditions": [{"type": "Completed", "status": "Unknown", "reason": "InProgress", "message": "Upgrade in progress"}]}}'
```
- Don't take too long to execute the following commands, because the `Upgrade` CR won't remain in the patched state indefinitely.
- Try to create a new node:
```
kubectl apply -f - <<EOF
apiVersion: v1
kind: Node
metadata:
  name: test-node
spec:
  podCIDR: 192.168.0.33/32
EOF
```
- The creation should be successful.
```
$ kubectl apply -f - <<EOF
apiVersion: v1
kind: Node
metadata:
  name: test-node
spec:
  podCIDR: 192.168.0.33/32
EOF
node/test-node created
```
- Get the list of nodes:
```
$ k get Nodes                                                           
NAME               STATUS     ROLES                AGE    VERSION
harvester-node-0   Ready      control-plane,etcd   150m   v1.35.5+rke2r1
test-node          NotReady   <none>               37s    
```
<img width="1510" height="447" alt="grafik" src="https://github.com/user-attachments/assets/1086451a-8984-4110-b8c4-9c2fab157b28" />

**Cleanup**
```
$ kubectl scale deployment harvester -n harvester-system --replicas=1
$ kubectl delete node test-node
$ kubectl delete upgrade.harvesterhci.io test-upgrade -n harvester-system
```

#### Additional documentation or context
