### PR TITLE
VM Builder: Add clock accessor functions

### DIFF
--- a/pkg/builder/clock.go
+++ b/pkg/builder/clock.go
@@ -1,0 +1,124 @@
+package builder
+
+import (
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+// ClockOffsetUTC configures the UTC offset
+// If an offset is specified, guest changes to the clock will be kept during reboots and are not
+// reset.
+func (v *VMBuilder) ClockOffsetUTC(seconds int) *VMBuilder {
+	v.ensureClock()
+	clock := v.VirtualMachine.Spec.Template.Spec.Domain.Clock
+	clock.ClockOffset = kubevirtv1.ClockOffset{
+		UTC: &kubevirtv1.ClockOffsetUTC{OffsetSeconds: new(seconds)},
+	}
+	return v
+}
+
+// ClockOffsetTimezone sets the guest clock to the specified timezone.
+// Zone name follows the TZ environment variable format (e.g. 'America/New_York').
+func (v *VMBuilder) ClockOffsetTimezone(timezone string) *VMBuilder {
+	v.ensureClock()
+	clock := v.VirtualMachine.Spec.Template.Spec.Domain.Clock
+	clock.ClockOffset = kubevirtv1.ClockOffset{
+		Timezone: new(kubevirtv1.ClockOffsetTimezone(timezone)),
+	}
+	return v
+}
+
+// Attach a Timer to the VM
+// HPET (High Precision Event Timer) - multiple timers with periodic interrupts.
+//
+// Enabled set to false makes sure that the machine type or a preset can't add the timer.
+// Defaults to true.
+//
+// Policy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
+// One of "delay", "catchup", "merge", "discard".
+func (v *VMBuilder) ClockTimerHPET(enabled bool, policy string) *VMBuilder {
+	v.ensureClockTimer()
+	timer := v.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer
+	timer.HPET = &kubevirtv1.HPETTimer{
+		Enabled:    new(enabled),
+		TickPolicy: kubevirtv1.HPETTickPolicy(policy),
+	}
+	return v
+}
+
+// Attach a Timer to the VM
+// KVM 	(KVM clock) - lets guests read the host’s wall clock time (paravirtualized).
+// For linux guests.
+func (v *VMBuilder) ClockTimerKVM(enabled bool) *VMBuilder {
+	v.ensureClockTimer()
+	timer := v.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer
+	timer.KVM = &kubevirtv1.KVMTimer{
+		Enabled: new(enabled),
+	}
+	return v
+}
+
+// Attach a Timer to the VM
+// PIT (Programmable Interval Timer) - a timer with periodic interrupts.
+//
+// Enabled set to false makes sure that the machine type or a preset can't add the timer.
+// Defaults to true.
+//
+// Policy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
+// One of "delay", "catchup", "discard".
+func (v *VMBuilder) ClockTimerPIT(enabled bool, policy string) *VMBuilder {
+	v.ensureClockTimer()
+	timer := v.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer
+	timer.PIT = &kubevirtv1.PITTimer{
+		Enabled:    new(enabled),
+		TickPolicy: kubevirtv1.PITTickPolicy(policy),
+	}
+	return v
+}
+
+// Attach a Timer to the VM
+// RTC (Real Time Clock) - a continuously running timer with periodic interrupts.
+//
+// Enabled set to false makes sure that the machine type or a preset can't add the timer.
+// Defaults to true.
+//
+// Policy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
+// One of "delay", "catchup".
+//
+// Track the guest or the wall clock.
+func (v *VMBuilder) ClockTimerRTC(enabled bool, policy, track string) *VMBuilder {
+	v.ensureClockTimer()
+	timer := v.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer
+	timer.RTC = &kubevirtv1.RTCTimer{
+		Enabled:    new(enabled),
+		TickPolicy: kubevirtv1.RTCTickPolicy(policy),
+		Track:      kubevirtv1.RTCTimerTrack(track),
+	}
+	return v
+}
+
+// Attach a Timer to the VM
+// Hyperv (Hypervclock) - lets guests read the host’s wall clock time (paravirtualized).
+// For windows guests.
+func (v *VMBuilder) ClockTimerHyperV(enabled bool) *VMBuilder {
+	v.ensureClockTimer()
+	timer := v.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer
+	timer.Hyperv = &kubevirtv1.HypervTimer{
+		Enabled: new(enabled),
+	}
+	return v
+}
+
+// - - - Helpers
+
+func (v *VMBuilder) ensureClock() {
+	if v.VirtualMachine.Spec.Template.Spec.Domain.Clock == nil {
+		v.VirtualMachine.Spec.Template.Spec.Domain.Clock = &kubevirtv1.Clock{}
+	}
+}
+
+func (v *VMBuilder) ensureClockTimer() {
+	v.ensureClock()
+	if v.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer == nil {
+		v.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer = &kubevirtv1.Timer{}
+	}
+}

--- a/pkg/builder/clock_test.go
+++ b/pkg/builder/clock_test.go
@@ -1,0 +1,157 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+func TestClockOffsetUTC(t *testing.T) {
+	builder := NewVMBuilder("test clock offset UTC")
+
+	builder.ClockOffsetUTC(0)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.UTC)
+	assert.Equal(t, 0, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.UTC.OffsetSeconds)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.Timezone)
+}
+
+func TestClockOffsetTimezone(t *testing.T) {
+	builder := NewVMBuilder("test clock offset timezone")
+
+	builder.ClockOffsetTimezone("Europe/Berlin")
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.Timezone)
+	assert.Equal(t, kubevirtv1.ClockOffsetTimezone("Europe/Berlin"), *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.Timezone)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.UTC)
+}
+
+func TestClockTimerHPET(t *testing.T) {
+	builder := NewVMBuilder("test clock HPET timer")
+
+	builder.ClockTimerHPET(true, "catchup")
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET.Enabled)
+	assert.Equal(t, kubevirtv1.HPETTickPolicy("catchup"), builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET.TickPolicy)
+}
+
+func TestClockTimerKVM(t *testing.T) {
+	builder := NewVMBuilder("test clock KVM timer")
+
+	builder.ClockTimerKVM(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM.Enabled)
+}
+
+func TestClockTimerPIT(t *testing.T) {
+	builder := NewVMBuilder("test clock PIT timer")
+
+	builder.ClockTimerPIT(true, "discard")
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT.Enabled)
+	assert.Equal(t, kubevirtv1.PITTickPolicy("discard"), builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT.TickPolicy)
+}
+
+func TestClockTimerRTC(t *testing.T) {
+	builder := NewVMBuilder("test clock RTC timer")
+
+	builder.ClockTimerRTC(true, "discard", "wall")
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.Enabled)
+	assert.Equal(t, kubevirtv1.RTCTickPolicy("discard"), builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.TickPolicy)
+	assert.Equal(t, kubevirtv1.TrackWall, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.Track)
+}
+
+func TestClockTimerHyperV(t *testing.T) {
+	builder := NewVMBuilder("test clock HyperV timer")
+
+	builder.ClockTimerHyperV(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv.Enabled)
+}
+
+// Multiple timers can be attached to a single VM.
+func TestClockTimerKVMAndRTCCombined(t *testing.T) {
+	builder := NewVMBuilder("test clock KVM and RTC timers combined")
+
+	builder.ClockTimerKVM(true).ClockTimerRTC(true, "delay", "guest")
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.HPET)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.PIT)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC)
+	assert.Nil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM.Enabled)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.Enabled)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.Enabled)
+	assert.Equal(t, kubevirtv1.RTCTickPolicy("delay"), builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.TickPolicy)
+	assert.Equal(t, kubevirtv1.TrackGuest, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.RTC.Track)
+}
+
+func TestClockOffsetUTCCombined(t *testing.T) {
+	builder := NewVMBuilder("test clock offset UTC and a timer")
+
+	builder.ClockOffsetUTC(0).ClockTimerHyperV(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.UTC)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv.Enabled)
+	assert.Equal(t, 0, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.UTC.OffsetSeconds)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.Hyperv.Enabled)
+}
+
+func TestClockOffsetTimezoneCombined(t *testing.T) {
+	builder := NewVMBuilder("test clock offset timezone and a timer")
+
+	builder.ClockOffsetTimezone("Europe/Berlin").ClockTimerKVM(true)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.Timezone)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM)
+	assert.NotNil(t, builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM.Enabled)
+	assert.Equal(t, kubevirtv1.ClockOffsetTimezone("Europe/Berlin"), *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.ClockOffset.Timezone)
+	assert.Equal(t, true, *builder.VirtualMachine.Spec.Template.Spec.Domain.Clock.Timer.KVM.Enabled)
+}


### PR DESCRIPTION
#### Problem:

The VM Builder interface doesn't support VM clock settings

#### Solution:

Add functions to VM Builder interface for setting timezone settings and attachtime timers to the VM.
This allows greater customization of VMs which require accurate timekeeping.

#### Related Issue(s):

related-to: https://github.com/harvester/harvester/issues/10161

#### Test plan:

Unit tests included.

#### Additional documentation or context

https://kubevirt.io/user-guide/compute/virtual_hardware/#clock

The VM Builder interface is used in the Harvester Terraform provider to construct the VirtualMachine data.