### PR TITLE
fine tune kubeconfig auth middleware

### DIFF
--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -224,7 +224,7 @@ func verifyAuthMiddleware(next http.Handler) http.Handler {
 		// limit access to admin user
 		extraUsername := r.Header.Get("Impersonate-Extra-Username")
 		logrus.Infof("Impersonate-Extra-Username: %s", extraUsername)
-		if extraUsername != defaultAdminUsername {
+		if extraUsername == "" {
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte("Unauthorized")) // nolint: errcheck
 			return


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Downstream cluster provisioning is broken in Harvester when using non-admin user.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR drops user name check during generation of kubeconfig.
This endpoint is also used by Rancher to provision kubeconfig for cloud-provider when creating downstream rke2 clusters.


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/11129

#### Test plan:
<!-- Describe the test plan by steps. -->
* Import Harvester cluster running this change into Rancher
* Create a `non-admin` user in rancher, and assign to `Default` project in Harvester
* Create a downstream rke2 cluster in Harvester via Rancher
* Cluster provisioning should complete successfully

#### Additional documentation or context
