### PR TITLE
VM Builder: Add VM features

### DIFF
--- a/pkg/builder/features.go
+++ b/pkg/builder/features.go
@@ -1,0 +1,279 @@
+package builder
+
+import (
+	"k8s.io/utils/ptr"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+// - - - VM Features - - -
+
+// enable/disable ACPI feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+func (v *VMBuilder) FeatureACPI(enabled bool) *VMBuilder {
+	v.ensureFeatures()
+	features := v.VirtualMachine.Spec.Template.Spec.Domain.Features
+	features.ACPI = kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable APIC feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featureapic
+func (v *VMBuilder) FeatureAPIC(enabled, endOfInterrupt bool) *VMBuilder {
+	v.ensureFeatures()
+	features := v.VirtualMachine.Spec.Template.Spec.Domain.Features
+	features.APIC = &kubevirtv1.FeatureAPIC{
+		FeatureState: kubevirtv1.FeatureState{
+			Enabled: ptr.To(enabled),
+		},
+		EndOfInterrupt: endOfInterrupt,
+	}
+	return v
+}
+
+// enable/disable HyperV Passthrough feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_hypervpassthrough
+func (v *VMBuilder) FeatureHyperVPassthrough(enabled bool) *VMBuilder {
+	v.ensureFeatures()
+	features := v.VirtualMachine.Spec.Template.Spec.Domain.Features
+	features.HypervPassthrough = &kubevirtv1.HyperVPassthrough{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable HyperV Relaxed feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVRelaxed(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.Relaxed = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable HyperV VAPIC feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVVAPIC(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.VAPIC = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable and configure HyperV Spinlocks feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurespinlocks
+func (v *VMBuilder) FeatureHyperVSpinlocks(enabled bool, retries uint32) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.Spinlocks = &kubevirtv1.FeatureSpinlocks{
+		FeatureState: kubevirtv1.FeatureState{
+			Enabled: ptr.To(enabled),
+		},
+		Retries: ptr.To(max(uint32(4096), retries)), // Retries value must be at least 4096
+	}
+	return v
+}
+
+// enable/disable HyperV VP Index feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVVPIndex(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.VPIndex = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable HyperV Runtime feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVRuntime(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.Runtime = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable HyperV SyNIC feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVSyNIC(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.SyNIC = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable and configure HyperV SyNIC Timer feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_synictimer
+func (v *VMBuilder) FeatureHyperVSyNICTimer(enabled, direct bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.SyNICTimer = &kubevirtv1.SyNICTimer{
+		FeatureState: kubevirtv1.FeatureState{
+			Enabled: ptr.To(enabled),
+		},
+		Direct: &kubevirtv1.FeatureState{
+			Enabled: ptr.To(direct),
+		},
+	}
+	return v
+}
+
+// enable/disable HyperV Reset feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVReset(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.Reset = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable and configure HyperV Vendor ID feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurevendorid
+func (v *VMBuilder) FeatureHyperVVendorID(enabled bool, vendorid string) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.VendorID = &kubevirtv1.FeatureVendorID{
+		FeatureState: kubevirtv1.FeatureState{
+			Enabled: ptr.To(enabled),
+		},
+		VendorID: vendorid,
+	}
+	return v
+}
+
+// enable/disable HyperV Frequencies feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVFrequencies(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.Frequencies = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable HyperV Reenlightenment feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVReenlightenment(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.Reenlightenment = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable and configure HyperV TLB Flush feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_tlbflush
+func (v *VMBuilder) FeatureHyperVTLBFlush(enabled, direct, extended bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.TLBFlush = &kubevirtv1.TLBFlush{
+		FeatureState: kubevirtv1.FeatureState{
+			Enabled: ptr.To(enabled),
+		},
+		Direct: &kubevirtv1.FeatureState{
+			Enabled: ptr.To(direct),
+		},
+		Extended: &kubevirtv1.FeatureState{
+			Enabled: ptr.To(extended),
+		},
+	}
+	return v
+}
+
+// enable/disable HyperV IPI feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVIPI(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.IPI = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable HyperV EVMCS feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurehyperv
+func (v *VMBuilder) FeatureHyperVEVMCS(enabled bool) *VMBuilder {
+	v.ensureFeatureHyperV()
+	hyperv := v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv
+	hyperv.EVMCS = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable SMM feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+func (v *VMBuilder) FeatureSMM(enabled bool) *VMBuilder {
+	v.ensureFeatures()
+	features := v.VirtualMachine.Spec.Template.Spec.Domain.Features
+	features.SMM = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// enable/disable KVM feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_featurekvm
+func (v *VMBuilder) FeatureKVM(hidden bool) *VMBuilder {
+	v.ensureFeatures()
+	features := v.VirtualMachine.Spec.Template.Spec.Domain.Features
+	features.KVM = &kubevirtv1.FeatureKVM{Hidden: hidden}
+	return v
+}
+
+// enable/disable paravirtualized spinlocks feature for VM.
+// See also:
+// https://kubevirt.io/api-reference/v1.8.3/definitions.html#_v1_features
+func (v *VMBuilder) FeaturePVSpinlock(enabled bool) *VMBuilder {
+	v.ensureFeatures()
+	features := v.VirtualMachine.Spec.Template.Spec.Domain.Features
+	features.Pvspinlock = &kubevirtv1.FeatureState{Enabled: ptr.To(enabled)}
+	return v
+}
+
+// - - - helper functions - - -
+
+// ensureFeatures creates an empty kubevirtv1.Features struct if necessary
+func (v *VMBuilder) ensureFeatures() {
+	if v.VirtualMachine.Spec.Template.Spec.Domain.Features == nil {
+		v.VirtualMachine.Spec.Template.Spec.Domain.Features = &kubevirtv1.Features{}
+	}
+}
+
+// ensureFeatureHyperV creates an empty kubevirtv1.Features struct if necessary and populates the
+// Hyerpv property of that struct with en empty kubevirtv1.FeatureHyperv struct if necessary
+func (v *VMBuilder) ensureFeatureHyperV() {
+	v.ensureFeatures()
+	if v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv == nil {
+		v.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv = &kubevirtv1.FeatureHyperv{}
+	}
+}

--- a/pkg/builder/features_test.go
+++ b/pkg/builder/features_test.go
@@ -1,0 +1,433 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureACPI(t *testing.T) {
+	builder := NewVMBuilder("test ACPI")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureACPI(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.ACPI)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.ACPI.Enabled)
+
+	builder.FeatureACPI(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.ACPI)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.ACPI.Enabled)
+}
+
+func TestFeatureAPIC(t *testing.T) {
+	builder := NewVMBuilder("test APIC")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureAPIC(true, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.FeatureState.Enabled)
+	assert.Equal(t, true, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.EndOfInterrupt)
+
+	builder.FeatureAPIC(true, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.FeatureState.Enabled)
+	assert.Equal(t, false, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.EndOfInterrupt)
+
+	builder.FeatureAPIC(false, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.FeatureState.Enabled)
+	assert.Equal(t, true, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.EndOfInterrupt)
+
+	builder.FeatureAPIC(false, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.FeatureState.Enabled)
+	assert.Equal(t, false, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.APIC.EndOfInterrupt)
+}
+
+func TestFeatureHyperVPassthrough(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Passthrough")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVPassthrough(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.HypervPassthrough)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.HypervPassthrough.Enabled)
+
+	builder.FeatureHyperVPassthrough(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.HypervPassthrough)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.HypervPassthrough.Enabled)
+}
+
+func TestFeatureHyperVRelaxed(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Relaxed")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVRelaxed(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Relaxed)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Relaxed.Enabled)
+
+	builder.FeatureHyperVRelaxed(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Relaxed)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Relaxed.Enabled)
+}
+
+func TestFeatureHyperVVAPIC(t *testing.T) {
+	builder := NewVMBuilder("test HyperV VAPIC")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVVAPIC(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VAPIC)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VAPIC.Enabled)
+
+	builder.FeatureHyperVVAPIC(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VAPIC)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VAPIC.Enabled)
+}
+
+func TestFeatureHyperVSpinlocks(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Spinlocks")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVSpinlocks(true, uint32(8192))
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks.FeatureState.Enabled)
+	assert.Equal(t, uint32(8192), *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks.Retries)
+
+	builder.FeatureHyperVSpinlocks(false, uint32(4096))
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks.FeatureState.Enabled)
+	assert.Equal(t, uint32(4096), *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Spinlocks.Retries)
+}
+
+func TestFeatureHyperVVPIndex(t *testing.T) {
+	builder := NewVMBuilder("test HyperV VPIndex")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVVPIndex(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VPIndex)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VPIndex.Enabled)
+
+	builder.FeatureHyperVVPIndex(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VPIndex)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VPIndex.Enabled)
+}
+
+func TestFeatureHyperVRuntime(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Runtime")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVRuntime(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Runtime)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Runtime.Enabled)
+
+	builder.FeatureHyperVRuntime(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Runtime)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Runtime.Enabled)
+}
+
+func TestFeatureHyperVSyNIC(t *testing.T) {
+	builder := NewVMBuilder("test HyperV SyNIC")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVSyNIC(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNIC)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNIC.Enabled)
+
+	builder.FeatureHyperVSyNIC(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNIC)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNIC.Enabled)
+}
+
+func TestFeatureHyperVSyNICTimer(t *testing.T) {
+	builder := NewVMBuilder("test HyperV SyNIC Timer")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVSyNICTimer(true, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct.Enabled)
+
+	builder.FeatureHyperVSyNICTimer(true, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct.Enabled)
+
+	builder.FeatureHyperVSyNICTimer(false, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct.Enabled)
+
+	builder.FeatureHyperVSyNICTimer(false, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.SyNICTimer.Direct.Enabled)
+}
+
+func TestFeatureHyperVReset(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Reset")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVReset(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reset)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reset.Enabled)
+
+	builder.FeatureHyperVReset(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reset)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reset.Enabled)
+}
+
+func TestFeatureHyperVVendorID(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Vendor ID")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVVendorID(true, "foobar")
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID.FeatureState.Enabled)
+	assert.Equal(t, "foobar", builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID.VendorID)
+
+	builder.FeatureHyperVVendorID(false, "barfoo")
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID.FeatureState.Enabled)
+	assert.Equal(t, "barfoo", builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.VendorID.VendorID)
+}
+
+func TestFeatureHyperVFrequencies(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Frequencies")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVFrequencies(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies.Enabled)
+
+	builder.FeatureHyperVFrequencies(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies.Enabled)
+}
+
+func TestFeatureHyperVReenlightenment(t *testing.T) {
+	builder := NewVMBuilder("test HyperV Reenlightenment")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVReenlightenment(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment.Enabled)
+
+	builder.FeatureHyperVReenlightenment(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment.Enabled)
+}
+
+func TestFeatureHyperVTLBFlush(t *testing.T) {
+	builder := NewVMBuilder("test HyperV TLB Flush")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVTLBFlush(true, true, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+
+	builder.FeatureHyperVTLBFlush(true, true, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+
+	builder.FeatureHyperVTLBFlush(true, false, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+
+	builder.FeatureHyperVTLBFlush(true, false, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+
+	builder.FeatureHyperVTLBFlush(false, true, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+
+	builder.FeatureHyperVTLBFlush(false, true, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+
+	builder.FeatureHyperVTLBFlush(false, false, true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+
+	builder.FeatureHyperVTLBFlush(false, false, false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.FeatureState.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Direct.Enabled)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush.Extended.Enabled)
+}
+
+func TestFeatureHyperVIPI(t *testing.T) {
+	builder := NewVMBuilder("test HyperV IPI")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVIPI(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.IPI)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.IPI.Enabled)
+
+	builder.FeatureHyperVIPI(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.IPI)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.IPI.Enabled)
+}
+
+func TestFeatureHyperVEVMCS(t *testing.T) {
+	builder := NewVMBuilder("test HyperV EVMCS")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureHyperVEVMCS(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS.Enabled)
+
+	builder.FeatureHyperVEVMCS(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS.Enabled)
+}
+
+func TestFeatureSMM(t *testing.T) {
+	builder := NewVMBuilder("test PVSpinlock")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureSMM(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.SMM)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.SMM.Enabled)
+
+	builder.FeatureSMM(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.SMM)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.SMM.Enabled)
+}
+
+func TestFeatureKVM(t *testing.T) {
+	builder := NewVMBuilder("test KVM")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeatureKVM(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.KVM)
+	assert.Equal(t, true, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.KVM.Hidden)
+
+	builder.FeatureKVM(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.KVM)
+	assert.Equal(t, false, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.KVM.Hidden)
+}
+
+func TestFeaturePVSpinlock(t *testing.T) {
+	builder := NewVMBuilder("test PVSpinlock")
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+
+	builder.FeaturePVSpinlock(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Pvspinlock)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Pvspinlock.Enabled)
+
+	builder.FeaturePVSpinlock(false)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Pvspinlock)
+	assert.Equal(t, false, *builder.VirtualMachine.Spec.Template.Spec.Domain.Features.Pvspinlock.Enabled)
+}


### PR DESCRIPTION
#### Problem:

The VM Builder interface doesn't support VM Feature settings.

#### Solution:

Add accessor functions for VM feature settings to the VM Builder interface.

See also https://pkg.go.dev/kubevirt.io/api@v1.8.3/core/v1#Features

#### Related Issue(s):

related-to: harvester/harvester#10161

#### Test plan:

Unit tests included.

#### Additional documentation or context

The VM Feature settings allow users to enable special functionality for improved VM behavior. 

E.g. VM performance may be improved by using paravirtual spinlocks (PV Spinlocks) as opposed to test-and-set locks. However this is strongly use-case dependent, since contention (overcommit) on the host side and kernel support on the guest side matters.
See: https://clovertrail.github.io/jekyll/theme/2017/10/17/KVM-Paravirt-Spinlocks-Perf.html
Therefore it's desirable to let users enable or disable VM features depending on the needs they identify.