### PR TITLE
feat: add dual stack IPv4 Family First config

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/harvester/harvester/pkg/installer/config"
 	"github.com/harvester/harvester/pkg/installer/console"
@@ -61,7 +60,7 @@ Executes the Harvester installer if no command is specified.`,
 						return err
 					}
 					if len(paths) == 0 || cmd.Bool("force") {
-						err = config.UpdateManagementInterfaceConfig(harvesterCfg.ManagementInterface, harvesterCfg.OS.DNSNameservers, cmd.String("connection-path"), false, strings.Contains(harvesterCfg.Install.ClusterPodCIDR, ","))
+						err = config.UpdateManagementInterfaceConfig(harvesterCfg.ManagementInterface, harvesterCfg.OS.DNSNameservers, cmd.String("connection-path"), false, harvesterCfg.Install.IsIPv6Enabled())
 						if err != nil {
 							return err
 						}

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/harvester/harvester/pkg/installer/config"
 	"github.com/harvester/harvester/pkg/installer/console"
@@ -60,7 +61,7 @@ Executes the Harvester installer if no command is specified.`,
 						return err
 					}
 					if len(paths) == 0 || cmd.Bool("force") {
-						err = config.UpdateManagementInterfaceConfig(harvesterCfg.ManagementInterface, harvesterCfg.OS.DNSNameservers, cmd.String("connection-path"), false)
+						err = config.UpdateManagementInterfaceConfig(harvesterCfg.ManagementInterface, harvesterCfg.OS.DNSNameservers, cmd.String("connection-path"), false, strings.Contains(harvesterCfg.Install.ClusterPodCIDR, ","))
 						if err != nil {
 							return err
 						}

--- a/pkg/installer/config/config.go
+++ b/pkg/installer/config/config.go
@@ -167,6 +167,11 @@ type Install struct {
 	ClusterPodCIDR     string `json:"clusterPodCidr,omitempty"`
 	ClusterServiceCIDR string `json:"clusterServiceCidr,omitempty"`
 
+	// IPv6Enabled is set by the installer UI for join/install modes where
+	// ClusterPodCIDR is not provided. For create mode the flag is derived
+	// from the CIDR input instead.
+	IPv6Enabled bool `json:"ipv6Enabled,omitempty"`
+
 	ForceEFI      bool     `json:"forceEfi,omitempty"`
 	Device        string   `json:"device,omitempty"`
 	ConfigURL     string   `json:"configUrl,omitempty"`
@@ -540,7 +545,11 @@ func GenerateRancherdConfig(config *HarvesterConfig) (*yipSchema.YipConfig, erro
 		return nil, err
 	}
 
-	if err := UpdateManagementInterfaceConfig(config.ManagementInterface, config.OS.DNSNameservers, NMConnectionPath, true); err != nil {
+	ipv6Enabled, err := isIPv6Enabled(config.Install.ClusterPodCIDR)
+	if err != nil {
+		return nil, err
+	}
+	if err := UpdateManagementInterfaceConfig(config.ManagementInterface, config.OS.DNSNameservers, NMConnectionPath, true, ipv6Enabled); err != nil {
 		return nil, err
 	}
 

--- a/pkg/installer/config/config.go
+++ b/pkg/installer/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/imdario/mergo"
@@ -204,12 +205,7 @@ type Install struct {
 // (IPv4+IPv6). It returns true when IPFamilies contains IPFamilyIPv6.
 // An empty or nil IPFamilies slice means IPv4-only and returns false.
 func (i *Install) IsIPv6Enabled() bool {
-	for _, f := range i.IPFamilies {
-		if f == IPFamilyIPv6 {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(i.IPFamilies, IPFamilyIPv6)
 }
 
 type File struct {

--- a/pkg/installer/config/config.go
+++ b/pkg/installer/config/config.go
@@ -167,10 +167,11 @@ type Install struct {
 	ClusterPodCIDR     string `json:"clusterPodCidr,omitempty"`
 	ClusterServiceCIDR string `json:"clusterServiceCidr,omitempty"`
 
-	// IPv6Enabled is set by the installer UI for join/install modes where
-	// ClusterPodCIDR is not provided. For create mode the flag is derived
-	// from the CIDR input instead.
-	IPv6Enabled bool `json:"ipv6Enabled,omitempty"`
+	// IPFamilies defines the IP stack mode for this node using the same
+	// convention as Kubernetes ipFamilies: ["IPv4"] for single-stack IPv4
+	// or ["IPv4","IPv6"] for dual-stack IPv4-first.
+	// An empty or nil slice defaults to IPv4-only.
+	IPFamilies []string `json:"ipFamilies,omitempty"`
 
 	ForceEFI      bool     `json:"forceEfi,omitempty"`
 	Device        string   `json:"device,omitempty"`
@@ -197,6 +198,18 @@ type Install struct {
 	Harvester               HarvesterChartValues `json:"harvester,omitempty"`
 	RawDiskImagePath        string               `json:"rawDiskImagePath,omitempty"`
 	PersistentPartitionSize string               `json:"persistentPartitionSize,omitempty"`
+}
+
+// IsIPv6Enabled reports whether the install is configured for dual-stack
+// (IPv4+IPv6). It returns true when IPFamilies contains IPFamilyIPv6.
+// An empty or nil IPFamilies slice means IPv4-only and returns false.
+func (i *Install) IsIPv6Enabled() bool {
+	for _, f := range i.IPFamilies {
+		if f == IPFamilyIPv6 {
+			return true
+		}
+	}
+	return false
 }
 
 type File struct {
@@ -545,10 +558,7 @@ func GenerateRancherdConfig(config *HarvesterConfig) (*yipSchema.YipConfig, erro
 		return nil, err
 	}
 
-	ipv6Enabled, err := isIPv6Enabled(config.Install.ClusterPodCIDR)
-	if err != nil {
-		return nil, err
-	}
+	ipv6Enabled := config.Install.IsIPv6Enabled()
 	if err := UpdateManagementInterfaceConfig(config.ManagementInterface, config.OS.DNSNameservers, NMConnectionPath, true, ipv6Enabled); err != nil {
 		return nil, err
 	}

--- a/pkg/installer/config/constants.go
+++ b/pkg/installer/config/constants.go
@@ -30,4 +30,22 @@ const (
 	SysctlDisableIPv6All     = "net.ipv6.conf.all.disable_ipv6"
 	SysctlDisableIPv6Default = "net.ipv6.conf.default.disable_ipv6"
 	SysctlDisableIPv6Lo      = "net.ipv6.conf.lo.disable_ipv6"
+
+	// Default cluster network values used when the user leaves fields blank.
+	// Dual-stack variants append the matching Harvester ULA IPv6 prefix.
+	DefaultPodCIDR              = "10.52.0.0/16"
+	DefaultServiceCIDR          = "10.53.0.0/16"
+	DefaultClusterDNS           = "10.53.0.10"
+	DefaultDualStackPodCIDR     = "10.52.0.0/16,fd52::/56"
+	DefaultDualStackServiceCIDR = "10.53.0.0/16,fd53::/112"
+	// DefaultDualStackClusterDNS pairs the IPv4 DNS address with its IPv6
+	// equivalent in the fd53::/112 service prefix (host 0xa == 10).
+	DefaultDualStackClusterDNS = "10.53.0.10,fd53::a"
+
+	// IPFamilyIPv4 and IPFamilyIPv6 are the individual IP family identifiers,
+	// matching the Kubernetes ipFamilies convention.
+	// IPFamilies on the Install struct holds a slice of these values, e.g.
+	// ["IPv4"] for single-stack or ["IPv4","IPv6"] for dual-stack IPv4-first.
+	IPFamilyIPv4 = "IPv4"
+	IPFamilyIPv6 = "IPv6"
 )

--- a/pkg/installer/config/cos.go
+++ b/pkg/installer/config/cos.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -195,7 +196,26 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	// disable multipath for longhorn
 	disableLonghornMultipathing(&initramfs)
 
-	// write a persistent sysctl drop-in and apply at runtime; persists after reboot
+	// Write a persistent sysctl drop-in whose value matches the install's IPv6 choice.
+	// For dual-stack, IPv6 is enabled (disable_ipv6=0); for IPv4-only it is disabled (disable_ipv6=1).
+	// For create mode the choice is derived from the cluster CIDR.
+	// For join/install modes the installer UI explicitly asks the user and stores the result
+	// in cfg.Install.IPv6Enabled — never infer it from the empty CIDR.
+	var ipv6Enabled bool
+	if cfg.Install.Mode == ModeCreate {
+		ipv6Enabled, err = isIPv6Enabled(cfg.Install.ClusterPodCIDR)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		ipv6Enabled = cfg.Install.IPv6Enabled
+	}
+	ipv6SysctlVal := "1"
+	ipv6FileHeader := "# Written by harvester-installer (IPv4-only install)\n"
+	if ipv6Enabled {
+		ipv6SysctlVal = "0"
+		ipv6FileHeader = "# Written by harvester-installer (dual-stack install)\n"
+	}
 	initramfs.Directories = append(initramfs.Directories, yipSchema.Directory{
 		Path:        "/etc/sysctl.d",
 		Permissions: 0755,
@@ -204,8 +224,11 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	})
 	initramfs.Files = append(initramfs.Files, yipSchema.File{
 		Path: "/etc/sysctl.d/zz-harvester-enable-ipv6.conf",
-		Content: fmt.Sprintf("# Written by harvester-installer: overrides /etc/sysctl.d/ipv6.conf\n%s = 0\n%s = 0\n%s = 0\n",
-			SysctlDisableIPv6All, SysctlDisableIPv6Default, SysctlDisableIPv6Lo),
+		Content: fmt.Sprintf("%s%s = %s\n%s = %s\n%s = %s\n",
+			ipv6FileHeader,
+			SysctlDisableIPv6All, ipv6SysctlVal,
+			SysctlDisableIPv6Default, ipv6SysctlVal,
+			SysctlDisableIPv6Lo, ipv6SysctlVal),
 		Permissions: 0644,
 		Owner:       0,
 		Group:       0,
@@ -213,9 +236,9 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	if initramfs.Sysctl == nil {
 		initramfs.Sysctl = make(map[string]string)
 	}
-	initramfs.Sysctl[SysctlDisableIPv6All] = "0"
-	initramfs.Sysctl[SysctlDisableIPv6Default] = "0"
-	initramfs.Sysctl[SysctlDisableIPv6Lo] = "0"
+	initramfs.Sysctl[SysctlDisableIPv6All] = ipv6SysctlVal
+	initramfs.Sysctl[SysctlDisableIPv6Default] = ipv6SysctlVal
+	initramfs.Sysctl[SysctlDisableIPv6Lo] = ipv6SysctlVal
 
 	// TOP
 	if cfg.Install.Mode != ModeInstall {
@@ -231,7 +254,7 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 			initramfs.Systemctl.Enable = append(initramfs.Systemctl.Enable, timeWaitSyncService)
 		}
 
-		err = UpdateManagementInterfaceConfig(cfg.ManagementInterface, cfg.OS.DNSNameservers, NMConnectionPath, false)
+		err = UpdateManagementInterfaceConfig(cfg.ManagementInterface, cfg.OS.DNSNameservers, NMConnectionPath, false, ipv6Enabled)
 		if err != nil {
 			return nil, err
 		}
@@ -567,7 +590,7 @@ func SaveOriginalNetworkConfig() error {
 
 // UpdateManagementInterfaceConfig generates NetworkManager connection profiles.
 // It restarts networking and waits for the connection to be up if applyConfig is true.
-func UpdateManagementInterfaceConfig(mgmtInterface Network, dnsNameServers []string, configPath string, applyConfig bool) error {
+func UpdateManagementInterfaceConfig(mgmtInterface Network, dnsNameServers []string, configPath string, applyConfig bool, ipv6Enabled bool) error {
 	if len(mgmtInterface.Interfaces) == 0 {
 		return errors.New("no slave defined for management network bond")
 	}
@@ -599,7 +622,7 @@ func UpdateManagementInterfaceConfig(mgmtInterface Network, dnsNameServers []str
 		return err
 	}
 
-	if err := updateBridge(MgmtInterfaceName, &mgmtInterface, dnsNameServers, configPath); err != nil {
+	if err := updateBridge(MgmtInterfaceName, &mgmtInterface, dnsNameServers, configPath, ipv6Enabled); err != nil {
 		return err
 	}
 
@@ -684,7 +707,7 @@ func updateBond(name string, network *Network, configPath string) error {
 	return nil
 }
 
-func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, configPath string) error {
+func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, configPath string, ipv6Enabled bool) error {
 	// add Bridge named MgmtInterfaceName and attach Bond named MgmtBondInterfaceName to bridge
 
 	// pvid is always 1, if vlan id is 1, it means untagged vlan.
@@ -718,9 +741,10 @@ func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, co
 	}
 	// add bridge
 	bridgeData := map[string]interface{}{
-		"Bridge":     bridgeMgmt,
-		"BridgeName": MgmtInterfaceName,
-		"DNSServers": "",
+		"Bridge":      bridgeMgmt,
+		"BridgeName":  MgmtInterfaceName,
+		"DNSServers":  "",
+		"IPv6Enabled": ipv6Enabled,
 	}
 	if !needVlanInterface && len(dnsNameServers) > 0 {
 		bridgeData["DNSServers"] = strings.Join(dnsNameServers, ";") + ";"
@@ -741,9 +765,10 @@ func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, co
 		vlanMgmt.SubnetMask = maskToCIDR(vlanMgmt.SubnetMask)
 
 		vlanData := map[string]interface{}{
-			"BridgeName": name,
-			"Vlan":       vlanMgmt,
-			"DNSServers": "",
+			"BridgeName":  name,
+			"Vlan":        vlanMgmt,
+			"DNSServers":  "",
+			"IPv6Enabled": ipv6Enabled,
 		}
 		if len(dnsNameServers) > 0 {
 			vlanData["DNSServers"] = strings.Join(dnsNameServers, ";") + ";"
@@ -992,4 +1017,39 @@ WantedBy=sysinit.target`)
 		Owner:       0,
 		Group:       0,
 	})
+}
+
+// isIPv6Enabled reports whether clusterPodCIDR describes a valid dual-stack
+// configuration: exactly two comma-separated prefixes in IPv4-first order.
+// An empty value returns (false, nil). A single IPv4 CIDR returns (false, nil).
+// A single IPv6-only CIDR returns an error (unsupported mode).
+// A two-part value with a malformed prefix returns (false, err).
+func isIPv6Enabled(clusterPodCIDR string) (bool, error) {
+	parts := strings.Split(clusterPodCIDR, ",")
+	if len(parts) == 1 {
+		cidr := strings.TrimSpace(parts[0])
+		if cidr == "" {
+			return false, nil
+		}
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return false, err
+		}
+		if !prefix.Addr().Is4() {
+			return false, fmt.Errorf("IPv6-only CIDR %q is not supported; use IPv4 or IPv4,IPv6 for dual-stack", cidr)
+		}
+		return false, nil
+	}
+	if len(parts) != 2 {
+		return false, fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
+	}
+	first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return false, err
+	}
+	second, err := netip.ParsePrefix(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return false, err
+	}
+	return first.Addr().Is4() && !second.Addr().Is4(), nil
 }

--- a/pkg/installer/config/cos.go
+++ b/pkg/installer/config/cos.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -198,18 +197,11 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 
 	// Write a persistent sysctl drop-in whose value matches the install's IPv6 choice.
 	// For dual-stack, IPv6 is enabled (disable_ipv6=0); for IPv4-only it is disabled (disable_ipv6=1).
-	// For create mode the choice is derived from the cluster CIDR.
-	// For join/install modes the installer UI explicitly asks the user and stores the result
-	// in cfg.Install.IPv6Enabled — never infer it from the empty CIDR.
-	var ipv6Enabled bool
-	if cfg.Install.Mode == ModeCreate {
-		ipv6Enabled, err = isIPv6Enabled(cfg.Install.ClusterPodCIDR)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		ipv6Enabled = cfg.Install.IPv6Enabled
-	}
+	// IPFamilies is set by the installer UI for all modes (create, join, install).
+	// A config produced by an older build will have an empty IPFamilies slice,
+	// which IsIPv6Enabled() maps to IPv4-only -- the only mode supported before
+	// dual-stack was introduced.
+	ipv6Enabled := cfg.Install.IsIPv6Enabled()
 	ipv6SysctlVal := "1"
 	ipv6FileHeader := "# Written by harvester-installer (IPv4-only install)\n"
 	if ipv6Enabled {
@@ -1017,39 +1009,4 @@ WantedBy=sysinit.target`)
 		Owner:       0,
 		Group:       0,
 	})
-}
-
-// isIPv6Enabled reports whether clusterPodCIDR describes a valid dual-stack
-// configuration: exactly two comma-separated prefixes in IPv4-first order.
-// An empty value returns (false, nil). A single IPv4 CIDR returns (false, nil).
-// A single IPv6-only CIDR returns an error (unsupported mode).
-// A two-part value with a malformed prefix returns (false, err).
-func isIPv6Enabled(clusterPodCIDR string) (bool, error) {
-	parts := strings.Split(clusterPodCIDR, ",")
-	if len(parts) == 1 {
-		cidr := strings.TrimSpace(parts[0])
-		if cidr == "" {
-			return false, nil
-		}
-		prefix, err := netip.ParsePrefix(cidr)
-		if err != nil {
-			return false, err
-		}
-		if !prefix.Addr().Is4() {
-			return false, fmt.Errorf("IPv6-only CIDR %q is not supported; use IPv4 or IPv4,IPv6 for dual-stack", cidr)
-		}
-		return false, nil
-	}
-	if len(parts) != 2 {
-		return false, fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
-	}
-	first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
-	if err != nil {
-		return false, err
-	}
-	second, err := netip.ParsePrefix(strings.TrimSpace(parts[1]))
-	if err != nil {
-		return false, err
-	}
-	return first.Addr().Is4() && !second.Addr().Is4(), nil
 }

--- a/pkg/installer/config/cos_test.go
+++ b/pkg/installer/config/cos_test.go
@@ -294,9 +294,9 @@ func TestConvertToCOS_EnableIPv6(t *testing.T) {
 	conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
 	assert.NoError(t, err)
 	conf.Mode = ModeInstall
-	// For non-create modes, IPv6 is driven by the explicit flag set by the installer UI (or
-	// config.yaml for PXE). ClusterPodCIDR is empty for join/install nodes and is not used.
-	conf.Install.IPv6Enabled = true
+	// For all modes, IPv6 is driven by the IPFamilies slice set by the installer UI
+	// (or config.yaml for PXE). Set dual-stack so IsIPv6Enabled() returns true.
+	conf.Install.IPFamilies = []string{IPFamilyIPv4, IPFamilyIPv6}
 
 	yipConfig, err := ConvertToCOS(conf)
 	assert.NoError(t, err)

--- a/pkg/installer/config/cos_test.go
+++ b/pkg/installer/config/cos_test.go
@@ -294,6 +294,9 @@ func TestConvertToCOS_EnableIPv6(t *testing.T) {
 	conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
 	assert.NoError(t, err)
 	conf.Mode = ModeInstall
+	// For non-create modes, IPv6 is driven by the explicit flag set by the installer UI (or
+	// config.yaml for PXE). ClusterPodCIDR is empty for join/install nodes and is not used.
+	conf.Install.IPv6Enabled = true
 
 	yipConfig, err := ConvertToCOS(conf)
 	assert.NoError(t, err)

--- a/pkg/installer/config/cos_test.go
+++ b/pkg/installer/config/cos_test.go
@@ -309,3 +309,59 @@ func TestConvertToCOS_EnableIPv6(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertToCOS_IPv4OnlySysctl(t *testing.T) {
+	testCases := []struct {
+		name       string
+		ipFamilies []string
+		check      func(t *testing.T, initramfs yipSchema.Stage)
+	}{
+		{
+			name:       "explicit IPv4-only: drop-in file writes disable_ipv6=1",
+			ipFamilies: []string{IPFamilyIPv4},
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				for _, f := range initramfs.Files {
+					if f.Path == "/etc/sysctl.d/zz-harvester-enable-ipv6.conf" {
+						assert.Contains(t, f.Content, SysctlDisableIPv6All+" = 1")
+						assert.Contains(t, f.Content, SysctlDisableIPv6Default+" = 1")
+						assert.Contains(t, f.Content, SysctlDisableIPv6Lo+" = 1")
+						assert.Contains(t, f.Content, "IPv4-only install")
+						return
+					}
+				}
+				t.Error("drop-in file not found")
+			},
+		},
+		{
+			name:       "explicit IPv4-only: sysctl map writes disable_ipv6=1",
+			ipFamilies: []string{IPFamilyIPv4},
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				assert.Equal(t, "1", initramfs.Sysctl[SysctlDisableIPv6All])
+				assert.Equal(t, "1", initramfs.Sysctl[SysctlDisableIPv6Default])
+				assert.Equal(t, "1", initramfs.Sysctl[SysctlDisableIPv6Lo])
+			},
+		},
+		{
+			name:       "empty IPFamilies (legacy config): treated as IPv4-only",
+			ipFamilies: []string{},
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				assert.Equal(t, "1", initramfs.Sysctl[SysctlDisableIPv6All])
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
+			assert.NoError(t, err)
+			conf.Mode = ModeInstall
+			conf.Install.IPFamilies = tc.ipFamilies
+
+			yipConfig, err := ConvertToCOS(conf)
+			assert.NoError(t, err)
+
+			initramfs := yipConfig.Stages["initramfs"][0]
+			tc.check(t, initramfs)
+		})
+	}
+}

--- a/pkg/installer/config/templates/nm-bridge.nmconnection
+++ b/pkg/installer/config/templates/nm-bridge.nmconnection
@@ -33,4 +33,10 @@ address1={{ .Bridge.IP }}/{{ .Bridge.SubnetMask }},{{ .Bridge.Gateway }}
 {{- end }}
 
 [ipv6]
+{{ if .IPv6Enabled -}}
+method=auto
+addr-gen-mode=eui64
+ip6-privacy=0
+{{- else -}}
 method=disabled
+{{- end }}

--- a/pkg/installer/config/templates/nm-bridge.nmconnection
+++ b/pkg/installer/config/templates/nm-bridge.nmconnection
@@ -35,7 +35,7 @@ address1={{ .Bridge.IP }}/{{ .Bridge.SubnetMask }},{{ .Bridge.Gateway }}
 [ipv6]
 {{ if .IPv6Enabled -}}
 method=auto
-addr-gen-mode=eui64
+addr-gen-mode=stable-privacy
 ip6-privacy=0
 {{- else -}}
 method=disabled

--- a/pkg/installer/config/templates/nm-vlan.nmconnection
+++ b/pkg/installer/config/templates/nm-vlan.nmconnection
@@ -25,4 +25,10 @@ address1={{ .Vlan.IP }}/{{ .Vlan.SubnetMask }},{{ .Vlan.Gateway }}
 {{- end }}
 
 [ipv6]
+{{ if .IPv6Enabled -}}
+method=auto
+addr-gen-mode=eui64
+ip6-privacy=0
+{{- else -}}
 method=disabled
+{{- end }}

--- a/pkg/installer/config/templates/nm-vlan.nmconnection
+++ b/pkg/installer/config/templates/nm-vlan.nmconnection
@@ -27,7 +27,7 @@ address1={{ .Vlan.IP }}/{{ .Vlan.SubnetMask }},{{ .Vlan.Gateway }}
 [ipv6]
 {{ if .IPv6Enabled -}}
 method=auto
-addr-gen-mode=eui64
+addr-gen-mode=stable-privacy
 ip6-privacy=0
 {{- else -}}
 method=disabled

--- a/pkg/installer/console/constant.go
+++ b/pkg/installer/console/constant.go
@@ -96,7 +96,7 @@ const (
 	clusterNetworkNotePanel      = "clusterNetworkNotePanel"
 	clusterNetworkDNSNotePanel   = "clusterNetworkDNSNotePanel"
 	clusterNetworkValidatorPanel = "clusterNetworkValidatorPanel"
-	clusterNetworkNote           = "Note: Defaults are pre-filled. The DNS IP must be within the service CIDR range. Pod and service CIDRs must not overlap."
+	clusterNetworkNote           = "Note: Defaults are pre-filled. For dual-stack, use comma-separated IPv4,IPv6 values (pod 10.52.0.0/16,fd52::/56; service 10.53.0.0/16,fd53::/112; DNS 10.53.0.10,fd53::a), with IPv4 first. DNS must be within the service CIDR; pod and service CIDRs must not overlap."
 
 	clusterTokenCreateNote = "Note: The token is used for adding nodes to the cluster"
 	clusterTokenJoinNote   = "Note: Input the token of the existing cluster"

--- a/pkg/installer/console/constant.go
+++ b/pkg/installer/console/constant.go
@@ -13,6 +13,7 @@ const (
 	diskNotePanel               = "diskNote"
 	preflightCheckPanel         = "preflightCheck"
 	askCreatePanel              = "askCreate"
+	askIPv6Panel                = "askIPv6"
 	serverURLPanel              = "serverUrl"
 	passwordPanel               = "osPassword"
 	passwordConfirmPanel        = "osPasswordConfirm"
@@ -89,7 +90,7 @@ const (
 	clusterNetworkNotePanel      = "clusterNetworkNotePanel"
 	clusterNetworkDNSNotePanel   = "clusterNetworkDNSNotePanel"
 	clusterNetworkValidatorPanel = "clusterNetworkValidatorPanel"
-	clusterNetworkNote           = "Note: Leave blank to use the default pod CIDR 10.52.0.0/16, service CIDR 10.53.0.0/16 and cluster DNS 10.53.0.10. If the service CIDR is changed, the DNS IP must be updated to be within the service CIDR."
+	clusterNetworkNote           = "Note: Leave blank to use the default pod CIDR 10.52.0.0/16, service CIDR 10.53.0.0/16 and cluster DNS 10.53.0.10. For dual-stack, use comma-separated IPv4,IPv6 values (e.g. 10.42.0.0/16,fd42::/48). IPv4 must be listed first. If the service CIDR is changed, the DNS IP must be updated to be within the service CIDR."
 
 	clusterTokenCreateNote = "Note: The token is used for adding nodes to the cluster"
 	clusterTokenJoinNote   = "Note: Input the token of the existing cluster"

--- a/pkg/installer/console/constant.go
+++ b/pkg/installer/console/constant.go
@@ -25,6 +25,7 @@ const (
 	askBondModePanel            = "askBondMode"
 	bondNotePanel               = "bondNote"
 	askNetworkMethodPanel       = "askNetworkMethod"
+	askNetworkTypePanel         = "askNetworkType"
 	hostnamePanel               = "hostname"
 	addressPanel                = "address"
 	addrMaskPanel               = "mask"
@@ -63,6 +64,7 @@ const (
 	askInterfaceLabel     = "Management NIC"
 	askVlanIDLabel        = "VLAN ID (optional)"
 	askNetworkMethodLabel = "IPv4 Method"
+	askNetworkTypeLabel   = "Network type"
 	hostNameLabel         = "HostName"
 	addressLabel          = "IPv4 Address"
 	addrMaskLabel         = "IPv4 Mask"
@@ -74,6 +76,10 @@ const (
 
 	networkMethodDHCPText   = "Automatic (DHCP)"
 	networkMethodStaticText = "Static"
+
+	// ipFamiliesDualStack is the dropdown sentinel value for IPv4+IPv6 dual-stack.
+	// It is converted to Install.IPFamilies = ["IPv4","IPv6"] when confirmed.
+	ipFamiliesDualStack = "IPv4,IPv6"
 
 	vipTitle          = "Configure VIP"
 	vipLabel          = "VIP"
@@ -90,7 +96,7 @@ const (
 	clusterNetworkNotePanel      = "clusterNetworkNotePanel"
 	clusterNetworkDNSNotePanel   = "clusterNetworkDNSNotePanel"
 	clusterNetworkValidatorPanel = "clusterNetworkValidatorPanel"
-	clusterNetworkNote           = "Note: Leave blank to use the default pod CIDR 10.52.0.0/16, service CIDR 10.53.0.0/16 and cluster DNS 10.53.0.10. For dual-stack, use comma-separated IPv4,IPv6 values (e.g. 10.42.0.0/16,fd42::/48). IPv4 must be listed first. If the service CIDR is changed, the DNS IP must be updated to be within the service CIDR."
+	clusterNetworkNote           = "Note: Defaults are pre-filled. The DNS IP must be within the service CIDR range. Pod and service CIDRs must not overlap."
 
 	clusterTokenCreateNote = "Note: The token is used for adding nodes to the cluster"
 	clusterTokenJoinNote   = "Note: Input the token of the existing cluster"

--- a/pkg/installer/console/install_panels.go
+++ b/pkg/installer/console/install_panels.go
@@ -165,6 +165,7 @@ func setPanels(c *Console) error {
 		addFooterPanel,
 		addPreflightCheckPanel,
 		addAskCreatePanel,
+		addAskIPv6Panel,
 		addAskRolePanel,
 		addDiskPanel,
 		addHostnamePanel,
@@ -869,7 +870,7 @@ func addAskCreatePanel(c *Console) error {
 			// all packages are already install
 			// configure hostname and network
 			if c.config.Install.Mode == config.ModeJoin {
-				return showRolePage(c)
+				return showIPv6Page(c)
 			}
 			if alreadyInstalled {
 				return showNetworkPage(c)
@@ -885,6 +886,14 @@ func showPasswordPage(c *Console) error {
 	return showNext(c, passwordConfirmPanel, passwordPanel)
 }
 
+func showIPv6Page(c *Console) error {
+	setLocation := createVerticalLocatorWithName(c)
+	if err := setLocation(askIPv6Panel, 3); err != nil {
+		return err
+	}
+	return showNext(c, askIPv6Panel)
+}
+
 func showRolePage(c *Console) error {
 	setLocation := createVerticalLocatorWithName(c)
 
@@ -893,6 +902,93 @@ func showRolePage(c *Console) error {
 	}
 
 	return showNext(c, askRolePanel)
+}
+
+// addAskIPv6Panel shows a Yes/No prompt for enabling IPv6 on join-mode nodes.
+// IPv6 is disabled by default; enabling it is required for dual-stack clusters.
+func addAskIPv6Panel(c *Console) error {
+	const (
+		optNo  = "no"
+		optYes = "yes"
+	)
+	var awaitingIPv6Ack bool
+
+	optionsFunc := func() ([]widgets.Option, error) {
+		return []widgets.Option{
+			{Value: optNo, Text: "No"},
+			{Value: optYes, Text: "Yes"},
+		}, nil
+	}
+
+	v, err := widgets.NewSelect(c.Gui, askIPv6Panel, "", optionsFunc)
+	if err != nil {
+		return err
+	}
+
+	v.PreShow = func() error {
+		awaitingIPv6Ack = false
+		if c.config.Install.IPv6Enabled {
+			v.Value = optYes
+		} else {
+			v.Value = optNo
+		}
+		if err := c.setContentByName(titlePanel, "Enable IPv6 on this node?"); err != nil {
+			return err
+		}
+		if err := c.setContentByName(validatorPanel, ""); err != nil {
+			return err
+		}
+		return c.setContentByName(notePanel,
+			"Note: Enabling IPv6 is required for Dual Stack (IPv4, IPv6) configurations.")
+	}
+
+	gotoPrev := func(_ *gocui.Gui, _ *gocui.View) error {
+		c.CloseElements(askIPv6Panel)
+		if err := c.setContentByName(validatorPanel, ""); err != nil {
+			return err
+		}
+		if err := c.setContentByName(notePanel, ""); err != nil {
+			return err
+		}
+		return showNext(c, askCreatePanel)
+	}
+
+	v.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
+			selected, err := v.GetData()
+			if err != nil {
+				return err
+			}
+
+			if selected == optYes && !awaitingIPv6Ack {
+				// First Enter on "Yes": show the experimental warning in the
+				// validator panel (red) and ask the user to press Enter once more.
+				awaitingIPv6Ack = true
+				return c.setContentByName(validatorPanel,
+					"WARNING: Dual-stack networking (IPv4, IPv6) is an experimental feature "+
+						"and may behave unexpectedly in production. "+
+						"Press Enter again to confirm, or press ESC to go back.")
+			}
+
+			// Reset warning and store choice.
+			awaitingIPv6Ack = false
+			if err := c.setContentByName(validatorPanel, ""); err != nil {
+				return err
+			}
+			if err := c.setContentByName(notePanel, ""); err != nil {
+				return err
+			}
+			c.config.Install.IPv6Enabled = (selected == optYes)
+
+			if err = v.Close(); err != nil {
+				return err
+			}
+			return showRolePage(c)
+		},
+		gocui.KeyEsc: gotoPrev,
+	}
+	c.AddElement(askIPv6Panel, v)
+	return nil
 }
 
 func addAskRolePanel(c *Console) error {
@@ -919,6 +1015,10 @@ func addAskRolePanel(c *Console) error {
 	}
 	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		c.CloseElements(askRolePanel)
+		// In join mode the page before role is the IPv6 prompt.
+		if c.config.Install.Mode == config.ModeJoin {
+			return showIPv6Page(c)
+		}
 		return showNext(c, askCreatePanel)
 	}
 	askRoleV.PreShow = func() error {
@@ -1995,7 +2095,12 @@ func addClusterNetworkPanel(c *Console) error {
 			clusterNetworkValidatorPanel)
 	}
 
+	// awaitingDualStackAck tracks whether the user has seen the dual-stack
+	// experimental warning and needs to press Enter once more to confirm.
+	var awaitingDualStackAck bool
+
 	prevPage := func(_ *gocui.Gui, _ *gocui.View) error {
+		awaitingDualStackAck = false
 		closePage()
 		return showNetworkPage(c)
 	}
@@ -2075,9 +2180,41 @@ func addClusterNetworkPanel(c *Console) error {
 		if cidr == "" {
 			return nil
 		}
-
-		_, err := netip.ParsePrefix(cidr)
-		return err
+		parts := strings.Split(cidr, ",")
+		if len(parts) > 2 {
+			return fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
+		}
+		for _, p := range parts {
+			if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
+				return fmt.Errorf("%q is not a valid CIDR (expected e.g. 10.42.0.0/16 or fd42::/48)", strings.TrimSpace(p))
+			}
+		}
+		if len(parts) == 1 {
+			// A single CIDR must be IPv4; IPv6-only is not a supported mode.
+			single, err := netip.ParsePrefix(strings.TrimSpace(parts[0])) // already validated above
+			if err != nil {
+				return err
+			}
+			if !single.Addr().Is4() {
+				return fmt.Errorf("a single CIDR must be IPv4 (e.g. 10.42.0.0/16); for dual-stack provide IPv4,IPv6")
+			}
+		}
+		if len(parts) == 2 {
+			firstStr := strings.TrimSpace(parts[0])
+			secondStr := strings.TrimSpace(parts[1])
+			first, err := netip.ParsePrefix(firstStr)
+			if err != nil {
+				return err
+			}
+			second, err := netip.ParsePrefix(secondStr)
+			if err != nil {
+				return err
+			}
+			if !first.Addr().Is4() || second.Addr().Is4() {
+				return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.42.0.0/16,fd42::/48)")
+			}
+		}
+		return nil
 	}
 
 	validateDNSIP := func(ip string) error {
@@ -2090,20 +2227,52 @@ func addClusterNetworkPanel(c *Console) error {
 			return nil
 		}
 
-		// the DNS IP address must be well-formed and within the
-		// service CIDR
-		ipAddr, err := netip.ParseAddr(ip)
-		if err != nil {
-			return fmt.Errorf("invalid cluster DNS IP: %w", err)
+		// Build a map from Is4() bool → service prefix so each DNS address
+		// can be matched to the CIDR of its own address family.
+		svcParts := strings.Split(serviceCIDR, ",")
+		svcNets := make(map[bool]netip.Prefix, len(svcParts))
+		for _, part := range svcParts {
+			part = strings.TrimSpace(part)
+			prefix, parseErr := netip.ParsePrefix(part)
+			if parseErr != nil {
+				return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", parseErr)
+			}
+			svcNets[prefix.Addr().Is4()] = prefix
 		}
 
-		svcNet, err := netip.ParsePrefix(serviceCIDR)
-		if err != nil {
-			return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", err)
+		// A single DNS IP must be IPv4; IPv6-only is not a supported mode.
+		if !strings.Contains(ip, ",") {
+			singleAddr, parseErr := netip.ParseAddr(strings.TrimSpace(ip))
+			if parseErr == nil && !singleAddr.Is4() {
+				return fmt.Errorf("a single DNS IP must be IPv4 (e.g. 10.53.0.10); for dual-stack provide IPv4,IPv6 (e.g. 10.53.0.10,fd53::a)")
+			}
 		}
 
-		if !svcNet.Contains(ipAddr) {
-			return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", ip, serviceCIDR)
+		// Validate each DNS address against the service CIDR of the same family.
+		dnsParts := strings.Split(ip, ",")
+		if len(dnsParts) > 2 {
+			return fmt.Errorf("at most two DNS IPs (IPv4,IPv6) are allowed, got %d", len(dnsParts))
+		}
+		parsed := make([]netip.Addr, 0, len(dnsParts))
+		for _, part := range dnsParts {
+			part = strings.TrimSpace(part)
+			ipAddr, parseErr := netip.ParseAddr(part)
+			if parseErr != nil {
+				return fmt.Errorf("invalid cluster DNS IP: %w", parseErr)
+			}
+			svcNet, ok := svcNets[ipAddr.Is4()]
+			if !ok {
+				return fmt.Errorf("invalid cluster DNS IP: %s has no matching service CIDR for its address family", part)
+			}
+			if !svcNet.Contains(ipAddr) {
+				return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", part, svcNet)
+			}
+			parsed = append(parsed, ipAddr)
+		}
+		if len(parsed) == 2 {
+			if !parsed[0].Is4() || parsed[1].Is4() {
+				return fmt.Errorf("dual-stack DNS IPs must be in IPv4-first order (e.g. 10.53.0.10,fd53::a)")
+			}
 		}
 
 		return nil
@@ -2121,7 +2290,9 @@ func addClusterNetworkPanel(c *Console) error {
 				clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid pod CIDR: %s", err))
 		}
+
 		c.config.ClusterPodCIDR = podCIDR
+		awaitingDualStackAck = false
 
 		// reset any previous error in the validator panel before
 		// moving to the next panel
@@ -2143,6 +2314,7 @@ func addClusterNetworkPanel(c *Console) error {
 				fmt.Sprintf("Invalid service CIDR: %s", err))
 		}
 		c.config.ClusterServiceCIDR = serviceCIDR
+		awaitingDualStackAck = false
 
 		// reset any previous error in the validator panel before
 		// moving to the next panel
@@ -2158,11 +2330,28 @@ func addClusterNetworkPanel(c *Console) error {
 			return err
 		}
 		if err = validateDNSIP(dns); err != nil {
+			awaitingDualStackAck = false
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
 		c.config.ClusterDNS = dns
 
-		// reset the validator panel before moving to the next page
+		// All fields are validated. If dual-stack was configured, show an inline
+		// warning on the first Enter and require a second Enter to confirm.
+		if strings.Contains(c.config.ClusterPodCIDR, ",") {
+			if !awaitingDualStackAck {
+				awaitingDualStackAck = true
+				return c.setContentByName(clusterNetworkValidatorPanel,
+					"WARNING: Dual-stack networking (IPv4, IPv6) is an experimental feature "+
+						"and may behave unexpectedly in production. "+
+						"Press Enter again to confirm, or go back to change the configuration.")
+			}
+			// Second Enter: user confirmed, apply IPv6 and proceed.
+			awaitingDualStackAck = false
+			if err = applyKernelIPv6(true); err != nil {
+				return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
+			}
+		}
+
 		if err = c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err
 		}
@@ -2193,6 +2382,7 @@ func addClusterNetworkPanel(c *Console) error {
 	dnsInput.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyEsc: prevPage,
 		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
+			awaitingDualStackAck = false
 			return showNext(c, clusterServiceCIDRPanel)
 		},
 		gocui.KeyArrowDown: dnsConfirm,
@@ -2212,9 +2402,8 @@ func addClusterNetworkPanel(c *Console) error {
 	validatorPanel := widgets.NewPanel(c.Gui, clusterNetworkValidatorPanel)
 	validatorPanel.FgColor = gocui.ColorRed
 	validatorPanel.Focus = false
-	maxX, _ := c.Gui.Size()
-	validatorPanel.X1 = maxX / 8 * 6
-	setLocation(validatorPanel, 3)
+	validatorPanel.Wrap = true
+	setLocation(validatorPanel, 6)
 	c.AddElement(clusterNetworkValidatorPanel, validatorPanel)
 
 	return nil

--- a/pkg/installer/console/install_panels.go
+++ b/pkg/installer/console/install_panels.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/jroimartin/gocui"
 	"github.com/sirupsen/logrus"
@@ -165,7 +166,6 @@ func setPanels(c *Console) error {
 		addFooterPanel,
 		addPreflightCheckPanel,
 		addAskCreatePanel,
-		addAskIPv6Panel,
 		addAskRolePanel,
 		addDiskPanel,
 		addHostnamePanel,
@@ -870,7 +870,7 @@ func addAskCreatePanel(c *Console) error {
 			// all packages are already install
 			// configure hostname and network
 			if c.config.Install.Mode == config.ModeJoin {
-				return showIPv6Page(c)
+				return showRolePage(c)
 			}
 			if alreadyInstalled {
 				return showNetworkPage(c)
@@ -886,14 +886,6 @@ func showPasswordPage(c *Console) error {
 	return showNext(c, passwordConfirmPanel, passwordPanel)
 }
 
-func showIPv6Page(c *Console) error {
-	setLocation := createVerticalLocatorWithName(c)
-	if err := setLocation(askIPv6Panel, 3); err != nil {
-		return err
-	}
-	return showNext(c, askIPv6Panel)
-}
-
 func showRolePage(c *Console) error {
 	setLocation := createVerticalLocatorWithName(c)
 
@@ -902,93 +894,6 @@ func showRolePage(c *Console) error {
 	}
 
 	return showNext(c, askRolePanel)
-}
-
-// addAskIPv6Panel shows a Yes/No prompt for enabling IPv6 on join-mode nodes.
-// IPv6 is disabled by default; enabling it is required for dual-stack clusters.
-func addAskIPv6Panel(c *Console) error {
-	const (
-		optNo  = "no"
-		optYes = "yes"
-	)
-	var awaitingIPv6Ack bool
-
-	optionsFunc := func() ([]widgets.Option, error) {
-		return []widgets.Option{
-			{Value: optNo, Text: "No"},
-			{Value: optYes, Text: "Yes"},
-		}, nil
-	}
-
-	v, err := widgets.NewSelect(c.Gui, askIPv6Panel, "", optionsFunc)
-	if err != nil {
-		return err
-	}
-
-	v.PreShow = func() error {
-		awaitingIPv6Ack = false
-		if c.config.Install.IPv6Enabled {
-			v.Value = optYes
-		} else {
-			v.Value = optNo
-		}
-		if err := c.setContentByName(titlePanel, "Enable IPv6 on this node?"); err != nil {
-			return err
-		}
-		if err := c.setContentByName(validatorPanel, ""); err != nil {
-			return err
-		}
-		return c.setContentByName(notePanel,
-			"Note: Enabling IPv6 is required for Dual Stack (IPv4, IPv6) configurations.")
-	}
-
-	gotoPrev := func(_ *gocui.Gui, _ *gocui.View) error {
-		c.CloseElements(askIPv6Panel)
-		if err := c.setContentByName(validatorPanel, ""); err != nil {
-			return err
-		}
-		if err := c.setContentByName(notePanel, ""); err != nil {
-			return err
-		}
-		return showNext(c, askCreatePanel)
-	}
-
-	v.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
-			selected, err := v.GetData()
-			if err != nil {
-				return err
-			}
-
-			if selected == optYes && !awaitingIPv6Ack {
-				// First Enter on "Yes": show the experimental warning in the
-				// validator panel (red) and ask the user to press Enter once more.
-				awaitingIPv6Ack = true
-				return c.setContentByName(validatorPanel,
-					"WARNING: Dual-stack networking (IPv4, IPv6) is an experimental feature "+
-						"and may behave unexpectedly in production. "+
-						"Press Enter again to confirm, or press ESC to go back.")
-			}
-
-			// Reset warning and store choice.
-			awaitingIPv6Ack = false
-			if err := c.setContentByName(validatorPanel, ""); err != nil {
-				return err
-			}
-			if err := c.setContentByName(notePanel, ""); err != nil {
-				return err
-			}
-			c.config.Install.IPv6Enabled = (selected == optYes)
-
-			if err = v.Close(); err != nil {
-				return err
-			}
-			return showRolePage(c)
-		},
-		gocui.KeyEsc: gotoPrev,
-	}
-	c.AddElement(askIPv6Panel, v)
-	return nil
 }
 
 func addAskRolePanel(c *Console) error {
@@ -1015,10 +920,6 @@ func addAskRolePanel(c *Console) error {
 	}
 	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		c.CloseElements(askRolePanel)
-		// In join mode the page before role is the IPv6 prompt.
-		if c.config.Install.Mode == config.ModeJoin {
-			return showIPv6Page(c)
-		}
 		return showNext(c, askCreatePanel)
 	}
 	askRoleV.PreShow = func() error {
@@ -1405,9 +1306,9 @@ func addTokenPanel(c *Console) error {
 
 func showNetworkPage(c *Console) error {
 	if mgmtNetwork.Method != config.NetworkMethodStatic {
-		return showNext(c, askVlanIDPanel, askBondModePanel, askNetworkMethodPanel, askInterfacePanel)
+		return showNext(c, askVlanIDPanel, askBondModePanel, askNetworkMethodPanel, askNetworkTypePanel, askInterfacePanel)
 	}
-	return showNext(c, askVlanIDPanel, askBondModePanel, askNetworkMethodPanel, addressPanel, addrMaskPanel, gatewayPanel, mtuPanel, askInterfacePanel)
+	return showNext(c, askVlanIDPanel, askBondModePanel, askNetworkMethodPanel, addressPanel, addrMaskPanel, gatewayPanel, mtuPanel, askNetworkTypePanel, askInterfacePanel)
 }
 
 func showHostnamePage(c *Console) error {
@@ -1581,6 +1482,17 @@ func addNetworkPanel(c *Console) error {
 		return err
 	}
 
+	askNetworkTypeV, err := widgets.NewDropDown(c.Gui, askNetworkTypePanel, askNetworkTypeLabel, getNetworkTypeOptions)
+	if err != nil {
+		return err
+	}
+
+	if c.config.Install.IsIPv6Enabled() {
+		askNetworkTypeV.Value = ipFamiliesDualStack
+	} else {
+		askNetworkTypeV.Value = config.IPFamilyIPv4
+	}
+
 	addressV, err := widgets.NewInput(c.Gui, addressPanel, addressLabel, false)
 	if err != nil {
 		return err
@@ -1657,6 +1569,7 @@ func addNetworkPanel(c *Console) error {
 			askVlanIDPanel,
 			askBondModePanel,
 			askNetworkMethodPanel,
+			askNetworkTypePanel,
 			addressPanel,
 			addrMaskPanel,
 			gatewayPanel,
@@ -1670,10 +1583,19 @@ func addNetworkPanel(c *Console) error {
 		return applyNetworks(
 			mgmtNetwork,
 			c.config.Hostname,
+			c.config.Install.IsIPv6Enabled(),
 		)
 	}
 
 	preGotoNextPage := func() (string, error) {
+		ipv6Enabled := c.config.Install.IsIPv6Enabled()
+
+		// Enable or disable IPv6 in the kernel before NetworkManager applies
+		// the interface config so that NM can configure IPv6 if needed.
+		if err := applyKernelIPv6(ipv6Enabled); err != nil {
+			return fmt.Sprintf("Failed to configure IPv6 kernel settings: %s", err), nil
+		}
+
 		err := setupNetwork()
 		if err != nil {
 			return fmt.Sprintf("Configure network failed: %s", err), nil
@@ -1701,6 +1623,14 @@ func addNetworkPanel(c *Console) error {
 		}
 		if !isDefaultRouteExist && mgmtNetwork.Method == config.NetworkMethodDHCP {
 			return ErrMsgNoDefaultRoute, nil
+		}
+
+		// For dual-stack mode, verify the management bridge has acquired a
+		// non-link-local IPv6 address (via SLAAC or DHCPv6) before proceeding.
+		if ipv6Enabled {
+			if err := checkIPv6Address(config.MgmtInterfaceName, 15*time.Second, 1*time.Second); err != nil {
+				return err.Error(), nil
+			}
 		}
 
 		return "", nil
@@ -1873,6 +1803,7 @@ func addNetworkPanel(c *Console) error {
 	c.AddElement(askBondModePanel, askBondModeV)
 
 	// askNetworkMethodV
+	var awaitingDualStackAck bool
 	askNetworkMethodVConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
 		selected, err := askNetworkMethodV.GetData()
 		if err != nil {
@@ -1884,7 +1815,13 @@ func addNetworkPanel(c *Console) error {
 		}
 
 		c.CloseElements(mtuPanel, gatewayPanel, addrMaskPanel, addressPanel)
-		return gotoNextPage(askNetworkMethodPanel)
+		awaitingDualStackAck = false
+		if c.config.Install.IsIPv6Enabled() {
+			askNetworkTypeV.Value = ipFamiliesDualStack
+		} else {
+			askNetworkTypeV.Value = config.IPFamilyIPv4
+		}
+		return showNext(c, askNetworkTypePanel)
 	}
 	askNetworkMethodV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyArrowUp:   gotoNextPanel(c, []string{askBondModePanel}),
@@ -2049,7 +1986,14 @@ func addNetworkPanel(c *Console) error {
 			return updateValidatorMessage(msg)
 		}
 
-		return gotoNextPage(mtuPanel)
+		// Reset ack flag and sync Value before focusing the Network type panel.
+		awaitingDualStackAck = false
+		if c.config.Install.IsIPv6Enabled() {
+			askNetworkTypeV.Value = ipFamiliesDualStack
+		} else {
+			askNetworkTypeV.Value = config.IPFamilyIPv4
+		}
+		return showNext(c, askNetworkTypePanel)
 	}
 	mtuV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyArrowUp:   gotoNextPanel(c, []string{gatewayPanel}, validateMTU),
@@ -2060,9 +2004,61 @@ func addNetworkPanel(c *Console) error {
 	setLocation(mtuV.Panel, 3)
 	c.AddElement(mtuPanel, mtuV)
 
+	// askNetworkTypeV
+	askNetworkTypeV.PreShow = func() error {
+		if mgmtNetwork.Method == config.NetworkMethodStatic {
+			askNetworkTypeV.SetLocation(mtuV.X0, mtuV.Y1, mtuV.X1, mtuV.Y1+3)
+		} else {
+			askNetworkTypeV.SetLocation(askNetworkMethodV.X0, askNetworkMethodV.Y1, askNetworkMethodV.X1, askNetworkMethodV.Y1+3)
+		}
+		return nil
+	}
+	askNetworkTypeVConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
+		selected, err := askNetworkTypeV.GetData()
+		if err != nil {
+			return err
+		}
+		if selected == ipFamiliesDualStack && !awaitingDualStackAck {
+			awaitingDualStackAck = true
+			// Restore the regular note, then show the red warning below it.
+			// Focus must stay on the Network type dropdown so a second Enter
+			// can confirm; set Focus=false before Show() to avoid stealing it.
+			if err := showBondNote(); err != nil {
+				return err
+			}
+			networkValidatorV.Focus = false
+			return c.setContentByName(networkValidatorPanel,
+				"WARNING: Dual-stack networking (IPv4,IPv6) is an experimental feature "+
+					"and may behave unexpectedly in production. "+
+					"Press Enter again to confirm, or press ESC to cancel.")
+		}
+		awaitingDualStackAck = false
+		if selected == ipFamiliesDualStack {
+			c.config.Install.IPFamilies = []string{config.IPFamilyIPv4, config.IPFamilyIPv6}
+		} else {
+			c.config.Install.IPFamilies = []string{config.IPFamilyIPv4}
+		}
+		return gotoNextPage(askNetworkTypePanel)
+	}
+	askNetworkTypeV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
+		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
+			awaitingDualStackAck = false
+			c.CloseElement(networkValidatorPanel)
+			if mgmtNetwork.Method == config.NetworkMethodStatic {
+				return showNext(c, mtuPanel)
+			}
+			return showNext(c, askNetworkMethodPanel)
+		},
+		gocui.KeyArrowDown: askNetworkTypeVConfirm,
+		gocui.KeyEnter:     askNetworkTypeVConfirm,
+		gocui.KeyEsc:       gotoPrevPage,
+	}
+	setLocation(askNetworkTypeV.Panel, 3)
+	c.AddElement(askNetworkTypePanel, askNetworkTypeV)
+
 	// bondNoteV
 	bondNoteV.Wrap = true
-	setLocation(bondNoteV, 8)
+	setLocation(bondNoteV, 4)
 	c.AddElement(bondNotePanel, bondNoteV)
 
 	// networkValidatorV
@@ -2095,12 +2091,12 @@ func addClusterNetworkPanel(c *Console) error {
 			clusterNetworkValidatorPanel)
 	}
 
-	// awaitingDualStackAck tracks whether the user has seen the dual-stack
-	// experimental warning and needs to press Enter once more to confirm.
-	var awaitingDualStackAck bool
-
 	prevPage := func(_ *gocui.Gui, _ *gocui.View) error {
-		awaitingDualStackAck = false
+		// Clear saved cluster network values so the next visit always
+		// pre-fills based on the IP family that is selected at that time
+		c.config.ClusterPodCIDR = ""
+		c.config.ClusterServiceCIDR = ""
+		c.config.ClusterDNS = ""
 		closePage()
 		return showNetworkPage(c)
 	}
@@ -2123,7 +2119,13 @@ func addClusterNetworkPanel(c *Console) error {
 	}
 	podCIDRInput.PreShow = func() error {
 		c.Cursor = true
-		podCIDRInput.Value = c.config.ClusterPodCIDR
+		if c.config.ClusterPodCIDR != "" {
+			podCIDRInput.Value = c.config.ClusterPodCIDR
+		} else if c.config.Install.IsIPv6Enabled() {
+			podCIDRInput.Value = config.DefaultDualStackPodCIDR
+		} else {
+			podCIDRInput.Value = config.DefaultPodCIDR
+		}
 
 		if err := c.setContentByName(
 			titlePanel,
@@ -2154,7 +2156,13 @@ func addClusterNetworkPanel(c *Console) error {
 
 	serviceCIDRInput.PreShow = func() error {
 		c.Cursor = true
-		serviceCIDRInput.Value = c.config.ClusterServiceCIDR
+		if c.config.ClusterServiceCIDR != "" {
+			serviceCIDRInput.Value = c.config.ClusterServiceCIDR
+		} else if c.config.Install.IsIPv6Enabled() {
+			serviceCIDRInput.Value = config.DefaultDualStackServiceCIDR
+		} else {
+			serviceCIDRInput.Value = config.DefaultServiceCIDR
+		}
 		return nil
 	}
 
@@ -2170,111 +2178,13 @@ func addClusterNetworkPanel(c *Console) error {
 
 	dnsInput.PreShow = func() error {
 		c.Cursor = true
-		dnsInput.Value = c.config.ClusterDNS
-		return nil
-	}
-
-	// define inputs validators
-	validateCIDR := func(cidr string) error {
-		cidr = strings.TrimSpace(cidr)
-		if cidr == "" {
-			return nil
+		if c.config.ClusterDNS != "" {
+			dnsInput.Value = c.config.ClusterDNS
+		} else if c.config.Install.IsIPv6Enabled() {
+			dnsInput.Value = config.DefaultDualStackClusterDNS
+		} else {
+			dnsInput.Value = config.DefaultClusterDNS
 		}
-		parts := strings.Split(cidr, ",")
-		if len(parts) > 2 {
-			return fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
-		}
-		for _, p := range parts {
-			if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
-				return fmt.Errorf("%q is not a valid CIDR (expected e.g. 10.42.0.0/16 or fd42::/48)", strings.TrimSpace(p))
-			}
-		}
-		if len(parts) == 1 {
-			// A single CIDR must be IPv4; IPv6-only is not a supported mode.
-			single, err := netip.ParsePrefix(strings.TrimSpace(parts[0])) // already validated above
-			if err != nil {
-				return err
-			}
-			if !single.Addr().Is4() {
-				return fmt.Errorf("a single CIDR must be IPv4 (e.g. 10.42.0.0/16); for dual-stack provide IPv4,IPv6")
-			}
-		}
-		if len(parts) == 2 {
-			firstStr := strings.TrimSpace(parts[0])
-			secondStr := strings.TrimSpace(parts[1])
-			first, err := netip.ParsePrefix(firstStr)
-			if err != nil {
-				return err
-			}
-			second, err := netip.ParsePrefix(secondStr)
-			if err != nil {
-				return err
-			}
-			if !first.Addr().Is4() || second.Addr().Is4() {
-				return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.42.0.0/16,fd42::/48)")
-			}
-		}
-		return nil
-	}
-
-	validateDNSIP := func(ip string) error {
-		ip = strings.TrimSpace(ip)
-		serviceCIDR, err := serviceCIDRInput.GetData()
-		if err != nil {
-			return err
-		}
-		if ip == "" && serviceCIDR == "" {
-			return nil
-		}
-
-		// Build a map from Is4() bool → service prefix so each DNS address
-		// can be matched to the CIDR of its own address family.
-		svcParts := strings.Split(serviceCIDR, ",")
-		svcNets := make(map[bool]netip.Prefix, len(svcParts))
-		for _, part := range svcParts {
-			part = strings.TrimSpace(part)
-			prefix, parseErr := netip.ParsePrefix(part)
-			if parseErr != nil {
-				return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", parseErr)
-			}
-			svcNets[prefix.Addr().Is4()] = prefix
-		}
-
-		// A single DNS IP must be IPv4; IPv6-only is not a supported mode.
-		if !strings.Contains(ip, ",") {
-			singleAddr, parseErr := netip.ParseAddr(strings.TrimSpace(ip))
-			if parseErr == nil && !singleAddr.Is4() {
-				return fmt.Errorf("a single DNS IP must be IPv4 (e.g. 10.53.0.10); for dual-stack provide IPv4,IPv6 (e.g. 10.53.0.10,fd53::a)")
-			}
-		}
-
-		// Validate each DNS address against the service CIDR of the same family.
-		dnsParts := strings.Split(ip, ",")
-		if len(dnsParts) > 2 {
-			return fmt.Errorf("at most two DNS IPs (IPv4,IPv6) are allowed, got %d", len(dnsParts))
-		}
-		parsed := make([]netip.Addr, 0, len(dnsParts))
-		for _, part := range dnsParts {
-			part = strings.TrimSpace(part)
-			ipAddr, parseErr := netip.ParseAddr(part)
-			if parseErr != nil {
-				return fmt.Errorf("invalid cluster DNS IP: %w", parseErr)
-			}
-			svcNet, ok := svcNets[ipAddr.Is4()]
-			if !ok {
-				return fmt.Errorf("invalid cluster DNS IP: %s has no matching service CIDR for its address family", part)
-			}
-			if !svcNet.Contains(ipAddr) {
-				return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", part, svcNet)
-			}
-			parsed = append(parsed, ipAddr)
-		}
-		if len(parsed) == 2 {
-			if !parsed[0].Is4() || parsed[1].Is4() {
-				return fmt.Errorf("dual-stack DNS IPs must be in IPv4-first order (e.g. 10.53.0.10,fd53::a)")
-			}
-		}
-
 		return nil
 	}
 
@@ -2290,12 +2200,13 @@ func addClusterNetworkPanel(c *Console) error {
 				clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid pod CIDR: %s", err))
 		}
+		if err := validateCIDRMatchesIPFamilies(podCIDR, c.config.Install.IsIPv6Enabled()); err != nil {
+			return c.setContentByName(clusterNetworkValidatorPanel,
+				fmt.Sprintf("Invalid pod CIDR: %s", err))
+		}
 
 		c.config.ClusterPodCIDR = podCIDR
-		awaitingDualStackAck = false
 
-		// reset any previous error in the validator panel before
-		// moving to the next panel
 		if err := c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err
 		}
@@ -2313,11 +2224,15 @@ func addClusterNetworkPanel(c *Console) error {
 				clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid service CIDR: %s", err))
 		}
+		if err = validateCIDRMatchesIPFamilies(serviceCIDR, c.config.Install.IsIPv6Enabled()); err != nil {
+			return c.setContentByName(clusterNetworkValidatorPanel,
+				fmt.Sprintf("Invalid service CIDR: %s", err))
+		}
+		if err = validateCIDRConsistency(c.config.ClusterPodCIDR, serviceCIDR); err != nil {
+			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
+		}
 		c.config.ClusterServiceCIDR = serviceCIDR
-		awaitingDualStackAck = false
 
-		// reset any previous error in the validator panel before
-		// moving to the next panel
 		if err = c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err
 		}
@@ -2329,28 +2244,13 @@ func addClusterNetworkPanel(c *Console) error {
 		if err != nil {
 			return err
 		}
-		if err = validateDNSIP(dns); err != nil {
-			awaitingDualStackAck = false
+		if err = validateDNSIP(dns, c.config.ClusterServiceCIDR); err != nil {
+			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
+		}
+		if err = validateDNSMatchesIPFamilies(dns, c.config.Install.IsIPv6Enabled()); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
 		c.config.ClusterDNS = dns
-
-		// All fields are validated. If dual-stack was configured, show an inline
-		// warning on the first Enter and require a second Enter to confirm.
-		if strings.Contains(c.config.ClusterPodCIDR, ",") {
-			if !awaitingDualStackAck {
-				awaitingDualStackAck = true
-				return c.setContentByName(clusterNetworkValidatorPanel,
-					"WARNING: Dual-stack networking (IPv4, IPv6) is an experimental feature "+
-						"and may behave unexpectedly in production. "+
-						"Press Enter again to confirm, or go back to change the configuration.")
-			}
-			// Second Enter: user confirmed, apply IPv6 and proceed.
-			awaitingDualStackAck = false
-			if err = applyKernelIPv6(true); err != nil {
-				return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
-			}
-		}
 
 		if err = c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err
@@ -2382,7 +2282,6 @@ func addClusterNetworkPanel(c *Console) error {
 	dnsInput.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyEsc: prevPage,
 		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
-			awaitingDualStackAck = false
 			return showNext(c, clusterServiceCIDRPanel)
 		},
 		gocui.KeyArrowDown: dnsConfirm,
@@ -2406,6 +2305,199 @@ func addClusterNetworkPanel(c *Console) error {
 	setLocation(validatorPanel, 6)
 	c.AddElement(clusterNetworkValidatorPanel, validatorPanel)
 
+	return nil
+}
+
+// validateCIDR checks that cidr is a valid CIDR string (or empty).
+// At most two comma-separated CIDRs are allowed (dual-stack).
+// A single CIDR must be IPv4; the first of two must be IPv4 and the second IPv6
+// (IPv4-first order -- the only supported dual-stack variant).
+func validateCIDR(cidr string) error {
+	cidr = strings.TrimSpace(cidr)
+	if cidr == "" {
+		return nil
+	}
+	parts := strings.Split(cidr, ",")
+	if len(parts) > 2 {
+		return fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
+	}
+	for _, p := range parts {
+		if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
+			return fmt.Errorf("%q is not a valid CIDR (expected e.g. 10.52.0.0/16 or fd52::/56)", strings.TrimSpace(p))
+		}
+	}
+	if len(parts) == 1 {
+		single, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return err
+		}
+		if !single.Addr().Is4() {
+			return fmt.Errorf("a single CIDR must be IPv4 (e.g. 10.52.0.0/16); for dual-stack provide IPv4,IPv6")
+		}
+	}
+	if len(parts) == 2 {
+		first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return err
+		}
+		second, err := netip.ParsePrefix(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return err
+		}
+		if !first.Addr().Is4() || second.Addr().Is4() {
+			return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.52.0.0/16,fd52::/56)")
+		}
+	}
+	return nil
+}
+
+// validateCIDRConsistency checks that podCIDR and serviceCIDR are compatible:
+// both must have the same number of entries (both single-stack or both dual-stack)
+// and their ranges must not overlap.
+func validateCIDRConsistency(podCIDR, serviceCIDR string) error {
+	podCIDR = strings.TrimSpace(podCIDR)
+	serviceCIDR = strings.TrimSpace(serviceCIDR)
+	if podCIDR == "" || serviceCIDR == "" {
+		return nil
+	}
+	podParts := strings.Split(podCIDR, ",")
+	svcParts := strings.Split(serviceCIDR, ",")
+	if len(podParts) != len(svcParts) {
+		if len(podParts) > len(svcParts) {
+			return fmt.Errorf("pod CIDR is dual-stack but service CIDR is single-stack; both must use the same number of CIDRs")
+		}
+		return fmt.Errorf("service CIDR is dual-stack but pod CIDR is single-stack; both must use the same number of CIDRs")
+	}
+	podPrefixes := make([]netip.Prefix, 0, len(podParts))
+	for _, p := range podParts {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
+		if err != nil {
+			return err
+		}
+		podPrefixes = append(podPrefixes, prefix.Masked())
+	}
+	svcPrefixes := make([]netip.Prefix, 0, len(svcParts))
+	for _, p := range svcParts {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
+		if err != nil {
+			return err
+		}
+		svcPrefixes = append(svcPrefixes, prefix.Masked())
+	}
+	for _, pod := range podPrefixes {
+		for _, svc := range svcPrefixes {
+			if pod.Overlaps(svc) {
+				return fmt.Errorf("pod CIDR %s and service CIDR %s must not overlap", pod, svc)
+			}
+		}
+	}
+	return nil
+}
+
+// validateDNSIP checks that ip (comma-separated DNS addresses) are valid and
+// each falls within the matching-family service CIDR.
+// An empty ip with a non-empty serviceCIDR is allowed (defaults will be used).
+func validateDNSIP(ip, serviceCIDR string) error {
+	ip = strings.TrimSpace(ip)
+	serviceCIDR = strings.TrimSpace(serviceCIDR)
+	if ip == "" && serviceCIDR == "" {
+		return nil
+	}
+
+	// Build a map from Is4() bool -> service prefix so each DNS address
+	// can be matched to the CIDR of its own address family.
+	svcParts := strings.Split(serviceCIDR, ",")
+	svcNets := make(map[bool]netip.Prefix, len(svcParts))
+	for _, part := range svcParts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		prefix, parseErr := netip.ParsePrefix(part)
+		if parseErr != nil {
+			return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", parseErr)
+		}
+		svcNets[prefix.Addr().Is4()] = prefix
+	}
+
+	if ip == "" {
+		return nil
+	}
+
+	// A single DNS IP must be IPv4; IPv6-only is not a supported mode.
+	if !strings.Contains(ip, ",") {
+		singleAddr, parseErr := netip.ParseAddr(strings.TrimSpace(ip))
+		if parseErr == nil && !singleAddr.Is4() {
+			return fmt.Errorf("a single DNS IP must be IPv4 (e.g. 10.53.0.10); for dual-stack provide IPv4,IPv6 (e.g. 10.53.0.10,fd53::a)")
+		}
+	}
+
+	dnsParts := strings.Split(ip, ",")
+	if len(dnsParts) > 2 {
+		return fmt.Errorf("at most two DNS IPs (IPv4,IPv6) are allowed, got %d", len(dnsParts))
+	}
+	parsed := make([]netip.Addr, 0, len(dnsParts))
+	for _, part := range dnsParts {
+		part = strings.TrimSpace(part)
+		ipAddr, parseErr := netip.ParseAddr(part)
+		if parseErr != nil {
+			return fmt.Errorf("invalid cluster DNS IP: %w", parseErr)
+		}
+		svcNet, ok := svcNets[ipAddr.Is4()]
+		if !ok {
+			return fmt.Errorf("invalid cluster DNS IP: %s has no matching service CIDR for its address family", part)
+		}
+		if !svcNet.Contains(ipAddr) {
+			return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", part, svcNet)
+		}
+		if ipAddr == svcNet.Masked().Addr() {
+			return fmt.Errorf("invalid cluster DNS IP: %s is the network address of %s and cannot be used as a host address", part, svcNet)
+		}
+		parsed = append(parsed, ipAddr)
+	}
+	if len(parsed) == 2 {
+		if !parsed[0].Is4() || parsed[1].Is4() {
+			return fmt.Errorf("dual-stack DNS IPs must be in IPv4-first order (e.g. 10.53.0.10,fd53::a)")
+		}
+	}
+	return nil
+}
+
+// validateCIDRMatchesIPFamilies enforces that the CIDR stack mode matches the
+// configured IP families: IPv4-only mode requires a single IPv4 CIDR; dual-stack
+// mode requires exactly two CIDRs in IPv4,IPv6 order.
+// An empty cidr is always allowed (defaults are applied later).
+func validateCIDRMatchesIPFamilies(cidr string, ipv6Enabled bool) error {
+	cidr = strings.TrimSpace(cidr)
+	if cidr == "" {
+		return nil
+	}
+	isDual := strings.Contains(cidr, ",")
+	if ipv6Enabled {
+		if !isDual {
+			return fmt.Errorf("dual-stack mode (IPv4,IPv6) requires both an IPv4 and an IPv6 CIDR (e.g. 10.52.0.0/16,fd52::/56)")
+		}
+	} else {
+		if isDual {
+			return fmt.Errorf("IPv4-only mode requires a single IPv4 CIDR")
+		}
+	}
+	return nil
+}
+
+// validateDNSMatchesIPFamilies enforces DNS IP constraints based on the
+// configured IP families: IPv4-only mode requires a single IPv4 DNS address.
+// Dual-stack mode allows a single IPv4 address or IPv4+IPv6 pair.
+// An empty dns string is always allowed.
+func validateDNSMatchesIPFamilies(dns string, ipv6Enabled bool) error {
+	dns = strings.TrimSpace(dns)
+	if dns == "" {
+		return nil
+	}
+	isDual := strings.Contains(dns, ",")
+	if !ipv6Enabled && isDual {
+		return fmt.Errorf("IPv4-only mode requires a single IPv4 DNS address")
+	}
 	return nil
 }
 
@@ -2469,6 +2561,19 @@ func getNetworkMethodOptions() ([]widgets.Option, error) {
 		{
 			Value: config.NetworkMethodStatic,
 			Text:  networkMethodStaticText,
+		},
+	}, nil
+}
+
+func getNetworkTypeOptions() ([]widgets.Option, error) {
+	return []widgets.Option{
+		{
+			Value: config.IPFamilyIPv4,
+			Text:  "IPv4 only",
+		},
+		{
+			Value: ipFamiliesDualStack,
+			Text:  "IPv4,IPv6 (dual-stack, IPv4-first)",
 		},
 	}, nil
 }
@@ -2800,7 +2905,7 @@ func addInstallPanel(c *Console) error {
 				// Only need to do this for automatic installs, as manual installs will
 				// have already run applyNetworks()
 				printToPanel(c.Gui, "Configuring network...", installPanel)
-				if err := applyNetworks(c.config.ManagementInterface, c.config.Hostname); err != nil {
+				if err := applyNetworks(c.config.ManagementInterface, c.config.Hostname, c.config.Install.IsIPv6Enabled()); err != nil {
 					printToPanel(c.Gui, fmt.Sprintf("Can't apply networks: %s", err), installPanel)
 					return
 				}
@@ -3381,6 +3486,7 @@ func configureInstallModeDHCP(c *Console) {
 	err := applyNetworks(
 		mgmtNetwork,
 		c.config.Hostname,
+		c.config.Install.IsIPv6Enabled(),
 	)
 	if err != nil {
 		logrus.Error(err)

--- a/pkg/installer/console/install_panels.go
+++ b/pkg/installer/console/install_panels.go
@@ -2198,7 +2198,7 @@ func addClusterNetworkPanel(c *Console) error {
 				fmt.Sprintf("Invalid pod CIDR: %s", err))
 		}
 
-		c.config.ClusterPodCIDR = podCIDR
+		c.config.ClusterPodCIDR = strings.TrimSpace(podCIDR)
 
 		if err := c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err
@@ -2224,7 +2224,7 @@ func addClusterNetworkPanel(c *Console) error {
 		if err = util.ValidateCIDRConsistency(c.config.ClusterPodCIDR, serviceCIDR); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
-		c.config.ClusterServiceCIDR = serviceCIDR
+		c.config.ClusterServiceCIDR = strings.TrimSpace(serviceCIDR)
 
 		if err = c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err
@@ -2243,7 +2243,7 @@ func addClusterNetworkPanel(c *Console) error {
 		if err = util.ValidateDNSMatchesIPFamilies(dns, c.config.Install.IsIPv6Enabled()); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
-		c.config.ClusterDNS = dns
+		c.config.ClusterDNS = strings.TrimSpace(dns)
 
 		if err = c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err

--- a/pkg/installer/console/install_panels.go
+++ b/pkg/installer/console/install_panels.go
@@ -3,7 +3,6 @@ package console
 import (
 	"fmt"
 	"net"
-	"net/netip"
 	"os"
 	"slices"
 	"strconv"
@@ -2195,12 +2194,12 @@ func addClusterNetworkPanel(c *Console) error {
 			return err
 		}
 
-		if err := validateCIDR(podCIDR); err != nil {
+		if err := util.ValidateCIDR(podCIDR); err != nil {
 			return c.setContentByName(
 				clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid pod CIDR: %s", err))
 		}
-		if err := validateCIDRMatchesIPFamilies(podCIDR, c.config.Install.IsIPv6Enabled()); err != nil {
+		if err := util.ValidateCIDRMatchesIPFamilies(podCIDR, c.config.Install.IsIPv6Enabled()); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid pod CIDR: %s", err))
 		}
@@ -2219,16 +2218,16 @@ func addClusterNetworkPanel(c *Console) error {
 			return err
 		}
 
-		if err = validateCIDR(serviceCIDR); err != nil {
+		if err = util.ValidateCIDR(serviceCIDR); err != nil {
 			return c.setContentByName(
 				clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid service CIDR: %s", err))
 		}
-		if err = validateCIDRMatchesIPFamilies(serviceCIDR, c.config.Install.IsIPv6Enabled()); err != nil {
+		if err = util.ValidateCIDRMatchesIPFamilies(serviceCIDR, c.config.Install.IsIPv6Enabled()); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid service CIDR: %s", err))
 		}
-		if err = validateCIDRConsistency(c.config.ClusterPodCIDR, serviceCIDR); err != nil {
+		if err = util.ValidateCIDRConsistency(c.config.ClusterPodCIDR, serviceCIDR); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
 		c.config.ClusterServiceCIDR = serviceCIDR
@@ -2244,10 +2243,10 @@ func addClusterNetworkPanel(c *Console) error {
 		if err != nil {
 			return err
 		}
-		if err = validateDNSIP(dns, c.config.ClusterServiceCIDR); err != nil {
+		if err = util.ValidateDNSIP(dns, c.config.ClusterServiceCIDR); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
-		if err = validateDNSMatchesIPFamilies(dns, c.config.Install.IsIPv6Enabled()); err != nil {
+		if err = util.ValidateDNSMatchesIPFamilies(dns, c.config.Install.IsIPv6Enabled()); err != nil {
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
 		c.config.ClusterDNS = dns
@@ -2305,199 +2304,6 @@ func addClusterNetworkPanel(c *Console) error {
 	setLocation(validatorPanel, 6)
 	c.AddElement(clusterNetworkValidatorPanel, validatorPanel)
 
-	return nil
-}
-
-// validateCIDR checks that cidr is a valid CIDR string (or empty).
-// At most two comma-separated CIDRs are allowed (dual-stack).
-// A single CIDR must be IPv4; the first of two must be IPv4 and the second IPv6
-// (IPv4-first order -- the only supported dual-stack variant).
-func validateCIDR(cidr string) error {
-	cidr = strings.TrimSpace(cidr)
-	if cidr == "" {
-		return nil
-	}
-	parts := strings.Split(cidr, ",")
-	if len(parts) > 2 {
-		return fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
-	}
-	for _, p := range parts {
-		if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
-			return fmt.Errorf("%q is not a valid CIDR (expected e.g. 10.52.0.0/16 or fd52::/56)", strings.TrimSpace(p))
-		}
-	}
-	if len(parts) == 1 {
-		single, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
-		if err != nil {
-			return err
-		}
-		if !single.Addr().Is4() {
-			return fmt.Errorf("a single CIDR must be IPv4 (e.g. 10.52.0.0/16); for dual-stack provide IPv4,IPv6")
-		}
-	}
-	if len(parts) == 2 {
-		first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
-		if err != nil {
-			return err
-		}
-		second, err := netip.ParsePrefix(strings.TrimSpace(parts[1]))
-		if err != nil {
-			return err
-		}
-		if !first.Addr().Is4() || second.Addr().Is4() {
-			return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.52.0.0/16,fd52::/56)")
-		}
-	}
-	return nil
-}
-
-// validateCIDRConsistency checks that podCIDR and serviceCIDR are compatible:
-// both must have the same number of entries (both single-stack or both dual-stack)
-// and their ranges must not overlap.
-func validateCIDRConsistency(podCIDR, serviceCIDR string) error {
-	podCIDR = strings.TrimSpace(podCIDR)
-	serviceCIDR = strings.TrimSpace(serviceCIDR)
-	if podCIDR == "" || serviceCIDR == "" {
-		return nil
-	}
-	podParts := strings.Split(podCIDR, ",")
-	svcParts := strings.Split(serviceCIDR, ",")
-	if len(podParts) != len(svcParts) {
-		if len(podParts) > len(svcParts) {
-			return fmt.Errorf("pod CIDR is dual-stack but service CIDR is single-stack; both must use the same number of CIDRs")
-		}
-		return fmt.Errorf("service CIDR is dual-stack but pod CIDR is single-stack; both must use the same number of CIDRs")
-	}
-	podPrefixes := make([]netip.Prefix, 0, len(podParts))
-	for _, p := range podParts {
-		prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
-		if err != nil {
-			return err
-		}
-		podPrefixes = append(podPrefixes, prefix.Masked())
-	}
-	svcPrefixes := make([]netip.Prefix, 0, len(svcParts))
-	for _, p := range svcParts {
-		prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
-		if err != nil {
-			return err
-		}
-		svcPrefixes = append(svcPrefixes, prefix.Masked())
-	}
-	for _, pod := range podPrefixes {
-		for _, svc := range svcPrefixes {
-			if pod.Overlaps(svc) {
-				return fmt.Errorf("pod CIDR %s and service CIDR %s must not overlap", pod, svc)
-			}
-		}
-	}
-	return nil
-}
-
-// validateDNSIP checks that ip (comma-separated DNS addresses) are valid and
-// each falls within the matching-family service CIDR.
-// An empty ip with a non-empty serviceCIDR is allowed (defaults will be used).
-func validateDNSIP(ip, serviceCIDR string) error {
-	ip = strings.TrimSpace(ip)
-	serviceCIDR = strings.TrimSpace(serviceCIDR)
-	if ip == "" && serviceCIDR == "" {
-		return nil
-	}
-
-	// Build a map from Is4() bool -> service prefix so each DNS address
-	// can be matched to the CIDR of its own address family.
-	svcParts := strings.Split(serviceCIDR, ",")
-	svcNets := make(map[bool]netip.Prefix, len(svcParts))
-	for _, part := range svcParts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		prefix, parseErr := netip.ParsePrefix(part)
-		if parseErr != nil {
-			return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", parseErr)
-		}
-		svcNets[prefix.Addr().Is4()] = prefix
-	}
-
-	if ip == "" {
-		return nil
-	}
-
-	// A single DNS IP must be IPv4; IPv6-only is not a supported mode.
-	if !strings.Contains(ip, ",") {
-		singleAddr, parseErr := netip.ParseAddr(strings.TrimSpace(ip))
-		if parseErr == nil && !singleAddr.Is4() {
-			return fmt.Errorf("a single DNS IP must be IPv4 (e.g. 10.53.0.10); for dual-stack provide IPv4,IPv6 (e.g. 10.53.0.10,fd53::a)")
-		}
-	}
-
-	dnsParts := strings.Split(ip, ",")
-	if len(dnsParts) > 2 {
-		return fmt.Errorf("at most two DNS IPs (IPv4,IPv6) are allowed, got %d", len(dnsParts))
-	}
-	parsed := make([]netip.Addr, 0, len(dnsParts))
-	for _, part := range dnsParts {
-		part = strings.TrimSpace(part)
-		ipAddr, parseErr := netip.ParseAddr(part)
-		if parseErr != nil {
-			return fmt.Errorf("invalid cluster DNS IP: %w", parseErr)
-		}
-		svcNet, ok := svcNets[ipAddr.Is4()]
-		if !ok {
-			return fmt.Errorf("invalid cluster DNS IP: %s has no matching service CIDR for its address family", part)
-		}
-		if !svcNet.Contains(ipAddr) {
-			return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", part, svcNet)
-		}
-		if ipAddr == svcNet.Masked().Addr() {
-			return fmt.Errorf("invalid cluster DNS IP: %s is the network address of %s and cannot be used as a host address", part, svcNet)
-		}
-		parsed = append(parsed, ipAddr)
-	}
-	if len(parsed) == 2 {
-		if !parsed[0].Is4() || parsed[1].Is4() {
-			return fmt.Errorf("dual-stack DNS IPs must be in IPv4-first order (e.g. 10.53.0.10,fd53::a)")
-		}
-	}
-	return nil
-}
-
-// validateCIDRMatchesIPFamilies enforces that the CIDR stack mode matches the
-// configured IP families: IPv4-only mode requires a single IPv4 CIDR; dual-stack
-// mode requires exactly two CIDRs in IPv4,IPv6 order.
-// An empty cidr is always allowed (defaults are applied later).
-func validateCIDRMatchesIPFamilies(cidr string, ipv6Enabled bool) error {
-	cidr = strings.TrimSpace(cidr)
-	if cidr == "" {
-		return nil
-	}
-	isDual := strings.Contains(cidr, ",")
-	if ipv6Enabled {
-		if !isDual {
-			return fmt.Errorf("dual-stack mode (IPv4,IPv6) requires both an IPv4 and an IPv6 CIDR (e.g. 10.52.0.0/16,fd52::/56)")
-		}
-	} else {
-		if isDual {
-			return fmt.Errorf("IPv4-only mode requires a single IPv4 CIDR")
-		}
-	}
-	return nil
-}
-
-// validateDNSMatchesIPFamilies enforces DNS IP constraints based on the
-// configured IP families: IPv4-only mode requires a single IPv4 DNS address.
-// Dual-stack mode allows a single IPv4 address or IPv4+IPv6 pair.
-// An empty dns string is always allowed.
-func validateDNSMatchesIPFamilies(dns string, ipv6Enabled bool) error {
-	dns = strings.TrimSpace(dns)
-	if dns == "" {
-		return nil
-	}
-	isDual := strings.Contains(dns, ",")
-	if !ipv6Enabled && isDual {
-		return fmt.Errorf("IPv4-only mode requires a single IPv4 DNS address")
-	}
 	return nil
 }
 

--- a/pkg/installer/console/install_panels.go
+++ b/pkg/installer/console/install_panels.go
@@ -1589,12 +1589,6 @@ func addNetworkPanel(c *Console) error {
 	preGotoNextPage := func() (string, error) {
 		ipv6Enabled := c.config.Install.IsIPv6Enabled()
 
-		// Enable or disable IPv6 in the kernel before NetworkManager applies
-		// the interface config so that NM can configure IPv6 if needed.
-		if err := applyKernelIPv6(ipv6Enabled); err != nil {
-			return fmt.Sprintf("Failed to configure IPv6 kernel settings: %s", err), nil
-		}
-
 		err := setupNetwork()
 		if err != nil {
 			return fmt.Sprintf("Configure network failed: %s", err), nil

--- a/pkg/installer/console/network.go
+++ b/pkg/installer/console/network.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -58,7 +59,7 @@ func checkDefaultRoute() (bool, error) {
 	return false, nil
 }
 
-func applyNetworks(network config.Network, hostname string) error {
+func applyNetworks(network config.Network, hostname string, ipv6Enabled bool) error {
 	if err := config.RestoreOriginalNetworkConfig(); err != nil {
 		return err
 	}
@@ -113,7 +114,7 @@ func applyNetworks(network config.Network, hostname string) error {
 		}
 	}
 
-	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true, false)
+	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true, ipv6Enabled)
 	if err != nil {
 		return err
 	}
@@ -297,4 +298,45 @@ func applyKernelIPv6(enabled bool) error {
 		}
 	}
 	return nil
+}
+
+// checkIPv6Address verifies that ifaceName has at least one non-link-local,
+// non-loopback IPv6 unicast address assigned. It polls for up to maxWait,
+// sleeping pollInterval between attempts, to allow time for SLAAC assignment.
+// Returns an error if no qualifying address is found within the deadline.
+func checkIPv6Address(ifaceName string, maxWait, pollInterval time.Duration) error {
+	deadline := time.Now().Add(maxWait)
+	for {
+		iface, err := net.InterfaceByName(ifaceName)
+		if err != nil {
+			return fmt.Errorf("interface %s not found: %w", ifaceName, err)
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return fmt.Errorf("failed to list addresses on %s: %w", ifaceName, err)
+		}
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.To4() != nil {
+				continue // skip non-IPv6
+			}
+			if ip.IsLinkLocalUnicast() || ip.IsLoopback() {
+				continue // skip link-local and loopback
+			}
+			logrus.Infof("IPv6 address found on %s: %s", ifaceName, ip)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("no non-link-local IPv6 address found on interface %s after %s; "+
+		"ensure the network provides IPv6 via SLAAC or DHCPv6 before selecting dual-stack mode", ifaceName, maxWait)
 }

--- a/pkg/installer/console/network.go
+++ b/pkg/installer/console/network.go
@@ -113,19 +113,7 @@ func applyNetworks(network config.Network, hostname string) error {
 		}
 	}
 
-	// enable IPv6 before applying NetworkManager profiles
-	for _, param := range []string{
-		config.SysctlDisableIPv6All,
-		config.SysctlDisableIPv6Default,
-		config.SysctlDisableIPv6Lo,
-	} {
-		// #nosec G204
-		if out, execErr := exec.Command("sysctl", "-w", fmt.Sprintf("%s=0", param)).CombinedOutput(); execErr != nil {
-			logrus.Warnf("Failed to enable IPv6 sysctl %s: %v (%s)", param, execErr, string(out))
-		}
-	}
-
-	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true)
+	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true, false)
 	if err != nil {
 		return err
 	}
@@ -280,6 +268,32 @@ func filterNICSBySession(hwDeviceMap map[string]netlink.Link, links []netlink.Li
 					break //device is already removed, no point checking for other addresses
 				}
 			}
+		}
+	}
+	return nil
+}
+
+// applyKernelIPv6 enables (enabled=true) or disables (enabled=false) IPv6 in the
+// running kernel by writing the disable_ipv6 sysctls. Called at the cluster-CIDR
+// confirm step so the live installer session matches the chosen networking mode.
+// For dual-stack (enabled=true) any sysctl failure is returned as a hard error.
+// For IPv4-only (enabled=false) failures are logged as warnings only.
+func applyKernelIPv6(enabled bool) error {
+	value := "0"
+	if !enabled {
+		value = "1"
+	}
+	for _, param := range []string{
+		config.SysctlDisableIPv6All,
+		config.SysctlDisableIPv6Default,
+		config.SysctlDisableIPv6Lo,
+	} {
+		//nolint:gosec // G204: param and value are controlled internal strings
+		if out, execErr := exec.Command("sysctl", "-w", fmt.Sprintf("%s=%s", param, value)).CombinedOutput(); execErr != nil {
+			if enabled {
+				return fmt.Errorf("failed to enable IPv6 (%s): %v (%s)", param, execErr, string(out))
+			}
+			logrus.Warnf("Failed to disable IPv6 sysctl %s: %v (%s)", param, execErr, string(out))
 		}
 	}
 	return nil

--- a/pkg/installer/console/network.go
+++ b/pkg/installer/console/network.go
@@ -114,6 +114,10 @@ func applyNetworks(network config.Network, hostname string, ipv6Enabled bool) er
 		}
 	}
 
+	if err := applyKernelIPv6(ipv6Enabled); err != nil {
+		return err
+	}
+
 	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true, ipv6Enabled)
 	if err != nil {
 		return err

--- a/pkg/installer/util/ip.go
+++ b/pkg/installer/util/ip.go
@@ -19,30 +19,21 @@ func ValidateCIDR(cidr string) error {
 	if len(parts) > 2 {
 		return fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
 	}
+	prefixes := make([]netip.Prefix, 0, len(parts))
 	for _, p := range parts {
-		if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
+		if err != nil {
 			return fmt.Errorf("%q is not a valid CIDR (expected e.g. 10.52.0.0/16 or fd52::/56)", strings.TrimSpace(p))
 		}
+		prefixes = append(prefixes, prefix)
 	}
-	if len(parts) == 1 {
-		single, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
-		if err != nil {
-			return err
-		}
-		if !single.Addr().Is4() {
+	switch len(prefixes) {
+	case 1:
+		if !prefixes[0].Addr().Is4() {
 			return fmt.Errorf("a single CIDR must be IPv4 (e.g. 10.52.0.0/16); for dual-stack provide IPv4,IPv6")
 		}
-	}
-	if len(parts) == 2 {
-		first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
-		if err != nil {
-			return err
-		}
-		second, err := netip.ParsePrefix(strings.TrimSpace(parts[1]))
-		if err != nil {
-			return err
-		}
-		if !first.Addr().Is4() || second.Addr().Is4() {
+	case 2:
+		if !prefixes[0].Addr().Is4() || prefixes[1].Addr().Is4() {
 			return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.52.0.0/16,fd52::/56)")
 		}
 	}
@@ -124,7 +115,7 @@ func ValidateDNSIP(ip, serviceCIDR string) error {
 
 	// A single DNS IP must be IPv4; IPv6-only is not a supported mode.
 	if !strings.Contains(ip, ",") {
-		singleAddr, parseErr := netip.ParseAddr(strings.TrimSpace(ip))
+		singleAddr, parseErr := netip.ParseAddr(ip)
 		if parseErr == nil && !singleAddr.Is4() {
 			return fmt.Errorf("a single DNS IP must be IPv4 (e.g. 10.53.0.10); for dual-stack provide IPv4,IPv6 (e.g. 10.53.0.10,fd53::a)")
 		}
@@ -171,14 +162,11 @@ func ValidateCIDRMatchesIPFamilies(cidr string, ipv6Enabled bool) error {
 		return nil
 	}
 	isDual := strings.Contains(cidr, ",")
-	if ipv6Enabled {
-		if !isDual {
-			return fmt.Errorf("dual-stack mode (IPv4,IPv6) requires both an IPv4 and an IPv6 CIDR (e.g. 10.52.0.0/16,fd52::/56)")
-		}
-	} else {
-		if isDual {
-			return fmt.Errorf("IPv4-only mode requires a single IPv4 CIDR")
-		}
+	if ipv6Enabled && !isDual {
+		return fmt.Errorf("dual-stack mode (IPv4,IPv6) requires both an IPv4 and an IPv6 CIDR (e.g. 10.52.0.0/16,fd52::/56)")
+	}
+	if !ipv6Enabled && isDual {
+		return fmt.Errorf("IPv4-only mode requires a single IPv4 CIDR")
 	}
 	return nil
 }

--- a/pkg/installer/util/ip.go
+++ b/pkg/installer/util/ip.go
@@ -1,0 +1,200 @@
+package util
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// ValidateCIDR checks that cidr is a valid CIDR string (or empty).
+// At most two comma-separated CIDRs are allowed (dual-stack).
+// A single CIDR must be IPv4; the first of two must be IPv4 and the second IPv6
+// (IPv4-first order -- the only supported dual-stack variant).
+func ValidateCIDR(cidr string) error {
+	cidr = strings.TrimSpace(cidr)
+	if cidr == "" {
+		return nil
+	}
+	parts := strings.Split(cidr, ",")
+	if len(parts) > 2 {
+		return fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
+	}
+	for _, p := range parts {
+		if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
+			return fmt.Errorf("%q is not a valid CIDR (expected e.g. 10.52.0.0/16 or fd52::/56)", strings.TrimSpace(p))
+		}
+	}
+	if len(parts) == 1 {
+		single, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return err
+		}
+		if !single.Addr().Is4() {
+			return fmt.Errorf("a single CIDR must be IPv4 (e.g. 10.52.0.0/16); for dual-stack provide IPv4,IPv6")
+		}
+	}
+	if len(parts) == 2 {
+		first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return err
+		}
+		second, err := netip.ParsePrefix(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return err
+		}
+		if !first.Addr().Is4() || second.Addr().Is4() {
+			return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.52.0.0/16,fd52::/56)")
+		}
+	}
+	return nil
+}
+
+// ValidateCIDRConsistency checks that podCIDR and serviceCIDR are compatible:
+// both must have the same number of entries (both single-stack or both dual-stack)
+// and their ranges must not overlap.
+func ValidateCIDRConsistency(podCIDR, serviceCIDR string) error {
+	podCIDR = strings.TrimSpace(podCIDR)
+	serviceCIDR = strings.TrimSpace(serviceCIDR)
+	if podCIDR == "" || serviceCIDR == "" {
+		return nil
+	}
+	podParts := strings.Split(podCIDR, ",")
+	svcParts := strings.Split(serviceCIDR, ",")
+	if len(podParts) != len(svcParts) {
+		if len(podParts) > len(svcParts) {
+			return fmt.Errorf("pod CIDR is dual-stack but service CIDR is single-stack; both must use the same number of CIDRs")
+		}
+		return fmt.Errorf("service CIDR is dual-stack but pod CIDR is single-stack; both must use the same number of CIDRs")
+	}
+	podPrefixes := make([]netip.Prefix, 0, len(podParts))
+	for _, p := range podParts {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
+		if err != nil {
+			return err
+		}
+		podPrefixes = append(podPrefixes, prefix.Masked())
+	}
+	svcPrefixes := make([]netip.Prefix, 0, len(svcParts))
+	for _, p := range svcParts {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
+		if err != nil {
+			return err
+		}
+		svcPrefixes = append(svcPrefixes, prefix.Masked())
+	}
+	for _, pod := range podPrefixes {
+		for _, svc := range svcPrefixes {
+			if pod.Overlaps(svc) {
+				return fmt.Errorf("pod CIDR %s and service CIDR %s must not overlap", pod, svc)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateDNSIP checks that ip (comma-separated DNS addresses) are valid and
+// each falls within the matching-family service CIDR.
+// An empty ip with a non-empty serviceCIDR is allowed (defaults will be used).
+func ValidateDNSIP(ip, serviceCIDR string) error {
+	ip = strings.TrimSpace(ip)
+	serviceCIDR = strings.TrimSpace(serviceCIDR)
+	if ip == "" && serviceCIDR == "" {
+		return nil
+	}
+
+	// Build a map from Is4() bool -> service prefix so each DNS address
+	// can be matched to the CIDR of its own address family.
+	svcParts := strings.Split(serviceCIDR, ",")
+	svcNets := make(map[bool]netip.Prefix, len(svcParts))
+	for _, part := range svcParts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		prefix, parseErr := netip.ParsePrefix(part)
+		if parseErr != nil {
+			return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", parseErr)
+		}
+		svcNets[prefix.Addr().Is4()] = prefix
+	}
+
+	if ip == "" {
+		return nil
+	}
+
+	// A single DNS IP must be IPv4; IPv6-only is not a supported mode.
+	if !strings.Contains(ip, ",") {
+		singleAddr, parseErr := netip.ParseAddr(strings.TrimSpace(ip))
+		if parseErr == nil && !singleAddr.Is4() {
+			return fmt.Errorf("a single DNS IP must be IPv4 (e.g. 10.53.0.10); for dual-stack provide IPv4,IPv6 (e.g. 10.53.0.10,fd53::a)")
+		}
+	}
+
+	dnsParts := strings.Split(ip, ",")
+	if len(dnsParts) > 2 {
+		return fmt.Errorf("at most two DNS IPs (IPv4,IPv6) are allowed, got %d", len(dnsParts))
+	}
+	parsed := make([]netip.Addr, 0, len(dnsParts))
+	for _, part := range dnsParts {
+		part = strings.TrimSpace(part)
+		ipAddr, parseErr := netip.ParseAddr(part)
+		if parseErr != nil {
+			return fmt.Errorf("invalid cluster DNS IP: %w", parseErr)
+		}
+		svcNet, ok := svcNets[ipAddr.Is4()]
+		if !ok {
+			return fmt.Errorf("invalid cluster DNS IP: %s has no matching service CIDR for its address family", part)
+		}
+		if !svcNet.Contains(ipAddr) {
+			return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", part, svcNet)
+		}
+		if ipAddr == svcNet.Masked().Addr() {
+			return fmt.Errorf("invalid cluster DNS IP: %s is the network address of %s and cannot be used as a host address", part, svcNet)
+		}
+		parsed = append(parsed, ipAddr)
+	}
+	if len(parsed) == 2 {
+		if !parsed[0].Is4() || parsed[1].Is4() {
+			return fmt.Errorf("dual-stack DNS IPs must be in IPv4-first order (e.g. 10.53.0.10,fd53::a)")
+		}
+	}
+	return nil
+}
+
+// ValidateCIDRMatchesIPFamilies enforces that the CIDR stack mode matches the
+// configured IP families: IPv4-only mode requires a single IPv4 CIDR; dual-stack
+// mode requires exactly two CIDRs in IPv4,IPv6 order.
+// An empty cidr is always allowed (defaults are applied later).
+func ValidateCIDRMatchesIPFamilies(cidr string, ipv6Enabled bool) error {
+	cidr = strings.TrimSpace(cidr)
+	if cidr == "" {
+		return nil
+	}
+	isDual := strings.Contains(cidr, ",")
+	if ipv6Enabled {
+		if !isDual {
+			return fmt.Errorf("dual-stack mode (IPv4,IPv6) requires both an IPv4 and an IPv6 CIDR (e.g. 10.52.0.0/16,fd52::/56)")
+		}
+	} else {
+		if isDual {
+			return fmt.Errorf("IPv4-only mode requires a single IPv4 CIDR")
+		}
+	}
+	return nil
+}
+
+// ValidateDNSMatchesIPFamilies enforces DNS IP constraints based on the
+// configured IP families: IPv4-only mode requires a single IPv4 DNS address.
+// Dual-stack mode allows a single IPv4 address or IPv4+IPv6 pair.
+// An empty dns string is always allowed.
+func ValidateDNSMatchesIPFamilies(dns string, ipv6Enabled bool) error {
+	dns = strings.TrimSpace(dns)
+	if dns == "" {
+		return nil
+	}
+	isDual := strings.Contains(dns, ",")
+	if !ipv6Enabled && isDual {
+		return fmt.Errorf("IPv4-only mode requires a single IPv4 DNS address")
+	}
+	return nil
+}

--- a/pkg/installer/util/ip_test.go
+++ b/pkg/installer/util/ip_test.go
@@ -8,9 +8,10 @@ import (
 
 func TestValidateCIDR(t *testing.T) {
 	tests := []struct {
-		name    string
-		cidr    string
-		wantErr bool
+		name        string
+		cidr        string
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name:    "empty string is allowed",
@@ -109,9 +110,12 @@ func TestValidateCIDR(t *testing.T) {
 			err := ValidateCIDR(tc.cidr)
 			if tc.wantErr {
 				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+				return
 			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -211,8 +215,18 @@ func TestValidateCIDRConsistency(t *testing.T) {
 			svcCIDR:     "0.0.0.0/0,::/0",
 			wantErr:     true,
 			errContains: "must not overlap",
+		}, {
+			name:    "invalid pod CIDR part returns parse error",
+			podCIDR: "not-a-cidr",
+			svcCIDR: "10.53.0.0/16",
+			wantErr: true,
 		},
-	}
+		{
+			name:    "invalid service CIDR part returns parse error",
+			podCIDR: "10.52.0.0/16",
+			svcCIDR: "not-a-cidr",
+			wantErr: true,
+		}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateCIDRConsistency(tc.podCIDR, tc.svcCIDR)
@@ -221,9 +235,9 @@ func TestValidateCIDRConsistency(t *testing.T) {
 				if tc.errContains != "" {
 					assert.Contains(t, err.Error(), tc.errContains)
 				}
-			} else {
-				assert.NoError(t, err)
+				return
 			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -344,8 +358,19 @@ func TestValidateDNSIP(t *testing.T) {
 			ip:          "192.168.1.1",
 			serviceCIDR: "0.0.0.0/0",
 			wantErr:     false,
+		}, {
+			name:        "service CIDR with trailing comma skips empty part",
+			ip:          "10.53.0.10",
+			serviceCIDR: "10.53.0.0/16,",
+			wantErr:     false,
 		},
-	}
+		{
+			name:        "invalid service CIDR returns parse error",
+			ip:          "10.53.0.10",
+			serviceCIDR: "not-a-cidr",
+			wantErr:     true,
+			errContains: "the service CIDR must be valid",
+		}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateDNSIP(tc.ip, tc.serviceCIDR)
@@ -354,9 +379,9 @@ func TestValidateDNSIP(t *testing.T) {
 				if tc.errContains != "" {
 					assert.Contains(t, err.Error(), tc.errContains)
 				}
-			} else {
-				assert.NoError(t, err)
+				return
 			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -370,16 +395,9 @@ func TestValidateCIDRMatchesIPFamilies(t *testing.T) {
 		errContains string
 	}{
 		{
-			name:        "empty CIDR is always allowed (IPv4-only mode)",
-			cidr:        "",
-			ipv6Enabled: false,
-			wantErr:     false,
-		},
-		{
-			name:        "empty CIDR is always allowed (dual-stack mode)",
-			cidr:        "",
-			ipv6Enabled: true,
-			wantErr:     false,
+			name:    "empty CIDR is always allowed",
+			cidr:    "",
+			wantErr: false,
 		},
 		{
 			name:        "IPv4-only mode accepts single IPv4 CIDR",
@@ -447,9 +465,9 @@ func TestValidateCIDRMatchesIPFamilies(t *testing.T) {
 				if tc.errContains != "" {
 					assert.Contains(t, err.Error(), tc.errContains)
 				}
-			} else {
-				assert.NoError(t, err)
+				return
 			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -463,16 +481,9 @@ func TestValidateDNSMatchesIPFamilies(t *testing.T) {
 		errContains string
 	}{
 		{
-			name:        "empty DNS is always allowed (IPv4-only mode)",
-			dns:         "",
-			ipv6Enabled: false,
-			wantErr:     false,
-		},
-		{
-			name:        "empty DNS is always allowed (dual-stack mode)",
-			dns:         "",
-			ipv6Enabled: true,
-			wantErr:     false,
+			name:    "empty DNS is always allowed",
+			dns:     "",
+			wantErr: false,
 		},
 		{
 			name:        "IPv4-only mode accepts single IPv4 DNS",
@@ -508,9 +519,9 @@ func TestValidateDNSMatchesIPFamilies(t *testing.T) {
 				if tc.errContains != "" {
 					assert.Contains(t, err.Error(), tc.errContains)
 				}
-			} else {
-				assert.NoError(t, err)
+				return
 			}
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/installer/util/ip_test.go
+++ b/pkg/installer/util/ip_test.go
@@ -1,0 +1,516 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateCIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		cidr    string
+		wantErr bool
+	}{
+		{
+			name:    "empty string is allowed",
+			cidr:    "",
+			wantErr: false,
+		},
+		{
+			name:    "whitespace-only is allowed",
+			cidr:    "  ",
+			wantErr: false,
+		},
+		{
+			name:    "valid single IPv4 CIDR",
+			cidr:    "10.52.0.0/16",
+			wantErr: false,
+		},
+		{
+			name:    "valid dual-stack IPv4-first",
+			cidr:    "10.52.0.0/16,fd52::/56",
+			wantErr: false,
+		},
+		{
+			name:    "valid dual-stack with spaces around comma",
+			cidr:    "10.52.0.0/16 , fd52::/56",
+			wantErr: false,
+		},
+		{
+			name:    "single IPv6 CIDR is rejected",
+			cidr:    "fd52::/56",
+			wantErr: true,
+		},
+		{
+			name:    "dual-stack IPv6-first order is rejected",
+			cidr:    "fd52::/56,10.52.0.0/16",
+			wantErr: true,
+		},
+		{
+			name:    "dual-stack two IPv4 CIDRs is rejected",
+			cidr:    "10.52.0.0/16,10.53.0.0/16",
+			wantErr: true,
+		},
+		{
+			name:    "three CIDRs are rejected",
+			cidr:    "10.52.0.0/16,fd52::/56,10.53.0.0/16",
+			wantErr: true,
+		},
+		{
+			name:    "invalid CIDR string is rejected",
+			cidr:    "not-a-cidr",
+			wantErr: true,
+		},
+		{
+			name:    "bare IP without prefix length is rejected",
+			cidr:    "10.52.0.1",
+			wantErr: true,
+		},
+		// Large-pool cases: validate no integer overflow in prefix parsing.
+		{
+			name:    "IPv4 /1 covers half the address space",
+			cidr:    "0.0.0.0/1",
+			wantErr: false,
+		},
+		{
+			name:    "IPv4 /0 covers the entire address space",
+			cidr:    "0.0.0.0/0",
+			wantErr: false,
+		},
+		{
+			name:    "IPv6 /1 as single CIDR is rejected (must be IPv4)",
+			cidr:    "::/1",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 /0 as single CIDR is rejected (must be IPv4)",
+			cidr:    "::/0",
+			wantErr: true,
+		},
+		{
+			name:    "dual-stack with IPv4 /1 and IPv6 /1",
+			cidr:    "0.0.0.0/1,::/1",
+			wantErr: false,
+		},
+		{
+			name:    "dual-stack with IPv4 /0 and IPv6 /0",
+			cidr:    "0.0.0.0/0,::/0",
+			wantErr: false,
+		},
+		{
+			name:    "dual-stack with IPv4 /2 and IPv6 /2",
+			cidr:    "0.0.0.0/2,::/2",
+			wantErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCIDR(tc.cidr)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateCIDRConsistency(t *testing.T) {
+	tests := []struct {
+		name        string
+		podCIDR     string
+		svcCIDR     string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "both empty is allowed",
+			wantErr: false,
+		},
+		{
+			name:    "empty pod CIDR is allowed",
+			svcCIDR: "10.53.0.0/16",
+			wantErr: false,
+		},
+		{
+			name:    "empty service CIDR is allowed",
+			podCIDR: "10.52.0.0/16",
+			wantErr: false,
+		},
+		{
+			name:    "matching single-stack CIDRs",
+			podCIDR: "10.52.0.0/16",
+			svcCIDR: "10.53.0.0/16",
+			wantErr: false,
+		},
+		{
+			name:    "matching dual-stack CIDRs",
+			podCIDR: "10.52.0.0/16,fd52::/56",
+			svcCIDR: "10.53.0.0/16,fd53::/112",
+			wantErr: false,
+		},
+		{
+			name:        "pod dual-stack, service single-stack is rejected",
+			podCIDR:     "10.52.0.0/16,fd52::/56",
+			svcCIDR:     "10.53.0.0/16",
+			wantErr:     true,
+			errContains: "pod CIDR is dual-stack but service CIDR is single-stack",
+		},
+		{
+			name:        "pod single-stack, service dual-stack is rejected",
+			podCIDR:     "10.52.0.0/16",
+			svcCIDR:     "10.53.0.0/16,fd53::/112",
+			wantErr:     true,
+			errContains: "service CIDR is dual-stack but pod CIDR is single-stack",
+		},
+		{
+			name:        "overlapping IPv4 CIDRs are rejected",
+			podCIDR:     "10.52.0.0/16",
+			svcCIDR:     "10.52.0.0/24",
+			wantErr:     true,
+			errContains: "must not overlap",
+		},
+		{
+			name:        "overlapping IPv6 CIDRs in dual-stack are rejected",
+			podCIDR:     "10.52.0.0/16,fd52::/56",
+			svcCIDR:     "10.53.0.0/16,fd52::/64",
+			wantErr:     true,
+			errContains: "must not overlap",
+		},
+		// Large-pool cases: validate no integer overflow in overlap detection.
+		{
+			name:    "non-overlapping IPv4 /1 halves of the address space",
+			podCIDR: "0.0.0.0/1",
+			svcCIDR: "128.0.0.0/1",
+			wantErr: false,
+		},
+		{
+			name:        "overlapping huge IPv4 /1 and /2 are rejected",
+			podCIDR:     "0.0.0.0/1",
+			svcCIDR:     "0.0.0.0/2",
+			wantErr:     true,
+			errContains: "must not overlap",
+		},
+		{
+			name:    "non-overlapping dual-stack /1 halves of both address spaces",
+			podCIDR: "0.0.0.0/1,::/1",
+			svcCIDR: "128.0.0.0/1,8000::/1",
+			wantErr: false,
+		},
+		{
+			name:        "overlapping huge dual-stack /1 and /2 IPv6 are rejected",
+			podCIDR:     "0.0.0.0/1,::/1",
+			svcCIDR:     "128.0.0.0/1,::/2",
+			wantErr:     true,
+			errContains: "must not overlap",
+		},
+		{
+			name:        "entire IPv4 /0 and entire IPv6 /0 dual-stack do not overlap each other",
+			podCIDR:     "0.0.0.0/0,::/0",
+			svcCIDR:     "0.0.0.0/0,::/0",
+			wantErr:     true,
+			errContains: "must not overlap",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCIDRConsistency(tc.podCIDR, tc.svcCIDR)
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateDNSIP(t *testing.T) {
+	tests := []struct {
+		name        string
+		ip          string
+		serviceCIDR string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "both empty is allowed",
+			wantErr: false,
+		},
+		{
+			name:        "empty DNS with valid service CIDR is allowed (defaults used)",
+			serviceCIDR: "10.53.0.0/16",
+			wantErr:     false,
+		},
+		{
+			name:        "valid IPv4 DNS within service CIDR",
+			ip:          "10.53.0.10",
+			serviceCIDR: "10.53.0.0/16",
+			wantErr:     false,
+		},
+		{
+			name:        "valid dual-stack DNS within dual-stack service CIDR",
+			ip:          "10.53.0.10,fd53::a",
+			serviceCIDR: "10.53.0.0/16,fd53::/112",
+			wantErr:     false,
+		},
+		{
+			name:        "single IPv6 DNS is rejected",
+			ip:          "fd53::a",
+			serviceCIDR: "fd53::/112",
+			wantErr:     true,
+			errContains: "a single DNS IP must be IPv4",
+		},
+		{
+			name:        "DNS not in service CIDR is rejected",
+			ip:          "10.54.0.10",
+			serviceCIDR: "10.53.0.0/16",
+			wantErr:     true,
+			errContains: "is not in the service CIDR",
+		},
+		{
+			name:        "DNS is the network address of service CIDR",
+			ip:          "10.53.0.0",
+			serviceCIDR: "10.53.0.0/16",
+			wantErr:     true,
+			errContains: "is the network address",
+		},
+		{
+			name:        "three DNS IPs are rejected",
+			ip:          "10.53.0.10,fd53::a,10.53.0.11",
+			serviceCIDR: "10.53.0.0/16",
+			wantErr:     true,
+			errContains: "at most two DNS IPs",
+		},
+		{
+			name:        "dual-stack DNS in IPv6-first order is rejected",
+			ip:          "fd53::a,10.53.0.10",
+			serviceCIDR: "10.53.0.0/16,fd53::/112",
+			wantErr:     true,
+			errContains: "IPv4-first order",
+		},
+		{
+			name:        "IPv4 DNS with no matching service CIDR family",
+			ip:          "10.53.0.10",
+			serviceCIDR: "fd53::/112",
+			wantErr:     true,
+			errContains: "no matching service CIDR",
+		},
+		{
+			name:        "invalid DNS IP string is rejected",
+			ip:          "not-an-ip",
+			serviceCIDR: "10.53.0.0/16",
+			wantErr:     true,
+		},
+		// Large-pool cases: validate no integer overflow in membership check.
+		{
+			name:        "IPv4 DNS within a /1 service pool",
+			ip:          "1.2.3.4",
+			serviceCIDR: "0.0.0.0/1",
+			wantErr:     false,
+		},
+		{
+			name:        "IPv4 DNS outside a /1 service pool",
+			ip:          "200.0.0.1",
+			serviceCIDR: "0.0.0.0/1",
+			wantErr:     true,
+			errContains: "is not in the service CIDR",
+		},
+		{
+			name:        "network address of a /1 pool is rejected",
+			ip:          "0.0.0.0",
+			serviceCIDR: "0.0.0.0/1",
+			wantErr:     true,
+			errContains: "is the network address",
+		},
+		{
+			name:        "dual-stack DNS within /1 pools for both families",
+			ip:          "1.2.3.4,::1",
+			serviceCIDR: "0.0.0.0/1,::/1",
+			wantErr:     false,
+		},
+		{
+			name:        "IPv6 network address of /1 pool is rejected",
+			ip:          "1.2.3.4,::",
+			serviceCIDR: "0.0.0.0/1,::/1",
+			wantErr:     true,
+			errContains: "is the network address",
+		},
+		{
+			name:        "IPv4 DNS within a /0 entire-space service pool",
+			ip:          "192.168.1.1",
+			serviceCIDR: "0.0.0.0/0",
+			wantErr:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateDNSIP(tc.ip, tc.serviceCIDR)
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateCIDRMatchesIPFamilies(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidr        string
+		ipv6Enabled bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "empty CIDR is always allowed (IPv4-only mode)",
+			cidr:        "",
+			ipv6Enabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "empty CIDR is always allowed (dual-stack mode)",
+			cidr:        "",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "IPv4-only mode accepts single IPv4 CIDR",
+			cidr:        "10.52.0.0/16",
+			ipv6Enabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "dual-stack mode accepts dual-stack CIDR",
+			cidr:        "10.52.0.0/16,fd52::/56",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "IPv4-only mode rejects dual-stack CIDR",
+			cidr:        "10.52.0.0/16,fd52::/56",
+			ipv6Enabled: false,
+			wantErr:     true,
+			errContains: "IPv4-only mode requires a single IPv4 CIDR",
+		},
+		{
+			name:        "dual-stack mode rejects single CIDR",
+			cidr:        "10.52.0.0/16",
+			ipv6Enabled: true,
+			wantErr:     true,
+			errContains: "dual-stack mode (IPv4,IPv6) requires both an IPv4 and an IPv6 CIDR",
+		},
+		// Large-pool cases: family-check must not depend on prefix size.
+		{
+			name:        "IPv4-only mode accepts /1",
+			cidr:        "0.0.0.0/1",
+			ipv6Enabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "IPv4-only mode accepts /0",
+			cidr:        "0.0.0.0/0",
+			ipv6Enabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "dual-stack mode accepts /1 IPv4 and /1 IPv6",
+			cidr:        "0.0.0.0/1,::/1",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "dual-stack mode accepts /0 IPv4 and /0 IPv6",
+			cidr:        "0.0.0.0/0,::/0",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "dual-stack mode accepts /2 IPv4 and /2 IPv6",
+			cidr:        "0.0.0.0/2,::/2",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCIDRMatchesIPFamilies(tc.cidr, tc.ipv6Enabled)
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateDNSMatchesIPFamilies(t *testing.T) {
+	tests := []struct {
+		name        string
+		dns         string
+		ipv6Enabled bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "empty DNS is always allowed (IPv4-only mode)",
+			dns:         "",
+			ipv6Enabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "empty DNS is always allowed (dual-stack mode)",
+			dns:         "",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "IPv4-only mode accepts single IPv4 DNS",
+			dns:         "10.53.0.10",
+			ipv6Enabled: false,
+			wantErr:     false,
+		},
+		{
+			name:        "dual-stack mode accepts single IPv4 DNS",
+			dns:         "10.53.0.10",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "dual-stack mode accepts IPv4+IPv6 DNS pair",
+			dns:         "10.53.0.10,fd53::a",
+			ipv6Enabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "IPv4-only mode rejects dual DNS pair",
+			dns:         "10.53.0.10,fd53::a",
+			ipv6Enabled: false,
+			wantErr:     true,
+			errContains: "IPv4-only mode requires a single IPv4 DNS address",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateDNSMatchesIPFamilies(tc.dns, tc.ipv6Enabled)
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding dual stack IPv4 Family First config to installer including the following:
* extend CIDR/DNS validators in the install pannel for dual stack support
* show warning that the feature is experimental when dual stack is configured
* extending the note to menton the support
* configure sysctl to enale or disable IPv6 depending on the config; no longer unconditional
* configure networkamanager profile with ipv6 if dual stack is enabled
* fix converttocos test by adding the condition on which it's enabled
* add panel to enable IPv6 when node is joining - default is disabled/no

#### Problem:
You could not have harvester node through installer to enable dual stack config

#### Solution:
Add panel to installer for when harvester is created and when nodes join a cluster to configure dual stack 

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10796

#### Test plan:

UX tests:
1. Installer shows no warning when config is ipv4 only; only note present dual stack is configurable and possible on both join and create
2. Installer warns and prompts enter when dual stack is configured
3. Installer rejects dual stack configs with IPv6 family first or IPv6 only
4. Installer rejects bad IPv6 values
5. Fields are cross validated (cidr coincide, dns not in range)
6. Dual Stack harvester config on non ipv6 capable network fails

Functional Tests:
1. IPv4 only does not configure IPv6; only kernel level ipv6 enabled is accepted
2. Dual stack config enables IPv6 across the stack:
2.1 on host level - kernel, networkmanager bridges/vlan/interface
2.2 on application/rke2 level - dual stack preferred - IPv4,IPv6 only
3. Config file installation - non interactive is validating dual stack ipv4 first config (comma in the end is rejected, 3 values added etc)
4. Joining a node to the cluster in Dual Stack mode works and second node configures dual stack as well
5. Upgrade to version with installer does not accidentally enable ipv6 config on NM level
6. Config is saved across reboots for both IPv4 and Dual Stack

#### Test Results:

Set Up:

<details>
<summary>Virtual Network</summary>

In Connection details in Virtual Machine Manager you'd need Virtual Network with IPv4 and IPv6 ranges:
<img width="1665" height="981" alt="image" src="https://github.com/user-attachments/assets/0c0983cb-1299-4fe2-9ba5-232307d5206a" />

And just before beginning installation check custom config:
<img width="1276" height="870" alt="image" src="https://github.com/user-attachments/assets/f19a4f5c-3ac5-401d-99cd-cacf89cbbf73" />
pick NIC to be the network interface:
<img width="1626" height="1039" alt="image" src="https://github.com/user-attachments/assets/5e2b37ad-420d-4001-9182-0a9c819d7ced" />

Contents:

```
<network>
  <name>virbr4</name>
  <uuid>81d9e815-d918-4a9a-ba30-791e969e2de5</uuid>
  <forward mode="nat">
    <nat ipv6="yes">
      <port start="1024" end="65535"/>
    </nat>
  </forward>
  <bridge name="virbr4" stp="on" delay="0"/>
  <mac address="52:54:00:ce:ec:f7"/>
  <domain name="virbr4"/>
  <ip address="192.168.103.1" netmask="255.255.255.0">
    <dhcp>
      <range start="192.168.103.128" end="192.168.103.254"/>
    </dhcp>
  </ip>
  <ip family="ipv6" address="fd00:cafe:4::1" prefix="64">
    <dhcp>
      <range start="fd00:cafe:4::100" end="fd00:cafe:4::1ff"/>
    </dhcp>
  </ip>
</network>
```
</details>

<details>
<summary>Harvester Network Config</summary>

In the: `Configure cluster network`:
<img width="1279" height="436" alt="image" src="https://github.com/user-attachments/assets/38e7c5a1-cf5d-43f9-b9e9-264e3014e7b4" />

Following config works with the Virtual Network configured in above step (the `virbr4`):

| Field In Installer  |      Value      |
|----------|-------------|
|Pod CIDR|	10.52.0.0/16,fd42::/48|
|Service CIDR|	10.53.0.0/16,fd43::/112|
|Cluster DNS|	10.53.0.10 or 10.53.0.10,fd43::a|

Automatically configured depending on the `Network type` picked in `Configure network` panel:
<img width="1279" height="864" alt="image" src="https://github.com/user-attachments/assets/0b3c1a1b-d79b-4baf-8077-ebb4696c9739" />

</details>

UX tests: 

<details>
<summary>1. Installer shows no warning when config is ipv4 only; only note present dual stack is configurable and possible on both join and create</summary>
When IPv4 Is configured note is always present that dual stack is configurable:
<img width="1279" height="864" alt="image" src="https://github.com/user-attachments/assets/886d3204-3863-4d35-aa98-1b3fd9587b50" />
<img width="1279" height="864" alt="image" src="https://github.com/user-attachments/assets/5628b6c0-d7cf-40ae-a282-12afeb20697b" />

1st enter to continue - next without warning:
<img width="1276" height="863" alt="image" src="https://github.com/user-attachments/assets/1debe8f1-cdd2-4c92-a887-c59b0b9483a6" />

Final config:
<img width="1276" height="863" alt="image" src="https://github.com/user-attachments/assets/95c3b712-b48a-4411-a7d0-6ee525c4f275" />

And on join same:
<img width="1276" height="863" alt="image" src="https://github.com/user-attachments/assets/dd989369-34c5-4873-88cb-25e74751c8b2" />

After enter no warning:
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/5a4b6f21-7a51-4e0d-af9d-349c50b4eef7" />

</details>

<details>
<summary>2. Installer warns and prompts enter when dual stack is configured</summary>
Configure Dual Stack:
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/b2c8a905-1ec2-434b-9233-38a6a3f1e43f" />

After pressing 1st Enter:
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/3b1dffd9-1e3b-4187-a963-6bb32c0540e8" />

Second enter moves to next panel but first is checking assignment:
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/1d4182c1-c2f2-4653-bc19-c6230eecd79c" />

And the cluster network has preconfigured defaults on passing:
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/4aa59a0c-1037-4d5c-8791-8f5efcf0de81" />

Final proper config with Dual Stack IPv4 Family First enabled:
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/2cd64f26-ad35-42ca-b5d7-dcee2d18344e" />

</details>

<details>
<summary>3. Installer rejects dual stack configs with IPv6 family first or IPv6 only</summary>
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/0e4fd689-34bd-4a05-8316-78e288c97bc3" />
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/76b78681-a9bb-46d8-be5a-cad7642eb638" />
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/8151bc40-d3c1-49f1-9dec-242fee763a58" />


Dual Stack IPv6 Family first:
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/2e8de773-0fa9-4bf5-af9f-e5dc4617cac7" />
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/ab96e0b0-fb0e-48c2-997c-96743f8588cb" />
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/6cc3fca4-090c-4ecb-b300-1b92d3c8812d" />

</details>

<details>
<summary>4. Installer rejects bad IPv6 values</summary>
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/d4416731-4e7e-4ee7-bfe0-f1c53c9d41e5" />
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/f9625ac4-0c0f-465c-a172-9add4927d258" />
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/56d2fc60-7b92-4e21-8f86-8b6283baebe7" />
<img width="1281" height="868" alt="image" src="https://github.com/user-attachments/assets/6a6e253e-94cd-4288-8d6b-444cb69dbf1b" />
</details>

<details>
<summary>5. Fields are cross validated (cidr coincide, dns not in range)</summary>
Exact IPv4 CIDR Overlap:
<img width="1279" height="873" alt="image" src="https://github.com/user-attachments/assets/a626a86b-beec-4e64-ab26-edacc6d574ba" />
Exact IPv6 CIDR Overlap:
<img width="1279" height="873" alt="image" src="https://github.com/user-attachments/assets/6f51d83c-9aba-4264-9253-5559c8ce28db" />

Partial / Nested IPv4 Overlap:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/f0cf64bf-a0d3-4868-b2a0-3d0bf123809c" />
Partial / Nested IPv6 Overlap:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/b1f75328-795a-40b1-a1b5-9b70cbeb3f70" />

IPv4 DNS IP Outside Service CIDR:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/9cbf4157-5698-4e0c-af0b-17d9569eb693" />
IPv6 DNS IP Outside Service CIDR:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/1b5f1fd8-a39a-47b2-bb24-70c132d57bfc" />

DNS IPv4 Set Inside Pod CIDR:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/930a1e86-dc60-43bf-b207-24c4c4a2ceb4" />
DNS IPv6 Set Inside Pod CIDR:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/c50645ae-85a5-4d04-90ac-c3c69895a570" />

IPv4 Invalid Prefix Length Notation:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/7090926d-fdc0-459d-9838-aecfb7fe151a" />
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/2b624fc1-5690-4088-9dfe-5f7df486edb4" />

IPv6 Invalid Prefix Length Notation:
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/10205f40-76e0-4681-a30f-8afbc9d009a9" />
<img width="1273" height="866" alt="image" src="https://github.com/user-attachments/assets/42e8b680-189f-40e3-abfd-a7e72314b3cd" />

IPv4 DNS Assigned to Network/Base Address:
<img width="1281" height="867" alt="image" src="https://github.com/user-attachments/assets/50c0441b-57d5-4416-9d38-21d39976e215" />
IPv6 DNS Assigned to Network/Base Address:
<img width="1281" height="867" alt="image" src="https://github.com/user-attachments/assets/c6112693-6168-4262-9fbc-b09fb9359069" />

</details>

<details>
<summary>6. Dual Stack harvester config on non ipv6 capable network fails</summary>

On default network with ipv4 only capability:
<img width="1582" height="925" alt="image" src="https://github.com/user-attachments/assets/6c35fbd5-fef5-440e-81a4-40b5b86524cb" />

`node-1` is configured with it:
<img width="1582" height="925" alt="image" src="https://github.com/user-attachments/assets/d79c8e8a-7f25-4441-9da8-a57968f6853b" />

With this content:
```
<network>
  <name>default</name>
  <uuid>99fdf9cc-efcf-4114-8923-049a3a84416e</uuid>
  <forward mode="nat">
    <nat>
      <port start="1024" end="65535"/>
    </nat>
  </forward>
  <bridge name="virbr0" stp="on" delay="0"/>
  <mac address="52:54:00:35:ca:03"/>
  <ip address="192.168.122.1" netmask="255.255.255.0">
    <dhcp>
      <range start="192.168.122.2" end="192.168.122.254"/>
    </dhcp>
  </ip>
```

Network cannot acquire IPv6 address so mode fails:
<img width="1278" height="867" alt="image" src="https://github.com/user-attachments/assets/29543b94-2590-447c-9e8a-0df831b4d5d1" />

</network>

</details>

Functional Tests: 

<details>
<summary>1. IPv4 only does not configure IPv6; only kernel level ipv6 enabled is accepted</summary>

check: https://github.com/harvester/harvester-installer/pull/1315
</details>

<details>
<summary>2. Dual stack config enables IPv6 across the stack</summary>

Config:
<img width="1281" height="867" alt="image" src="https://github.com/user-attachments/assets/a40b6369-9ffe-4ead-951b-4ea132327ea5" />
Result:
<img width="1281" height="867" alt="image" src="https://github.com/user-attachments/assets/dedd26f6-71d9-4194-b5fc-5e253aed3a00" />

Test Results:
```
node-1:/home/rancher # # Kernel IPv6 must be enabled - all three = 0
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6 net.ipv6.conf.default.disable_ipv6 net.ipv6.conf.lo.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # cat /etc/sysctl.d/zz-harvester-enable-ipv6.conf
# Written by harvester-installer (dual-stack install)
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # # NetworkManager is method=auto
node-1:/home/rancher # grep -A5 '\[ipv6\]' /etc/NetworkManager/system-connections/bridge-mgmt.nmconnection
[ipv6]
method=auto
addr-gen-mode=stable-privacy
ip6-privacy=0
node-1:/home/rancher # nmcli -f connection.id,ipv6.method con show bridge-mgmt bond-mgmt
connection.id:                          bridge-mgmt
ipv6.method:                            auto

connection.id:                          bond-mgmt
node-1:/home/rancher # # IPv6 addresses assigned on bridge
node-1:/home/rancher # ip -6 addr show dev mgmt-br scope global
3: mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    inet6 fd00:cafe:4::1dc/128 scope global dynamic noprefixroute 
       valid_lft 85951sec preferred_lft 85951sec
node-1:/home/rancher # ip addr show dev mgmt-br scope global
3: mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 52:54:00:1b:c9:fd brd ff:ff:ff:ff:ff:ff
    inet 192.168.103.226/24 brd 192.168.103.255 scope global dynamic noprefixroute mgmt-br
       valid_lft 3137sec preferred_lft 3137sec
    inet6 fd00:cafe:4::1dc/128 scope global dynamic noprefixroute 
       valid_lft 85938sec preferred_lft 85938sec
node-1:/home/rancher # ip  route show default
default via 192.168.103.1 dev mgmt-br proto dhcp src 192.168.103.226 metric 425 
node-1:/home/rancher # ip -6 route show default
default via fe80::5054:ff:fece:ecf7 dev mgmt-br proto ra metric 20425 pref medium
node-1:/home/rancher # # rke2 with dual stack config
node-1:/home/rancher # cat /etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml
cni: multus,canal
cluster-cidr: 10.52.0.0/16,fd52::/56
service-cidr: 10.53.0.0/16,fd53::/112
cluster-dns: 10.53.0.10,fd53::a
tls-san:
  - 192.168.103.251

kubelet-arg:
- "max-pods=200"
audit-policy-file: /etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
node-1:/home/rancher # kubectl get node -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.podCIDRs}{"\n"}{end}'
node-1  ["10.52.0.0/24","fd52::/64"]
node-1:/home/rancher # # services running with prefer dual stack has actually 2 Families
node-1:/home/rancher # kubectl get svc -A -o custom-columns="NAME:.metadata.name,POLICY:.spec.ipFamilyPolicy,FAMILIES:.spec.ipFamilies,IPS:.spec.clusterIPs"
NAME                                  POLICY            FAMILIES      IPS
capi-webhook-service                  SingleStack       [IPv4]        [10.53.204.195]
gitjob                                SingleStack       [IPv4]        [10.53.34.117]
monitoring-fleet-controller           SingleStack       [IPv4]        [10.53.42.37]
monitoring-gitjob                     SingleStack       [IPv4]        [10.53.56.205]
harvester-cluster-repo                SingleStack       [IPv4]        [10.53.160.229]
imperative-api-extension              SingleStack       [IPv4]        [10.53.247.136]
rancher                               SingleStack       [IPv4]        [10.53.12.124]
rancher-internal                      SingleStack       [IPv4]        [10.53.9.39]
rancher-webhook                       SingleStack       [IPv4]        [10.53.251.177]
kubernetes                            SingleStack       [IPv4]        [10.53.0.1]
cdi-api                               SingleStack       [IPv4]        [10.53.44.248]
cdi-prometheus-metrics                SingleStack       [IPv4]        [10.53.199.214]
cdi-uploadproxy                       SingleStack       [IPv4]        [10.53.178.134]
harvester                             SingleStack       [IPv4]        [10.53.131.65]
harvester-load-balancer-webhook       SingleStack       [IPv4]        [10.53.78.211]
harvester-network-webhook             SingleStack       [IPv4]        [10.53.200.136]
harvester-node-disk-manager-webhook   SingleStack       [IPv4]        [10.53.142.28]
harvester-node-manager-webhook        SingleStack       [IPv4]        [10.53.212.102]
harvester-webhook                     SingleStack       [IPv4]        [10.53.88.108]
kubevirt-operator-webhook             SingleStack       [IPv4]        [10.53.114.120]
kubevirt-prometheus-metrics           SingleStack       [IPv4]        [None]
virt-api                              SingleStack       [IPv4]        [10.53.21.15]
virt-exportproxy                      SingleStack       [IPv4]        [10.53.53.53]
rke2-coredns-rke2-coredns             PreferDualStack   [IPv4 IPv6]   [10.53.0.10 fd53::a]
rke2-metrics-server                   PreferDualStack   [IPv4 IPv6]   [10.53.119.74 fd53::3b1d]
rke2-traefik                          PreferDualStack   [IPv4 IPv6]   [10.53.65.137 fd53::63d7]
longhorn-admission-webhook            SingleStack       [IPv4]        [10.53.141.167]
longhorn-backend                      SingleStack       [IPv4]        [10.53.144.159]
longhorn-frontend                     SingleStack       [IPv4]        [10.53.80.133]
longhorn-recovery-backend             SingleStack       [IPv4]        [10.53.39.152]
node-1:/home/rancher # kubectl get svc kubernetes -o jsonpath='{.spec.clusterIPs}{"\n"}{.spec.ipFamilies}{"\n"}'
["10.53.0.1"]
["IPv4"]
node-1:/home/rancher # # actual dns tests to show both IPv4 and IPv6 DNS work from inside a pod
node-1:/home/rancher # kubectl run dnstest --image=busybox --restart=Never --rm -it -- nslookup kubernetes.default 10.53.0.10
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
Server:         10.53.0.10
Address:        10.53.0.10:53

** server can't find kubernetes.default: NXDOMAIN

** server can't find kubernetes.default: NXDOMAIN

Session ended, resume using 'kubectl attach dnstest -c dnstest -n default -i -t' command
pod "dnstest" deleted from default namespace
pod default/dnstest terminated (Error)
node-1:/home/rancher # kubectl run dnstest --image=busybox --restart=Never --rm -it -- nslookup kubernetes.default fd53::a
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
Session ended, resume using 'kubectl attach dnstest -c dnstest -n default -i -t' command
pod "dnstest" deleted from default namespace
pod default/dnstest terminated (Error)
node-1:/home/rancher # kubectl run dnstest --image=busybox --restart=Never --rm -it -- nslookup kubernetes.default fd53::a
Server:         fd53::a
Address:        [fd53::a]:53

** server can't find kubernetes.default: NXDOMAIN

** server can't find kubernetes.default: NXDOMAIN

All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
warning: couldn't attach to pod/dnstest, falling back to streaming logs: unable to upgrade connection: container dnstest not found in pod dnstest_default
Server:         fd53::a
Address:        [fd53::a]:53

** server can't find kubernetes.default: NXDOMAIN

** server can't find kubernetes.default: NXDOMAIN

pod "dnstest" deleted from default namespace
pod default/dnstest terminated (Error)
node-1:/home/rancher # kubectl run iptest --image=busybox --restart=Never -- sleep 3600
pod/iptest created
node-1:/home/rancher # kubectl get pod iptest -o jsonpath='{.status.podIPs}{"\n"}'
[{"ip":"10.52.0.89"},{"ip":"fd52::59"}]
node-1:/home/rancher # kubectl delete pod iptest
pod "iptest" deleted from default namespace
node-1:/home/rancher # # test actual pod communication over IPv6 inside kubernetes on the harvester node
node-1:/home/rancher # kubectl run pod-a --image=busybox --restart=Never -- sleep 3600
pod/pod-a created
node-1:/home/rancher # kubectl run pod-b --image=busybox --restart=Never -- sleep 3600
pod/pod-b created
node-1:/home/rancher # kubectl wait pod pod-a pod-b --for=condition=Ready --timeout=60s
pod/pod-a condition met
pod/pod-b condition met
node-1:/home/rancher # kubectl get pod pod-a -o jsonpath='{.status.podIPs}{"\n"}'
[{"ip":"10.52.0.90"},{"ip":"fd52::5a"}]
node-1:/home/rancher # kubectl get pod pod-b -o jsonpath='{.status.podIPs}{"\n"}'
[{"ip":"10.52.0.91"},{"ip":"fd52::5b"}]
node-1:/home/rancher # kubectl exec pod-a -- ping -6 -c3 "fd52::5b"
PING fd52::5b (fd52::5b): 56 data bytes
64 bytes from fd52::5b: seq=0 ttl=63 time=0.193 ms
64 bytes from fd52::5b: seq=1 ttl=63 time=0.490 ms
64 bytes from fd52::5b: seq=2 ttl=63 time=0.217 ms

--- fd52::5b ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.193/0.300/0.490 ms
node-1:/home/rancher # kubectl exec pod-a -- ping -c3 "10.52.0.91"
PING 10.52.0.91 (10.52.0.91): 56 data bytes
64 bytes from 10.52.0.91: seq=0 ttl=63 time=0.105 ms
64 bytes from 10.52.0.91: seq=1 ttl=63 time=0.083 ms
64 bytes from 10.52.0.91: seq=2 ttl=63 time=0.055 ms

--- 10.52.0.91 ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.055/0.081/0.105 ms
node-1:/home/rancher # # DNS Resolution works from inside the pods
node-1:/home/rancher # kubectl exec pod-a -- nslookup kubernetes fd53::a
Server:         fd53::a
Address:        [fd53::a]:53

** server can't find kubernetes: NXDOMAIN

** server can't find kubernetes: NXDOMAIN

command terminated with exit code 1
node-1:/home/rancher # kubectl delete pods pod-a pod-b
pod "pod-a" deleted from default namespace
pod "pod-b" deleted from default namespace
node-1:/home/rancher # 

```

</details>

> Note: kubernetes service itself is single stack IPv4 even when RKE2 is configured dual stack because this is the default behavior - described in last step in non goals in the [Dual Stack k8s KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/563-dual-stack#non-goals) stating:
Enable Kubernetes api-server dual-stack addresses listening and binding. **Additionally enable dual-stack for Kubernetes default service.**

<details>
<summary>3. Config file installation - non interactive is validating dual stack ipv4 first config (comma in the end is rejected, 3 values added etc)</summary>
TBD
</details>

<details>
<summary>4. Joining a node to the cluster in Dual Stack mode works and second node configures dual stack as well</summary>

Config of `node-1` is in test above and config of `node-2` is:
<img width="1281" height="867" alt="image" src="https://github.com/user-attachments/assets/1c61504e-2f05-4b39-aaa9-94ca38e8a067" />

Eventually cluster reports Ready on most [recent commit](https://github.com/harvester/harvester/commit/2b14926b94101a98eb9c6d651a16ae6e543b2f78):
<img width="2560" height="1221" alt="image" src="https://github.com/user-attachments/assets/7016df0a-f353-410f-b709-836ea31d0988" />


On `node-2` ipv6 is enabled on kernel level and has ipv6 address on mgmt interface and both families are present:
```
node-2:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6 net.ipv6.conf.default.disable_ipv6 net.ipv6.conf.lo.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
node-2:/home/rancher # ip -6 addr show mgmt-br
3: mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    inet6 fd00:cafe:4::17e/128 scope global dynamic noprefixroute 
       valid_lft 86274sec preferred_lft 86274sec
    inet6 fe80::2ab9:d473:3a9:7803/64 scope link noprefixroute 
       valid_lft forever preferred_lft forever
node-2:/home/rancher # ip addr show mgmt-br
3: mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 52:54:00:f5:b1:75 brd ff:ff:ff:ff:ff:ff
    inet 192.168.103.141/24 brd 192.168.103.255 scope global dynamic noprefixroute mgmt-br
       valid_lft 3467sec preferred_lft 3467sec
    inet6 fd00:cafe:4::17e/128 scope global dynamic noprefixroute 
       valid_lft 86269sec preferred_lft 86269sec
    inet6 fe80::2ab9:d473:3a9:7803/64 scope link noprefixroute 
       valid_lft forever prefer
```

On `node-1`, `node-2` shows with second IP and the machine and node are both ready:
```
node-1:/home/rancher # kubectl get node node-2 -o jsonpath='{.status.addresses}' | jq '.[]'
{
  "address": "192.168.103.141",
  "type": "InternalIP"
}
{
  "address": "fd00:cafe:4::17e",
  "type": "InternalIP"
}
{
  "address": "node-2",
  "type": "Hostname"
}
node-1:/home/rancher # kubectl get machines -n fleet-local
NAME                  CLUSTER   NODE NAME   FAILURE DOMAIN   READY   AVAILABLE   UP-TO-DATE   PHASE     AGE     VERSION
custom-409755146cf4   local     node-2                       True    True                     Running   3m53s   
custom-c8119804380f   local     node-1                       True    True                     Running   26m     
node-1:/home/rancher # kubectl get nodes -o wide
NAME     STATUS   ROLES                AGE     VERSION          INTERNAL-IP       EXTERNAL-IP   OS-IMAGE                   KERNEL-VERSION                     CONTAINER-RUNTIME
node-1   Ready    control-plane,etcd   28m     v1.36.3+rke2r1   192.168.103.226   <none>        Harvester a740216e-dirty   6.12.0-160000.36-default (amd64)   containerd://2.3.3-k3s1
node-2   Ready    <none>               3m50s   v1.36.3+rke2r1   192.168.103.141   <none>        Harvester a740216e-dirty   6.12.0-160000.36-default (amd64)   containerd://2.3.3-k3s1
node-1:/home/rancher #
```
</details>


<details>
<summary>5.Upgrade to version with installer does not accidentally enable ipv6 config on NM level</summary>
TBD
</details>

<details>
<summary>6. Config is saved across reboots for both IPv4 and Dual Stack</summary>
TBD
</details>

Working results can be seen in the original PR: https://github.com/harvester/harvester-installer/pull/1315

#### Additional documentation or context

Original installer PR reopened here: https://github.com/harvester/harvester-installer/pull/1315
Dual Stack IPv4 Family First HEP: https://github.com/harvester/harvester/blob/master/enhancements/20260528-dual-stack-ipv4-first.md
