### PR TITLE
Add shareable volume support for VM disks

### DIFF
--- a/pkg/api/vm/handler.go
+++ b/pkg/api/vm/handler.go
@@ -1013,6 +1013,12 @@ func (h *vmActionHandler) addVolume(ctx context.Context, namespace, name string,
 		return err
 	}
 
+	if input.Shareable {
+		if err := virtualmachine.CheckShareableVolume(h.pvcCache, h.storageClassCache, namespace, input.VolumeSourceName); err != nil {
+			return err
+		}
+	}
+
 	vm, err := h.vmCache.Get(namespace, name)
 	if err != nil {
 		return err
@@ -1029,6 +1035,9 @@ func (h *vmActionHandler) addVolume(ctx context.Context, namespace, name string,
 				Bus: "scsi",
 			},
 		},
+	}
+	if input.Shareable {
+		newDisk.Shareable = ptr.To(true)
 	}
 	newVol := kubevirtv1.Volume{
 		Name: input.DiskName,

--- a/pkg/api/vm/types.go
+++ b/pkg/api/vm/types.go
@@ -44,6 +44,7 @@ type CreateTemplateInput struct {
 type AddVolumeInput struct {
 	DiskName         string `json:"diskName"`
 	VolumeSourceName string `json:"volumeSourceName"`
+	Shareable        bool   `json:"shareable,omitempty"`
 }
 
 type RemoveVolumeInput struct {

--- a/pkg/util/virtualmachine/virtualmachine.go
+++ b/pkg/util/virtualmachine/virtualmachine.go
@@ -175,6 +175,70 @@ func volumeSupportRWXForVM(accessModes []corev1.PersistentVolumeAccessMode, prov
 	return slices.Contains(accessModes, corev1.ReadWriteMany)
 }
 
+// CheckShareableVolume checks whether the given PVC can back a shareable disk.
+// Concurrent writers on different nodes require a block-mode RWX volume, and
+// Longhorn does not support that for VMs, so a provisioner other than Longhorn
+// is required. KubeVirt itself performs no admission validation on shareable
+// disks, so this is the only gate.
+func CheckShareableVolume(pvcCache v1.PersistentVolumeClaimCache, scCache ctlstoragev1.StorageClassCache, pvcNS, pvcName string) error {
+	pvc, err := pvcCache.Get(pvcNS, pvcName)
+	if apierrors.IsNotFound(err) {
+		// Unlike other checks we do not skip runtime-created PVCs
+		// (volumeClaimTemplates): a shareable disk shares an existing volume,
+		// and skipping would admit a spec whose PVC turns out to be
+		// non-shareable once created.
+		return fmt.Errorf("PVC %s/%s does not exist: a shareable disk requires an existing volume", pvcNS, pvcName)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get PVC %s/%s, err: %s", pvcNS, pvcName, err)
+	}
+
+	provisioner := util.GetProvisionedPVCProvisioner(pvc, scCache)
+	if !volumeSupportRWXForVM(pvc.Spec.AccessModes, provisioner) {
+		return fmt.Errorf("PVC %s/%s cannot back a shareable disk: a ReadWriteMany volume from a provisioner other than Longhorn is required", pvcNS, pvcName)
+	}
+	if pvc.Spec.VolumeMode == nil || *pvc.Spec.VolumeMode != corev1.PersistentVolumeBlock {
+		return fmt.Errorf("PVC %s/%s cannot back a shareable disk: volumeMode must be Block", pvcNS, pvcName)
+	}
+	return nil
+}
+
+// HasShareableDisk returns the name of the first disk with shareable enabled.
+func HasShareableDisk(vm *kubevirtv1.VirtualMachine) (string, bool) {
+	if vm.Spec.Template == nil {
+		return "", false
+	}
+	for _, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+		if disk.Shareable != nil && *disk.Shareable {
+			return disk.Name, true
+		}
+	}
+	return "", false
+}
+
+// VMUsesPVCAsShareable returns true if the VM attaches the given PVC through a
+// disk with shareable enabled.
+func VMUsesPVCAsShareable(vm *kubevirtv1.VirtualMachine, pvcName string) bool {
+	if vm.Spec.Template == nil {
+		return false
+	}
+	shareableDisks := map[string]struct{}{}
+	for _, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+		if disk.Shareable != nil && *disk.Shareable {
+			shareableDisks[disk.Name] = struct{}{}
+		}
+	}
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil || volume.PersistentVolumeClaim.ClaimName != pvcName {
+			continue
+		}
+		if _, ok := shareableDisks[volume.Name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func isDiskSataCdRom(disk *kubevirtv1.Disk) bool {
 	return disk.CDRom != nil && disk.CDRom.Bus == kubevirtv1.DiskBusSATA
 }

--- a/pkg/webhook/resources/virtualmachine/validator.go
+++ b/pkg/webhook/resources/virtualmachine/validator.go
@@ -323,6 +323,9 @@ func (v *vmValidator) checkVMSpec(vm *kubevirtv1.VirtualMachine) error {
 	if err := v.checkOccupiedPVCs(vm); err != nil {
 		return err
 	}
+	if err := v.checkShareableVolumes(vm); err != nil {
+		return err
+	}
 	if err := v.checkTerminationGracePeriodSeconds(vm); err != nil {
 		return err
 	}
@@ -369,6 +372,68 @@ func (v *vmValidator) checkVolumeReq(newVM *kubevirtv1.VirtualMachine) error {
 			if pvc.Annotations[util.AnnotationGoldenImage] == "true" {
 				return werror.NewInvalidError(fmt.Sprintf("PVC %s/%s is a golden image, it can't be used as a hotplug volume in VM", pvcNS, pvcName), "status.volumeRequests")
 			}
+		}
+	}
+	return nil
+}
+
+// checkShareableVolumes validates every disk with shareable enabled:
+//   - the backing volume must be a PVC that passes CheckShareableVolume
+//     (block-mode RWX from a provisioner other than Longhorn). KubeVirt has no
+//     admission validation on shareable at all, so this webhook is the only gate.
+//   - the disk cache must be unset or none; virt-launcher rejects other cache
+//     modes at VM start, we surface the error at admission instead.
+//   - the disk must not be the boot disk.
+func (v *vmValidator) checkShareableVolumes(vm *kubevirtv1.VirtualMachine) error {
+	if vm.Spec.Template == nil {
+		return nil
+	}
+
+	volumes := vm.Spec.Template.Spec.Volumes
+	volumesByName := make(map[string]*corev1.PersistentVolumeClaimVolumeSource, len(volumes))
+	for i := range volumes {
+		if volumes[i].PersistentVolumeClaim != nil {
+			volumesByName[volumes[i].Name] = &volumes[i].PersistentVolumeClaim.PersistentVolumeClaimVolumeSource
+		}
+	}
+
+	disks := vm.Spec.Template.Spec.Domain.Devices.Disks
+	anyBootOrder := false
+	for i := range disks {
+		if disks[i].BootOrder != nil {
+			anyBootOrder = true
+			break
+		}
+	}
+
+	for i := range disks {
+		disk := &disks[i]
+		if disk.Shareable == nil || !*disk.Shareable {
+			continue
+		}
+
+		// without any explicit bootOrder the first disk boots
+		if (disk.BootOrder != nil && *disk.BootOrder == 1) || (!anyBootOrder && i == 0) {
+			return werror.NewInvalidError(
+				fmt.Sprintf("disk %s cannot be shareable: a shareable disk cannot be used as the boot disk", disk.Name),
+				"spec.template.spec.domain.devices.disks")
+		}
+
+		if disk.Cache != "" && disk.Cache != kubevirtv1.CacheNone {
+			return werror.NewInvalidError(
+				fmt.Sprintf("disk %s cannot be shareable: a shareable disk requires cache mode none, got %s", disk.Name, disk.Cache),
+				"spec.template.spec.domain.devices.disks")
+		}
+
+		pvcSource, ok := volumesByName[disk.Name]
+		if !ok {
+			return werror.NewInvalidError(
+				fmt.Sprintf("disk %s cannot be shareable: a shareable disk must be backed by a persistent volume claim", disk.Name),
+				"spec.template.spec.volumes")
+		}
+
+		if err := vmutil.CheckShareableVolume(v.pvcCache, v.scCache, vm.Namespace, pvcSource.ClaimName); err != nil {
+			return werror.NewInvalidError(err.Error(), "spec.template.spec.volumes")
 		}
 	}
 	return nil

--- a/pkg/webhook/resources/virtualmachine/validator_test.go
+++ b/pkg/webhook/resources/virtualmachine/validator_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	corefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
@@ -1802,6 +1803,147 @@ func TestCheckTargetVolumes(t *testing.T) {
 				}
 			} else {
 				assert.Nil(t, err, tc.name)
+			}
+		})
+	}
+}
+
+func TestCheckShareableVolumes(t *testing.T) {
+	blockMode := corev1.PersistentVolumeBlock
+	fsMode := corev1.PersistentVolumeFilesystem
+
+	newPVC := func(name, provisioner string, accessMode corev1.PersistentVolumeAccessMode, volumeMode *corev1.PersistentVolumeMode) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   "default",
+				Annotations: map[string]string{util.AnnStorageProvisioner: provisioner},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{accessMode},
+				VolumeMode:  volumeMode,
+			},
+		}
+	}
+
+	pvcVolume := func(name, claimName string) kubevirtv1.Volume {
+		return kubevirtv1.Volume{
+			Name: name,
+			VolumeSource: kubevirtv1.VolumeSource{
+				PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName},
+				},
+			},
+		}
+	}
+
+	// rootdisk boots (bootOrder 1), data disk carries the shareable flag
+	newVM := func(dataDisk kubevirtv1.Disk, volumes ...kubevirtv1.Volume) *kubevirtv1.VirtualMachine {
+		rootDisk := kubevirtv1.Disk{Name: "rootdisk", BootOrder: ptr.To(uint(1))}
+		return &kubevirtv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "vm1", Namespace: "default"},
+			Spec: kubevirtv1.VirtualMachineSpec{
+				Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: kubevirtv1.VirtualMachineInstanceSpec{
+						Domain: kubevirtv1.DomainSpec{
+							Devices: kubevirtv1.Devices{Disks: []kubevirtv1.Disk{rootDisk, dataDisk}},
+						},
+						Volumes: append([]kubevirtv1.Volume{pvcVolume("rootdisk", "root-pvc")}, volumes...),
+					},
+				},
+			},
+		}
+	}
+
+	shareableDisk := kubevirtv1.Disk{Name: "datadisk", Shareable: ptr.To(true)}
+
+	tests := []struct {
+		name     string
+		pvc      *corev1.PersistentVolumeClaim
+		vm       *kubevirtv1.VirtualMachine
+		errorKey string
+	}{
+		{
+			name: "non-shareable disks pass",
+			vm:   newVM(kubevirtv1.Disk{Name: "datadisk"}, pvcVolume("datadisk", "data-pvc")),
+		},
+		{
+			name: "shareable RWX block third-party volume passes",
+			pvc:  newPVC("data-pvc", "some.san.csi.io", corev1.ReadWriteMany, &blockMode),
+			vm:   newVM(shareableDisk, pvcVolume("datadisk", "data-pvc")),
+		},
+		{
+			name:     "shareable PVC not found rejected (requires an existing volume)",
+			vm:       newVM(shareableDisk, pvcVolume("datadisk", "data-pvc")),
+			errorKey: "requires an existing volume",
+		},
+		{
+			name:     "shareable RWO volume rejected",
+			pvc:      newPVC("data-pvc", "some.san.csi.io", corev1.ReadWriteOnce, &blockMode),
+			vm:       newVM(shareableDisk, pvcVolume("datadisk", "data-pvc")),
+			errorKey: "ReadWriteMany",
+		},
+		{
+			name:     "shareable filesystem volume rejected",
+			pvc:      newPVC("data-pvc", "some.san.csi.io", corev1.ReadWriteMany, &fsMode),
+			vm:       newVM(shareableDisk, pvcVolume("datadisk", "data-pvc")),
+			errorKey: "volumeMode must be Block",
+		},
+		{
+			name:     "shareable Longhorn volume rejected",
+			pvc:      newPVC("data-pvc", util.CSIProvisionerLonghorn, corev1.ReadWriteMany, &blockMode),
+			vm:       newVM(shareableDisk, pvcVolume("datadisk", "data-pvc")),
+			errorKey: "provisioner other than Longhorn",
+		},
+		{
+			name: "shareable boot disk rejected",
+			pvc:  newPVC("data-pvc", "some.san.csi.io", corev1.ReadWriteMany, &blockMode),
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Name: "vm1", Namespace: "default"},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtv1.VirtualMachineInstanceSpec{
+							Domain: kubevirtv1.DomainSpec{
+								Devices: kubevirtv1.Devices{Disks: []kubevirtv1.Disk{{Name: "datadisk", Shareable: ptr.To(true)}}},
+							},
+							Volumes: []kubevirtv1.Volume{pvcVolume("datadisk", "data-pvc")},
+						},
+					},
+				},
+			},
+			errorKey: "boot disk",
+		},
+		{
+			name:     "shareable disk with writeback cache rejected",
+			pvc:      newPVC("data-pvc", "some.san.csi.io", corev1.ReadWriteMany, &blockMode),
+			vm:       newVM(kubevirtv1.Disk{Name: "datadisk", Shareable: ptr.To(true), Cache: kubevirtv1.CacheWriteBack}, pvcVolume("datadisk", "data-pvc")),
+			errorKey: "cache mode none",
+		},
+		{
+			name:     "shareable disk without PVC volume rejected",
+			vm:       newVM(shareableDisk, kubevirtv1.Volume{Name: "datadisk", VolumeSource: kubevirtv1.VolumeSource{ContainerDisk: &kubevirtv1.ContainerDiskSource{Image: "img"}}}),
+			errorKey: "backed by a persistent volume claim",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			harvesterFakeClientset := fake.NewSimpleClientset()
+			if tc.pvc != nil {
+				assert.NoError(t, harvesterFakeClientset.Tracker().Add(tc.pvc))
+			}
+			validator := &vmValidator{
+				pvcCache: fakeclients.PersistentVolumeClaimCache(harvesterFakeClientset.CoreV1().PersistentVolumeClaims),
+				scCache:  fakeclients.StorageClassCache(harvesterFakeClientset.StorageV1().StorageClasses),
+			}
+
+			err := validator.checkShareableVolumes(tc.vm)
+
+			if tc.errorKey != "" {
+				assert.Error(t, err, tc.name)
+				assert.Contains(t, err.Error(), tc.errorKey, tc.name)
+			} else {
+				assert.NoError(t, err, tc.name)
 			}
 		})
 	}

--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -18,6 +18,7 @@ import (
 	restorecommon "github.com/harvester/harvester/pkg/restore/common"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
+	vmutil "github.com/harvester/harvester/pkg/util/virtualmachine"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/indexeres"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -128,6 +129,13 @@ func (v *virtualMachineBackupValidator) validateStandardBackup(vmb *v1beta1.Virt
 	// Validate VM migration.
 	if err := v.checkVMInstanceMigration(vm); err != nil {
 		return werror.NewInvalidError(err.Error(), fieldSourceName)
+	}
+	// A shareable disk may be written by multiple VMs concurrently, so a
+	// backup or snapshot of it cannot be consistent.
+	if diskName, ok := vmutil.HasShareableDisk(vm); ok {
+		return werror.NewInvalidError(
+			fmt.Sprintf("cannot back up VM %s/%s: disk %s is shareable and may be written by multiple VMs concurrently", vm.Namespace, vm.Name, diskName),
+			fieldSourceName)
 	}
 	// Check the total snapshot size.
 	if err := v.checkTotalSnapshotSize(vm); err != nil {

--- a/pkg/webhook/resources/volumesnapshot/validator.go
+++ b/pkg/webhook/resources/volumesnapshot/validator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
+	vmutil "github.com/harvester/harvester/pkg/util/virtualmachine"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
 	webhookutil "github.com/harvester/harvester/pkg/webhook/util"
@@ -71,6 +72,21 @@ func (v *volumeSnapshotValidator) Create(_ *types.Request, newObj runtime.Object
 		// resource quota is already checked in the VMBackup webhook, skip it here
 		if owner.Kind == "VirtualMachineBackup" {
 			continue
+		}
+	}
+
+	pvcName := *newVolumeSnapshot.Spec.Source.PersistentVolumeClaimName
+	attachedVMs, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, ref.Construct(newVolumeSnapshot.Namespace, pvcName))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return werror.NewInternalError(fmt.Sprintf("failed to get VM by PVC %s/%s, err: %s", newVolumeSnapshot.Namespace, pvcName, err))
+	}
+	// A shareable PVC may be written by multiple VMs concurrently, so a
+	// snapshot of it cannot be consistent.
+	for _, vm := range attachedVMs {
+		if vmutil.VMUsesPVCAsShareable(vm, pvcName) {
+			return werror.NewInvalidError(
+				fmt.Sprintf("cannot snapshot PVC %s/%s: it is attached to VM %s/%s as a shareable disk and may be written by multiple VMs concurrently", newVolumeSnapshot.Namespace, pvcName, vm.Namespace, vm.Name),
+				"spec.source.persistentVolumeClaimName")
 		}
 	}
 


### PR DESCRIPTION
Allow attaching a block-mode RWX volume from a third-party storage provisioner to multiple VMs as a shareable disk (KubeVirt disk.shareable).

- vm webhook: validate disks with shareable enabled — the backing PVC must be a block-mode RWX volume from a provisioner other than Longhorn (KubeVirt performs no admission validation on shareable at all, so this webhook is the only gate), the disk cache must be unset or none (surfacing at admission what virt-launcher would only fail at VM start), and the disk must not be the boot disk. Multi-VM occupancy is already handled by the existing non-shareable PVC index.
- vm API: AddVolumeInput gains a shareable field so a volume can be hot-plugged as a shareable disk.
- vmbackup/volumesnapshot webhooks: reject backups and snapshots that involve shareable disks since concurrent writers make them inconsistent.

Related issue: harvester/harvester#9649

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Add shareable capability for 3rd-party storage vendor

#### Solution:
Add shareable capability and checking mechanism

#### Related Issue(s):
harvester/harvester#9649

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
