### PR TITLE
add hotfix_base_version to override base version

### DIFF
--- a/.github/workflows/build-hotfix.yml
+++ b/.github/workflows/build-hotfix.yml
@@ -3,6 +3,10 @@ name: build hotfix images
 on:
   workflow_dispatch:
     inputs:
+      hotfix_base_version:
+        description: 'Base version for hotfix, must be vX.Y.Z (e.g. v1.9.1)'
+        required: true
+        type: string
       image_tag:
         description: 'Image tag to push, must be vX.Y.Z-hotfix* (e.g. v1.9.1-hotfix1)'
         required: true
@@ -21,6 +25,7 @@ jobs:
       env:
         BRANCH: ${{ github.ref_name }}
         IMAGE_TAG: ${{ inputs.image_tag }}
+        HOTFIX_BASE_VERSION: ${{ inputs.hotfix_base_version }}
       run: |
         if [[ ! "$BRANCH" =~ ^v[0-9]+\.[0-9]+$ ]]; then
           echo "this workflow must be dispatched on a version branch like v1.9, got: $BRANCH"

--- a/scripts/version
+++ b/scripts/version
@@ -44,6 +44,11 @@ fi
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 
+    if [[ -n "$HOTFIX_BASE_VERSION" ]]; then
+        echo "HOTFIX_BASE_VERSION is set, overriding VERSION with HOTFIX_BASE_VERSION: $HOTFIX_BASE_VERSION"
+        VERSION="$HOTFIX_BASE_VERSION"
+    fi
+
     if [[ -z "$SPRINT_RELEASE" ]]; then
         echo "Checking minimum upgradable version, if no minimum upgradeable version, will fail with \`Error: no matches found\`"
         # Search for minimum upgradable version.


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Recent PR to allow hotfix images need a minor change to override version reported by harvester pods.

Currently ci sets the tag as version, which is subsequently passed as a build argument to the harvester binary.

Combined with hotfix versioning schema, this breaks semver checks in the upgrade controller.

As a result subsequent upgrades from hotfix image get impacted.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR adds an extra variable `HOTFIX_BASE_VERSION` which needs to be defined while triggering CI.

This will override the VERSION passed during binary builds and will ensure that the new image reports the same semver version after replacement of hotfix images.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/11207

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
