### PR TITLE
fix: mergify to check test properly and remove renovate auto merge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -54,41 +54,32 @@ pull_request_rules:
       assignees:
         - "{{ author }}"
 
-- name: Automatically merge Renovate PRs
-  conditions:
-  - check-success="Build binaries (x64)"
-  - check-success="Build binaries (arm64)"
-  - author = renovate[bot]
-  - -conflict
-  actions:
-    merge:
-      method: rebase
-
 - name: Automatically merge Backport PRs
   conditions:
-  - check-success="Build binaries (x64)"
-  - check-success="Build binaries (arm64)"
+  - check-success="calling-build-factory / Build binaries (arm64)"
+  - check-success="calling-build-factory / Build binaries (arm64)"
   - author = mergify[bot]
   - -conflict
   actions:
     merge:
-      method: rebase
+      method: squash
 
 - name: Automatically approve Renovate PRs
   conditions:
-  - check-success="Build binaries (x64)"
-  - check-success="Build binaries (arm64)"
+  - check-success="calling-build-factory / Build binaries (x64)"
+  - check-success="calling-build-factory / Build binaries (arm64)"
   - author = renovate[bot]
   - -conflict
   actions:
     review:
       type: APPROVE
+      bot_account: harvesterhci-io-github-bot
 
 # Mergify can't approve its own PRs, so we need to use a bot account
 - name: Automatically approve Backport PRs
   conditions:
-  - check-success="Build binaries (x64)"
-  - check-success="Build binaries (arm64)"
+  - check-success="calling-build-factory / Build binaries (x64)"
+  - check-success="calling-build-factory / Build binaries (arm64)"
   - author = mergify[bot]
   - -conflict
   actions:


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
- Current mergify approve / merge condition never achieve, it miss `calling-build-factory /` prefix

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- add the mising prefix `calling-build-factory /` 
- remove the renovate auto merge (should only auto merge the patch updates, which has been address in https://github.com/harvester/dependency-automation/pull/24