### PR TITLE
Bump snapshot-controller image to v8.6.0

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -479,7 +479,7 @@ csi-snapshotter:
 
   image:
     repository: registry.k8s.io/sig-storage/snapshot-controller
-    tag: v8.5.0
+    tag: v8.6.0
 
 longhorn:
   ## Specify whether to install longhorn,


### PR DESCRIPTION
#### Problem:
we bumped longhorn to v1.12.1-rc1 in master branch https://github.com/harvester/harvester/commit/36d28d4d9438c51b1f04c812ca16e8e2a7216a57, and longhorn v1.12.1-rc1 use csi-snapshotter v8.6.0, https://github.com/longhorn/longhorn/blob/v1.12.1-rc1/deploy/longhorn.yaml#L5686, so we need to bump snapshot-controller to the same version v8.6.0

#### Solution:
bump snapshot-controller to v8.6.0

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10732

#### Test plan:


#### Additional documentation or context
