### PR TITLE
Disable network polices in Longhorn chart and sync the policies

### DIFF
--- a/deploy/charts/harvester/templates/longhorn-network-policy.yaml
+++ b/deploy/charts/harvester/templates/longhorn-network-policy.yaml
@@ -124,7 +124,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/recovery-backend: longhorn-recovery-backend
   policyTypes:
     - Ingress
   ingress:
@@ -141,7 +141,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/admission-webhook: longhorn-admission-webhook
   policyTypes:
     - Ingress
   ingress:
@@ -158,7 +158,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: longhorn-manager
+      longhorn.io/admission-webhook: longhorn-admission-webhook
   policyTypes:
     - Ingress
   ingress:

--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -529,6 +529,10 @@ longhorn:
     jobEnabled: false
     upgradeVersionCheck: false
 
+  networkPolicies:
+    # defined in longhorn-network-policy.yaml already
+    restrictInternalTraffic: false
+
 rancherEmbedded: false
 
 webhook:


### PR DESCRIPTION
The network policies inside the Longhorn chart are now enabled by default. 

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Network policies are now [enabled by default](https://github.com/longhorn/longhorn/commit/0b8fe1ed0d49b5b0d5e038bdcba9f6c9ec59eacd#diff-e0d116085e8b80ad8008014fc52fe21e94183f0c729088a640875dd17a9b497d) on Longhorn (.Values.networkPolicies.restrictInternalTraffic=true), which is conflicting with the Longhorn policies we hold in the [Harvester chart.](https://github.com/harvester/harvester/blob/master/deploy/charts/harvester/templates/longhorn-network-policy.yaml)

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Disable the network policy files in Longhorn and use our own files to minimize upgrade risks.

Related-to: 
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11214


#### Test plan:
<!-- Describe the test plan by steps. -->
- Deploy a new Harvester cluster and make sure the mcc-harvester bundle is not "Modified"
```
$kubectl get bundle mcc-harvester -n fleet-local
NAME            BUNDLEDEPLOYMENTS-READY   STATUS
mcc-harvester   1/1
```

- Ensure Longhorn operations are normal.
- Upgrade from v1.8.x ISO should work.
#### Additional documentation or context
