### PR TITLE
fix: add synictimer.direct.enabled to Windows VM templates

### DIFF
--- a/pkg/data/template.go
+++ b/pkg/data/template.go
@@ -440,6 +440,8 @@ spec:
                   enabled: true
                 synictimer:
                   enabled: true
+                  direct:
+                    enabled: true
                 ipi:
                   enabled: true
                 runtime:
@@ -553,6 +555,8 @@ spec:
                   enabled: true
                 synictimer:
                   enabled: true
+                  direct:
+                    enabled: true
                 ipi:
                   enabled: true
                 runtime:
@@ -684,6 +688,8 @@ spec:
                   enabled: true
                 synictimer:
                   enabled: true
+                  direct:
+                    enabled: true
                 ipi:
                   enabled: true
                 runtime:
@@ -815,6 +821,8 @@ spec:
                   enabled: true
                 synictimer:
                   enabled: true
+                  direct:
+                    enabled: true
                 ipi:
                   enabled: true
                 runtime:
@@ -946,6 +954,8 @@ spec:
                   enabled: true
                 synictimer:
                   enabled: true
+                  direct:
+                    enabled: true
                 ipi:
                   enabled: true
                 runtime:
@@ -1081,6 +1091,8 @@ spec:
                   enabled: true
                 synictimer:
                   enabled: true
+                  direct:
+                    enabled: true
                 ipi:
                   enabled: true
                 runtime:


### PR DESCRIPTION
#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
https://github.com/harvester/harvester/issues/11124 require to add synictimer.direct.enabled  but it miss to add this.
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add missing direct: enabled: true to synictimer configuration in all Windows VM templates

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/11124
#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
