### PR TITLE
fix: remove IPv4 address size cap

### DIFF
--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -2037,6 +2037,9 @@ func (v *settingValidator) countNonWitnessNodes() (int, error) {
 // with any config in the c2 map. Nil configs are skipped, so if a peer setting does not
 // exist yet (e.g. during fresh install), its overlap check is safely bypassed. Overlap
 // detection uses netip arithmetic — safe for any prefix length including large IPv6 subnets.
+//
+// An overlap is permitted when the intersection of c1 and c2 is completely covered by the
+// union of their exclude ranges: no IP in the intersection is usable by both networks simultaneously.
 func checkNetworkOverlap(c1Name string, c1 *networkutil.Config, c2 map[string]*networkutil.Config) error {
 	if c1 == nil {
 		return nil
@@ -2075,7 +2078,18 @@ func checkNetworkOverlap(c1Name string, c1 *networkutil.Config, c2 map[string]*n
 		if c2Prefix.Bits() > c1Prefix.Bits() {
 			intersection = c2Prefix
 		}
-		if isIntersectionCoveredByExcludes(intersection, c1Excludes) {
+
+		allExcludes := make([]netip.Prefix, 0, len(c1Excludes)+len(config.Exclude))
+		allExcludes = append(allExcludes, c1Excludes...)
+		for _, exStr := range config.Exclude {
+			ex, err := netip.ParsePrefix(exStr)
+			if err != nil {
+				return err
+			}
+			allExcludes = append(allExcludes, ex.Masked())
+		}
+
+		if isCoveredByPrefixes(intersection, allExcludes) {
 			continue
 		}
 
@@ -2084,13 +2098,48 @@ func checkNetworkOverlap(c1Name string, c1 *networkutil.Config, c2 map[string]*n
 	return nil
 }
 
-func isIntersectionCoveredByExcludes(intersection netip.Prefix, excludes []netip.Prefix) bool {
+func rightHalfPrefix(p netip.Prefix) netip.Prefix {
+	a16 := p.Addr().As16()
+
+	bitPos := p.Bits()
+	if p.Addr().Is4() {
+		bitPos += 96
+	}
+	byteIdx := bitPos / 8
+	a16[byteIdx] |= 1 << uint(7-bitPos%8)
+	addr := netip.AddrFrom16(a16)
+	if p.Addr().Is4() {
+		addr = addr.Unmap()
+	}
+	return netip.PrefixFrom(addr, p.Bits()+1).Masked()
+}
+
+func subtractPrefix(target, ex netip.Prefix) []netip.Prefix {
+	if !ex.Overlaps(target) {
+		return []netip.Prefix{target}
+	}
+	if ex.Bits() <= target.Bits() && ex.Contains(target.Addr()) {
+		return nil
+	}
+	left := netip.PrefixFrom(target.Addr(), target.Bits()+1).Masked()
+	right := rightHalfPrefix(target)
+	result := subtractPrefix(left, ex)
+	return append(result, subtractPrefix(right, ex)...)
+}
+
+func isCoveredByPrefixes(target netip.Prefix, excludes []netip.Prefix) bool {
+	remaining := []netip.Prefix{target}
 	for _, ex := range excludes {
-		if ex.Bits() <= intersection.Bits() && ex.Contains(intersection.Addr()) {
+		if len(remaining) == 0 {
 			return true
 		}
+		var next []netip.Prefix
+		for _, r := range remaining {
+			next = append(next, subtractPrefix(r, ex)...)
+		}
+		remaining = next
 	}
-	return false
+	return len(remaining) == 0
 }
 
 func validateDefaultVMTerminationGracePeriodSecondsHelper(value string) error {

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -69,7 +69,6 @@ import (
 )
 
 const (
-	minSNPrefixLength                 = 16
 	mcmFeature                        = "multi-cluster-management"
 	labelAppNameKey                   = "app.kubernetes.io/name"
 	labelAppNameValuePrometheus       = "prometheus"
@@ -1880,9 +1879,6 @@ func validateIncludeExcludeRanges(config *networkutil.Config, includePrefixLen i
 		}
 
 		excludePrefixLen, _ := network.Mask.Size()
-		if excludePrefixLen < minSNPrefixLength {
-			return fmt.Errorf("min supported prefix length for network is %d, exclude Range PrefixLen received %d", minSNPrefixLength, excludePrefixLen)
-		}
 
 		//validate if include and exclude overlap
 		overlap, err := isOverlap(config.Range, excludeIP)
@@ -1929,9 +1925,6 @@ func (v *settingValidator) checkNetworkRangeValid(config *networkutil.Config) er
 	}
 
 	prefixLen, _ := network.Mask.Size()
-	if prefixLen < minSNPrefixLength {
-		return fmt.Errorf("min supported prefix length for network is %d, include Range PrefixLen received %d", minSNPrefixLength, prefixLen)
-	}
 
 	if err = validateIncludeExcludeRanges(config, prefixLen); err != nil {
 		return err
@@ -2042,32 +2035,62 @@ func (v *settingValidator) countNonWitnessNodes() (int, error) {
 
 // checkNetworkOverlap checks that the c1 config does not have overlapping usable IP addresses
 // with any config in the c2 map. Nil configs are skipped, so if a peer setting does not
-// exist yet (e.g. during fresh install), its overlap check is safely bypassed.
+// exist yet (e.g. during fresh install), its overlap check is safely bypassed. Overlap
+// detection uses netip arithmetic — safe for any prefix length including large IPv6 subnets.
 func checkNetworkOverlap(c1Name string, c1 *networkutil.Config, c2 map[string]*networkutil.Config) error {
 	if c1 == nil {
 		return nil
 	}
 
-	c1UsableIPs, err := webhookUtil.GetUsableIPAddresses(c1.Range, c1.Exclude)
+	c1Prefix, err := netip.ParsePrefix(c1.Range)
 	if err != nil {
 		return err
+	}
+	c1Prefix = c1Prefix.Masked()
+
+	c1Excludes := make([]netip.Prefix, 0, len(c1.Exclude))
+	for _, exStr := range c1.Exclude {
+		ex, err := netip.ParsePrefix(exStr)
+		if err != nil {
+			return err
+		}
+		c1Excludes = append(c1Excludes, ex.Masked())
 	}
 
 	for name, config := range c2 {
 		if config == nil {
 			continue
 		}
-		ips, err := webhookUtil.GetUsableIPAddresses(config.Range, config.Exclude)
+		c2Prefix, err := netip.ParsePrefix(config.Range)
 		if err != nil {
 			return err
 		}
-		for ip := range c1UsableIPs {
-			if _, ok := ips[ip]; ok {
-				return fmt.Errorf("%s: the network configuration is overlapped with %s", c1Name, name)
-			}
+		c2Prefix = c2Prefix.Masked()
+
+		if !c1Prefix.Overlaps(c2Prefix) {
+			continue
 		}
+
+		intersection := c1Prefix
+		if c2Prefix.Bits() > c1Prefix.Bits() {
+			intersection = c2Prefix
+		}
+		if isIntersectionCoveredByExcludes(intersection, c1Excludes) {
+			continue
+		}
+
+		return fmt.Errorf("%s: the network configuration is overlapped with %s", c1Name, name)
 	}
 	return nil
+}
+
+func isIntersectionCoveredByExcludes(intersection netip.Prefix, excludes []netip.Prefix) bool {
+	for _, ex := range excludes {
+		if ex.Bits() <= intersection.Bits() && ex.Contains(intersection.Addr()) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateDefaultVMTerminationGracePeriodSecondsHelper(value string) error {

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -2680,6 +2680,35 @@ func Test_checkNetworkOverlap(t *testing.T) {
 			errMsg:  "storage-network: the network configuration is overlapped with rwx-network",
 		},
 		{
+			// Two /25 excludes together cover the full /24 intersection (union coverage).
+			// The old single-exclude check would have flagged this as a conflict.
+			name:   "union of two c1 /25 excludes covers c2 /24 intersection, no error",
+			c1Name: "storage-network",
+			c1: &networkutil.Config{
+				Range:   "10.0.0.0/16",
+				Exclude: []string{"10.0.4.0/25", "10.0.4.128/25"}, // together cover 10.0.4.0/24
+			},
+			c2: map[string]*networkutil.Config{
+				"vm-migration-network": {Range: "10.0.4.0/24"},
+			},
+			wantErr: false,
+		},
+		{
+			// c2 explicitly excludes the sub-range that overlaps c1 from its own side.
+			name:   "c2 excludes its overlapping portion, no error",
+			c1Name: "storage-network",
+			c1: &networkutil.Config{
+				Range: "10.0.4.0/24",
+			},
+			c2: map[string]*networkutil.Config{
+				"vm-migration-network": {
+					Range:   "10.0.4.0/23",           // covers 10.0.4.0/24 (overlaps c1) + 10.0.5.0/24
+					Exclude: []string{"10.0.4.0/24"}, // excludes the portion overlapping c1
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:    "invalid CIDR in c1, return error",
 			c1Name:  "storage-network",
 			c1:      &networkutil.Config{Range: "not-a-cidr"},

--- a/pkg/webhook/resources/setting/validator_test.go
+++ b/pkg/webhook/resources/setting/validator_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/rancher/wrangler/v3/pkg/webhook"
@@ -1376,7 +1375,7 @@ func Test_validateStorageNetworkConfig(t *testing.T) {
 			errMsg: "not allowed on",
 		},
 		{
-			name: "IPv6 /120 range rejected by To4() guard (minSNPrefixLength=16 alone would not protect: 120>=16)",
+			name: "IPv6 /120 range rejected — only IPv4 ranges are supported",
 			args: &v1beta1.Setting{
 				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
 				Default:    "",
@@ -1385,13 +1384,22 @@ func Test_validateStorageNetworkConfig(t *testing.T) {
 			errMsg: "IPv6 ranges are not supported",
 		},
 		{
-			name: "IPv6 /64 range rejected by To4() guard (minSNPrefixLength=16 alone would not protect: 64>=16)",
+			name: "IPv6 /64 range rejected — only IPv4 ranges are supported",
 			args: &v1beta1.Setting{
 				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
 				Default:    "",
 				Value:      `{"vlan":100, "clusterNetwork":"mgmt", "range":"fd00::/64"}`,
 			},
 			errMsg: "IPv6 ranges are not supported",
+		},
+		{
+			name: "IPv4 /0 full address space accepted",
+			args: &v1beta1.Setting{
+				ObjectMeta: metav1.ObjectMeta{Name: settings.StorageNetworkName},
+				Default:    "",
+				Value:      `{"vlan":100, "clusterNetwork":"mgmt", "range":"0.0.0.0/0"}`,
+			},
+			errMsg: "",
 		},
 		{
 			name: "fail to create storage-network with same vlan-id as VM Network when exclusive vlan is enabled",
@@ -2639,8 +2647,37 @@ func Test_checkNetworkOverlap(t *testing.T) {
 				Range:   "192.168.1.0/30",
 				Exclude: []string{"192.168.1.1/32", "192.168.1.2/32"},
 			},
-			c2:      map[string]*networkutil.Config{"vm-migration-network": {Range: "192.168.1.1/32"}},
+			c2: map[string]*networkutil.Config{
+				"vm-migration-network": {Range: "192.168.1.1/32"},
+				"rwx-network":          {Range: "192.168.1.2/32"},
+			},
 			wantErr: false,
+		},
+		{
+			name:   "c1 wide /22 excludes carve out large ranges for two c2 networks, no error",
+			c1Name: "storage-network",
+			c1: &networkutil.Config{
+				Range:   "10.0.0.0/16",                          // ~65k IPs
+				Exclude: []string{"10.0.4.0/22", "10.0.8.0/22"}, // 1022 IPs each, reserved
+			},
+			c2: map[string]*networkutil.Config{
+				"vm-migration-network": {Range: "10.0.4.0/22"}, // 1022 usable IPs
+				"rwx-network":          {Range: "10.0.8.0/22"}, // 1022 usable IPs
+			},
+			wantErr: false,
+		},
+		{
+			name:   "c1 excludes only one /22, second c2 /22 is not excluded, returns error",
+			c1Name: "storage-network",
+			c1: &networkutil.Config{
+				Range:   "10.0.0.0/16",
+				Exclude: []string{"10.0.4.0/22"},
+			},
+			c2: map[string]*networkutil.Config{
+				"rwx-network": {Range: "10.0.8.0/22"},
+			},
+			wantErr: true,
+			errMsg:  "storage-network: the network configuration is overlapped with rwx-network",
 		},
 		{
 			name:    "invalid CIDR in c1, return error",
@@ -2937,78 +2974,5 @@ func Test_checkExclusiveVlan(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
-	}
-}
-
-// Test_validateUpdateVMMigrationNetwork_IPv6OOM demonstrates that submitting an
-// IPv6 /64 range through the full webhook Update path (v.Update) hangs the
-// process when the To4() guard in checkNetworkRangeValid is removed.
-//
-// Why minSNPrefixLength = 16 is not enough:
-//
-//	IPv4 /16: prefixLen=16, 16 < 16 = false → passes → 2^16 = 65,534 hosts → enumerable in ms
-//	IPv6 /64: prefixLen=64, 64 < 16 = false → passes → 2^64 ≈ 1.8×10¹⁹ hosts → never enumerates
-//
-// The same "prefix length must be ≥ 16" boundary that is safe for IPv4 (32-bit
-// address space) is catastrophic for IPv6 (128-bit address space). The constant
-// was designed for IPv4 and provides zero protection against large IPv6 subnets.
-//
-// Full call chain that hangs:
-//
-//	v.Update
-//	  └─ validateUpdateVMMigrationNetwork
-//	       └─ validateNetworkHelper
-//	            ├─ checkNetworkRangeValid  ← guard commented out; 64 >= 16 passes
-//	            └─ checkVMMigrationNetworkRangeValid
-//	                 └─ GetUsableIPAddressesCount("2001:db8::/64")
-//	                      └─ incrementIP loop  ← 2^64 iterations, never returns
-func Test_validateUpdateVMMigrationNetwork_IPv6OOM(t *testing.T) {
-	clientset := fake.NewSimpleClientset()
-	v := NewValidator(
-		fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
-		fakeclients.NodeCache(clientset.CoreV1().Nodes),
-		nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, nil, nil, nil,
-	)
-
-	oldSetting := &v1beta1.Setting{
-		ObjectMeta: metav1.ObjectMeta{Name: settings.VMMigrationNetworkSettingName},
-		Value:      `{"vlan":100,"clusterNetwork":"mgmt","range":"192.168.50.0/24"}`,
-	}
-	// Updating to an IPv6 /64 range.
-	// With the To4() guard commented out, 64 < minSNPrefixLength(16) = false,
-	// so checkNetworkRangeValid passes and execution reaches
-	// GetUsableIPAddressesCount which tries to enumerate 2^64 host addresses.
-	newSetting := &v1beta1.Setting{
-		ObjectMeta: metav1.ObjectMeta{Name: settings.VMMigrationNetworkSettingName},
-		Value:      `{"vlan":100,"clusterNetwork":"mgmt","range":"2001:db8::/64"}`,
-	}
-
-	done := make(chan error, 1)
-	go func() {
-		done <- v.Update(nil, oldSetting, newSetting)
-	}()
-
-	select {
-	case err := <-done:
-		// If the To4() guard in checkNetworkRangeValid is active it rejects IPv6
-		// immediately — that is the correct protected behaviour, so the test passes.
-		if err != nil && strings.Contains(err.Error(), "IPv6") {
-			t.Logf("PROTECTED: v.Update rejected IPv6 /64 immediately: %v", err)
-			return
-		}
-		// Any other return (nil or unrelated error) means the guard is gone AND
-		// the enumeration somehow finished — that should never happen for /64.
-		t.Fatalf("v.Update returned unexpectedly (err=%v) for IPv6 /64 — "+
-			"expected either an IPv6 rejection error (guard present) or a hang (guard absent). "+
-			"minSNPrefixLength=16 checks prefixLen<16; 64>=16, so without the guard "+
-			"GetUsableIPAddressesCount must enumerate 2^64 addresses. "+
-			"Compare: IPv4 /16 = 65,534 hosts (safe); IPv6 /64 = 2^64 hosts (catastrophic).", err)
-	case <-time.After(10 * time.Second):
-		// Guard is absent: v.Update is still looping inside GetUsableIPAddressesCount
-		// after 10 seconds — 2^64 iterations cannot complete on any hardware.
-		// This confirms the OOM/DoS risk when the To4() guard is removed.
-		// The leaked goroutine exits with the test process.
-		t.Log("UNPROTECTED (guard absent): v.Update hung as expected — OOM/DoS risk confirmed")
 	}
 }

--- a/pkg/webhook/util/ip.go
+++ b/pkg/webhook/util/ip.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"math"
 	"net"
+	"net/netip"
 )
 
 // incrementIP increments the IP address by 1.
@@ -39,12 +41,64 @@ func GetUsableIPAddresses(includeRange string, excludeRange []string) (map[strin
 	return includeIPAddrMap, nil
 }
 
+// GetUsableIPAddressesCount returns the number of usable IP addresses in
+// includeRange after subtracting addresses covered by excludeRange CIDRs.
+// It uses arithmetic rather than enumeration, making it safe for any prefix
+// length including large IPv6 subnets up to integer limit.
 func GetUsableIPAddressesCount(includeRange string, excludeRange []string) (int, error) {
-	usableIPAddrMap, err := GetUsableIPAddresses(includeRange, excludeRange)
+	netPrefix, err := netip.ParsePrefix(includeRange)
 	if err != nil {
 		return 0, err
 	}
-	return len(usableIPAddrMap), nil
+	netPrefix = netPrefix.Masked()
+
+	maxBits := 32
+	if netPrefix.Addr().Is6() {
+		maxBits = 128
+	}
+	hostBits := maxBits - netPrefix.Bits()
+
+	// 1<<63 (2^63) overflows int64 so directly return MaxInt
+	// which trivially has enough IPs for any cluster
+	if hostBits >= 63 {
+		return math.MaxInt, nil
+	}
+
+	total := int(1 << uint(hostBits))
+
+	if netPrefix.Addr().Is4() {
+		// subtract network address and broadcast required by IPv4
+		if total >= 2 {
+			total -= 2
+		} else {
+			total = 0
+		}
+	} else {
+		// subtract network address only there is no broadcast address for IPv6
+		if total >= 1 {
+			total--
+		}
+	}
+
+	for _, exStr := range excludeRange {
+		exPrefix, err := netip.ParsePrefix(exStr)
+		if err != nil {
+			return 0, err
+		}
+		exPrefix = exPrefix.Masked()
+
+		// only subtract if the exclude range is fully contained within the include range
+		if netPrefix.Bits() <= exPrefix.Bits() && netPrefix.Contains(exPrefix.Addr()) {
+			exHostBits := maxBits - exPrefix.Bits()
+			total -= int(1 << uint(exHostBits))
+		}
+	}
+
+	if total < 0 {
+		total = 0
+	}
+
+	return total, nil
 }
 
 func getIPAddressesFromSubnet(ipNetSubnets []string, include bool) (ipAddrList map[string]struct{}, err error) {

--- a/pkg/webhook/util/ip.go
+++ b/pkg/webhook/util/ip.go
@@ -58,9 +58,18 @@ func GetUsableIPAddressesCount(includeRange string, excludeRange []string) (int,
 	}
 	hostBits := maxBits - netPrefix.Bits()
 
-	// 1<<63 (2^63) overflows int64 so directly return MaxInt
-	// which trivially has enough IPs for any cluster
+	// 1<<63 (2^63) overflows int64 so return MaxInt - but first check if a single
+	// exclude wipes out the entire include range (identical prefix -> 0 usable).
 	if hostBits >= 63 {
+		for _, exStr := range excludeRange {
+			exPrefix, exErr := netip.ParsePrefix(exStr)
+			if exErr != nil {
+				return 0, exErr
+			}
+			if exPrefix.Masked() == netPrefix {
+				return 0, nil
+			}
+		}
 		return math.MaxInt, nil
 	}
 
@@ -74,10 +83,25 @@ func GetUsableIPAddressesCount(includeRange string, excludeRange []string) (int,
 			total = 0
 		}
 	} else {
-		// subtract network address only there is no broadcast address for IPv6
+		// subtract network address only - there is no broadcast address for IPv6
 		if total >= 1 {
 			total--
 		}
+	}
+
+	// Precompute the include's reserved addresses so we can avoid
+	// double-subtracting them when an exclude CIDR spans them.
+	reservedNet := netPrefix.Addr()
+	hasBroadcast := netPrefix.Addr().Is4()
+	var reservedBroadcast netip.Addr
+	if hasBroadcast {
+		n := netPrefix.Addr().As4()
+		m := net.CIDRMask(netPrefix.Bits(), 32)
+		var b [4]byte
+		for i := range b {
+			b[i] = n[i] | ^m[i]
+		}
+		reservedBroadcast = netip.AddrFrom4(b)
 	}
 
 	for _, exStr := range excludeRange {
@@ -90,7 +114,20 @@ func GetUsableIPAddressesCount(includeRange string, excludeRange []string) (int,
 		// only subtract if the exclude range is fully contained within the include range
 		if netPrefix.Bits() <= exPrefix.Bits() && netPrefix.Contains(exPrefix.Addr()) {
 			exHostBits := maxBits - exPrefix.Bits()
-			total -= int(1 << uint(exHostBits))
+			exCount := int(1 << uint(exHostBits))
+
+			// The reserved network address and IPv4 broadcast were already removed
+			// from total above. If the exclude CIDR spans them, subtract only the
+			// genuinely usable addresses the exclude covers (avoid double-counting).
+			if exPrefix.Contains(reservedNet) {
+				exCount--
+			}
+			if hasBroadcast && exPrefix.Contains(reservedBroadcast) {
+				exCount--
+			}
+			if exCount > 0 {
+				total -= exCount
+			}
 		}
 	}
 

--- a/pkg/webhook/util/ip_test.go
+++ b/pkg/webhook/util/ip_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,98 +10,135 @@ import (
 )
 
 func Test_ipAddressRange(t *testing.T) {
-
 	tests := []struct {
-		name        string
-		config      *networkutil.Config
-		expectedErr bool
+		name          string
+		config        *networkutil.Config
+		expectedErr   bool
+		expectedCount int
 	}{
 		{
-			name: "exclude a subset of include range,returns > MinallocatableIPAddrs addresses",
+			name: "IPv4 /24 exclude /30 subset",
 			config: &networkutil.Config{
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.1/30"},
 			},
-			expectedErr: false,
+			expectedCount: 250,
 		},
 		{
-			name: "exclude a subset of include range,returns > MinallocatableIPAddrs addresses",
+			name: "IPv4 /24 exclude /28 subset",
 			config: &networkutil.Config{
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.1/28"},
 			},
-			expectedErr: false,
+			expectedCount: 238,
 		},
 		{
-			name: "valid include range,returns > MinallocatableIPAddrs addresses",
+			name: "IPv4 /27 no excludes",
 			config: &networkutil.Config{
 				Range:   "192.168.2.0/27",
 				Exclude: []string{},
 			},
-			expectedErr: false,
+			expectedCount: 30,
 		},
 		{
-			name: "exclude all from include subnet,returns no allocatable addresses",
+			name: "IPv4 /24 exclude entire subnet returns 0",
 			config: &networkutil.Config{
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.0/24"},
 			},
-			expectedErr: true,
+			expectedCount: 0,
 		},
 		{
-			name: "exclude all from include subnet,returns no allocatable addresses",
+			name: "IPv4 /30 exclude same-width range returns 0",
 			config: &networkutil.Config{
 				Range:   "192.168.2.0/30",
 				Exclude: []string{"192.168.2.1/30"},
 			},
-			expectedErr: true,
+			expectedCount: 0,
 		},
 		{
-			name: "no allocatable ip addresses in include range",
+			name: "IPv4 /32 single host has no usable addresses",
 			config: &networkutil.Config{
 				Range:   "192.168.2.0/32",
 				Exclude: []string{},
 			},
-			expectedErr: true,
+			expectedCount: 0,
 		},
 		{
-			name: "no allocatable ip addresses in include range",
+			name: "IPv4 /31 has no usable addresses",
 			config: &networkutil.Config{
 				Range:   "192.168.2.0/31",
 				Exclude: []string{},
 			},
+			expectedCount: 0,
+		},
+		{
+			name: "invalid include range returns parse error",
+			config: &networkutil.Config{
+				Range:   "invalid/31",
+				Exclude: []string{},
+			},
 			expectedErr: true,
 		},
 		{
-			name: "IPv6 /120 subnet returns > 16 usable addresses",
+			name: "invalid exclude range returns parse error",
+			config: &networkutil.Config{
+				Range:   "2001:db8::/120",
+				Exclude: []string{"invalid/120"},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "IPv6 /120 has 255 usable addresses",
 			config: &networkutil.Config{
 				Range:   "2001:db8::/120",
 				Exclude: []string{},
 			},
-			expectedErr: false, // 255 usable addresses (256 total, minus network address; no broadcast exclusion for IPv6)
+			expectedCount: 255, // 256 total, minus network address only (no broadcast in IPv6)
 		},
 		{
-			name: "IPv6 /128 subnet returns 0 usable addresses",
+			name: "IPv6 /128 single host has no usable addresses",
 			config: &networkutil.Config{
 				Range:   "2001:db8::1/128",
 				Exclude: []string{},
 			},
-			expectedErr: true,
+			expectedCount: 0,
 		},
 		{
-			name: "IPv6 /120 with full exclusion returns 0 usable addresses",
+			name: "IPv6 /120 exclude entire subnet returns 0",
 			config: &networkutil.Config{
 				Range:   "2001:db8::/120",
 				Exclude: []string{"2001:db8::/120"},
 			},
-			expectedErr: true,
+			expectedCount: 0,
+		},
+		{
+			name: "IPv4 /0 full address space",
+			config: &networkutil.Config{
+				Range:   "0.0.0.0/0",
+				Exclude: []string{},
+			},
+			expectedCount: (1 << 32) - 2,
+		},
+		{
+			name: "IPv6 /0 full address space",
+			config: &networkutil.Config{
+				Range:   "::/0",
+				Exclude: []string{},
+			},
+			expectedCount: math.MaxInt,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			count, _ := GetUsableIPAddressesCount(tt.config.Range, tt.config.Exclude)
-			assert.Equal(t, tt.expectedErr, count < 16)
+			count, err := GetUsableIPAddressesCount(tt.config.Range, tt.config.Exclude)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedCount, count)
 		})
 	}
 }

--- a/pkg/webhook/util/ip_test.go
+++ b/pkg/webhook/util/ip_test.go
@@ -22,7 +22,7 @@ func Test_ipAddressRange(t *testing.T) {
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.1/30"},
 			},
-			expectedCount: 250,
+			expectedCount: 251, // /30 masks to .0/30 covering .0-.3; .0 already removed as network addr
 		},
 		{
 			name: "IPv4 /24 exclude /28 subset",
@@ -30,7 +30,7 @@ func Test_ipAddressRange(t *testing.T) {
 				Range:   "192.168.2.0/24",
 				Exclude: []string{"192.168.2.1/28"},
 			},
-			expectedCount: 238,
+			expectedCount: 239, // /28 masks to .0/28 covering .0-.15; .0 already removed as network addr
 		},
 		{
 			name: "IPv4 /27 no excludes",


### PR DESCRIPTION
Removing the IPv4 address size cap by increaseing the IP address count limitation which was currently set at ~65000 addresses 2^16 to 2^63 - the integer cap.

For IPv4 max address is 2^32 and for IPv6 is even higher at 2^128 addresses. This change addresses that limitation so IPv6 can be included with it's bigger capacity capped at 2^63 at the moment as this is the limit where integer overflows.

The change includes the following:
* in util package counting IP addresses now happens with constant complexity by using prefix arithmetic as opposed to the previous method of allocating map containing all IP addresses to calculate ranges and exclusions - thus removing OOM behavior as we work with integers only
* tests for the util package are updated so they assert expected count of IP addresses along with expected error
* validation webhook now compares overlapping ranges with netip package as opposed to the map based approach bringing down complexity to linear and again removing the OOM behavior from the previous implementation
* removed stand alone OOM test as now it's single test scenario - IPv4 /0 full address space accepted
* fix some test case naming on the validation side as we no longer cap at 65000 addresses
* extended overlap test case with more realistic ranges and augmented the test "c1 exclude removes overlap, no error" to show 2+ networks truly skip overlaps if excluded on the new network setting

#### Problem:
Today we limit the ip range prefix with 16. This means that we can't hit the 32 bit limit of IPv4 let alone use the IPv6 limits which reach up to 128 bit addresses. If we remove the limit on webhook level the implementation in our code causes OOM.

#### Solution:
Reduce the complexity where we calculate the ranges to constant and linear to remove the OOM behavior and allow maximum capacity of IPv4 address ranges and at least reach 63 bits of the IPv6's 128 allowance without OOM. 

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11012

#### Test plan:
Unit tests changed as part of the PR.

End-to-end tests: TODO

#### Additional documentation or context
N/A