### PR TITLE
feat: add converge ration for vm migration

### DIFF
--- a/package/upgrade/migrations/upgrade_manifests/v1.10.0/pre-hook.sh
+++ b/package/upgrade/migrations/upgrade_manifests/v1.10.0/pre-hook.sh
@@ -1,0 +1,99 @@
+patch_harvester_vm_migration_details_dashboard() {
+  echo "Patch configmap/harvester-vm-migration-details-dashboard..."
+  local patch_json
+  patch_json=$(
+    kubectl get -n cattle-dashboards configmap harvester-vm-migration-details-dashboard -o json |
+      jq --argjson new_panel '{
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "description": "Convergence ratio: dirty_rate / transfer_rate. < 1: converging — ≥ 1: not converging, migration will abort. Shows -1 when transfer rate is zero (migration not yet active).",
+        "fieldConfig": {
+          "defaults": {
+            "color": {"mode": "palette-classic"},
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {"type": "linear"},
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {"group": "A", "mode": "none"},
+              "thresholdsStyle": {"mode": "line+area"},
+              "axisSoftMin": -1.5,
+              "axisSoftMax": 2
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"color": "grey",  "value": null},
+                {"color": "green", "value": 0},
+                {"color": "red",   "value": 1}
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+        "id": 12,
+        "options": {
+          "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false},
+          "tooltip": {"mode": "single", "sort": "none"}
+        },
+        "targets": [
+          {
+            "datasource": {"type": "prometheus", "uid": "prometheus"},
+            "editorMode": "code",
+            "expr": "(\n  (\n    kubevirt_vmi_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n    / kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n  )\n  and on(namespace, name) (\n    kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} > 0\n  )\n)\nor on(namespace, name) (\n  kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} == 0\n  * 0 + -1\n)",
+            "legendFormat": "dirty / transfer",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Dirty / Transfer Rate Ratio",
+        "type": "timeseries"
+      }' '
+        .data."harvester_vm_migration_details.json" | fromjson |
+        .panels |= (
+          map(
+            if .title == "Migration Memory Transfer Rate" then
+              .targets[0].expr = "kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}"
+            else
+              .
+            end
+          ) |
+          if map(.title) | index("Dirty / Transfer Rate Ratio") | not then
+            . + [$new_panel]
+          else
+            map(
+              if .title == "Dirty / Transfer Rate Ratio" then
+                $new_panel
+              else
+                .
+              end
+            )
+          end
+        )'
+  )
+  if [ -z "$patch_json" ]; then
+    echo "Something goes wrong, the patch json is empty... skip this patch"
+    return 0
+  fi
+  patch_json=$(echo '{"data":{"harvester_vm_migration_details.json": ""}}' |
+    jq --arg arg "$patch_json" '.data."harvester_vm_migration_details.json"=$arg')
+  kubectl patch -n cattle-dashboards configmap harvester-vm-migration-details-dashboard \
+    --type merge -p "$patch_json"
+}
+patch_harvester_vm_migration_details_dashboard

--- a/package/upgrade/migrations/upgrade_manifests/v1.9.0/pre-hook.sh
+++ b/package/upgrade/migrations/upgrade_manifests/v1.9.0/pre-hook.sh
@@ -47,7 +47,7 @@ patch_harvester_vm_migration_details_dashboard() {
           "overrides": []
         },
         "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
-        "id": 12,
+        "id": 10,
         "options": {
           "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false},
           "tooltip": {"mode": "single", "sort": "none"}
@@ -56,13 +56,13 @@ patch_harvester_vm_migration_details_dashboard() {
           {
             "datasource": {"type": "prometheus", "uid": "prometheus"},
             "editorMode": "code",
-            "expr": "(\n  (\n    kubevirt_vmi_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n    / kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n  )\n  and on(namespace, name) (\n    kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} > 0\n  )\n)\nor on(namespace, name) (\n  kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} == 0\n  * 0 + -1\n)",
+            "expr": "(\n  (\n    kubevirt_vmi_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n    / kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n  )\n  and on(namespace, name) (\n    kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} > 0\n  )\n)\nor on(namespace, name) (\n  (kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} == 0)\n  * 0 - 1\n)",
             "legendFormat": "dirty / transfer",
             "range": true,
             "refId": "A"
           }
         ],
-        "title": "Dirty / Transfer Rate Ratio",
+        "title": "Migration Memory Dirty vs Transfer Rate Ratio",
         "type": "timeseries"
       }' '
         .data."harvester_vm_migration_details.json" | fromjson |
@@ -74,16 +74,10 @@ patch_harvester_vm_migration_details_dashboard() {
               .
             end
           ) |
-          if map(.title) | index("Dirty / Transfer Rate Ratio") | not then
-            . + [$new_panel]
+          if map(.title) | index("Migration Memory Dirty vs Transfer Rate Ratio") | not then
+            . + [($new_panel | .id = 10)]
           else
-            map(
-              if .title == "Dirty / Transfer Rate Ratio" then
-                $new_panel
-              else
-                .
-              end
-            )
+            .
           end
         )'
   )
@@ -96,4 +90,3 @@ patch_harvester_vm_migration_details_dashboard() {
   kubectl patch -n cattle-dashboards configmap harvester-vm-migration-details-dashboard \
     --type merge -p "$patch_json"
 }
-patch_harvester_vm_migration_details_dashboard

--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -70,6 +70,9 @@ pre_upgrade_manifest() {
     echo "Executing ${UPGRADE_PREVIOUS_VERSION} pre-hook..."
     # Use source to pass current shell's variables to target script
     source "/usr/local/share/migrations/upgrade_manifests/${UPGRADE_PREVIOUS_VERSION}/pre-hook.sh"
+    if [[ "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.9\.[0-9]+$ ]]; then
+      patch_harvester_vm_migration_details_dashboard
+    fi
   fi
 
   # Safety Gate: Ensure rke2-multus helmchart failurePolicy is 'abort' before proceeding.

--- a/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
+++ b/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
@@ -1974,7 +1974,7 @@ resources:
               "overrides": []
             },
             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
-            "id": 12,
+            "id": 10,
             "options": {
               "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false},
               "tooltip": {"mode": "single", "sort": "none"}
@@ -1983,13 +1983,13 @@ resources:
               {
                 "datasource": {"type": "prometheus", "uid": "prometheus"},
                 "editorMode": "code",
-                "expr": "(\n  (\n    kubevirt_vmi_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n    / kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n  )\n  and on(namespace, name) (\n    kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} > 0\n  )\n)\nor on(namespace, name) (\n  kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} == 0\n  * 0 + -1\n)",
+                "expr": "(\n  (\n    kubevirt_vmi_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n    / kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n  )\n  and on(namespace, name) (\n    kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} > 0\n  )\n)\nor on(namespace, name) (\n  (kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} == 0)\n  * 0 - 1\n)",
                 "legendFormat": "dirty / transfer",
                 "range": true,
                 "refId": "A"
               }
             ],
-            "title": "Dirty / Transfer Rate Ratio",
+            "title": "Migration Memory Dirty vs Transfer Rate Ratio",
             "type": "timeseries"
           }
         ],

--- a/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
+++ b/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
@@ -1929,6 +1929,68 @@ resources:
             ],
             "title": "Migration Dirty Memory Rate",
             "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "description": "Convergence ratio: dirty_rate / transfer_rate. < 1: converging — ≥ 1: not converging, migration will abort. Shows -1 when transfer rate is zero (migration not yet active).",
+            "fieldConfig": {
+              "defaults": {
+                "color": {"mode": "palette-classic"},
+                "custom": {
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {"type": "linear"},
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {"group": "A", "mode": "none"},
+                  "thresholdsStyle": {"mode": "line+area"},
+                  "axisSoftMin": -1.5,
+                  "axisSoftMax": 2
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"color": "grey",  "value": null},
+                    {"color": "green", "value": 0},
+                    {"color": "red",   "value": 1}
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+            "id": 12,
+            "options": {
+              "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false},
+              "tooltip": {"mode": "single", "sort": "none"}
+            },
+            "targets": [
+              {
+                "datasource": {"type": "prometheus", "uid": "prometheus"},
+                "editorMode": "code",
+                "expr": "(\n  (\n    kubevirt_vmi_migration_dirty_memory_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n    / kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"}\n  )\n  and on(namespace, name) (\n    kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} > 0\n  )\n)\nor on(namespace, name) (\n  kubevirt_vmi_migration_memory_transfer_rate_bytes{namespace=\"$namespace\", name=\"$vm\"} == 0\n  * 0 + -1\n)",
+                "legendFormat": "dirty / transfer",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Dirty / Transfer Rate Ratio",
+            "type": "timeseries"
           }
         ],
         "schemaVersion": 37,


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
- Current chart does not know if the migration is converge or not.
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Add new ration to tell the user that the migration whether the migration converge or not.
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/11401

#### Test plan:
<!-- Describe the test plan by steps. -->
1. turn on rancher-monitoring add on
2. Migration normally goes fast, so please restrict migration bandwidth to 5Mi first 
  ```
  kubectl patch kubevirt kubevirt -n harvester-system --type merge -p '{"spec":{"configuration":{"migrations":{"bandwidthPerMigration":"5Mi"}}}}'
  ```
3. prepare ubuntu-cloud-image.iso, with 2 vCPU / 4G RAM
4. prepare the cloud-init you can login
5. Run `stress-ng --vm 2 --vm-bytes 500M` 
6. Migrate the vm, see the metrics

Examples
```bash
#cloud-config
package_update: true
packages:
  - qemu-guest-agent
runcmd:
  - - systemctl
    - enable
    - --now
    - qemu-guest-agent.service
ssh_pwauth: true
chpasswd:
  users:
    - name: ubuntu
      password: ubuntu
      type: text
  expire: false
```


#### Expected result
<img width="1879" height="879" alt="Screenshot 2026-08-14 at 6 16 58 PM" src="https://github.com/user-attachments/assets/8fe51b27-d383-4938-91b2-caaaa74082bc" />


#### Additional documentation or context
