### PR TITLE
http: expose curl errors during image list downloads

### DIFF
--- a/scripts/lib/http
+++ b/scripts/lib/http
@@ -6,5 +6,5 @@ get_url()
   local save_to=$2
 
   echo "Download ${from} to ${save_to}..."
-  curl -sfL $from -o $save_to
+  curl -fL --no-progress-meter $from -o $save_to
 }

--- a/scripts/lib/image
+++ b/scripts/lib/image
@@ -19,7 +19,10 @@ save_image_list()
 
   case $in_file in
     http*)
-      images=$(curl -sfL $in_file)
+      if ! images=$(curl -fL --no-progress-meter $in_file); then
+        echo "Failed to download image list from ${in_file}" >&2
+        exit 1
+      fi
       ;;
     *)
       images=$(<$in_file)


### PR DESCRIPTION
Show error output when curl commands fail. Previously, the `-s` flag silenced all output, making failed downloads difficult to troubleshoot.

The following are examples of downloading RKE2 artifacts:

```
Preparing RKE2 images...
[cache] MISS: rke2/v1.35.6-rke2r1 — downloading
Download http://172.17.0.1/harvester/rke2/v1.35.6+rke2r1/rke2-images.linux-amd64.txt to /go/src/github.com/harvester/harvester/package/harvester-os/iso/bundle/harvester/images-lists/rke2-images.linux-amd64-v1.35.6-rke2r1.txt...
curl: (22) The requested URL returned error: 404
```

```
Preparing RKE2 images...
[cache] MISS: rke2/v1.35.6-rke2r1 — downloading
Download http://172.17.0.1/harvester/rke2/v1.35.6+rke2r1/rke2-images.linux-amd64.txt to /go/src/github.com/harvester/harvester/package/harvester-os/iso/bundle/harvester/images-lists/rke2-images.linux-amd64-v1.35.6-rke2r1.txt...
Download http://172.17.0.1/harvester/rke2/v1.35.6+rke2r1/rke2-images.linux-amd64.tar.zst to /go/src/github.com/harvester/harvester/package/harvester-os/iso/bundle/harvester/images/rke2-images.linux-amd64-v1.35.6-rke2r1.tar.zst...
[cache] HIT: multus/d16dc695f16fe0c8
curl: (22) The requested URL returned error: 404
Failed to download image list from http://172.17.0.1/harvester/rke2/v1.35.6+rke2r1/rke2-images-traefik.linux-amd64.txt
```
