### PR TITLE
refresh validator webhook sa token

### DIFF
--- a/pkg/webhook/resources/upgrade/validator.go
+++ b/pkg/webhook/resources/upgrade/validator.go
@@ -66,7 +66,6 @@ func NewValidator(
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
 	endpointCache v1.EndpointsCache,
 	httpClient *http.Client,
-	bearToken string,
 ) types.Validator {
 	return &upgradeValidator{
 		upgrades:          upgrades,
@@ -83,7 +82,6 @@ func NewValidator(
 		endpointCache:     endpointCache,
 		settingCache:      settingCache,
 		httpClient:        httpClient,
-		bearToken:         bearToken,
 	}
 }
 
@@ -104,7 +102,6 @@ type upgradeValidator struct {
 	endpointCache     v1.EndpointsCache
 	settingCache      ctlharvesterv1.SettingCache
 	httpClient        *http.Client
-	bearToken         string
 }
 
 func (v *upgradeValidator) Resource() types.Resource {
@@ -665,7 +662,6 @@ func (v *upgradeValidator) getKubeletConfigz(nodeName, kubeletURL string) (*kube
 	if err != nil {
 		return nil, werror.NewInternalError(fmt.Sprintf("node %s, can't make http.NewRequest to get %s, err: %+v", nodeName, url, err))
 	}
-	req.Header.Set("Authorization", "Bearer "+v.bearToken)
 
 	resp, err := v.httpClient.Do(req)
 	if err != nil {
@@ -694,7 +690,6 @@ func (v *upgradeValidator) getKubeletStatsSummary(nodeName, kubeletURL string) (
 	if err != nil {
 		return nil, werror.NewInternalError(fmt.Sprintf("node %s, can't make http.NewRequest to get %s, err: %+v", nodeName, url, err))
 	}
-	req.Header.Set("Authorization", "Bearer "+v.bearToken)
 
 	resp, err := v.httpClient.Do(req)
 	if err != nil {

--- a/pkg/webhook/resources/upgrade/validator_test.go
+++ b/pkg/webhook/resources/upgrade/validator_test.go
@@ -634,7 +634,7 @@ func Test_validateAddons(t *testing.T) {
 		clientset := fake.NewSimpleClientset()
 		fakeAddonCache := fakeclients.AddonCache(clientset.HarvesterhciV1beta1().Addons)
 
-		validator := NewValidator(nil, fakeAddonCache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "").(*upgradeValidator)
+		validator := NewValidator(nil, fakeAddonCache, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*upgradeValidator)
 		addon := getTestAddon(tc.enabled)
 		if tc.addonState != "" {
 			setAddonState(addon, tc.addonState)

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/webhook"
+	"k8s.io/client-go/transport"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ctlkubeovnv1 "github.com/harvester/harvester/pkg/generated/controllers/kubeovn.io/v1"
@@ -44,11 +44,21 @@ import (
 )
 
 func Validation(clients *clients.Clients, options *config.Options, crdExists bool) (http.Handler, []types.Resource, error) {
-	bearToken, err := os.ReadFile(clients.RESTConfig.BearerTokenFile)
+	baseTransport, err := util.GetHTTPTransportWithCertificates(clients.RESTConfig)
 	if err != nil {
 		return nil, nil, err
 	}
-	transport, err := util.GetHTTPTransportWithCertificates(clients.RESTConfig)
+
+	// Wrap the transport so the service account token is periodically re-read
+	// from disk and injected as the bearer token. Under RKE2's CIS profile the
+	// projected SA token is bound with a short lifetime and rotated on disk, so
+	// a token read once at startup would expire (~1h) and cause kubelet calls
+	// to fail with HTTP 401.
+	kubeletTransport, err := transport.NewBearerAuthWithRefreshRoundTripper(
+		clients.RESTConfig.BearerToken,
+		clients.RESTConfig.BearerTokenFile,
+		baseTransport,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,10 +141,9 @@ func Validation(clients *clients.Clients, options *config.Options, crdExists boo
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 			clients.Core.Endpoints().Cache(),
 			&http.Client{
-				Transport: transport,
+				Transport: kubeletTransport,
 				Timeout:   time.Second * 20,
 			},
-			string(bearToken),
 		),
 		upgradelog.NewValidator(
 			clients.HarvesterFactory.Harvesterhci().V1beta1().Upgrade().Cache(),


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

We (RGS) have customers that require the RKE2 backing Harvester have the CIS profile enabled.

CIS sets `--service-account-max-token-expiration=3600s` on the kube-apiserver. This means any single token the API server mints is valid for at most 1 hour.

The kubelet requests a projected token for the pod (with expirationSeconds=3600), writes it to the file, and also runs a background loop that re-requests a brand new token from the API server at ~80% of the TTL (~48 minutes) and atomically rewrites the file with the new token string.

harvester-webhook currently reads this file once at startup and never reads it again. So after an hour, anything requiring the validator webhook starts to fail until you restart that deployment.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

`pkg/webhook/server/validation.go`

- Removed the one-time os.ReadFile(...BearerTokenFile).

- Wrapped the kubelet HTTP transport with client-go's `transport.NewBearerAuthWithRefreshRoundTripper(BearerToken, BearerTokenFile, baseTransport)`. This round tripper re-reads the token file on a ~1-minute cadence (via NewCachedFileTokenSource, designed exactly for projected SA tokens) and injects the Authorization: Bearer header itself. Passing both the token and the file path keeps dev/kubeconfig setups working.

- Dropped the now-unused string(bearToken) argument.

`pkg/webhook/resources/upgrade/validator.go`

- Removed the bearToken parameter and struct field.
- Removed the manual req.Header.Set("Authorization", "Bearer "+v.bearToken) in both getKubeletConfigz and getKubeletStatsSummary — this was essential, since the refreshing round tripper deliberately skips requests that already have an Authorization header set.

`pkg/webhook/resources/upgrade/validator_test.go` — dropped the trailing "" from the NewValidator call.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

Issue: https://github.com/harvester/harvester/issues/11084

#### Test plan:
<!-- Describe the test plan by steps. -->

Wait an hour+ after the harvester-webhook pod has started, then initiate an upgrade. The validator webhook doesn't fail.

#### Additional documentation or context
