### PR TITLE
[DNM] Rollout kube-vip instead of killing pods

### DIFF
--- a/pkg/controller/master/rancher/register.go
+++ b/pkg/controller/master/rancher/register.go
@@ -37,6 +37,7 @@ const (
 	keyKubevipHwaddr                = "kube-vip.io/hwaddr"
 	keyKubevipIgnoreServiceSecurity = "kube-vip.io/ignore-service-security"
 	keyKubevipLoadBalancerIPs       = "kube-vip.io/loadbalancerIPs"
+	kubeVipDaemonSetName            = "kube-vip"
 
 	VipConfigmapName                  = "vip"
 	vipDHCPMode                       = "dhcp"
@@ -70,6 +71,8 @@ type Handler struct {
 	NamespaceClient          ctlcorev1.NamespaceClient
 	SettingClient            v1beta1.SettingClient
 	DynamicClient            dynamic.Interface
+	DaemonSetController      ctlappsv1.DaemonSetController
+	DaemonSetClient          ctlappsv1.DaemonSetClient
 	ctx                      context.Context
 	RestConfig               *rest.Config
 }
@@ -125,6 +128,8 @@ func Register(ctx context.Context, management *config.Management, options config
 			NamespaceController:      namespaces,
 			SettingClient:            settings,
 			DynamicClient:            dynamicClient,
+			DaemonSetController:      daemonSets,
+			DaemonSetClient:          daemonSets,
 			ctx:                      ctx,
 			RestConfig:               management.RestConfig,
 		}

--- a/pkg/controller/master/rancher/register.go
+++ b/pkg/controller/master/rancher/register.go
@@ -3,29 +3,20 @@ package rancher
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"strconv"
-	"strings"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	rancherv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	ctlappsv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apps/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
-
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/harvester/harvester/pkg/config"
 	"github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	networkingv1 "github.com/harvester/harvester/pkg/generated/controllers/networking.k8s.io/v1"
-	"github.com/harvester/harvester/pkg/util"
 )
 
 const (
@@ -158,136 +149,6 @@ func Register(ctx context.Context, management *config.Management, options config
 	return nil
 }
 
-// registerExposeService help to create ingress-expose svc in the kube-system namespace,
-// by default it is nodePort, if the VIP is enabled it will be set to LoadBalancer type service.
-func (h *Handler) registerExposeService() error {
-	// verify if traefik exists
-	traefikExists, err := h.doesTraefikExist()
-	if err != nil {
-		return err
-	}
-
-	// if traefik does not exist yet, then we continue working
-	// as normal operation and using ingress
-	if !traefikExists {
-		_, err := h.Services.Get(util.KubeSystemNamespace, ingressExposeServiceName, v1.GetOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if apierrors.IsNotFound(err) {
-			return h.createIngressExposeService()
-		}
-		return nil
-	}
-
-	// clean up old nginx service as it is no longer needed
-	if err := h.cleanupIngressExpose(); err != nil {
-		return fmt.Errorf("error cleaning up ingress expose service: %w", err)
-	}
-	// traefik exists post rke2 upgrade
-	// and we can just traefik service annotations
-	return h.patchTraefikServiceAnnotations()
-
-}
-
-func (h *Handler) createIngressExposeService() error {
-	vip, err := h.getVipConfig()
-	if err != nil {
-		return err
-	}
-
-	svc := &corev1.Service{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      ingressExposeServiceName,
-			Namespace: util.KubeSystemNamespace,
-			Annotations: map[string]string{
-				keyKubevipIgnoreServiceSecurity: trueStr,
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
-			Selector: map[string]string{
-				appLabelName: util.Rke2IngressNginxAppName,
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "https-internal",
-					Port:       443,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(443),
-				},
-				{
-					Name:       "http",
-					Port:       80,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(80),
-				},
-			},
-		},
-	}
-
-	// set vip loadBalancer type and ip
-	enabled, err := strconv.ParseBool(vip.Enabled)
-	if err != nil {
-		return err
-	}
-	if enabled && vip.ServiceType == corev1.ServiceTypeLoadBalancer {
-		svc.Spec.Type = vip.ServiceType
-		// After kube-vip v0.5.2, it uses annotation kube-vip.io/loadbalancerIPs to set the loadBalancerIP
-		if strings.ToLower(vip.Mode) == vipDHCPMode {
-			svc.Annotations[keyKubevipRequestIP] = vip.IP
-			svc.Annotations[keyKubevipHwaddr] = vip.HwAddress
-			svc.Annotations[keyKubevipLoadBalancerIPs] = vipDHCPLoadBalancerIP
-		} else {
-			svc.Annotations[keyKubevipLoadBalancerIPs] = vip.IP
-		}
-	}
-
-	if _, err := h.Services.Create(svc); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// cleanUpLegacyExposeService removes rancher-expose service in cattle-system
-func (h *Handler) cleanUpLegacyExposeService() error {
-	if err := h.Services.Delete(util.CattleSystemNamespaceName, rancherExposeServiceName, &v1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	return nil
-}
-
-func (h *Handler) getVipConfig() (*VIPConfig, error) {
-	vipConfig := &VIPConfig{}
-	conf, err := h.Configmaps.Get(h.Namespace, VipConfigmapName, v1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	if err := mapstructure.Decode(conf.Data, vipConfig); err != nil {
-		return nil, err
-	}
-	return vipConfig, nil
-}
-
-func (h *Handler) restartKubevipPods() error {
-	pods, err := h.podCache.List(util.HarvesterSystemNamespaceName, labels.Set(map[string]string{
-		"app.kubernetes.io/name": "kube-vip",
-	}).AsSelector())
-	if err != nil {
-		return err
-	}
-
-	for i := range pods {
-		if err := h.podClient.Delete(util.HarvesterSystemNamespaceName, pods[i].Name, &v1.DeleteOptions{}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // RancherTokenOnChange updates the expiresAt field of the token.
 // Although we have embedded rancher, we don't start the rancher's token controller.
 // So, we should have our own handler to update the token.
@@ -314,75 +175,4 @@ func (h *Handler) RancherTokenOnChange(_ string, token *v3.Token) (*v3.Token, er
 	}
 
 	return token, nil
-}
-
-// checks if rke2-traefik service already exists
-// which means underlying rke2 has been swapped out to using traefik as
-// ingress controller
-func (h *Handler) doesTraefikExist() (bool, error) {
-	_, err := h.Services.Get(util.KubeSystemNamespace, traefikServiceName, v1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
-// patchTraefikServiceAnnotations will update the traefik service with kubevip annotations
-// if needed
-func (h *Handler) patchTraefikServiceAnnotations() error {
-	svc, err := h.Services.Get(util.KubeSystemNamespace, traefikServiceName, v1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("error fetching traefik service while attempting to update annotations: %w", err)
-	}
-
-	vip, err := h.getVipConfig()
-	if err != nil {
-		return fmt.Errorf("error fetching vip configuration while attempt to update traefik service annotations: %w", err)
-	}
-
-	// set vip loadBalancer type and ip
-	enabled, err := strconv.ParseBool(vip.Enabled)
-	if err != nil {
-		return err
-	}
-
-	svcCopy := svc.DeepCopy()
-
-	if enabled && vip.ServiceType == corev1.ServiceTypeLoadBalancer {
-		svc.Spec.Type = vip.ServiceType
-		if svc.Annotations == nil {
-			svc.Annotations = make(map[string]string)
-		}
-		svc.Annotations[keyKubevipIgnoreServiceSecurity] = trueStr
-		// After kube-vip v0.5.2, it uses annotation kube-vip.io/loadbalancerIPs to set the loadBalancerIP
-		if strings.ToLower(vip.Mode) == vipDHCPMode {
-			svc.Annotations[keyKubevipRequestIP] = vip.IP
-			svc.Annotations[keyKubevipHwaddr] = vip.HwAddress
-			svc.Annotations[keyKubevipLoadBalancerIPs] = vipDHCPLoadBalancerIP
-		} else {
-			svc.Annotations[keyKubevipLoadBalancerIPs] = vip.IP
-		}
-	}
-	if !reflect.DeepEqual(svc, svcCopy) {
-		if _, err = h.Services.Update(svc); err != nil {
-			return fmt.Errorf("error updating %s svc: %w", svc.Name, err)
-		}
-
-		// svc got updated, restart kubevip to ensure changes take effect
-		return h.restartKubevipPods()
-	}
-
-	return err
-}
-
-// remove nginx ingress expose service
-func (h *Handler) cleanupIngressExpose() error {
-	err := h.Services.Delete(util.KubeSystemNamespace, ingressExposeServiceName, &v1.DeleteOptions{})
-	if !apierrors.IsNotFound(err) {
-		return err
-	}
-	return nil
 }

--- a/pkg/controller/master/rancher/service.go
+++ b/pkg/controller/master/rancher/service.go
@@ -1,17 +1,20 @@
 package rancher
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/harvester/harvester/pkg/util"
@@ -130,20 +133,47 @@ func (h *Handler) getVipConfig() (*VIPConfig, error) {
 	return vipConfig, nil
 }
 
-func (h *Handler) restartKubevipPods() error {
-	pods, err := h.podCache.List(util.HarvesterSystemNamespaceName, labels.Set(map[string]string{
-		"app.kubernetes.io/name": "kube-vip",
-	}).AsSelector())
+func (h *Handler) rolloutKubevipDaemonSet(reason string) error {
+	now := time.Now().Format(time.RFC3339)
+	stampedReason := fmt.Sprintf("[%s] %s", now, reason)
+
+	patchPayload := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]string{
+						// Generic standard key "kubectl.kubernetes.io/restartedAt" for kubectl compatibility
+						util.AnnotationKubectlRestartedAt: now,
+						// Harvester controller specific tracking
+						util.AnnotationHarvesterRestartedBy:   controllerRancherName,
+						util.AnnotationHarvesterRestartedAt:   now,
+						util.AnnotationHarvesterRestartReason: stampedReason,
+					},
+				},
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patchPayload)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal restart patch payload: %w", err)
 	}
 
-	for i := range pods {
-		if err := h.podClient.Delete(util.HarvesterSystemNamespaceName, pods[i].Name, &v1.DeleteOptions{}); err != nil {
-			return err
+	_, err = h.DaemonSetClient.Patch(
+		util.HarvesterSystemNamespaceName,
+		kubeVipDaemonSetName,
+		types.StrategicMergePatchType,
+		patchBytes,
+	)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Note: If the kube-vip DaemonSet is missing/deleted, gracefully skip the rollout
+			// restart to avoid throwing errors that cause the Harvester controller to crash loop.
+			logrus.Warnf("DaemonSet %s not found, skipping rollout restart for: %s", kubeVipDaemonSetName, stampedReason)
+			return nil
 		}
+		return fmt.Errorf("failed to rollout restart daemonset %s: %w", kubeVipDaemonSetName, err)
 	}
-
 	return nil
 }
 
@@ -166,6 +196,10 @@ func (h *Handler) doesTraefikExist() (bool, error) {
 func (h *Handler) patchTraefikServiceAnnotations() error {
 	svc, err := h.Services.Get(util.KubeSystemNamespace, traefikServiceName, v1.GetOptions{})
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Warnf("service %s/%s not found, skipping annotation patch", util.KubeSystemNamespace, traefikServiceName)
+			return nil
+		}
 		return fmt.Errorf("error fetching traefik service while attempting to update annotations: %w", err)
 	}
 
@@ -183,27 +217,32 @@ func (h *Handler) patchTraefikServiceAnnotations() error {
 	svcCopy := svc.DeepCopy()
 
 	if enabled && vip.ServiceType == corev1.ServiceTypeLoadBalancer {
-		svc.Spec.Type = vip.ServiceType
-		if svc.Annotations == nil {
-			svc.Annotations = make(map[string]string)
+		svcCopy.Spec.Type = vip.ServiceType
+		if svcCopy.Annotations == nil {
+			svcCopy.Annotations = make(map[string]string)
 		}
-		svc.Annotations[keyKubevipIgnoreServiceSecurity] = trueStr
+		svcCopy.Annotations[keyKubevipIgnoreServiceSecurity] = trueStr
 		// After kube-vip v0.5.2, it uses annotation kube-vip.io/loadbalancerIPs to set the loadBalancerIP
 		if strings.ToLower(vip.Mode) == vipDHCPMode {
-			svc.Annotations[keyKubevipRequestIP] = vip.IP
-			svc.Annotations[keyKubevipHwaddr] = vip.HwAddress
-			svc.Annotations[keyKubevipLoadBalancerIPs] = vipDHCPLoadBalancerIP
+			svcCopy.Annotations[keyKubevipRequestIP] = vip.IP
+			svcCopy.Annotations[keyKubevipHwaddr] = vip.HwAddress
+			svcCopy.Annotations[keyKubevipLoadBalancerIPs] = vipDHCPLoadBalancerIP
 		} else {
-			svc.Annotations[keyKubevipLoadBalancerIPs] = vip.IP
+			svcCopy.Annotations[keyKubevipLoadBalancerIPs] = vip.IP
 		}
 	}
 	if !reflect.DeepEqual(svc, svcCopy) {
-		if _, err = h.Services.Update(svc); err != nil {
-			return fmt.Errorf("error updating %s svc: %w", svc.Name, err)
+		reason := fmt.Sprintf("Service %s (old type %s) is updated to align with vip config and DaemonSet %s is rolled out", traefikServiceName, svc.Spec.Type, kubeVipDaemonSetName)
+		logrus.Infof("%s", reason)
+		if _, err = h.Services.Update(svcCopy); err != nil {
+			return fmt.Errorf("error updating %s svc: %w", svcCopy.Name, err)
 		}
 
-		// svc got updated, restart kubevip to ensure changes take effect
-		return h.restartKubevipPods()
+		// svc got updated, rollout kubevip to ensure changes take effect
+		// Note: If rollouttKubevipDaemonSet fails here, it won't re-execute on subsequent reconciliations
+		// because reflect.DeepEqual(svc, svcCopy) will evaluate to true since the Service update already succeeded.
+		// This will be optimized later.
+		return h.rolloutKubevipDaemonSet(reason)
 	}
 
 	return err

--- a/pkg/controller/master/rancher/service.go
+++ b/pkg/controller/master/rancher/service.go
@@ -1,0 +1,219 @@
+package rancher
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/harvester/harvester/pkg/util"
+)
+
+// registerExposeService help to create ingress-expose svc in the kube-system namespace,
+// by default it is nodePort, if the VIP is enabled it will be set to LoadBalancer type service.
+func (h *Handler) registerExposeService() error {
+	// verify if traefik exists
+	traefikExists, err := h.doesTraefikExist()
+	if err != nil {
+		return err
+	}
+
+	// if traefik does not exist yet, then we continue working
+	// as normal operation and using ingress
+	if !traefikExists {
+		_, err := h.Services.Get(util.KubeSystemNamespace, ingressExposeServiceName, v1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		if apierrors.IsNotFound(err) {
+			return h.createIngressExposeService()
+		}
+		return nil
+	}
+
+	// clean up old nginx service as it is no longer needed
+	if err := h.cleanupIngressExpose(); err != nil {
+		return fmt.Errorf("error cleaning up ingress expose service: %w", err)
+	}
+	// traefik exists post rke2 upgrade
+	// and we can just traefik service annotations
+	return h.patchTraefikServiceAnnotations()
+
+}
+
+func (h *Handler) createIngressExposeService() error {
+	vip, err := h.getVipConfig()
+	if err != nil {
+		return err
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ingressExposeServiceName,
+			Namespace: util.KubeSystemNamespace,
+			Annotations: map[string]string{
+				keyKubevipIgnoreServiceSecurity: trueStr,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Selector: map[string]string{
+				appLabelName: util.Rke2IngressNginxAppName,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "https-internal",
+					Port:       443,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(443),
+				},
+				{
+					Name:       "http",
+					Port:       80,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(80),
+				},
+			},
+		},
+	}
+
+	// set vip loadBalancer type and ip
+	enabled, err := strconv.ParseBool(vip.Enabled)
+	if err != nil {
+		return err
+	}
+	if enabled && vip.ServiceType == corev1.ServiceTypeLoadBalancer {
+		svc.Spec.Type = vip.ServiceType
+		// After kube-vip v0.5.2, it uses annotation kube-vip.io/loadbalancerIPs to set the loadBalancerIP
+		if strings.ToLower(vip.Mode) == vipDHCPMode {
+			svc.Annotations[keyKubevipRequestIP] = vip.IP
+			svc.Annotations[keyKubevipHwaddr] = vip.HwAddress
+			svc.Annotations[keyKubevipLoadBalancerIPs] = vipDHCPLoadBalancerIP
+		} else {
+			svc.Annotations[keyKubevipLoadBalancerIPs] = vip.IP
+		}
+	}
+
+	if _, err := h.Services.Create(svc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// cleanUpLegacyExposeService removes rancher-expose service in cattle-system
+func (h *Handler) cleanUpLegacyExposeService() error {
+	if err := h.Services.Delete(util.CattleSystemNamespaceName, rancherExposeServiceName, &v1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) getVipConfig() (*VIPConfig, error) {
+	vipConfig := &VIPConfig{}
+	conf, err := h.Configmaps.Get(h.Namespace, VipConfigmapName, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := mapstructure.Decode(conf.Data, vipConfig); err != nil {
+		return nil, err
+	}
+	return vipConfig, nil
+}
+
+func (h *Handler) restartKubevipPods() error {
+	pods, err := h.podCache.List(util.HarvesterSystemNamespaceName, labels.Set(map[string]string{
+		"app.kubernetes.io/name": "kube-vip",
+	}).AsSelector())
+	if err != nil {
+		return err
+	}
+
+	for i := range pods {
+		if err := h.podClient.Delete(util.HarvesterSystemNamespaceName, pods[i].Name, &v1.DeleteOptions{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checks if rke2-traefik service already exists
+// which means underlying rke2 has been swapped out to using traefik as
+// ingress controller
+func (h *Handler) doesTraefikExist() (bool, error) {
+	_, err := h.Services.Get(util.KubeSystemNamespace, traefikServiceName, v1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// patchTraefikServiceAnnotations will update the traefik service with kubevip annotations
+// if needed
+func (h *Handler) patchTraefikServiceAnnotations() error {
+	svc, err := h.Services.Get(util.KubeSystemNamespace, traefikServiceName, v1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error fetching traefik service while attempting to update annotations: %w", err)
+	}
+
+	vip, err := h.getVipConfig()
+	if err != nil {
+		return fmt.Errorf("error fetching vip configuration while attempt to update traefik service annotations: %w", err)
+	}
+
+	// set vip loadBalancer type and ip
+	enabled, err := strconv.ParseBool(vip.Enabled)
+	if err != nil {
+		return err
+	}
+
+	svcCopy := svc.DeepCopy()
+
+	if enabled && vip.ServiceType == corev1.ServiceTypeLoadBalancer {
+		svc.Spec.Type = vip.ServiceType
+		if svc.Annotations == nil {
+			svc.Annotations = make(map[string]string)
+		}
+		svc.Annotations[keyKubevipIgnoreServiceSecurity] = trueStr
+		// After kube-vip v0.5.2, it uses annotation kube-vip.io/loadbalancerIPs to set the loadBalancerIP
+		if strings.ToLower(vip.Mode) == vipDHCPMode {
+			svc.Annotations[keyKubevipRequestIP] = vip.IP
+			svc.Annotations[keyKubevipHwaddr] = vip.HwAddress
+			svc.Annotations[keyKubevipLoadBalancerIPs] = vipDHCPLoadBalancerIP
+		} else {
+			svc.Annotations[keyKubevipLoadBalancerIPs] = vip.IP
+		}
+	}
+	if !reflect.DeepEqual(svc, svcCopy) {
+		if _, err = h.Services.Update(svc); err != nil {
+			return fmt.Errorf("error updating %s svc: %w", svc.Name, err)
+		}
+
+		// svc got updated, restart kubevip to ensure changes take effect
+		return h.restartKubevipPods()
+	}
+
+	return err
+}
+
+// remove nginx ingress expose service
+func (h *Handler) cleanupIngressExpose() error {
+	err := h.Services.Delete(util.KubeSystemNamespace, ingressExposeServiceName, &v1.DeleteOptions{})
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -249,6 +249,17 @@ const (
 
 	HarvesterInstallCordonedLabel               = prefix + "/install-cordoned"
 	HarvesterInstallCordonedProcessedAnnotation = prefix + "/install-cordoned-processed"
+
+	// AnnotationKubectlRestartedAt matches the annotation set by 'kubectl rollout restart'.
+	// Defined locally as upstream Kubernetes does not export a public constant for it.
+	AnnotationKubectlRestartedAt = "kubectl.kubernetes.io/restartedAt"
+
+	// Besides standard Kubernetes annotations (e.g., kubectl.kubernetes.io/restartedAt),
+	// we track Harvester-specific metadata to preserve historical context and observability,
+	// as standard keys can easily be overwritten by other controllers or manual operations.
+	AnnotationHarvesterRestartedBy   = prefix + "/restartedBy"
+	AnnotationHarvesterRestartedAt   = prefix + "/restartedAt"
+	AnnotationHarvesterRestartReason = prefix + "/restartReason"
 )
 
 var (


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

See the description on https://github.com/harvester/harvester/issues/11490#issue-5233353460, which lists those known limitations on current code.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Reorganize the code placement
2. Rollout kubevip, but keep current one-shot solution

**please reivew per commit to see the diff**

The main change is a new function `rolloutKubevipDaemonSet` and it's caller



#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11440

#### Test plan:
<!-- Describe the test plan by steps. -->

0. Set Harvester deployment with new image tag (if QA validating, the release should have include this fix)

1. Manually patch `helmchartconfig`, which causes the `rke2-traefik` service type change to `ClusterIP`, and it is out of sync with Harvester controller

1.1
```
kubectl patch helmchartconfig rke2-traefik -n kube-system --type=merge -p '
spec:
  valuesContent: |-
    logs:
      access:
        enabled: "true"
    service:
      spec:
        type: ClusterIP
    additionalArguments:
    - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=30m
    - --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30m
'
1.2
kubectl patch helmchartconfig rke2-traefik -n kube-system --type=merge -p '
spec:
  valuesContent: |-
    logs:
      access:
        enabled: "true"
    service:
      spec:
        type: LoadBalancer
    additionalArguments:
    - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=30m
    - --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30m
'
1.3
kubectl patch helmchartconfig rke2-traefik -n kube-system --type=merge -p '
spec:
  valuesContent: |-
    logs:
      access:
        enabled: "true"
    service:
      spec:
        type: ClusterIP
    additionalArguments:
    - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=30m
    - --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30m
'
```

2. Rollout Harvester deployment, to trigger the sync between Harvester and RKE2 (as the sync function is one-shot), the service type is amended to `LoadBalancer`, the `kube-vip` daemonset is rolled out by new Harvester POD automatically

```
kubectl rollout restart deployment harvester -n harvester-system
```

logs & objects:
```
harvester pod log:
time="2026-08-21T08:38:11Z" level=info msg="Service rke2-traefik (old type ClusterIP) is updated to align with vip config and DaemonSet kube-vip is rolled out"


harv41:/home/rancher # kubectl get daemonset -n harvester-system kube-vip -oyaml

spec:
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/instance: harvester
      app.kubernetes.io/name: kube-vip
  template:
    metadata:
      annotations:
        harvesterhci.io/restartReason: '[2026-08-21T08:38:11Z] Service rke2-traefik
          (old type ClusterIP) is updated to align with vip config and DaemonSet kube-vip
          is rolled out'
        harvesterhci.io/restartedAt: "2026-08-21T08:38:11Z"
        harvesterhci.io/restartedBy: harvester-rancher-controller
        kubectl.kubernetes.io/restartedAt: "2026-08-21T08:38:11Z"
      labels:
        app.kubernetes.io/instance: harvester
        app.kubernetes.io/name: kube-vip
    spec:

```

on multi-node env, the kube-vip rollout info:

```
harv41:/home/rancher # kubectl get pods -n harvester-system kube-vip-fwcvd -oyaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    harvesterhci.io/restartReason: '[2026-08-21T09:20:08Z] Service rke2-traefik (old
      type ClusterIP) is updated to align with vip config and DaemonSet kube-vip is
      rolled out'
    harvesterhci.io/restartedAt: "2026-08-21T09:20:08Z"
    harvesterhci.io/restartedBy: harvester-rancher-controller
    kubectl.kubernetes.io/restartedAt: "2026-08-21T09:20:08Z"
  creationTimestamp: "2026-08-21T09:20:09Z"
  generateName: kube-vip-
  generation: 1
 labels:
    app.kubernetes.io/instance: harvester
    app.kubernetes.io/name: kube-vip
    controller-revision-hash: 75bdbfcdc8
    pod-template-generation: "11"
  name: kube-vip-fwcvd
  namespace: harvester-system


harv41:/home/rancher # kubectl get pods -n harvester-system kube-vip-l25bd -oyaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    harvesterhci.io/restartReason: '[2026-08-21T09:20:08Z] Service rke2-traefik (old
      type ClusterIP) is updated to align with vip config and DaemonSet kube-vip is
      rolled out'
    harvesterhci.io/restartedAt: "2026-08-21T09:20:08Z"
    harvesterhci.io/restartedBy: harvester-rancher-controller
    kubectl.kubernetes.io/restartedAt: "2026-08-21T09:20:08Z"
  creationTimestamp: "2026-08-21T09:20:08Z"
  generateName: kube-vip-
  generation: 1
  labels:
    app.kubernetes.io/instance: harvester
    app.kubernetes.io/name: kube-vip
    controller-revision-hash: 75bdbfcdc8
    pod-template-generation: "11"
  name: kube-vip-l25bd
  namespace: harvester-system
```

#### Additional documentation or context
