### PR TITLE
ci: prevent Renovate bot from triggering e2e tests

### DIFF
--- a/.github/workflows/e2e-tests-factory.yml
+++ b/.github/workflows/e2e-tests-factory.yml
@@ -36,6 +36,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/v') && !startsWith(github.ref, 'refs/tags/v') }}
 jobs:
   build-push-images:
+    if: ${{ !(github.actor == 'renovate[bot]' && github.event_name == 'pull_request') }}
     name: Build and push images
     runs-on:
       group: e2e-ci

--- a/.github/workflows/e2e-tests-factory.yml
+++ b/.github/workflows/e2e-tests-factory.yml
@@ -162,6 +162,8 @@ jobs:
       matrix:
         arch: [x64]
     steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Configure envs
       run: |
         if [ "${{ matrix.arch }}" == "x64" ]; then

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,23 @@ on:
     - release-*
     - v*
   pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - '.github/workflows/e2e-tests.yml'
+      - '.github/workflows/e2e-tests-factory.yml'
+      - 'cmd/**'
+      - 'pkg/**'
+      - 'vendor/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'Makefile'
+      - 'scripts/build'
+      - 'package/**'
+      - '!cmd/installer/**'
+      - '!pkg/installer/**'
+      - '!package/harvester-repo/**'
+      - '!package/harvester-os/**'
   schedule:
     - cron: "10 1 * * *"
   workflow_dispatch:


### PR DESCRIPTION
- Skip the e2e tests if the event is a pull request created by Renovate. The test will be done when the PR is merged.
- Trigger e2e tests only on backend changes.

