### PR TITLE
chore: change upgrade image to pull yq, helm and kubectl from rancher's obs registry [DNM - awaiting CNS confirmation]

### DIFF
--- a/package/upgrade/Dockerfile
+++ b/package/upgrade/Dockerfile
@@ -4,41 +4,33 @@ FROM registry.suse.com/bci/bci-base:16.0
 ARG ARCH=amd64
 ENV ARCH=${ARCH}
 
-ARG KUBECTL_VERSION=v1.35.5
-ARG KUBECTL_SHA256_amd64=90f75ea6ecc9ea5633262e1c0b83a40560003b30fc94a04cb099404fcef0c224
-ARG KUBECTL_SHA256_arm64=ac69e06fd6860d69786692f5af1c3a1208ed54f8366a4d97ab15c172e99765ee
+ARG KUBECTL_OBS_PACKAGE=kubectl1.35
+ARG HELM_OBS_PACKAGE=helm3
 
 ARG KUBEVIRT_VERSION=v1.7.1
 ARG VIRTCTL_SHA256_amd64=e0efcfc708067fa45232f3bab9cb2de3dbcd812d4c9aab88c727025fb213079f
 ARG VIRTCTL_SHA256_arm64=7737d967bc8512abedfdaa8a61a3512f93894c12162f9dde4fab73402a4f42d5
-
-ARG YQ_VERSION=v4.52.4
-ARG YQ_SHA256_amd64=0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c
-ARG YQ_SHA256_arm64=4c2cc022a129be5cc1187959bb4b09bebc7fb543c5837b93001c68f97ce39a5d
 
 ARG WHARFIE_VERSION=v0.7.0
 ARG WHARFIE_SHA256_amd64=e5ff747b2f9f4155ce7b68917bac9dbe8a6a85727a94b0c8e6faca9252931e91
 ARG WHARFIE_SHA256_arm64=b8e02fe61d4f8cb1bd7927fd5e34b49b4dcf802c52670adfaa4527ed3d9afc41
 
 SHELL ["/bin/bash", "-c"]
-RUN zypper rm -y container-suseconnect && \
-    zypper --no-gpg-checks ref && \
-    zypper in -y curl e2fsprogs rsync awk zstd jq helm zip unzip nginx util-linux && zypper clean -a
 
-ENV KUBECTL_VERSION ${KUBECTL_VERSION}
-RUN KUBECTL_SHA256=KUBECTL_SHA256_${ARCH} && \
-    VIRTCTL_SHA256=VIRTCTL_SHA256_${ARCH} && \
-    YQ_SHA256=YQ_SHA256_${ARCH} && \
+RUN zypper addrepo --refresh https://download.opensuse.org/repositories/isv:/Rancher:/dependencies/pkgs rancher-obs-deps && \
+    zypper --gpg-auto-import-keys ref --force && \
+    zypper rm -y container-suseconnect && \
+    zypper in -y curl e2fsprogs rsync awk zstd jq zip unzip nginx util-linux && \
+    zypper in -y --from rancher-obs-deps yq ${HELM_OBS_PACKAGE} ${KUBECTL_OBS_PACKAGE} && \
+    zypper clean -a && \
+    ln -s /usr/bin/${KUBECTL_OBS_PACKAGE} /usr/bin/kubectl && \
+    ln -s /usr/bin/${HELM_OBS_PACKAGE} /usr/bin/helm
+
+RUN VIRTCTL_SHA256=VIRTCTL_SHA256_${ARCH} && \
     WHARFIE_SHA256=WHARFIE_SHA256_${ARCH} && \
-    curl -sfL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl > /usr/bin/kubectl && \
-    echo "${!KUBECTL_SHA256}  /usr/bin/kubectl" | sha256sum -c - && \
-    chmod +x /usr/bin/kubectl && \
     curl -sfL https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-${ARCH} -o /usr/bin/virtctl && \
     echo "${!VIRTCTL_SHA256}  /usr/bin/virtctl" | sha256sum -c - && \
     chmod +x /usr/bin/virtctl && \
-    curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH} -o /usr/bin/yq && \
-    echo "${!YQ_SHA256}  /usr/bin/yq" | sha256sum -c - && \
-    chmod +x /usr/bin/yq && \
     curl -sfL https://github.com/rancher/wharfie/releases/download/${WHARFIE_VERSION}/wharfie-${ARCH}  -o /usr/bin/wharfie && \
     echo "${!WHARFIE_SHA256}  /usr/bin/wharfie" | sha256sum -c - && \
     chmod +x /usr/bin/wharfie


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

To ensure the integrity of binaries downloaded from upstream remotes, we maintain checksum validation logic in our Dockerfiles and scripts. Rancher has recently introduced an [OBS registry](https://github.com/rancher/obs-build-packages) to host commonly used CLI tools like `kubectl`, `helm` and `yq`, to help maintain and distribute latest patch versions of these tools. We can use `zypper` to fetch and install these tools, with automatic support of artifact checksum and signature validation.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR updates the `upgrade` Dockerfile to fetch `kubectl`, `helm` and `yq` from the Rancher's OBS registry.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11176

#### Test plan:
<!-- Describe the test plan by steps. -->

* Run `make` locally.
* Ensures that the image contains the `helm`, `yq` and `kubectl` CLI:

```sh
b21679370aa0:/ # zypper se -is yq helm3 kubectl1.35
Loading repository data...
Reading installed packages...

S  | Name        | Type    | Version    | Arch   | Repository
---+-------------+---------+------------+--------+-----------------
i+ | helm3       | package | 3.21.3-4.1 | x86_64 | rancher-obs-deps
i+ | kubectl1.35 | package | 1.35.6-4.1 | x86_64 | rancher-obs-deps
i+ | yq          | package | 4-4.1      | x86_64 | rancher-obs-deps

b21679370aa0:/ # kubectl version --client
Client Version: v1.35.6
Kustomize Version: v5.7.1

b21679370aa0:/ # helm version
version.BuildInfo{Version:"v3.21+v3.21.3", GitCommit:"1ad6e68924fdf6fb0c7dcef8e9e1dfc0f36eaed6", GitTreeState:"clean", GoVersion:"go1.26.5"}

b21679370aa0:/ # yq --version
yq (https://github.com/mikefarah/yq/) version v4.53.3
```

#### Additional documentation or context
