### PR TITLE
fix: name restore-type VMImages based on the associated BI and SC from the data source

### DIFF
--- a/pkg/image/common/operator.go
+++ b/pkg/image/common/operator.go
@@ -16,6 +16,7 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/util"
 	lhdatastore "github.com/longhorn/longhorn-manager/datastore"
 	lhutil "github.com/longhorn/longhorn-manager/util"
 )
@@ -177,24 +178,37 @@ func (vmio *vmiOperator) GetDisplayName(vmi *harvesterv1.VirtualMachineImage) st
 	return vmi.Spec.DisplayName
 }
 
+func (vmio *vmiOperator) getSCByNames(names ...string) string {
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, err := vmio.scCache.Get(name); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
 func (vmio *vmiOperator) GetStorageClassName(vmi *harvesterv1.VirtualMachineImage) string {
 	if vmi.Spec.Backend == harvesterv1.VMIBackendCDI {
 		return vmi.Spec.TargetStorageClassName
 	}
 
+	restoreSCName, hasRestoreSCName := util.GetRestoreSCName(vmi)
 	scName := lhutil.AutoCorrectName(
 		fmt.Sprintf("lh-%s", vmio.GetUID(vmi)),
 		lhdatastore.NameMaximumLength,
 	)
-	_, err := vmio.scCache.Get(scName)
-	if err == nil {
-		return scName
+	legacySCName := fmt.Sprintf("longhorn-%s", vmi.Name)
+
+	if existingSCName := vmio.getSCByNames(restoreSCName, scName, legacySCName); existingSCName != "" {
+		return existingSCName
 	}
 
-	legacySCName := fmt.Sprintf("longhorn-%s", vmi.Name)
-	_, err = vmio.scCache.Get(legacySCName)
-	if err == nil {
-		return legacySCName
+	if hasRestoreSCName {
+		// Fresh restores should keep the BI/SC names derived from spec.url.
+		return restoreSCName
 	}
 
 	// If neither a storage class with the new naming nor with the old naming

--- a/pkg/image/common/operator_test.go
+++ b/pkg/image/common/operator_test.go
@@ -97,6 +97,77 @@ func TestGetStorageClassName(t *testing.T) {
 			},
 			ex: output{name: "lh-abcdefghi-jklmno-pqrstu-123456"},
 		},
+		{
+			desc: "Restore StorageClass from backingImage URL parameter when none exists",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "image-foobar",
+						UID:  "abcdefghi-jklmno-pqrstu-123456",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend:    harvesterv1.VMIBackendBackingImage,
+						SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+						URL:        "s3://mybucket@pcloud/?backingImage=vmi-06791a48-8d0d-4895-999b-28296f0e1c10",
+					},
+				},
+			},
+			ex: output{name: "lh-06791a48-8d0d-4895-999b-28296f0e1c10"},
+		},
+		{
+			desc: "Restore StorageClass uses existing legacy name",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-image-foobar",
+						},
+					},
+				},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "image-foobar",
+						UID:  "abcdefghi-jklmno-pqrstu-123456",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend:    harvesterv1.VMIBackendBackingImage,
+						SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+						URL:        "s3://mybucket@pcloud/?backingImage=vmi-06791a48-8d0d-4895-999b-28296f0e1c10",
+					},
+				},
+			},
+			ex: output{name: "longhorn-image-foobar"},
+		},
+		{
+			desc: "Restore StorageClass uses existing URL-derived name",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "lh-06791a48-8d0d-4895-999b-28296f0e1c10",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-image-foobar",
+						},
+					},
+				},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "image-foobar",
+						UID:  "abcdefghi-jklmno-pqrstu-123456",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend:    harvesterv1.VMIBackendBackingImage,
+						SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+						URL:        "s3://mybucket@pcloud/?backingImage=vmi-06791a48-8d0d-4895-999b-28296f0e1c10",
+					},
+				},
+			},
+			ex: output{name: "lh-06791a48-8d0d-4895-999b-28296f0e1c10"},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 
 	lhdatastore "github.com/longhorn/longhorn-manager/datastore"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
@@ -31,30 +33,85 @@ func backingImageName(image *harvesterv1.VirtualMachineImage) string {
 	return fmt.Sprintf("%s-%s", backingimagePrefix, image.UID)
 }
 
-func GetBackingImage(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (*lhv1beta2.BackingImage, error) {
-	bi, err := backingImageCache.Get(LonghornSystemNamespaceName, backingImageLegacyName(image))
-	if err == nil {
-		return bi, nil
-	}
-
-	if !errors.IsNotFound(err) {
-		return nil, err
-	}
-
-	bi, err = backingImageCache.Get(LonghornSystemNamespaceName, backingImageLegacyNameV2(image))
-	if err == nil {
-		return bi, nil
-	}
-
-	if !errors.IsNotFound(err) {
-		return nil, err
-	}
-
-	rectifyName := lhutil.AutoCorrectName(backingImageName(image), lhdatastore.NameMaximumLength)
-	return backingImageCache.Get(LonghornSystemNamespaceName, rectifyName)
+func defaultBackingImageName(image *harvesterv1.VirtualMachineImage) string {
+	return lhutil.AutoCorrectName(backingImageName(image), lhdatastore.NameMaximumLength)
 }
 
-func GetBackingImageName(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (string, error) {
+func restoreBackingImageName(image *harvesterv1.VirtualMachineImage) (string, bool) {
+	if image.Spec.SourceType != harvesterv1.VirtualMachineImageSourceTypeRestore {
+		return "", false
+	}
+
+	parsedURL, err := url.Parse(image.Spec.URL)
+	if err != nil {
+		return "", false
+	}
+
+	name := parsedURL.Query().Get(LonghornOptionBackingImageName)
+	if name == "" || !lhutil.ValidateName(name) {
+		return "", false
+	}
+
+	return name, true
+}
+
+func GetRestoreSCName(image *harvesterv1.VirtualMachineImage) (string, bool) {
+	biName, ok := restoreBackingImageName(image)
+	if !ok {
+		return "", false
+	}
+
+	scSuffix := strings.TrimPrefix(biName, backingimagePrefix+"-")
+	return lhutil.AutoCorrectName(fmt.Sprintf("lh-%s", scSuffix), lhdatastore.NameMaximumLength), true
+}
+
+func getBackingImageByNames(
+	backingImageCache ctllhv1.BackingImageCache,
+	names ...string,
+) (*lhv1beta2.BackingImage, error) {
+	var lastErr error
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+
+		bi, err := backingImageCache.Get(LonghornSystemNamespaceName, name)
+		if err == nil || !errors.IsNotFound(err) {
+			return bi, err
+		}
+		lastErr = err
+	}
+
+	return nil, lastErr
+}
+
+func backingImageNameForCreate(image *harvesterv1.VirtualMachineImage) string {
+	if biName, ok := restoreBackingImageName(image); ok {
+		return biName
+	}
+	return defaultBackingImageName(image)
+}
+
+func GetBackingImage(
+	backingImageCache ctllhv1.BackingImageCache,
+	image *harvesterv1.VirtualMachineImage,
+) (*lhv1beta2.BackingImage, error) {
+	names := []string{
+		backingImageLegacyName(image),
+		backingImageLegacyNameV2(image),
+		defaultBackingImageName(image),
+	}
+	if biName, ok := restoreBackingImageName(image); ok {
+		names = append([]string{biName}, names...)
+	}
+
+	return getBackingImageByNames(backingImageCache, names...)
+}
+
+func GetBackingImageName(
+	backingImageCache ctllhv1.BackingImageCache,
+	image *harvesterv1.VirtualMachineImage,
+) (string, error) {
 	bi, err := GetBackingImage(backingImageCache, image)
 	if err == nil {
 		return bi.Name, nil
@@ -64,7 +121,7 @@ func GetBackingImageName(backingImageCache ctllhv1.BackingImageCache, image *har
 		return "", err
 	}
 
-	return lhutil.AutoCorrectName(backingImageName(image), lhdatastore.NameMaximumLength), nil
+	return backingImageNameForCreate(image), nil
 }
 
 func GetBackingImageDataSourceName(backingImageCache ctllhv1.BackingImageCache, image *harvesterv1.VirtualMachineImage) (string, error) {

--- a/pkg/util/image_test.go
+++ b/pkg/util/image_test.go
@@ -1,0 +1,182 @@
+package util_test
+
+import (
+	"testing"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestGetBackingImageNameRestoreFromURL(t *testing.T) {
+	const (
+		imageUID               = "faec4fac-4330-46c7-b6fb-314288a012cd"
+		restoredBackingImage   = "vmi-06791a48-8d0d-4895-999b-28296f0e1c10"
+		restoreBackingImageURL = "s3://mybucket@pcloud/?backingImage=" + restoredBackingImage
+	)
+
+	tests := []struct {
+		name     string
+		vmi      *harvesterv1.VirtualMachineImage
+		expected string
+	}{
+		{
+			name: "restore image uses backingImage from url",
+			vmi: &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-zxhcn",
+					Namespace: "default",
+					UID:       imageUID,
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+					URL:        restoreBackingImageURL,
+				},
+			},
+			expected: restoredBackingImage,
+		},
+		{
+			name: "restore image without backingImage in url uses image uid",
+			vmi: &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-zxhcn",
+					Namespace: "default",
+					UID:       imageUID,
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+					URL:        "s3://mybucket@pcloud/",
+				},
+			},
+			expected: "vmi-" + imageUID,
+		},
+		{
+			name: "download image ignores backingImage url parameter",
+			vmi: &harvesterv1.VirtualMachineImage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-zxhcn",
+					Namespace: "default",
+					UID:       imageUID,
+				},
+				Spec: harvesterv1.VirtualMachineImageSpec{
+					SourceType: harvesterv1.VirtualMachineImageSourceTypeDownload,
+					URL:        restoreBackingImageURL,
+				},
+			},
+			expected: "vmi-" + imageUID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fakegenerated.NewSimpleClientset()
+			cache := fakeclients.BackingImageCache(clientset.LonghornV1beta2().BackingImages)
+
+			name, err := util.GetBackingImageName(cache, tt.vmi)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, name)
+		})
+	}
+}
+
+func TestGetBackingImageRestoreUsesURLName(t *testing.T) {
+	const (
+		legacyBackingImage   = "default-image-zxhcn"
+		restoredBackingImage = "vmi-06791a48-8d0d-4895-999b-28296f0e1c10"
+	)
+
+	vmi := &harvesterv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "image-zxhcn",
+			Namespace: "default",
+			UID:       "faec4fac-4330-46c7-b6fb-314288a012cd",
+		},
+		Spec: harvesterv1.VirtualMachineImageSpec{
+			SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+			URL:        "s3://mybucket@pcloud/?backingImage=" + restoredBackingImage,
+		},
+	}
+	clientset := fakegenerated.NewSimpleClientset(
+		&lhv1beta2.BackingImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      legacyBackingImage,
+				Namespace: util.LonghornSystemNamespaceName,
+			},
+		},
+		&lhv1beta2.BackingImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      restoredBackingImage,
+				Namespace: util.LonghornSystemNamespaceName,
+			},
+		},
+	)
+	cache := fakeclients.BackingImageCache(clientset.LonghornV1beta2().BackingImages)
+
+	bi, err := util.GetBackingImage(cache, vmi)
+	require.NoError(t, err)
+	require.Equal(t, restoredBackingImage, bi.Name)
+}
+
+func TestGetBackingImageNameRestoreUsesExistingLegacyName(t *testing.T) {
+	const legacyBackingImage = "default-image-zxhcn"
+
+	vmi := &harvesterv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "image-zxhcn",
+			Namespace: "default",
+			UID:       "faec4fac-4330-46c7-b6fb-314288a012cd",
+		},
+		Spec: harvesterv1.VirtualMachineImageSpec{
+			SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+			URL:        "s3://mybucket@pcloud/?backingImage=vmi-06791a48-8d0d-4895-999b-28296f0e1c10",
+		},
+	}
+	clientset := fakegenerated.NewSimpleClientset(
+		&lhv1beta2.BackingImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      legacyBackingImage,
+				Namespace: util.LonghornSystemNamespaceName,
+			},
+		},
+	)
+	cache := fakeclients.BackingImageCache(clientset.LonghornV1beta2().BackingImages)
+
+	name, err := util.GetBackingImageName(cache, vmi)
+	require.NoError(t, err)
+	require.Equal(t, legacyBackingImage, name)
+
+	bi, err := util.GetBackingImage(cache, vmi)
+	require.NoError(t, err)
+	require.Equal(t, legacyBackingImage, bi.Name)
+}
+
+func TestGetImageStorageClassParametersRestoreFromURL(t *testing.T) {
+	const restoredBackingImage = "vmi-06791a48-8d0d-4895-999b-28296f0e1c10"
+
+	vmi := &harvesterv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "image-zxhcn",
+			Namespace: "default",
+			UID:       "faec4fac-4330-46c7-b6fb-314288a012cd",
+		},
+		Spec: harvesterv1.VirtualMachineImageSpec{
+			SourceType: harvesterv1.VirtualMachineImageSourceTypeRestore,
+			URL:        "s3://mybucket@pcloud/?backingImage=" + restoredBackingImage,
+			StorageClassParameters: map[string]string{
+				"numberOfReplicas": "2",
+			},
+		},
+	}
+	clientset := fakegenerated.NewSimpleClientset()
+	cache := fakeclients.BackingImageCache(clientset.LonghornV1beta2().BackingImages)
+
+	params, err := util.GetImageStorageClassParameters(cache, vmi)
+	require.NoError(t, err)
+	require.Equal(t, restoredBackingImage, params[util.LonghornOptionBackingImageName])
+	require.Equal(t, "2", params["numberOfReplicas"])
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
https://github.com/harvester/harvester/issues/11145

#### Solution:
name restore-type VMImages based on the associated BI and SC from the data source

#### Related Issue(s):
name restore-type VMImages based on the associated BI and SC from the data source

#### Test plan:
https://github.com/harvester/harvester/issues/11145#issuecomment-5018460973


#### Additional documentation or context
