### PR TITLE
fix: using the kubevirt_vmi_migration_memory_transfer_rate_bytes instead of kubevirt_vmi_migration_disk_transfer_rate_bytes

### DIFF
--- a/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
+++ b/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
@@ -1827,7 +1827,7 @@ resources:
                   "uid": "prometheus"
                 },
                 "editorMode": "code",
-                "expr": "kubevirt_vmi_migration_disk_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}",
+                "expr": "kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}",
                 "legendFormat": "memory transfer rate",
                 "range": true,
                 "refId": "A"


### PR DESCRIPTION

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
- current live migration metric is not correct due to the kubevirt has remove `kubevirt_vmi_migration_disk_transfer_rate_bytes`
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- update to kubevirt_vmi_migration_memory_transfer_rate_bytes
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/11390

#### Test plan:
<!-- Describe the test plan by steps. -->
#### Env
- Fresh install
- Upgrade from pre-v1.9.0
#### Steps
Follow the step here https://github.com/harvester/harvester-installer/pull/953
Ensure the all four charts has value.

#### Before fix
<img width="1889" height="591" alt="Screenshot 2026-08-13 at 1 50 03 PM" src="https://github.com/user-attachments/assets/4743c67d-a871-4729-b5f5-7e53e664bf4a" />

#### After Fix
<img width="1699" height="644" alt="Screenshot 2026-08-13 at 1 46 18 PM" src="https://github.com/user-attachments/assets/2169d701-c17c-46dd-a523-5f54d8d7fc7d" />

#### Additional documentation or context
