### PR TITLE
enhancement: add a webhook to prevent VM backups for VMs with LH v2 volumes

### DIFF
--- a/pkg/webhook/resources/virtualmachinebackup/validator.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator.go
@@ -3,9 +3,11 @@ package virtualmachinebackup
 import (
 	"fmt"
 
+	longhornv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -36,6 +38,7 @@ func NewValidator(
 	vmrestores ctlharvesterv1.VirtualMachineRestoreCache,
 	pvcCache ctlcorev1.PersistentVolumeClaimCache,
 	engineCache ctllonghornv1.EngineCache,
+	volumeCache ctllonghornv1.VolumeCache,
 	scCache ctlstoragev1.StorageClassCache,
 	resourceQuotaCache ctlharvesterv1.ResourceQuotaCache,
 	vmimCache ctlkubevirtv1.VirtualMachineInstanceMigrationCache,
@@ -46,6 +49,7 @@ func NewValidator(
 		vmrestores:         vmrestores,
 		pvcCache:           pvcCache,
 		engineCache:        engineCache,
+		volumeCache:        volumeCache,
 		scCache:            scCache,
 		resourceQuotaCache: resourceQuotaCache,
 		vmimCache:          vmimCache,
@@ -62,6 +66,7 @@ type virtualMachineBackupValidator struct {
 	vmrestores         ctlharvesterv1.VirtualMachineRestoreCache
 	pvcCache           ctlcorev1.PersistentVolumeClaimCache
 	engineCache        ctllonghornv1.EngineCache
+	volumeCache        ctllonghornv1.VolumeCache
 	scCache            ctlstoragev1.StorageClassCache
 	resourceQuotaCache ctlharvesterv1.ResourceQuotaCache
 	vmimCache          ctlkubevirtv1.VirtualMachineInstanceMigrationCache
@@ -145,8 +150,12 @@ func (v *virtualMachineBackupValidator) validateVMBackupRecover(vmb *v1beta1.Vir
 	return webhookutil.IsLHBackupRelated(vmb, v.vmbr)
 }
 
-// checkBackupVolumeSnapshotClass checks if the volumeSnapshotClassName is configured for the provisioner used by the PVCs in the VirtualMachine.
-func (v *virtualMachineBackupValidator) checkBackupVolumeSnapshotClass(vm *kubevirtv1.VirtualMachine, newVMBackup *v1beta1.VirtualMachineBackup) error {
+// checkBackupVolumeSnapshotClass checks if the volumeSnapshotClassName is
+// configured for the provisioner used by the PVCs in the VirtualMachine.
+func (v *virtualMachineBackupValidator) checkBackupVolumeSnapshotClass(
+	vm *kubevirtv1.VirtualMachine,
+	newVMBackup *v1beta1.VirtualMachineBackup,
+) error {
 	// Load the CSI driver configuration.
 	cdc, err := util.LoadCSIDriverConfig(v.setting)
 	if err != nil {
@@ -168,12 +177,36 @@ func (v *virtualMachineBackupValidator) checkBackupVolumeSnapshotClass(vm *kubev
 			return fmt.Errorf("failed to get PVC %s/%s: %w", pvcNamespace, pvcName, err)
 		}
 
+		if err := v.checkLonghornV2Volume(vm, pvc); err != nil {
+			return err
+		}
+
 		if err := webhookutil.ValidateProvisionerAndConfig(pvc, v.scCache, v.vmbr.GetType(newVMBackup), cdc); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (v *virtualMachineBackupValidator) checkLonghornV2Volume(
+	vm *kubevirtv1.VirtualMachine,
+	pvc *corev1.PersistentVolumeClaim,
+) error {
+	if util.GetProvisionedPVCProvisioner(pvc, v.scCache) != util.CSIProvisionerLonghorn {
+		return nil
+	}
+
+	lhVolume, err := v.volumeCache.Get(util.LonghornSystemNamespaceName, pvc.Spec.VolumeName)
+	if err != nil {
+		return fmt.Errorf("failed to get Longhorn volume %s for PVC %s/%s: %w", pvc.Spec.VolumeName, pvc.Namespace, pvc.Name, err)
+	}
+	if lhVolume.Spec.DataEngine != longhornv1beta2.DataEngineTypeV2 {
+		return nil
+	}
+
+	return fmt.Errorf("vm %s/%s contains Longhorn v2 volume %s from PVC %s/%s, which does not support VM backup",
+		vm.Namespace, vm.Name, lhVolume.Name, pvc.Namespace, pvc.Name)
 }
 
 func (v *virtualMachineBackupValidator) checkBackupTarget() error {

--- a/pkg/webhook/resources/virtualmachinebackup/validator_test.go
+++ b/pkg/webhook/resources/virtualmachinebackup/validator_test.go
@@ -1,0 +1,182 @@
+package virtualmachinebackup
+
+import (
+	"strings"
+	"testing"
+
+	longhornv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester/pkg/backup/common"
+	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester/pkg/settings"
+	"github.com/harvester/harvester/pkg/util"
+	"github.com/harvester/harvester/pkg/util/fakeclients"
+)
+
+func TestCheckBackupVolumeSnapshotClassRejectsLonghornV2Volumes(t *testing.T) {
+	const (
+		namespace = "default"
+		vmName    = "test-vm"
+		pvcName   = "test-pvc"
+		pvName    = "pvc-123"
+	)
+
+	longhornSC := "longhorn"
+	otherSC := "other"
+
+	tests := []struct {
+		name        string
+		objects     []runtime.Object
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "rejects Longhorn v2 volume",
+			objects: []runtime.Object{
+				newCSIDriverConfigSetting(),
+				newPVC(namespace, pvcName, pvName, longhornSC),
+				newStorageClass(longhornSC, util.CSIProvisionerLonghorn),
+				newLonghornVolume(pvName, longhornv1beta2.DataEngineTypeV2),
+			},
+			wantErr:     true,
+			errContains: "contains Longhorn v2 volume",
+		},
+		{
+			name: "allows Longhorn v1 volume",
+			objects: []runtime.Object{
+				newCSIDriverConfigSetting(),
+				newPVC(namespace, pvcName, pvName, longhornSC),
+				newStorageClass(longhornSC, util.CSIProvisionerLonghorn),
+				newLonghornVolume(pvName, longhornv1beta2.DataEngineTypeV1),
+			},
+		},
+		{
+			name: "ignores non-Longhorn volume",
+			objects: []runtime.Object{
+				newCSIDriverConfigSetting(),
+				newPVC(namespace, pvcName, pvName, otherSC),
+				newStorageClass(otherSC, "example.com/csi"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tt.objects...)
+			validator := &virtualMachineBackupValidator{
+				setting:     fakeclients.HarvesterSettingCache(clientset.HarvesterhciV1beta1().Settings),
+				pvcCache:    fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+				volumeCache: fakeclients.LonghornVolumeCache(clientset.LonghornV1beta2().Volumes),
+				scCache:     fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
+				vmbr:        common.NewVMBackupReader(),
+			}
+
+			err := validator.checkBackupVolumeSnapshotClass(newVM(namespace, vmName, pvcName), newVMBackup(namespace, vmName))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error to contain %q, got %q", tt.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}
+
+func newVMBackup(namespace, sourceName string) *v1beta1.VirtualMachineBackup {
+	return &v1beta1.VirtualMachineBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test-backup",
+		},
+		Spec: v1beta1.VirtualMachineBackupSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: &v1beta1.SchemeGroupVersion.Group,
+				Kind:     "VirtualMachine",
+				Name:     sourceName,
+			},
+			Type: v1beta1.Backup,
+		},
+	}
+}
+
+func newVM(namespace, name, pvcName string) *kubevirtv1.VirtualMachine {
+	return &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Volumes: []kubevirtv1.Volume{
+						{
+							Name: "disk-0",
+							VolumeSource: kubevirtv1.VolumeSource{
+								PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvcName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newPVC(namespace, name, volumeName, storageClassName string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+			VolumeName:       volumeName,
+		},
+	}
+}
+
+func newStorageClass(name, provisioner string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: provisioner,
+	}
+}
+
+func newCSIDriverConfigSetting() *v1beta1.Setting {
+	return &v1beta1.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: settings.CSIDriverConfigSettingName,
+		},
+		Default: `{"driver.longhorn.io":{"volumeSnapshotClassName":"longhorn-snapshot","backupVolumeSnapshotClassName":"longhorn"},"example.com/csi":{"volumeSnapshotClassName":"example-snapshot","backupVolumeSnapshotClassName":"example-backup"}}`,
+	}
+}
+
+func newLonghornVolume(name string, dataEngine longhornv1beta2.DataEngineType) *longhornv1beta2.Volume {
+	return &longhornv1beta2.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: util.LonghornSystemNamespaceName,
+			Name:      name,
+		},
+		Spec: longhornv1beta2.VolumeSpec{
+			DataEngine: dataEngine,
+		},
+	}
+}

--- a/pkg/webhook/server/validation.go
+++ b/pkg/webhook/server/validation.go
@@ -156,6 +156,7 @@ func Validation(clients *clients.Clients, options *config.Options, crdExists boo
 			clients.HarvesterFactory.Harvesterhci().V1beta1().VirtualMachineRestore().Cache(),
 			clients.CoreFactory.Core().V1().PersistentVolumeClaim().Cache(),
 			clients.LonghornFactory.Longhorn().V1beta2().Engine().Cache(),
+			clients.LonghornFactory.Longhorn().V1beta2().Volume().Cache(),
 			clients.StorageFactory.Storage().V1().StorageClass().Cache(),
 			clients.HarvesterFactory.Harvesterhci().V1beta1().ResourceQuota().Cache(),
 			clients.KubevirtFactory.Kubevirt().V1().VirtualMachineInstanceMigration().Cache(),


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
https://github.com/harvester/harvester/issues/11151

#### Solution:
Add a webhook to prevent VM backups for VMs with LH v2 volumes

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11151


#### Test plan:
* Create a VM with a Longhorn v2 volume.
* Attempt to create a remote backup for the VM through the backend, for example using `kubectl`.
* Verify that the request is rejected by the webhook. 

#### Additional documentation or context
