### PR TITLE
fix: add z flag to image-cache volume mounts for SELinux compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,14 +228,14 @@ image-cache-show:
 	$(BANNER)
 	docker run --rm \
 	    -v $(MK_IMAGE_CACHE_VOLUME):/image-caches:ro \
-	    -v $(ROOT)/scripts/image-cache:/bin/image-cache:ro \
+	    -v $(ROOT)/scripts/image-cache:/bin/image-cache:ro,z \
 	    alpine image-cache show
 
 image-cache-debug:
 	$(BANNER)
 	docker run --rm -it \
 	    -v $(MK_IMAGE_CACHE_VOLUME):/image-caches:rw \
-	    -v $(ROOT)/scripts/image-cache:/bin/image-cache:ro \
+	    -v $(ROOT)/scripts/image-cache:/bin/image-cache:ro,z \
 	    alpine sh
 
 .DEFAULT_GOAL := default


### PR DESCRIPTION
The script is prohibited on systems with selinux on.

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

`make image-cache-show` doesn't work on systems with SELinux enabled.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Specify `-z` when bind-mounting the script. (https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label)

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
