### PR TITLE
Customize rke2-traefik serive type to LoadBalancer instead of default value ClusterIP

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1584,6 +1584,12 @@ migrate_longhorn_v1beta1_crds() {
 }
 
 patch_rke2_traefik_config() {
+  # This patch is only needed when the pre-upgrade cluster version is v1.8.*
+  if [[ ! "$UPGRADE_PREVIOUS_VERSION" =~ ^v1\.8[.-][a-zA-Z0-9.-]+$ ]]; then
+    echo "Skip check and apply of default rke2-traefik helm chart config: pre-upgrade version is not v1.8.x (actual: ${UPGRADE_PREVIOUS_VERSION})"
+    return
+  fi
+
   echo "Check and apply default rke2-traefik helm chart config"
 
   local name="rke2-traefik"
@@ -1604,6 +1610,9 @@ spec:
     logs:
       access:
         enabled: "true"
+    service:
+      spec:
+        type: LoadBalancer
     additionalArguments:
     - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=30m
     - --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30m
@@ -1612,7 +1621,7 @@ EOF
   # 2. Check if the resource exists
   local EXIT_CODE=0
   # Using a global variable to ensure EXIT_CODE is captured correctly under 'set -e'
-  rke2_traefik_chart_config_output=$(kubectl get helmchartconfig "$name" -n "$namespace" 2>&1) || EXIT_CODE=$?
+  rke2_traefik_chart_config_output=$(kubectl get helmchartconfig "${name}" -n "${namespace}" -o yaml 2>&1) || EXIT_CODE=$?
 
   if [[ $EXIT_CODE -ne 0 ]]; then
     if [[ "$rke2_traefik_chart_config_output" == *"NotFound"* || "$rke2_traefik_chart_config_output" == *"not found"* ]]; then
@@ -1625,6 +1634,18 @@ EOF
       return 1
     fi
   fi
+
+  # 3. Print existing resource configuration
+  echo "Resource helmchartconfig '${name}' exists:"
+  echo "--------------------------------------------------"
+  echo "${rke2_traefik_chart_config_output}"
+  echo "--------------------------------------------------"
+
+  # Note: Extracting and deep-merging spec.valuesContent (e.g., using yq to preserve custom Helm values)
+  # is intentionally skipped. Because valuesContent is an embedded YAML string inside the CRD, a proper merge
+  # requires parsing the raw string, performing a key-by-key YAML merge, and re-serializing it back into the spec.
+  # Since this patch is designed to initialize the canonical HelmChartConfig manifest matching the v1.9.0 default
+  # definition when missing, if the resource already exists, we assume its content is up to date and require no further changes.
 }
 
 # Since Rancher v2.15.0, tls-internal-cn-allowed-services is needed to be

--- a/pkg/installer/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/installer/config/templates/rancherd-10-harvester.yaml
@@ -228,6 +228,9 @@ resources:
       logs:
         access:
           enabled: "true"
+      service:
+        spec:
+          type: LoadBalancer
       additionalArguments:
       - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=30m
       - --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30m


### PR DESCRIPTION
Customize rke2-traefik serive type to LoadBalancer instead of default value ClusterIP

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

rke2-traefik sevice type has chance to be reset to default value ClusterIP.

rke service ensures it's charts on rke2 leader run;  Harvester leader pod also takes one-shot action to amend it. There are races.

Refer https://github.com/harvester/harvester/issues/11440#issuecomment-5358733012 about the manual issue producing & recovering steps.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Update helmchartconfig to customize the expected value.

2. Update the upgrade script to initialize the helmchartconfig object, also add a version check to ensure it only runs on v1.8.*-> v1.9.0 upgrade

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11440

#### Test plan:
<!-- Describe the test plan by steps. -->

Per https://github.com/harvester/harvester/issues/11440#issuecomment-5358733012

After this fix is merged, the issue will be gone.

Manual test:
```
./test-patch.sh 
----test on v1.9.0---
Skip check and apply of default rke2-traefik helm chart config: pre-upgrade version is not v1.8.x (actual: v1.9.0)
----test on v1.8.0---
helmchartconfig.helm.cattle.io "rke2-traefik" deleted from kube-system namespace
Check and apply default rke2-traefik helm chart config
Resource 'rke2-traefik' not found. Creating...
helmchartconfig.helm.cattle.io/rke2-traefik created
----test on v1.8.1-hot-fix---
Check and apply default rke2-traefik helm chart config
Resource helmchartconfig 'rke2-traefik' exists:
--------------------------------------------------
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"helm.cattle.io/v1","kind":"HelmChartConfig","metadata":{"annotations":{},"name":"rke2-traefik","namespace":"kube-system"},"spec":{"valuesContent":"logs:\n  access:\n    enabled: \"true\"\nservice:\n  spec:\n    type: LoadBalancer\nadditionalArguments:\n- --entryPoints.websecure.transport.respondingTimeouts.readTimeout=30m\n- --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30m"}}
  creationTimestamp: "2026-08-21T06:32:41Z"
  generation: 1
  name: rke2-traefik
  namespace: kube-system
  resourceVersion: "385128"
  uid: 38d4561e-c981-4b2e-b49e-66f100f0a04c
spec:
  failurePolicy: reinstall
  valuesContent: |-
    logs:
      access:
        enabled: "true"
    service:
      spec:
        type: LoadBalancer
    additionalArguments:
    - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=30m
    - --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30m
--------------------------------------------------

```

#### Additional documentation or context

Issue https://github.com/harvester/harvester/issues/11122 is likely to be triggered by this, combine the `kill kube-vip pod in a row` action.