### PR TITLE
enhancement: drop 'installer' from harvester-release.yaml, add 'osImage'

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -45,8 +45,8 @@ PRETTY_NAME="Harvester ${VERSION}"
 cat > harvester-release.yaml <<EOF
 harvester: ${HARVESTER_VERSION}
 harvesterChart: ${HARVESTER_CHART_VERSION}
-installer: ${HARVESTER_VERSION}
 os: ${PRETTY_NAME}
+osImage: ${BASE_OS_IMAGE}
 kubernetes: ${RKE2_VERSION}
 rancher: ${RANCHER_VERSION}
 monitoringChart: ${MONITORING_VERSION}


### PR DESCRIPTION
#### Problem:
The 'installer' commit hash is redundant now that harvester-installer has been integrated into the main harvester repo (it's the exact same value as is already present for 'harvester').

The current 'os' value is the pretty name of the release (e.g. "Harvester v1.8.1" for a release, or "Harvester 51c91ae4" for a dev build), but it would be really nice if we could see exactly which os2 image was used (e.g. v1.8-20260605) without having to go check the release notes.  This will be helpful for figuring out which harvester-nvidia-driver-toolkit you should be using, and for the forthcoming harvester-kernel-module-devel image.

#### Solution:
- Drop 'installer'
- Add 'osImage' (I did this rather than change the existing 'os' field, as that's used in the upgrade process).

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5859
https://github.com/harvester/harvester/issues/6285
https://github.com/harvester/harvester/issues/11263

#### Test plan:
Check `/etc/harvester-release.yaml`. Ensure 'installer' is gone, and 'osImage' is added. For master builds the latter should be set to `rancher/harvester-os:sle-micro-head`. For release builds it should be `rancher/harvester-os:v1.x-YYYYMMDD`, matching the link in the component section in the release nodes.

#### Additional documentation or context
