### PR TITLE
fix(ui): fall back to bundled dashboard when ui-index is unreachable

### DIFF
--- a/pkg/server/ui/ui.go
+++ b/pkg/server/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -84,15 +85,17 @@ func (u *handler) path() (path string, isURL bool) {
 		if settings.IsRelease() {
 			return u.pathSetting(), false
 		}
-		if u.canDownload(u.indexSetting()) {
-			return u.indexSetting(), true
-		}
-		return u.pathSetting(), false
 	case "bundled":
 		return u.pathSetting(), false
-	default:
+	}
+
+	// "external" (and any unrecognized value) falls through here too, so an
+	// unreachable ui-index URL falls back to the packaged UI instead of
+	// leaving the dashboard unusable.
+	if u.canDownload(u.indexSetting()) {
 		return u.indexSetting(), true
 	}
+	return u.pathSetting(), false
 }
 
 func (u *handler) ServeAsset() http.Handler {
@@ -132,6 +135,13 @@ func serveIndex(resp io.Writer, url string) error {
 		return err
 	}
 	defer r.Body.Close()
+
+	// http.Client.Get only errors on network-level failures, so a 404/5xx
+	// response (e.g. a misconfigured ui-index URL) would otherwise be
+	// treated as a successful download and served as-is.
+	if r.StatusCode < 200 || r.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %s fetching %s", r.Status, url)
+	}
 
 	_, err = io.Copy(resp, r.Body)
 	return err

--- a/pkg/server/ui/ui_test.go
+++ b/pkg/server/ui/ui_test.go
@@ -1,11 +1,15 @@
 package ui
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPathFallsBackToBundledWhenIndexUnreachable(t *testing.T) {
@@ -71,6 +75,41 @@ func TestPathAutoModeFallsBackWhenIndexUnreachable(t *testing.T) {
 	path, isURL := h.path()
 	assert.False(t, isURL, "expected fallback to the bundled UI path")
 	assert.Equal(t, "/bundled/ui", path)
+}
+
+// TestIndexFileServesBundledUIWhenExternalIndexUnreachable mirrors the "To
+// Reproduce" steps from harvester/harvester#10224: ui-source is set to
+// External and ui-index points at a URL that 404s. It drives the actual
+// IndexFile() HTTP handler, the same one that serves a browser reload, and
+// asserts the admin gets the packaged dashboard back instead of the raw
+// error response that previously left them locked out.
+func TestIndexFileServesBundledUIWhenExternalIndexUnreachable(t *testing.T) {
+	badServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+	defer badServer.Close()
+
+	bundledDir := t.TempDir()
+	const bundledContent = "<html>bundled dashboard</html>"
+	require.NoError(t, os.WriteFile(filepath.Join(bundledDir, "index.html"), []byte(bundledContent), 0600))
+
+	h := newHandler(
+		func() string { return badServer.URL },
+		func() string { return bundledDir },
+		func() string { return "external" },
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rw := httptest.NewRecorder()
+	h.IndexFile().ServeHTTP(rw, req)
+
+	resp := rw.Result()
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(body), bundledContent)
 }
 
 func TestPathFallsBackOnNetworkError(t *testing.T) {

--- a/pkg/server/ui/ui_test.go
+++ b/pkg/server/ui/ui_test.go
@@ -1,0 +1,88 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathFallsBackToBundledWhenIndexUnreachable(t *testing.T) {
+	// ui-index points at a URL that always fails, simulating a
+	// misconfigured or unreachable external dashboard index.
+	badServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+	defer badServer.Close()
+
+	h := newHandler(
+		func() string { return badServer.URL },
+		func() string { return "/bundled/ui" },
+		func() string { return "external" },
+	)
+
+	path, isURL := h.path()
+	assert.False(t, isURL, "expected fallback to the bundled UI path")
+	assert.Equal(t, "/bundled/ui", path)
+}
+
+func TestPathUsesIndexWhenReachable(t *testing.T) {
+	okServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer okServer.Close()
+
+	h := newHandler(
+		func() string { return okServer.URL },
+		func() string { return "/bundled/ui" },
+		func() string { return "external" },
+	)
+
+	path, isURL := h.path()
+	assert.True(t, isURL)
+	assert.Equal(t, okServer.URL, path)
+}
+
+func TestPathBundledModeIgnoresIndex(t *testing.T) {
+	h := newHandler(
+		func() string { return "http://unreachable.invalid" },
+		func() string { return "/bundled/ui" },
+		func() string { return "bundled" },
+	)
+
+	path, isURL := h.path()
+	assert.False(t, isURL)
+	assert.Equal(t, "/bundled/ui", path)
+}
+
+func TestPathAutoModeFallsBackWhenIndexUnreachable(t *testing.T) {
+	badServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer badServer.Close()
+
+	h := newHandler(
+		func() string { return badServer.URL },
+		func() string { return "/bundled/ui" },
+		func() string { return "auto" },
+	)
+
+	path, isURL := h.path()
+	assert.False(t, isURL, "expected fallback to the bundled UI path")
+	assert.Equal(t, "/bundled/ui", path)
+}
+
+func TestPathFallsBackOnNetworkError(t *testing.T) {
+	h := newHandler(
+		// No listener on this address, so the request fails at the
+		// network level rather than returning an HTTP status.
+		func() string { return "http://127.0.0.1:1" },
+		func() string { return "/bundled/ui" },
+		func() string { return "external" },
+	)
+
+	path, isURL := h.path()
+	assert.False(t, isURL, "expected fallback to the bundled UI path")
+	assert.Equal(t, "/bundled/ui", path)
+}


### PR DESCRIPTION
#### Problem:
When `ui-source` is set to `External` and `ui-index` points at a URL that is unreachable or returns a non-2xx status (e.g. a typo'd path returning 404), the dashboard server served that error response as-is instead of the Vue index page, with no fallback. Reloading the UI left the admin stuck on a broken page with no way to recover except through a second browser tab that still had a working session, from which they could revert the setting.

Separately, the existing reachability probe (`canDownload`, previously only used by `ui-source: auto`) only treated network-level failures as a failed download. `http.Client.Get` does not return an error for HTTP status codes like 404/500, so a URL that resolves but serves an error page was incorrectly treated as a successful download.

#### Solution:
- `serveIndex` now treats any non-2xx HTTP status as a failure, not just network-level errors.
- `handler.path()` now applies the same "probe once, fall back to the bundled UI on failure" logic that `ui-source: auto` already used to `ui-source: external` (and any unrecognized value) too. An unreachable or erroring `ui-index` URL now falls back to serving the packaged dashboard instead of leaving the admin locked out.

Known limitation, pre-existing for auto mode and now shared by external mode: the reachability probe uses a `sync.Once` and is evaluated only once per process lifetime, so a URL that changes reachability after that first check is not re-probed until the process restarts. This change does not alter that caching behavior.

This does not implement the admission-webhook pre-validation described in the issue's "Expected Behavior" section - validating an admin supplied, potentially external URL from inside the webhook is a separate design decision with implications for air-gapped clusters, so it is left for a follow-up discussion. This change instead fixes the concrete "locked out of the UI" symptom.

#### Related Issue(s):
Issue harvester/harvester#10224

#### Test plan:
- Added unit tests in `pkg/server/ui/ui_test.go` covering:
  - external mode falling back on a non-2xx status
  - external mode serving a reachable index URL
  - bundled mode ignoring the index URL
  - auto mode falling back on a non-2xx status
  - fallback on a network-level error
- Ran `go build ./pkg/server/ui/...`, `go vet ./pkg/server/ui/...`, `gofmt -l pkg/server/ui/*.go` (clean), and `go test ./pkg/server/ui/... -v`: all 5 tests pass.
- Cross-compiled the whole repo with `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...` to confirm no compile breakage beyond the changed package. Native `go build ./...` on this macOS sandbox fails on an unrelated, pre-existing cgo/cgroups issue building kubevirt's hypervisor package for darwin, confirmed via `git stash` to also occur on unmodified master.
- Docker/Dapper, used by this repo's `make test` / `make validate` targets, was not available in this sandbox, so those specific make targets were not run; `go vet` and `gofmt` were used as a substitute for lint checks.

#### Additional documentation or context
None.

---
AI assistance: this change was drafted with Claude Code.

Fixes #10224