### PR TITLE
introduce new setting traefik-default-tls-options to allow users to customize default tls options

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -379,6 +379,9 @@ command_pre_drain() {
 
   remove_rke2_canal_config
   disable_rke2_charts
+
+  # switch ingress
+  switch_ingress
 }
 
 get_node_rke2_version() {
@@ -839,7 +842,6 @@ command_post_drain() {
 
   generate_hostname_persistance
 
-  switch_ingress
   upgrade_os
 }
 
@@ -871,6 +873,9 @@ command_single_node_upgrade() {
   set_reserved_resource
   set_rke2_device_permissions
   set_oem_cleanup_kubelet
+
+  # switch ingress
+  switch_ingress
   # Upgarde RKE2
   upgrade_rke2
 
@@ -880,7 +885,7 @@ command_single_node_upgrade() {
   generate_networkmanager_config
 
   generate_hostname_persistance
-  switch_ingress
+  
   # Upgrade OS
   upgrade_os
 }

--- a/pkg/controller/master/rancher/daemonset.go
+++ b/pkg/controller/master/rancher/daemonset.go
@@ -93,6 +93,10 @@ func (h *Handler) triggerTLSCertificateSettingUpdate() error {
 		return fmt.Errorf("error looking up ssl certificate setting: %w", err)
 	}
 
+	if tlsCertificateSetting.Annotations == nil {
+		tlsCertificateSetting.Annotations = make(map[string]string)
+	}
+
 	tlsCertificateSettingCopy := tlsCertificateSetting.DeepCopy()
 	// update the setting value with the same value to trigger the change handler
 	delete(tlsCertificateSettingCopy.Annotations, util.AnnotationHash)

--- a/pkg/controller/master/setting/handler.go
+++ b/pkg/controller/master/setting/handler.go
@@ -44,6 +44,7 @@ var (
 		settings.OvercommitConfigSettingName,
 		// always run this when Harvester POD starts
 		settings.AdditionalGuestMemoryOverheadRatioName,
+		settings.TraefikDefaultTLSOptionsSettingName,
 	}
 	skipHashCheckSettings = []string{
 		settings.AutoRotateRKE2CertsSettingName,

--- a/pkg/controller/master/setting/register.go
+++ b/pkg/controller/master/setting/register.go
@@ -115,6 +115,7 @@ func Register(ctx context.Context, management *config.Management, options config
 		harvSettings.MaxHotplugRatioSettingName:                  controller.syncMaxHotplugRatio,
 		harvSettings.KubeVirtMigrationSettingName:                controller.syncKubeVirtMigration,
 		harvSettings.ClusterPodSecurityStandardSettingName:       controller.syncPodSecuritySetting,
+		harvSettings.TraefikDefaultTLSOptionsSettingName:         controller.syncTLSOption,
 		// for "backup-target" syncer, please check harvester-backup-target-controller
 		// for "storage-network" syncer, please check harvester-storage-network-controller
 		// for "vm-migration-network" syncer, please check harvester-vm-migration-network-controller

--- a/pkg/controller/master/setting/ssl_parameters.go
+++ b/pkg/controller/master/setting/ssl_parameters.go
@@ -1,82 +1,11 @@
 package setting
 
 import (
-	"encoding/json"
-	"strings"
-
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/settings"
-	"github.com/harvester/harvester/pkg/util"
-)
-
-const (
-	defaultTLSOptionName = "default"
 )
 
 func (h *Handler) syncSSLParameters(setting *harvesterv1.Setting) error {
-	sslParameter := &settings.SSLParameter{}
-	value := setting.Value
-	if value == "" {
-		value = setting.Default
-	}
-	if err := json.Unmarshal([]byte(value), sslParameter); err != nil {
-		return err
-	}
-
-	return h.updateSSLParameters(sslParameter)
-}
-
-func (h *Handler) updateSSLParameters(sslParameter *settings.SSLParameter) error {
-	logrus.Infof("Update SSL Parameters: Ciphers: %s, Protocols: %s", sslParameter.Ciphers, sslParameter.Protocols)
-
-	tlsOptionRes := schema.GroupVersionResource{Group: "traefik.io", Version: "v1alpha1", Resource: "tlsoptions"}
-	if sslParameter.Ciphers == "" {
-		return h.dynamicClient.Resource(tlsOptionRes).Namespace(util.KubeSystemNamespace).Delete(h.ctx, defaultTLSOptionName, metav1.DeleteOptions{})
-	}
-	ciphers := strings.Split(sslParameter.Ciphers, ":")
-	obj := generateUnstructuredTLSOption(ciphers)
-	return h.apply.WithDynamicLookup().WithSetID(util.HarvesterChartReleaseName).ApplyObjects(obj)
-}
-
-/*
-# Generate a TLSOption object
-# https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/crd/tls/tlsoption/
-apiVersion: traefik.io/v1alpha1
-kind: TLSOption
-metadata:
-  name: mytlsoption
-  namespace: default
-
-spec:
-  minVersion: VersionTLS12
-  sniStrict: true
-  cipherSuites:
-    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    - TLS_RSA_WITH_AES_256_GCM_SHA384
-  clientAuth:
-    secretNames:
-      - secret-ca1
-      - secret-ca2
-    clientAuthType: VerifyClientCertIfGiven
-*/
-
-func generateUnstructuredTLSOption(ciphers []string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "traefik.io/v1alpha1",
-			"kind":       "TLSOption",
-			"metadata": map[string]interface{}{
-				"name":      defaultTLSOptionName,
-				"namespace": util.KubeSystemNamespace,
-			},
-			"spec": map[string]interface{}{
-				"cipherSuites": ciphers,
-			},
-		},
-	}
+	// ssl parameters is deprecated in v1.9.x due to switch to traefik
+	// no actual operation is performed if user configures ssl parameters setting
+	return nil
 }

--- a/pkg/controller/master/setting/tlsoptions.go
+++ b/pkg/controller/master/setting/tlsoptions.go
@@ -1,0 +1,112 @@
+package setting
+
+import (
+	"encoding/json"
+	"fmt"
+
+	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	defaultTLSOptionName = "default"
+)
+
+func (h *Handler) syncTLSOption(setting *harvesterv1.Setting) error {
+	tlsOptionSpec := &settings.TLSOptionSpec{}
+	value := setting.Value
+	if value == "" {
+		value = setting.Default
+	}
+
+	if err := json.Unmarshal([]byte(value), tlsOptionSpec); err != nil {
+		return err
+	}
+
+	return h.updateTLSOption(tlsOptionSpec)
+}
+
+func (h *Handler) updateTLSOption(tlsOptionSpec *settings.TLSOptionSpec) error {
+	obj, err := generateUnstructuredTLSOption(tlsOptionSpec)
+	if err != nil {
+		return err
+	}
+	return h.apply.WithDynamicLookup().WithSetID(util.HarvesterChartReleaseName).ApplyObjects(obj)
+}
+
+/*
+# Generate a TLSOption object
+# https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/crd/tls/tlsoption/
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: mytlsoption
+  namespace: default
+
+spec:
+  minVersion: VersionTLS12
+  sniStrict: true
+  cipherSuites:
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_RSA_WITH_AES_256_GCM_SHA384
+  clientAuth:
+    secretNames:
+      - secret-ca1
+      - secret-ca2
+    clientAuthType: VerifyClientCertIfGiven
+*/
+
+func generateUnstructuredTLSOption(tlsOptionSpec *settings.TLSOptionSpec) (*unstructured.Unstructured, error) {
+	// to avoid deepcopy errors when dealing with unstructured objects, we need to convert the slice of string to slice of interface{}
+	cipherSuitesInterface := make([]interface{}, 0, len(tlsOptionSpec.CipherSuites))
+	for _, cipherSuite := range tlsOptionSpec.CipherSuites {
+		cipherSuitesInterface = append(cipherSuitesInterface, cipherSuite)
+	}
+
+	curvePreferencesInterface := make([]interface{}, 0, len(tlsOptionSpec.CurvePreferences))
+	for _, curvePreference := range tlsOptionSpec.CurvePreferences {
+		curvePreferencesInterface = append(curvePreferencesInterface, curvePreference)
+	}
+
+	alpnProtocolsInterface := make([]interface{}, 0, len(tlsOptionSpec.ALPNProtocols))
+	for _, alpnProtocol := range tlsOptionSpec.ALPNProtocols {
+		alpnProtocolsInterface = append(alpnProtocolsInterface, alpnProtocol)
+	}
+	clientAuthSecretNamesInterface := make([]interface{}, 0, len(tlsOptionSpec.ClientAuth.SecretNames))
+	for _, secretName := range tlsOptionSpec.ClientAuth.SecretNames {
+		clientAuthSecretNamesInterface = append(clientAuthSecretNamesInterface, secretName)
+	}
+
+	traefikOptionsObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "traefik.io/v1alpha1",
+			"kind":       "TLSOption",
+			"metadata": map[string]interface{}{
+				"name":      defaultTLSOptionName,
+				"namespace": util.KubeSystemNamespace,
+			},
+			"spec": map[string]interface{}{
+				"cipherSuites":          cipherSuitesInterface,
+				"minVersion":            tlsOptionSpec.MinVersion,
+				"maxVersion":            tlsOptionSpec.MaxVersion,
+				"sniStrict":             tlsOptionSpec.SniStrict,
+				"curvePreferences":      curvePreferencesInterface,
+				"alpnProtocols":         alpnProtocolsInterface,
+				"disableSessionTickets": tlsOptionSpec.DisableSessionTickets,
+			},
+		},
+	}
+	if tlsOptionSpec.ClientAuth.ClientAuthType != "" {
+		clientAuthMap := map[string]interface{}{
+			"secretNames":    clientAuthSecretNamesInterface,
+			"clientAuthType": tlsOptionSpec.ClientAuth.ClientAuthType,
+		}
+		if err := unstructured.SetNestedMap(traefikOptionsObj.Object, clientAuthMap, "spec", "clientAuth"); err != nil {
+			return nil, fmt.Errorf("failed to set clientAuth in TLSOption object: %w", err)
+		}
+	}
+
+	return traefikOptionsObj, nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -69,6 +69,7 @@ var (
 	VMMigrationNetwork                = NewSetting(VMMigrationNetworkSettingName, "")
 	KubeVirtMigration                 = NewSetting(KubeVirtMigrationSettingName, `{"parallelOutboundMigrationsPerNode":2,"parallelMigrationsPerCluster":5,"allowAutoConverge":false,"bandwidthPerMigration":0,"completionTimeoutPerGiB":150,"progressTimeout":150,"unsafeMigrationOverride":false,"allowPostCopy":false,"allowWorkloadDisruption":false,"disableTLS":false,"matchSELinuxLevelOnMigration":false}`)
 	ClusterPodSecurityStandardSetting = NewSetting(ClusterPodSecurityStandardSettingName, `{"enabled":false,"whitelistedNamespacesList":"", "privilegedNamespacesList":"", "restrictedNamespacesList":""}`)
+	TraefikDefaultTLSOptionSetting    = NewSetting(TraefikDefaultTLSOptionsSettingName, `{"minVersion":"VersionTLS12", "maxVersion":"VersionTLS13", "sniStrict":false,"cipherSuites":[],"clientAuth":{"secretNames":[],"clientAuthType":""}}`)
 )
 
 const (
@@ -125,6 +126,7 @@ const (
 	RancherClusterSettingName                         = "rancher-cluster"
 	KubeVirtMigrationSettingName                      = "kubevirt-migration"
 	ClusterPodSecurityStandardSettingName             = "cluster-pod-security-standard"
+	TraefikDefaultTLSOptionsSettingName               = "traefik-default-tls-options"
 
 	// settings have `default` and `value` string used in many places, replace them with const
 	KeywordDefault = "default"

--- a/pkg/settings/settings_helper.go
+++ b/pkg/settings/settings_helper.go
@@ -202,6 +202,49 @@ type AutoRotateRKE2Certs struct {
 	ExpiringInHours int  `json:"expiringInHours"`
 }
 
+// copied from https://github.com/traefik/traefik/blob/master/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsoption.go as we do not plan
+// on importing the whole traefik package just for this struct
+// the struct is only used to parse the string providing via the tlsoption setting and
+// synced to underlying harvester clusters default traefik tlsoption resource
+
+// TLSOptionSpec defines the desired state of a TLSOption.
+type TLSOptionSpec struct {
+	// MinVersion defines the minimum TLS version that Traefik will accept.
+	// Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+	// Default: VersionTLS10.
+	MinVersion string `json:"minVersion,omitempty"`
+	// MaxVersion defines the maximum TLS version that Traefik will accept.
+	// Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+	// Default: None.
+	MaxVersion string `json:"maxVersion,omitempty"`
+	// CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.
+	// More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#cipher-suites
+	CipherSuites []string `json:"cipherSuites,omitempty"`
+	// CurvePreferences defines the preferred elliptic curves.
+	// More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#curve-preferences
+	CurvePreferences []string `json:"curvePreferences,omitempty"`
+	// ClientAuth defines the server's policy for TLS Client Authentication.
+	ClientAuth ClientAuth `json:"clientAuth,omitempty"`
+	// SniStrict defines whether Traefik allows connections from clients connections that do not specify a server_name extension.
+	SniStrict bool `json:"sniStrict,omitempty"`
+	// ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.
+	// More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#alpn-protocols
+	ALPNProtocols []string `json:"alpnProtocols,omitempty"`
+	// DisableSessionTickets disables TLS session resumption via session tickets.
+	DisableSessionTickets bool `json:"disableSessionTickets,omitempty"`
+}
+
+// +k8s:deepcopy-gen=true
+
+// ClientAuth holds the TLS client authentication configuration.
+type ClientAuth struct {
+	// SecretNames defines the names of the referenced Kubernetes Secret storing certificate details.
+	SecretNames []string `json:"secretNames,omitempty"`
+	// ClientAuthType defines the client authentication type to apply.
+	// +kubebuilder:validation:Enum=NoClientCert;RequestClientCert;RequireAnyClientCert;VerifyClientCertIfGiven;RequireAndVerifyClientCert
+	ClientAuthType string `json:"clientAuthType,omitempty"`
+}
+
 func InitAutoRotateRKE2Certs() string {
 	autoRotateRKE2Certs := &AutoRotateRKE2Certs{
 		Enable:          false,

--- a/pkg/webhook/resources/setting/validator.go
+++ b/pkg/webhook/resources/setting/validator.go
@@ -70,7 +70,6 @@ import (
 
 const (
 	minSNPrefixLength                 = 16
-	mcmFeature                        = "multi-cluster-management"
 	labelAppNameKey                   = "app.kubernetes.io/name"
 	labelAppNameValuePrometheus       = "prometheus"
 	labelAppNameValueAlertManager     = "alertmanager"
@@ -220,6 +219,8 @@ func NewValidator(
 	validateSettingUpdateFuncs[settings.LHIMResourcesSettingName] = validator.validateUpdateLHIMResources
 	validateSettingDeleteFuncs[settings.LHIMResourcesSettingName] = validator.validateDeleteLHIMResources
 
+	validateSettingUpdateFuncs[settings.TraefikDefaultTLSOptionsSettingName] = validateTraefikDefaultTLSOptionsUpdate
+	validateSettingFuncs[settings.TraefikDefaultTLSOptionsSettingName] = validateTraefikDefaultTLSOptions
 	return validator
 }
 
@@ -2558,4 +2559,23 @@ func validateLonghornV2DataEngineMemorySize(newSetting *v1beta1.Setting) error {
 
 func validateUpdateLonghornV2DataEngineMemorySize(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
 	return validateLonghornV2DataEngineMemorySize(newSetting)
+}
+
+// verify if the default TLS options for Traefik are valid.
+func validateTraefikDefaultTLSOptions(setting *v1beta1.Setting) error {
+	tlsOptionSpec := &settings.TLSOptionSpec{}
+	value := setting.Value
+	if value == "" {
+		value = setting.Default
+	}
+
+	if err := json.Unmarshal([]byte(value), tlsOptionSpec); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTraefikDefaultTLSOptionsUpdate(_ *types.Request, _ *v1beta1.Setting, newSetting *v1beta1.Setting) error {
+	return validateTraefikDefaultTLSOptions(newSetting)
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR introduces the following changes:
* disables ssl-parameter sync as there is no equivalent for traefik. This setting will be deprecated in the docs
* adds a new setting `traefik-default-tls-options` to allow users to sync traefik default tls options via a harvester setting
* moves the ingress swap to pre-drain phase to avoid ingress swapping behaviour in HA setups.
* 
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10067

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
