### PR TITLE
feat: add install option to cordon newly joined nodes

### DIFF
--- a/pkg/api/node/formatter.go
+++ b/pkg/api/node/formatter.go
@@ -72,7 +72,7 @@ func Formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.AddAction(request, enableCPUManager)
 	resource.AddAction(request, disableCPUManager)
 
-	if resource.APIObject.Data().String("metadata", "annotations", ctlnode.MaintainStatusAnnotationKey) != "" {
+	if resource.APIObject.Data().String("metadata", "annotations", util.MaintainStatusAnnotationKey) != "" {
 		resource.AddAction(request, disableMaintenanceModeAction)
 		resource.AddAction(request, powerAction)
 	} else {
@@ -229,7 +229,7 @@ func (h ActionHandler) disableMaintenanceMode(nodeName string) error {
 		}
 		delete(node.Annotations, drainhelper.DrainAnnotation)
 		delete(node.Annotations, drainhelper.ForcedDrain)
-		delete(node.Annotations, ctlnode.MaintainStatusAnnotationKey)
+		delete(node.Annotations, util.MaintainStatusAnnotationKey)
 	}
 
 	err := h.retryMaintenanceModeUpdate(nodeName, disableMaintaenanceModeFunc, "disable")

--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -47,7 +47,6 @@ import (
 	volumeapi "github.com/harvester/harvester/pkg/api/volume"
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/builder"
-	nodecontroller "github.com/harvester/harvester/pkg/controller/master/node"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
@@ -725,7 +724,7 @@ func (h *vmActionHandler) findMigratableNodesByVMI(vmi *kubevirtv1.VirtualMachin
 }
 
 func isDrained(node *corev1.Node) bool {
-	if _, ok := node.Annotations[nodecontroller.MaintainStatusAnnotationKey]; ok {
+	if _, ok := node.Annotations[util.MaintainStatusAnnotationKey]; ok {
 		return ok
 	}
 	if _, ok := node.Annotations[drainhelper.DrainAnnotation]; ok {

--- a/pkg/controller/master/node/maintain_controller.go
+++ b/pkg/controller/master/node/maintain_controller.go
@@ -17,10 +17,7 @@ import (
 )
 
 const (
-	maintainNodeControllerName  = "maintain-node-controller"
-	MaintainStatusAnnotationKey = "harvesterhci.io/maintain-status"
-	MaintainStatusComplete      = "completed"
-	MaintainStatusRunning       = "running"
+	maintainNodeControllerName = "maintain-node-controller"
 )
 
 // maintainNodeHandler updates maintenance status of a node in its annotations, so that we can tell whether the node is
@@ -57,7 +54,7 @@ func (h *maintainNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev
 	if node == nil || node.DeletionTimestamp != nil {
 		return node, nil
 	}
-	if maintenanceStatus, ok := node.Annotations[MaintainStatusAnnotationKey]; !ok || maintenanceStatus != MaintainStatusRunning {
+	if maintenanceStatus, ok := node.Annotations[util.MaintainStatusAnnotationKey]; !ok || maintenanceStatus != util.MaintainStatusRunning {
 		return node, nil
 	}
 
@@ -110,7 +107,7 @@ func (h *maintainNodeHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev
 	}
 
 	toUpdate := node.DeepCopy()
-	toUpdate.Annotations[MaintainStatusAnnotationKey] = MaintainStatusComplete
+	toUpdate.Annotations[util.MaintainStatusAnnotationKey] = util.MaintainStatusComplete
 	return h.nodes.Update(toUpdate)
 }
 
@@ -121,7 +118,7 @@ func (h *maintainNodeHandler) OnNodeRemoved(_ string, node *corev1.Node) (*corev
 		return node, nil
 	}
 
-	if _, ok := node.Annotations[MaintainStatusAnnotationKey]; !ok {
+	if _, ok := node.Annotations[util.MaintainStatusAnnotationKey]; !ok {
 		return node, nil
 	}
 

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -311,6 +311,7 @@ func selectPromoteNode(nodeList []*corev1.Node) *corev1.Node {
 				managementOrHealthyHarvesterWorkerZones[zone] = true
 			}
 		} else if util.IsHealthyNode(node) && isHarvesterNode(node) &&
+			!node.Spec.Unschedulable &&
 			!isWorkerPreferredNode(node) && !isExtraWitnessNode(node, len(witnessPreferred), witnessPromoted) {
 			if zone != "" {
 				managementOrHealthyHarvesterWorkerZones[zone] = true

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -110,6 +110,20 @@ func (h *PromoteHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Nod
 		return nil, err
 	}
 
+	// The code in the installer adds `harvesterhci.io/install-cordoned=true`
+	// to the labels in `/etc/rancher/rancherd/config.yaml`, and then when
+	// rancherd deploys rke2, rancherd in turn adds that label to the config
+	// in /etc/rancher/rke2/config.yaml.d/40-rancherd.yaml.  This means that
+	// every time rke2-server or rke2-agent starts on a given node, it will
+	// add that label to the node, so we know that the user wants it to be
+	// initially cordoned right after install.  In order to ensure we only
+	// do the cordoning once, we later add `harvesterhci.io/install-cordoned-processed=true`
+	// to the node's annotations.  If that annotation is present, we know the
+	// cordon has been processed and we shouldn't try to cordon that node again.
+	if installCordoned, cordonProcessed := node.Labels[util.HarvesterInstallCordonedLabel], node.Annotations[util.HarvesterInstallCordonedProcessedAnnotation]; installCordoned == "true" && cordonProcessed != "true" {
+		return h.reconcileInstallCordonedNode(node, nodeList)
+	}
+
 	// early return if the node number not enough
 	if len(nodeList) < defaultSpecManagementNumber {
 		return node, nil
@@ -133,6 +147,29 @@ func (h *PromoteHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Nod
 	}
 
 	return node, nil
+}
+
+func (h *PromoteHandler) reconcileInstallCordonedNode(node *corev1.Node, nodeList []*corev1.Node) (*corev1.Node, error) {
+	toUpdate := node.DeepCopy()
+	if !toUpdate.Spec.Unschedulable {
+		// Set the node to unschedulable if it's not the last available.
+		if util.IsOtherNodeAvailable(toUpdate.Name, nodeList) {
+			logrus.WithFields(logrus.Fields{
+				"node": toUpdate.Name,
+			}).Info("Node labelled to be cordoned at install, setting it unschedulable")
+			toUpdate.Spec.Unschedulable = true
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"node": toUpdate.Name,
+			}).Info("Node labelled to be cordoned at install, but no other nodes are available - node will remain schedulable")
+		}
+	}
+	// Set an annotation to indicate we've processed the cordon once, and don't want to try this again
+	if toUpdate.Annotations == nil {
+		toUpdate.Annotations = make(map[string]string)
+	}
+	toUpdate.Annotations[util.HarvesterInstallCordonedProcessedAnnotation] = "true"
+	return h.nodes.Update(toUpdate)
 }
 
 // OnJobChanged

--- a/pkg/controller/master/node/promote_controller.go
+++ b/pkg/controller/master/node/promote_controller.go
@@ -121,7 +121,8 @@ func (h *PromoteHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Nod
 	// to the node's annotations.  If that annotation is present, we know the
 	// cordon has been processed and we shouldn't try to cordon that node again.
 	if installCordoned, cordonProcessed := node.Labels[util.HarvesterInstallCordonedLabel], node.Annotations[util.HarvesterInstallCordonedProcessedAnnotation]; installCordoned == "true" && cordonProcessed != "true" {
-		return h.reconcileInstallCordonedNode(node, nodeList)
+		toUpdate := reconcileInstallCordonedNode(node, nodeList)
+		return h.nodes.Update(toUpdate)
 	}
 
 	// early return if the node number not enough
@@ -149,7 +150,7 @@ func (h *PromoteHandler) OnNodeChanged(_ string, node *corev1.Node) (*corev1.Nod
 	return node, nil
 }
 
-func (h *PromoteHandler) reconcileInstallCordonedNode(node *corev1.Node, nodeList []*corev1.Node) (*corev1.Node, error) {
+func reconcileInstallCordonedNode(node *corev1.Node, nodeList []*corev1.Node) *corev1.Node {
 	toUpdate := node.DeepCopy()
 	if !toUpdate.Spec.Unschedulable {
 		// Set the node to unschedulable if it's not the last available.
@@ -169,7 +170,7 @@ func (h *PromoteHandler) reconcileInstallCordonedNode(node *corev1.Node, nodeLis
 		toUpdate.Annotations = make(map[string]string)
 	}
 	toUpdate.Annotations[util.HarvesterInstallCordonedProcessedAnnotation] = "true"
-	return h.nodes.Update(toUpdate)
+	return toUpdate
 }
 
 // OnJobChanged

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -106,6 +106,11 @@ func (n *NodeBuilder) NotReady() *NodeBuilder {
 	return n
 }
 
+func (n *NodeBuilder) Cordoned() *NodeBuilder {
+	n.node.Spec.Unschedulable = true
+	return n
+}
+
 var (
 	// normal nodes
 	mu1 = NewDefaultNodeBuilder().Name("m-unmanaged-1").Management()
@@ -134,6 +139,9 @@ var (
 	w1 = NewDefaultNodeBuilder().Name("w-1").Harvester().Worker()
 	w2 = NewDefaultNodeBuilder().Name("w-2").Harvester().Worker()
 	w3 = NewDefaultNodeBuilder().Name("w-3").Harvester().Worker()
+
+	wo1 = NewDefaultNodeBuilder().Name("w-cordoned-1").Harvester().Cordoned().Worker()
+	wo2 = NewDefaultNodeBuilder().Name("w-cordoned-2").Harvester().Cordoned().Worker()
 
 	w1rm  = NewDefaultNodeBuilder().Name("w-1-r-mgmt").Harvester().RoleMgmt().Worker()
 	w1rwk = NewDefaultNodeBuilder().Name("w-1-r-worker").Harvester().RoleWorker().Worker()
@@ -196,6 +204,20 @@ func Test_selectPromoteNode(t *testing.T) {
 			name: "one management and two worker",
 			args: args{
 				nodeList: []*corev1.Node{m1, w1, w2},
+			},
+			want: w1,
+		},
+		{
+			name: "one management and two cordoned workers",
+			args: args{
+				nodeList: []*corev1.Node{m1, wo1, wo2},
+			},
+			want: nil,
+		},
+		{
+			name: "one management and two cordoned workers and two ready workers",
+			args: args{
+				nodeList: []*corev1.Node{m1, wo1, wo2, w1, w2},
 			},
 			want: w1,
 		},

--- a/pkg/controller/master/node/promote_controller_test.go
+++ b/pkg/controller/master/node/promote_controller_test.go
@@ -790,3 +790,51 @@ func Test_selectPromoteNode(t *testing.T) {
 		})
 	}
 }
+
+func Test_reconcileInstallCordonedNode(t *testing.T) {
+	type args struct {
+		node     *corev1.Node
+		nodeList []*corev1.Node
+	}
+	tests := []struct {
+		name          string
+		args          args
+		unschedulable bool
+	}{
+		{
+			name: "one management (will not cordon)",
+			args: args{
+				node:     m1,
+				nodeList: []*corev1.Node{m1},
+			},
+			unschedulable: false,
+		},
+		{
+			name: "one management and one ready worker (will cordon worker)",
+			args: args{
+				node:     w1,
+				nodeList: []*corev1.Node{m1, w1},
+			},
+			unschedulable: true,
+		},
+		{
+			name: "one management and one cordoned worker (will not cordon management)",
+			args: args{
+				node:     m1,
+				nodeList: []*corev1.Node{m1, wo1},
+			},
+			unschedulable: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reconcileInstallCordonedNode(tt.args.node, tt.args.nodeList)
+			if got.Annotations[util.HarvesterInstallCordonedProcessedAnnotation] != "true" {
+				t.Errorf("processed node is missing %s annotation", util.HarvesterInstallCordonedProcessedAnnotation)
+			}
+			if got.Spec.Unschedulable != tt.unschedulable {
+				t.Errorf("node.Spec.Unschedulable = %v, want %v", got.Spec.Unschedulable, tt.unschedulable)
+			}
+		})
+	}
+}

--- a/pkg/controller/master/nodedrain/nodedrain_controller.go
+++ b/pkg/controller/master/nodedrain/nodedrain_controller.go
@@ -19,7 +19,6 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/config"
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/util"
@@ -225,7 +224,7 @@ func (ndc *ControllerHandler) OnNodeChange(_ string, node *corev1.Node) (*corev1
 		return node, err
 	}
 
-	nodeCopy.Annotations[ctlnode.MaintainStatusAnnotationKey] = ctlnode.MaintainStatusRunning
+	nodeCopy.Annotations[util.MaintainStatusAnnotationKey] = util.MaintainStatusRunning
 	delete(nodeCopy.Annotations, drainhelper.DrainAnnotation)
 	delete(nodeCopy.Annotations, drainhelper.ForcedDrain)
 
@@ -534,7 +533,7 @@ func (ndc *ControllerHandler) listVMILabelMaintainModeStrategy(node *corev1.Node
 
 func (ndc *ControllerHandler) cleanupMaintenanceModeAnnotations(node *corev1.Node) (*corev1.Node, error) {
 	nodeCopy := node.DeepCopy()
-	delete(nodeCopy.Annotations, ctlnode.MaintainStatusAnnotationKey)
+	delete(nodeCopy.Annotations, util.MaintainStatusAnnotationKey)
 	delete(nodeCopy.Annotations, drainhelper.DrainAnnotation)
 	delete(nodeCopy.Annotations, drainhelper.ForcedDrain)
 	nodeUpdate, err := ndc.nodes.Update(nodeCopy)

--- a/pkg/installer/config/config.go
+++ b/pkg/installer/config/config.go
@@ -181,6 +181,7 @@ type Install struct {
 	WithNetImages bool     `json:"withNetImages,omitempty"`
 	WipeAllDisks  bool     `json:"wipeAllDisks,omitempty"`
 	WipeDisksList []string `json:"wipeDisksList,omitempty"`
+	Cordoned      bool     `json:"cordoned,omitempty"`
 
 	// Following options are not cOS installer flag
 	ForceMBR bool   `json:"forceMbr,omitempty"`

--- a/pkg/installer/config/templates/rancherd-config.yaml
+++ b/pkg/installer/config/templates/rancherd-config.yaml
@@ -11,6 +11,8 @@ rancherVersion: {{ .RancherVersion }}
 rancherInstallerImage: rancher/system-agent-installer-rancher:{{ .RancherVersion }}
 labels:
  - harvesterhci.io/managed=true
+{{ if .Install.Cordoned }} - harvesterhci.io/install-cordoned=true
+{{ end -}}
 extraConfig:
   disable:
   - rke2-snapshot-controller

--- a/pkg/installer/console/validator.go
+++ b/pkg/installer/console/validator.go
@@ -56,6 +56,9 @@ var (
 	ErrMsgManagementInterfaceNotFound = "networks is deprecated, please use management_interface for new config and refer https://docs.harvesterhci.io/v1.1/install/harvester-configuration/#installmanagement_interface"
 	ErrMsgUnsupportedSchemeVersion    = "Unsupported Harvester Scheme Version %d, please use new config and refer https://docs.harvesterhci.io/v1.1/install/harvester-configuration/"
 
+	ErrMsgCordonedInvalidMode = fmt.Sprintf("install.cordoned can't be set in %s mode", config.ModeCreate)
+	ErrMsgCordonedInvalidRole = fmt.Sprintf("install.cordoned can't be set for nodes with the %s role", config.RoleWitness)
+
 	ErrContainerdRegistrySettingNotValidJSON = "could not parse containerd-registry as JSON"
 )
 
@@ -441,6 +444,15 @@ func commonCheck(cfg *config.HarvesterConfig) error {
 
 	if len(cfg.SSHAuthorizedKeys) == 0 && cfg.Password == "" {
 		return errors.New(ErrMsgNoCredentials)
+	}
+
+	if cfg.Install.Cordoned {
+		if cfg.Install.Mode == config.ModeCreate {
+			return errors.New(ErrMsgCordonedInvalidMode)
+		}
+		if cfg.Install.Role == config.RoleWitness {
+			return errors.New(ErrMsgCordonedInvalidRole)
+		}
 	}
 
 	return checkPersistentStatePaths(cfg.OS.PersistentStatePaths)

--- a/pkg/installer/console/validator_test.go
+++ b/pkg/installer/console/validator_test.go
@@ -135,6 +135,54 @@ func TestValidateConfig(t *testing.T) {
 			},
 			errMsg: ErrMsgMgmtInterfaceNotSpecified,
 		},
+		{
+			name: "invalid create config: install.cordoned is true",
+			cfg:  createCreateConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Install.Cordoned = true
+			},
+			errMsg: ErrMsgCordonedInvalidMode,
+		},
+		{
+			name: "invalid join config: install.cordoned is true for node with witness role",
+			cfg:  createJoinConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Install.Cordoned = true
+				c.Install.Role = config.RoleWitness
+			},
+			errMsg: ErrMsgCordonedInvalidRole,
+		},
+		{
+			name: "valid join config: install.cordoned is true for node with no role",
+			cfg:  createJoinConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Install.Cordoned = true
+			},
+		},
+		{
+			name: "valid join config: install.cordoned is true for node with default role",
+			cfg:  createJoinConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Install.Cordoned = true
+				c.Install.Role = config.RoleDefault
+			},
+		},
+		{
+			name: "valid join config: install.cordoned is true for node with management role",
+			cfg:  createJoinConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Install.Cordoned = true
+				c.Install.Role = config.RoleMgmt
+			},
+		},
+		{
+			name: "valid join config: install.cordoned is true for node with worker role",
+			cfg:  createJoinConfig(),
+			preApply: func(c *config.HarvesterConfig) {
+				c.Install.Cordoned = true
+				c.Install.Role = config.RoleWorker
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -231,6 +231,10 @@ const (
 
 	RKEControlPlaneRoleLabel = "rke.cattle.io/control-plane-role"
 
+	MaintainStatusAnnotationKey = prefix + "/maintain-status"
+	MaintainStatusComplete      = "completed"
+	MaintainStatusRunning       = "running"
+
 	LabelMaintainModeStrategy              = prefix + "/maintain-mode-strategy"
 	AnnotationMaintainModeStrategyNodeName = prefix + "/maintain-mode-strategy-node-name"
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -246,6 +246,9 @@ const (
 	HarvesterReportedConditionKey                      = prefix + "/condition"
 	HarvesterReportedConditionMessageKey               = prefix + "/condition-message"
 	ManagedTapBindingName                              = "managedtap"
+
+	HarvesterInstallCordonedLabel               = prefix + "/install-cordoned"
+	HarvesterInstallCordonedProcessedAnnotation = prefix + "/install-cordoned-processed"
 )
 
 var (

--- a/pkg/util/drainhelper/helper.go
+++ b/pkg/util/drainhelper/helper.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/drain"
 
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -137,7 +136,7 @@ func DrainPossible(nodeCache ctlcorev1.NodeCache, node *corev1.Node) error {
 
 	var availableNodes int
 	for _, v := range nodeMap {
-		_, ok := v.Annotations[ctlnode.MaintainStatusAnnotationKey]
+		_, ok := v.Annotations[util.MaintainStatusAnnotationKey]
 		logrus.Debugf("nodeName: %s,  annotation present: %v", v.Name, ok)
 		if !ok {
 			availableNodes++

--- a/pkg/util/drainhelper/helper_test.go
+++ b/pkg/util/drainhelper/helper_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/drain"
 
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
@@ -89,7 +88,7 @@ func Test_failsControlPlaneRequirementsHA(t *testing.T) {
 	clientset := fake.NewSimpleClientset(testNode, cpNode1, cpNode2, cpNode3)
 
 	cpNode1.Annotations = map[string]string{
-		ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+		util.MaintainStatusAnnotationKey: util.MaintainStatusRunning,
 	}
 
 	nodeCache := fakeclients.NodeCache(clientset.CoreV1().Nodes)

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -102,6 +102,20 @@ func IsManagementRole(node *corev1.Node) bool {
 	return false
 }
 
+// IsOtherNodeAvailable checks to ensure there's at least one other node
+// that's not in maintenance, and isn't cordoned.
+func IsOtherNodeAvailable(nodeName string, nodeList []*corev1.Node) bool {
+	for _, node := range nodeList {
+		if node.Name == nodeName {
+			continue
+		}
+		if _, ok := node.Annotations[MaintainStatusAnnotationKey]; !ok && !node.Spec.Unschedulable {
+			return true
+		}
+	}
+	return false
+}
+
 // count the number of nodes running instance manager pod
 func CountNonWitnessHealthyNodes(nodes []*corev1.Node) int {
 	count := 0

--- a/pkg/webhook/resources/node/validator.go
+++ b/pkg/webhook/resources/node/validator.go
@@ -132,23 +132,16 @@ func (v *nodeValidator) Update(_ *types.Request, oldObj runtime.Object, newObj r
 func validateCordonAndMaintenanceMode(oldNode, newNode *corev1.Node, nodeList []*corev1.Node) error {
 	// if old node already have "maintain-status" annotation or Unscheduleable=true,
 	// it has already been enabled, so we skip it
-	if _, ok := oldNode.Annotations[ctlnode.MaintainStatusAnnotationKey]; ok || oldNode.Spec.Unschedulable {
+	if _, ok := oldNode.Annotations[util.MaintainStatusAnnotationKey]; ok || oldNode.Spec.Unschedulable {
 		return nil
 	}
 	// if new node doesn't have "maintain-status" annotation and Unscheduleable=false, we skip it
-	if _, ok := newNode.Annotations[ctlnode.MaintainStatusAnnotationKey]; !ok && !newNode.Spec.Unschedulable {
+	if _, ok := newNode.Annotations[util.MaintainStatusAnnotationKey]; !ok && !newNode.Spec.Unschedulable {
 		return nil
 	}
-
-	for _, node := range nodeList {
-		if node.Name == oldNode.Name {
-			continue
-		}
-
-		// Return when we find another available node
-		if _, ok := node.Annotations[ctlnode.MaintainStatusAnnotationKey]; !ok && !node.Spec.Unschedulable {
-			return nil
-		}
+	// if there's another node available that's not in maintenance, and is schedulable, then everything is fine
+	if util.IsOtherNodeAvailable(oldNode.Name, nodeList) {
+		return nil
 	}
 	return werror.NewBadRequest("can't enable maintenance mode or cordon on the last available node")
 }

--- a/pkg/webhook/resources/node/validator_test.go
+++ b/pkg/webhook/resources/node/validator_test.go
@@ -77,7 +77,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Annotations: map[string]string{
-						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+						util.MaintainStatusAnnotationKey: util.MaintainStatusRunning,
 					},
 				},
 			},
@@ -120,7 +120,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Annotations: map[string]string{
-							ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusComplete,
+							util.MaintainStatusAnnotationKey: util.MaintainStatusComplete,
 						},
 					},
 				},
@@ -170,7 +170,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Annotations: map[string]string{
-						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+						util.MaintainStatusAnnotationKey: util.MaintainStatusRunning,
 					},
 				},
 			},
@@ -184,7 +184,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Annotations: map[string]string{
-							ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+							util.MaintainStatusAnnotationKey: util.MaintainStatusRunning,
 						},
 					},
 				},
@@ -202,7 +202,7 @@ func TestValidateCordonAndMaintenanceMode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
 					Annotations: map[string]string{
-						ctlnode.MaintainStatusAnnotationKey: ctlnode.MaintainStatusRunning,
+						util.MaintainStatusAnnotationKey: util.MaintainStatusRunning,
 					},
 				},
 			},

--- a/tests/integration/api/host_apis_test.go
+++ b/tests/integration/api/host_apis_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	nodeapi "github.com/harvester/harvester/pkg/api/node"
-	ctlnode "github.com/harvester/harvester/pkg/controller/master/node"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/tests/framework/cluster"
 	"github.com/harvester/harvester/tests/framework/helper"
 )
@@ -94,7 +94,7 @@ var _ = Describe("verify host APIs", func() {
 						return fmt.Errorf("expected node to be unschedulable")
 					}
 
-					_, ok := retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]
+					_, ok := retNode.Annotations[util.MaintainStatusAnnotationKey]
 					if !ok {
 						return fmt.Errorf("unable to find maintenance annotation")
 					}
@@ -117,7 +117,7 @@ var _ = Describe("verify host APIs", func() {
 					if !Expect(retNode.Spec.Unschedulable).To(BeEquivalentTo(false)) {
 						return false
 					}
-					return Expect(retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]).To(BeEmpty())
+					return Expect(retNode.Annotations[util.MaintainStatusAnnotationKey]).To(BeEmpty())
 				}, 30*time.Second, 1*time.Second)
 
 			})
@@ -172,7 +172,7 @@ var _ = Describe("verify host APIs", func() {
 						return fmt.Errorf("expected node to be schedulable")
 					}
 
-					_, ok := retNode.Annotations[ctlnode.MaintainStatusAnnotationKey]
+					_, ok := retNode.Annotations[util.MaintainStatusAnnotationKey]
 					if ok {
 						return fmt.Errorf("should not find maintenance annotation")
 					}


### PR DESCRIPTION
#### Problem:
It can be desirable to join new nodes to a Harvester cluster, but not have them immediately available for workloads.

#### Solution:
This commit adds a new harvester config option, `install.cordoned`. If this is set to `true`, it triggers the addition of a label to the node: `harvesterhci.io/install-cordoned=true`.

The promote handler's OnNodeChanged() function looks for this label, and if it's present, sets the node to unschedulable, and then adds an annotation to indicate the cordon was processed, and shouldn't be performed again.

The node will _not_ be cordoned if doing so would leave no other nodes available.  This means the first node when creating a cluster will never be automatically cordoned - it only works for nodes that are joining a cluster.

I added the logic to the promote handler because making a whole new controller just for this would be a bit ridiculous, and given the promote handler is responsible for manipulating nodes when they're added and removed, it seemed a sensible place.

The `install.cordoned` option is not exposed in the installer GUI, it must be via remote configuration file or kernel command line argument.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/4424

#### Test plan:
- Install a cluster with 2 or more nodes _without_ setting the `install.cordoned` config option. Verify the nodes come up and aren't cordoned.
- Install a cluster with 2 nodes, both with the default role, but specify `install.cordoned` in the harvester config file for the second node (if you were to specify `install.cordoned` for the first node, installation would fail with the error "install.cordoned can't be set in create mode").
  - The first node should be running normally.
  - The second node should be cordoned (check `kubectl get nodes` - if it says `SchedulingDisabled` for a node, then that node is cordoned).
  - Check the node labels. You should see the `harvesterhci.io/install-cordoned=true` label present on the second node. Once the node is cordoned, `harvesterhci.io/install-cordoned-processed=true` will be added as an annotation to indicate the cordon has been done.
- Add a third node to the cluster, again with the default role, and with `install.cordoned` in the config file. The second and third node should remain cordoned and should not automatically be promoted.
- Add a fourth node, again with the default role, and with `install.cordoned` in the config file. It should also come up cordoned and stay that way.
- Uncordon any two of the second, third and fourth nodes. Those nodes that you uncordon should now be automatically promoted to management.
- Reboot any of the nodes that initially came up cordoned, but were later uncordoned. They should remain uncordoned after reboot.
- Note: the `install.cordoned` option can't be applied to witness nodes (the install will fail with the error "install.cordoned can't be set for nodes with the witness role")
#### Additional documentation or context
HEP is at https://github.com/harvester/harvester/pull/11062