### PR TITLE
feat: set default RKE2 certs expiry date to 1000 and rotate them during upgrade

### DIFF
--- a/package/harvester-os/files/etc/systemd/system/rke2-agent.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/rke2-agent.service.d/override.conf
@@ -3,5 +3,6 @@ After=time-sync.target
 Wants=time-sync.target
 
 [Service]
+EnvironmentFile=-/etc/rancher/rke2/harvester-managed.env
 ExecStartPre=/usr/sbin/harv-update-rke2-server-url agent
 ExecStartPost=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=0

--- a/package/harvester-os/files/etc/systemd/system/rke2-server.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/rke2-server.service.d/override.conf
@@ -3,5 +3,6 @@ After=time-sync.target
 Wants=time-sync.target
 
 [Service]
+EnvironmentFile=-/etc/rancher/rke2/harvester-managed.env
 ExecStartPre=/usr/sbin/harv-update-rke2-server-url server
 ExecStartPost=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=0

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -517,6 +517,16 @@ save_nm_state()
     cp -a /etc/NetworkManager/system-connections/* ${nm_conn}
 }
 
+save_rke2_harvester_managed_env()
+{
+    save_dir=${TARGET}/etc/rancher/rke2
+    mkdir -p ${save_dir}
+
+    cat > ${save_dir}/harvester-managed.env <<EOF
+CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=1000
+EOF
+}
+
 do_data_disk_format()
 {
     if [ -z $HARVESTER_DATA_DISK ]; then
@@ -577,6 +587,7 @@ sparsify_passive_img
 get_iso  # For PXE Boot
 save_configs
 save_nm_state
+save_rke2_harvester_managed_env
 do_preload
 
 update_grub_settings

--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -596,11 +596,11 @@ generate_hostname_persistance() {
   # NetworkManager is new in Harvester v1.7.0
   # nodes installed via v1.5.x or lower which may have used fqdn hostnames
   # only render short hostname in the k8s node name however the
-  # harvester.config and /oem/90_custom.yaml set hostname to fqdn 
+  # harvester.config and /oem/90_custom.yaml set hostname to fqdn
   # the /oem/90_custom.yaml sets hostname to fqdn as part which was ignored
   # we need to ensure the hostname does not change after bump to NetworkManager
-  # as this will cause the node to be re-registered with apiserver using 
-  # the fqdn hostname which will cause upgrade to break as the node never 
+  # as this will cause the node to be re-registered with apiserver using
+  # the fqdn hostname which will cause upgrade to break as the node never
   # completes the upgrade
   if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.6\.[0-9]$ ]]; then
     echo "version: $UPGRADE_PREVIOUS_VERSION does not require generating Hostname override"
@@ -629,6 +629,62 @@ stages:
    network:
      - hostname: $CURRENT_HOSTNAME
 EOF
+}
+
+generate_rke2_harvester_managed_env() {
+  if [ -z "$UPGRADE_PREVIOUS_VERSION" ]; then
+    detect_upgrade
+  fi
+
+  if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.8\.[0-9]$ ]]; then
+    echo "version: $UPGRADE_PREVIOUS_VERSION does not require generating rke2 harvester-managed.env"
+    return
+  fi
+
+  local rke2_harvester_managed_env="${HOST_DIR}/etc/rancher/rke2/harvester-managed.env"
+  if [[ -f "$rke2_harvester_managed_env" ]]; then
+    echo "skipping rke2 harvester-managed.env generation as the file already exists"
+    return
+  fi
+
+  echo "Generating rke2 harvester-managed.env"
+  cat > ${rke2_harvester_managed_env} <<EOF
+CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=1000
+EOF
+
+  echo "Updating rke2-server.service.d/override.conf"
+  cat >> ${HOST_DIR}/etc/systemd/system/rke2-server.service.d/override.conf <<EOF
+EnvironmentFile=-/etc/rancher/rke2/harvester-managed.env
+EOF
+
+  echo "Updating rke2-agent.service.d/override.conf"
+  cat >> ${HOST_DIR}/etc/systemd/system/rke2-agent.service.d/override.conf <<EOF
+EnvironmentFile=-/etc/rancher/rke2/harvester-managed.env
+EOF
+
+  echo "Reloading systemd manager configuration"
+  chroot $HOST_DIR systemctl daemon-reload
+}
+
+rke2_certificate_rotate_for_role() {
+  local service=$1
+
+  echo "Stopping ${service}."
+  chroot $HOST_DIR systemctl stop $service
+
+  echo "Rotating certificates."
+  chroot $HOST_DIR /opt/rke2/bin/rke2 certificate rotate
+
+  echo "Starting ${service}."
+  chroot $HOST_DIR systemctl start $service
+}
+
+rke2_certificate_rotate() {
+  if chroot $HOST_DIR systemctl is-active --quiet rke2-server; then
+    rke2_certificate_rotate_for_role "rke2-server"
+  elif chroot $HOST_DIR systemctl is-active --quiet rke2-agent; then
+    rke2_certificate_rotate_for_role "rke2-agent"
+  fi
 }
 
 set_nic_names_by_mac_address() {
@@ -832,6 +888,9 @@ command_post_drain() {
 
   generate_hostname_persistance
 
+  generate_rke2_harvester_managed_env
+  rke2_certificate_rotate
+
   upgrade_os
 }
 
@@ -872,6 +931,10 @@ command_single_node_upgrade() {
   generate_networkmanager_config
 
   generate_hostname_persistance
+
+  generate_rke2_harvester_managed_env
+  rke2_certificate_rotate
+
   # Upgrade OS
   upgrade_os
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The current RKE2 certificate management experience can be improved. While the existing `auto-rotate-rke2-certs` setting is available, triggering certificate rotations mid-lifecycle can sometimes be unreliable and poses operational risks to active clusters. We need a safer, more predictable way to ensure certificates do not expire during the release lifecycle.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Introduced an new certificate management strategy with the following changes:
- Extend Expiry: Set the default certificate expiry to 1000 days.
- Auto-Rotate on Upgrade: Trigger certificate rotation automatically during upgrades, pushing the expiry date out with every update.

By tying certificate rotation directly to the cluster upgrade window, we avoid the operational risks of modifying live, in-production control planes mid-lifecycle. Certificates will naturally refresh during routine upgrades well before they ever risk expiration.

A new file `/etc/rancher/rke2/harvester-managed.env` with the content `CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=1000` is introduced, which is used by rke2-server and rke2-client systemd services to set the default certificate expiry. We make sure the certificate expiry is updated for fresh installation and upgrade.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10407

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Fresh Installation: Verify that a new installation defaults to a 1000-day certificate expiry
    1. single node cluster
       ```
       harvester-node-0:/home/rancher # awk -v ns=$(/opt/rke2/bin/rke2 certificate check --output json | jq '[.Certificates.[].ResidualTime] | min') 'BEGIN { days = ns / 86400000000000; printf "Days: %.2f\n", days }'
       INFO[0000] Server detected, checking agent and server certificates
       Days: 999.93
       ```
    1. 4-nodes cluster (2 Management + 1 Witness + 1 Worker)
1. Cluster Upgrade: Verify that upgrading an existing cluster bumps the certificate expiry out to 1000 days from the upgrade timestamp.
    1. Deploy a `v1.8.x` single-node cluster. Perform an upgrade to this PR's build.
    1. Deploy a `v1.8.x` 4-nodes cluster (2 Management + 1 Witness + 1 Worker). Perform an upgrade to this PR's build.

#### Additional documentation or context

The standard lifecycle of a Harvester release from General Availability (GA) to End of Life (EOL) is less than 2 years (~730 days). A 1000-day default limit provides a safe, comfortable buffer that eliminates the need to track and manage certificate rotations in the middle of a release cycle.

- https://www.suse.com/suse-harvester/support-matrix/all-supported-versions
- https://support.scc.suse.com/s/kb/How-to-extend-RKE2-K3s-self-signed-certificate-expiration
- https://docs.rke2.io/security/certificates#rotating-client-and-server-certificates-manually
- https://docs.harvesterhci.io/v1.8/advanced/index/#auto-rotate-rke2-certs
