### PR TITLE
fix: honor explicit VM resource requests in mutating webhook

### DIFF
--- a/pkg/webhook/resources/virtualmachine/mutator.go
+++ b/pkg/webhook/resources/virtualmachine/mutator.go
@@ -80,7 +80,7 @@ func (m *vmMutator) Create(request *types.Request, newObj runtime.Object) (types
 
 	logrus.Debugf("create VM %s/%s", vm.Namespace, vm.Name)
 
-	patchOps, err := m.patchResourceOvercommit(vm)
+	patchOps, err := m.patchResourceOvercommit(nil, vm)
 	if err != nil {
 		return patchOps, err
 	}
@@ -129,7 +129,7 @@ func (m *vmMutator) Update(request *types.Request, oldObj runtime.Object, newObj
 	var err error
 
 	if needUpdateResourceOvercommit(oldVM, newVM) {
-		patchOps, err = m.patchResourceOvercommit(newVM)
+		patchOps, err = m.patchResourceOvercommit(oldVM, newVM)
 	}
 	if err != nil {
 		return patchOps, err
@@ -237,12 +237,26 @@ func needUpdateResourceOvercommit(oldVM, newVM *kubevirtv1.VirtualMachine) bool 
 	return hostDevicesOvercommitNeeded(oldVM, newVM)
 }
 
-func (m *vmMutator) patchResourceOvercommit(vm *kubevirtv1.VirtualMachine) ([]string, error) {
+// oldVM is the previously admitted object (nil on Create). It is used to tell a
+// request the caller just changed apart from one that merely carries over a value
+// this mutator computed on a prior admission, so overcommit can keep recomputing
+// requests that are still mutator-owned while never clobbering one the caller set.
+func (m *vmMutator) patchResourceOvercommit(oldVM, vm *kubevirtv1.VirtualMachine) ([]string, error) {
 	var patchOps types.PatchOps
 	limits := vm.Spec.Template.Spec.Domain.Resources.Limits
 	cpu := limits.Cpu()
 	mem := limits.Memory()
-	requestsMissing := len(vm.Spec.Template.Spec.Domain.Resources.Requests) == 0
+	requests := vm.Spec.Template.Spec.Domain.Resources.Requests
+	requestsMissing := len(requests) == 0
+	var oldRequests v1.ResourceList
+	if oldVM != nil {
+		oldRequests = oldVM.Spec.Template.Spec.Domain.Resources.Requests
+	}
+	// honor a request the caller explicitly set or changed; if it is unchanged from
+	// the previously admitted object (or there is none, i.e. Create), it is still
+	// mutator-owned and safe to keep recomputing from limits/overcommit as before
+	cpuRequestSet := !requests.Cpu().IsZero() && (oldVM == nil || !requests.Cpu().Equal(*oldRequests.Cpu()))
+	memRequestSet := !requests.Memory().IsZero() && (oldVM == nil || !requests.Memory().Equal(*oldRequests.Memory()))
 	requestsToMutate := v1.ResourceList{}
 	overcommit, err := m.getOvercommit()
 	if err != nil || overcommit == nil {
@@ -258,7 +272,7 @@ func (m *vmMutator) patchResourceOvercommit(vm *kubevirtv1.VirtualMachine) ([]st
 		err = nil
 	}
 
-	if !cpu.IsZero() {
+	if !cpu.IsZero() && !cpuRequestSet {
 		var newRequest int64
 		if isDedicatedCPU(vm) {
 			// do not apply overcommitted resource since dedicated CPU requires guaranteed QoS
@@ -280,7 +294,7 @@ func (m *vmMutator) patchResourceOvercommit(vm *kubevirtv1.VirtualMachine) ([]st
 			return patchOps, err
 		}
 
-		memPatch, err := generateMemoryPatch(vm, mem, overcommit, agmorc, requestsMissing, requestsToMutate, isARM)
+		memPatch, err := generateMemoryPatch(vm, mem, overcommit, agmorc, requestsMissing, memRequestSet, requestsToMutate, isARM)
 		if err != nil {
 			return patchOps, err
 		}
@@ -302,6 +316,7 @@ func generateMemoryPatch(
 	overcommit *settings.Overcommit,
 	agmorc *settings.AdditionalGuestMemoryOverheadRatioConfig,
 	requestsMissing bool,
+	memRequestSet bool,
 	requestsToMutate v1.ResourceList,
 	isARM bool,
 ) (types.PatchOps, error) {
@@ -373,10 +388,12 @@ func generateMemoryPatch(
 		guestMemory.DeepCopyInto(quantity)
 	}
 
-	if requestsMissing {
-		requestsToMutate[v1.ResourceMemory] = *quantity
-	} else {
-		patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "%s"}`, quantity))
+	if !memRequestSet {
+		if requestsMissing {
+			requestsToMutate[v1.ResourceMemory] = *quantity
+		} else {
+			patchOps = append(patchOps, fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/memory", "value": "%s"}`, quantity))
+		}
 	}
 
 	// patch guest memory

--- a/pkg/webhook/resources/virtualmachine/mutator_test.go
+++ b/pkg/webhook/resources/virtualmachine/mutator_test.go
@@ -218,6 +218,25 @@ func TestPatchResourceOvercommit(t *testing.T) {
 			setting: `{"cpu":1000,"memory":1000,"storage":800}`,
 		},
 		{
+			name: "explicit requests are honored and not overwritten by overcommit",
+			resourceReq: kubevirtv1.ResourceRequirements{
+				Limits: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(int64(math.Pow(2, 30)), resource.BinarySI), // 1Gi
+				},
+				Requests: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(int64(512<<20), resource.BinarySI), // 512Mi
+				},
+			},
+			memory: nil,
+			patchOps: []string{
+				`{"op": "replace", "path": "/spec/template/spec/domain/memory", "value": {"guest":"924Mi"}}`, // 1Gi - 100Mi
+				`{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`,
+			},
+			setting: "",
+		},
+		{
 			name: "replace old guest memory",
 			resourceReq: kubevirtv1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
@@ -386,7 +405,7 @@ func TestPatchResourceOvercommit(t *testing.T) {
 
 			vm := createTestVM(tc.resourceReq, tc.cpu, tc.memory, annotations, "", "", nil)
 
-			actual, err := mutator.(*vmMutator).patchResourceOvercommit(vm)
+			actual, err := mutator.(*vmMutator).patchResourceOvercommit(nil, vm)
 
 			if expectError {
 				assert.NotNil(t, err)
@@ -413,6 +432,64 @@ func TestPatchResourceOvercommit(t *testing.T) {
 	for _, tc := range tests4 {
 		runTestCase(tc, map[string]string{"harvesterhci.io/reservedMemory": "384Mi"}, true, "guest memory is under the minimum requirement")
 	}
+}
+
+// TestPatchResourceOvercommitOnUpdate covers the Update path, where the admitted
+// object's requests may simply be carrying over a value this mutator computed on a
+// prior admission rather than something the caller just set. It must keep recomputing
+// a carried-over request when limits change (matching pre-fix behavior), while still
+// honoring a request the caller actually changed in this admission.
+func TestPatchResourceOvercommitOnUpdate(t *testing.T) {
+	setting := &harvesterv1.Setting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "overcommit-config",
+		},
+		Default: `{"cpu":200,"memory":400,"storage":800}`,
+	}
+
+	newCPUVM := func(limitMilli, requestMilli int64) *kubevirtv1.VirtualMachine {
+		resourceReq := kubevirtv1.ResourceRequirements{
+			Limits: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: *resource.NewMilliQuantity(limitMilli, resource.DecimalSI),
+			},
+			Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: *resource.NewMilliQuantity(requestMilli, resource.DecimalSI),
+			},
+		}
+		return createTestVM(resourceReq, nil, nil, nil, "", "", nil)
+	}
+
+	t.Run("carried-over request is still recomputed when the limit shrinks", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(setting.DeepCopy())
+		assert.Nil(t, err)
+		createDefaultKubeVirt(clientset)
+		mutator := setupTestMutator(clientset)
+
+		oldVM := newCPUVM(2000, 1000) // limit 2000m, request 1000m (200% overcommit)
+		newVM := newCPUVM(500, 1000)  // limit lowered to 500m, request left untouched by the caller
+
+		actual, err := mutator.(*vmMutator).patchResourceOvercommit(oldVM, newVM)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{
+			`{"op": "replace", "path": "/spec/template/spec/domain/resources/requests/cpu", "value": "250m"}`,
+		}, actual)
+	})
+
+	t.Run("explicitly changed request is honored, not recomputed", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(setting.DeepCopy())
+		assert.Nil(t, err)
+		createDefaultKubeVirt(clientset)
+		mutator := setupTestMutator(clientset)
+
+		oldVM := newCPUVM(2000, 1000) // limit 2000m, request 1000m (200% overcommit)
+		newVM := newCPUVM(2000, 300)  // caller explicitly set a different request
+
+		actual, err := mutator.(*vmMutator).patchResourceOvercommit(oldVM, newVM)
+		assert.Nil(t, err)
+		assert.Equal(t, []string(nil), actual)
+	})
 }
 
 func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testing.T) {
@@ -580,7 +657,7 @@ func TestPatchResourceOvercommitWithAdditionalGuestMemoryOverheadRatio(t *testin
 			mutator := setupTestMutator(clientset)
 			vm := createTestVM(tc.resourceReq, nil, tc.memory, annotations, "", "", nil)
 
-			actual, err := mutator.(*vmMutator).patchResourceOvercommit(vm)
+			actual, err := mutator.(*vmMutator).patchResourceOvercommit(nil, vm)
 			assert.Nil(t, err, tc.name)
 			assert.Equal(t, tc.patchOps, actual)
 		})
@@ -647,7 +724,7 @@ func TestPatchResourceOvercommitWithDedicatedCPUPlacement(t *testing.T) {
 	assert.Nil(t, err)
 	createDefaultKubeVirt(clientset)
 	mutator := setupTestMutator(clientset)
-	actual, err := mutator.(*vmMutator).patchResourceOvercommit(vm)
+	actual, err := mutator.(*vmMutator).patchResourceOvercommit(nil, vm)
 	assert.Nil(t, err)
 	assert.Equal(t,
 		[]string{
@@ -750,7 +827,7 @@ func TestPatchResourceOvercommitWithARMArchitecture(t *testing.T) {
 				fakeclients.KubeVirtCache(clientset.KubevirtV1().KubeVirts),
 				fakeclients.KubeovnSubnetCache(clientset.KubeovnV1().Subnets))
 
-			actual, err := mutator.(*vmMutator).patchResourceOvercommit(vm)
+			actual, err := mutator.(*vmMutator).patchResourceOvercommit(nil, vm)
 			assert.Nil(t, err, tc.name)
 
 			hasMaxSocketsPatch := slices.Contains(actual, `{"op": "replace", "path": "/spec/template/spec/domain/cpu/maxSockets", "value": 1}`)


### PR DESCRIPTION
#### Problem:
When creating or updating a `VirtualMachine` via the API (manifest, Terraform, etc.) with explicit `.spec.template.spec.domain.resources.requests.cpu`/`.memory`, the VM mutating webhook silently overwrote those values with ones derived from `.limits` and the cluster's overcommit-ratio setting. The webhook always recomputed the request whenever the corresponding limit was non-zero, without checking whether the caller had already set an explicit request for that resource.

#### Solution:
`patchResourceOvercommit`/`generateMemoryPatch` in `pkg/webhook/resources/virtualmachine/mutator.go` now only auto-populate a resource's request from limits/overcommit when the caller did not explicitly set it in the current admission (checked independently for cpu and memory):
- On Create there is no prior object, so any non-zero request present in the incoming object is caller-provided and is left untouched.
- On Update, the admitted object typically still carries whatever value the webhook itself computed on a prior admission (client-side merges resubmit the full live object). Treating "value present" as "explicitly set" would therefore freeze a webhook-owned request forever, even across a later limit change, and could leave `requests` above a shrunken `limits`. To avoid that, `patchResourceOvercommit` now also takes the previous object (`nil` on Create) and only treats a request as caller-set on Update when it differs from the value that was live before; an unchanged request is still recomputed from the new limits/overcommit exactly as it was before this fix.

All other overcommit-driven mutations (guest memory sizing, `maxSockets`, dedicated-CPU/host-device handling) are unchanged, since they don't touch the `requests` field.

#### Related Issue(s):
Issue harvester/harvester#10149

#### Test plan:
1. `gofmt -l` on the two changed files — clean.
2. `GOOS=linux CGO_ENABLED=0 go build ./pkg/webhook/...` and `GOOS=linux CGO_ENABLED=0 go vet ./pkg/webhook/...` — both clean.
3. `GOOS=linux CGO_ENABLED=0 golangci-lint run ./pkg/webhook/resources/virtualmachine/...` — 0 issues.
4. Added unit tests in `pkg/webhook/resources/virtualmachine/mutator_test.go`:
   - A new `TestPatchResourceOvercommit` case, `"explicit requests are honored and not overwritten by overcommit"`, reproducing the reported Create-time scenario (explicit cpu/memory requests alongside limits) and asserting the requests are no longer overwritten.
   - A new `TestPatchResourceOvercommitOnUpdate` with two subtests covering the Update path: a request left unchanged by the caller is still recomputed when the limit shrinks (avoiding `requests > limits`), and a request the caller explicitly changed is honored.
5. Manual reproduction: this specific package's `go test` cannot run natively on the (darwin) machine used for this change — it transitively imports `kubevirt.io/kubevirt/pkg/hypervisor/kvm` -> `opencontainers/runc` cgroups/ebpf code with no darwin build support (confirmed pre-existing/unrelated to this change by reproducing the identical failure against unmodified `master`), and no Docker/Dapper was available locally to run the repository's documented containerized unit-test target. As a substitute, the exact pre-fix and post-fix logic (copied verbatim) was exercised with a real, executed `go test` run in a throwaway, non-repository Go module depending only on lightweight packages (`k8s.io/api`, `k8s.io/apimachinery`, `kubevirt.io/api`). That run reproduced the reported bug against the old logic and confirmed the fix, including the Update carry-over case, against the new logic. A reviewer with a working local/CI Go test environment for this repository should still run the in-tree tests above (`go test ./pkg/webhook/resources/virtualmachine/...`) to confirm.

#### Additional documentation or context
AI-assistance disclosure: this change (analysis, implementation, and the added tests) was produced with the help of an AI coding assistant (Claude/Claude Code), including two rounds of independent adversarial review of the diff before this PR was opened. The round-1 review caught a real regression risk in the first version of the fix (a naive "value present = explicitly set" check would have frozen webhook-computed requests across Update, potentially leaving `requests > limits` after a limit reduction); the `oldVM`-aware comparison in the final diff was added specifically to address that, and round 2 confirmed no remaining blockers.

---
AI assistance: this change was drafted with Claude Code.

Fixes #10149