### PR TITLE
fix: relax checks of UPGRADE_PREVIOUS_VERSION upgrading from v1.8

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1631,7 +1631,7 @@ EOF
 # configured properly to prevent TLS certificate flapping
 # https://github.com/harvester/harvester/issues/11338
 apply_tls_internal_cn_allowed_services_setting() {
-  if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.8\.[0-9]$ ]]; then
+  if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.8[.-][a-zA-Z0-9.-]+$ ]]; then
     echo "Skip set tls-internal-cn-allowed-services if you are not upgrade from v1.8.x, current version: $UPGRADE_PREVIOUS_VERSION"
     return
   fi
@@ -1657,7 +1657,7 @@ EOF
 # system-agent-upgrader can complete successfully.
 # https://github.com/harvester/harvester/issues/11336
 annotate_management_cluster_provisioning_administrated() {
-  if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.8\.[0-9]$ ]]; then
+  if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.8[.-][a-zA-Z0-9.-]+$ ]]; then
     echo "Skip patch management cluster provisioning administrated if you are not upgrade from v1.8.x, current version: $UPGRADE_PREVIOUS_VERSION"
     return
   fi


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

To address https://github.com/harvester/harvester/issues/11336, https://github.com/harvester/harvester/issues/11338, the fixes are in `upgrade_manifests.sh` that are guarded by `UPGRADE_PREVIOUS_VERSION` checks. It's too strict, skipping proper fixes for versions like `v1.8.2-rc1` and `v1.8-6c76c552-head`.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Relax the check of `UPGRADE_PREVIOUS_VERSION`

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11336
https://github.com/harvester/harvester/issues/11338

#### Test plan:
<!-- Describe the test plan by steps. -->

upgrade from v1.8-head or v1.8.2-rc1

#### Additional documentation or context

```
❯ cat /tmp/a.sh
check_if_version_match () {
        if [[ "$1" =~ ^v1\.8[.-][a-zA-Z0-9.-]+$ ]]; then

                echo "[o] $1 does match"
        else
                echo "[x] $1 doesn't match"
        fi
}

check_if_version_match v1.8.0
check_if_version_match v1.8.2
check_if_version_match v1.8.2-rc2
check_if_version_match v1.8.2-hotfix-xxx
check_if_version_match v1.8-6c76c552-head
check_if_version_match v1.9.0

❯ bash /tmp/a.sh
[o] v1.8.0 does match
[o] v1.8.2 does match
[o] v1.8.2-rc2 does match
[o] v1.8.2-hotfix-xxx does match
[o] v1.8-6c76c552-head does match
[x] v1.9.0 doesn't match
```
