### PR TITLE
Allow upgrade image CDI scratch PVCs and set CDI scratch storage class

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -174,6 +174,7 @@ cdi:
       featureGates:
         - HonorWaitForFirstConsumer
         - WebhookPvcRendering
+      scratchSpaceStorageClass: harvester-longhorn
       podResourceRequirements:
         limits:
           memory: 2G

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -13,6 +13,7 @@ import (
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdicore "kubevirt.io/containerized-data-importer/pkg/common"
 	cdicommon "kubevirt.io/containerized-data-importer/pkg/controller/common"
 
 	harvesterv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
@@ -271,11 +272,24 @@ func (v *pvcValidator) isBelongToUpgradeImage(pvc *corev1.PersistentVolumeClaim)
 		return false, nil
 	}
 
+	isUpgradeImagePVC, err := v.isUpgradeImagePVC(pvc)
+	if err != nil || isUpgradeImagePVC {
+		return isUpgradeImagePVC, err
+	}
+
+	return v.isUpgradeImageScratchPVC(pvc)
+}
+
+func (v *pvcValidator) isUpgradeImagePVC(pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != util.StorageClassLonghornStatic {
+		return false, nil
+	}
+
 	for _, owner := range pvc.OwnerReferences {
 		// upgrade vm image will create 3 pvcs
 		// 1. image-xxxxx pvc (owner kind: DataVolume) with longhorn-static storage class, the owner here is the underlying data volume of upgrade vm image
 		// 2. prime-{uuid} pvc (owner kind: PersistentVolumeClaim) with longhorn-static storage class, the owner here is the image-xxxxx pvc
-		// 3. prime-{uuid}-scratch pvc (owner kind: Pod) with default storage class, generally harvester-longhorn, the owner here is the cdi importer/upload pod
+		// 3. prime-{uuid}-scratch pvc (owner kind: Pod), which can inherit longhorn-static from the data pvc when CDI scratchSpaceStorageClass is not set
 		// note that vm image and data volume and image-xxxxx pvc share the same name
 		if owner.Kind != util.DVObjectName && owner.Kind != util.PVCObjectName {
 			continue
@@ -295,6 +309,43 @@ func (v *pvcValidator) isBelongToUpgradeImage(pvc *corev1.PersistentVolumeClaim)
 	}
 
 	return false, nil
+}
+
+func (v *pvcValidator) isUpgradeImageScratchPVC(pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	scratchPVCSuffix := "-" + cdicore.ScratchNameSuffix
+
+	// CDI creates scratch PVCs with the importer pod as the controller owner.
+	if v.pvcCache == nil || !strings.HasSuffix(pvc.Name, scratchPVCSuffix) || !isControlledByPod(pvc) {
+		return false, nil
+	}
+
+	dataPVCName := strings.TrimSuffix(pvc.Name, scratchPVCSuffix)
+	if dataPVCName == "" || dataPVCName == pvc.Name {
+		return false, nil
+	}
+
+	dataPVC, err := v.pvcCache.Get(pvc.Namespace, dataPVCName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return v.isUpgradeImagePVC(dataPVC)
+}
+
+func isControlledByPod(pvc *corev1.PersistentVolumeClaim) bool {
+	for _, owner := range pvc.OwnerReferences {
+		if owner.APIVersion == corev1.SchemeGroupVersion.String() &&
+			owner.Kind == "Pod" &&
+			owner.UID != "" &&
+			owner.Controller != nil &&
+			*owner.Controller {
+			return true
+		}
+	}
+	return false
 }
 
 // isManagedByKubeVirt checks if a PVC creation request is legitimately from KubeVirt.

--- a/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
@@ -17,10 +17,26 @@ import (
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
 
+func newUpgradeImage(namespace, name string) *harvesterv1.VirtualMachineImage {
+	return &harvesterv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				util.AnnotationUpgradeImage: "True",
+			},
+		},
+		Spec: harvesterv1.VirtualMachineImageSpec{
+			TargetStorageClassName: util.StorageClassLonghornStatic,
+		},
+	}
+}
+
 func TestIsBelongToUpgradeImage(t *testing.T) {
 	tests := []struct {
 		name           string
 		pvc            *corev1.PersistentVolumeClaim
+		dataPVC        *corev1.PersistentVolumeClaim
 		image          *harvesterv1.VirtualMachineImage
 		expectedResult bool
 		expectError    bool
@@ -43,18 +59,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
 				},
 			},
-			image: &harvesterv1.VirtualMachineImage{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "upgrade-image",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.AnnotationUpgradeImage: "True",
-					},
-				},
-				Spec: harvesterv1.VirtualMachineImageSpec{
-					TargetStorageClassName: util.StorageClassLonghornStatic,
-				},
-			},
+			image:          newUpgradeImage("default", "upgrade-image"),
 			expectedResult: true,
 			expectError:    false,
 		},
@@ -76,19 +81,159 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
 				},
 			},
-			image: &harvesterv1.VirtualMachineImage{
+			image:          newUpgradeImage("default", "upgrade-image"),
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "scratch PVC owned by importer pod for upgrade image PVC",
+			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "upgrade-image",
+					Name:      "prime-test-scratch",
 					Namespace: "default",
-					Annotations: map[string]string{
-						util.AnnotationUpgradeImage: "True",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "importer-prime-test",
+							UID:        "pod-uid",
+							Controller: ptr.To(true),
+						},
 					},
 				},
-				Spec: harvesterv1.VirtualMachineImageSpec{
-					TargetStorageClassName: util.StorageClassLonghornStatic,
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
 				},
 			},
+			dataPVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       util.PVCObjectName,
+							Name:       "upgrade-image",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			image:          newUpgradeImage("default", "upgrade-image"),
 			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "scratch PVC owned by importer pod but data PVC is not an upgrade image PVC",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test-scratch",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "importer-prime-test",
+							UID:        "pod-uid",
+							Controller: ptr.To(true),
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			dataPVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test",
+					Namespace: "default",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "scratch PVC owned by importer pod but name does not match data PVC scratch name",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-scratch",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "importer-prime-test",
+							UID:        "pod-uid",
+							Controller: ptr.To(true),
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			dataPVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       util.PVCObjectName,
+							Name:       "upgrade-image",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			image:          newUpgradeImage("default", "upgrade-image"),
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "scratch PVC owned by importer pod but pod owner is not controller",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test-scratch",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "importer-prime-test",
+							UID:        "pod-uid",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			dataPVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       util.PVCObjectName,
+							Name:       "upgrade-image",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			image:          newUpgradeImage("default", "upgrade-image"),
+			expectedResult: false,
 			expectError:    false,
 		},
 		{
@@ -171,9 +316,14 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 				err := clientset.Tracker().Add(tc.image)
 				assert.Nil(t, err, "Failed to add image to fake client")
 			}
+			if tc.dataPVC != nil {
+				err := clientset.Tracker().Add(tc.dataPVC)
+				assert.Nil(t, err, "Failed to add data PVC to fake client")
+			}
 
 			validator := &pvcValidator{
 				imageCache: fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
+				pvcCache:   fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
 			}
 
 			result, err := validator.isBelongToUpgradeImage(tc.pvc)
@@ -218,6 +368,8 @@ func TestCreate(t *testing.T) {
 	tests := []struct {
 		name          string
 		pvc           *corev1.PersistentVolumeClaim
+		dataPVC       *corev1.PersistentVolumeClaim
+		image         *harvesterv1.VirtualMachineImage
 		sc            *storagev1.StorageClass
 		bi            *longhorn.BackingImage
 		sarDenied     bool
@@ -262,6 +414,45 @@ func TestCreate(t *testing.T) {
 			},
 			expectError:   true,
 			errorContains: "reserved storage class",
+		},
+		{
+			name: "create scratch PVC with reserved longhorn-static storage class for upgrade image import",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test-scratch",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "importer-prime-test",
+							UID:        "pod-uid",
+							Controller: ptr.To(true),
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			dataPVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       util.PVCObjectName,
+							Name:       "upgrade-image",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			image:       newUpgradeImage("default", "upgrade-image"),
+			expectError: false,
 		},
 		{
 			name: "create PVC with reserved vmstate-persistence storage class",
@@ -390,12 +581,20 @@ func TestCreate(t *testing.T) {
 			if tc.bi != nil {
 				assert.NoError(t, clientset.Tracker().Add(tc.bi))
 			}
+			if tc.image != nil {
+				assert.NoError(t, clientset.Tracker().Add(tc.image))
+			}
+			if tc.dataPVC != nil {
+				assert.NoError(t, clientset.Tracker().Add(tc.dataPVC))
+			}
 
 			var sar = allowedFakeSAR
 			if tc.sarDenied {
 				sar = denyFakeSAR
 			}
 			validator := &pvcValidator{
+				pvcCache:          fakeclients.PersistentVolumeClaimCache(clientset.CoreV1().PersistentVolumeClaims),
+				imageCache:        fakeclients.VirtualMachineImageCache(clientset.HarvesterhciV1beta1().VirtualMachineImages),
 				scCache:           fakeclients.StorageClassCache(clientset.StorageV1().StorageClasses),
 				backingImageCache: fakeclients.BackingImageCache(clientset.LonghornV1beta2().BackingImages),
 				sar:               sar,


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:

cdi 1.65.0 introduce a behavior change: https://github.com/kubevirt/containerized-data-importer/commit/48c01a9e7c8132871b8a67624cc98f56a382672a
now CDI can create scratch PVCs using the original data PVC’s storage class when `scratchSpaceStorageClass` is not configured.
Harvester upgrade repo images intentionally use the reserved `longhorn-static storage` class for the target PVC, but CDI scratch PVCs are temporary importer workspace and should use the normal Harvester storage class instead. If CDI inherits `longhorn-static`, Harvester’s PVC admission webhook rejects the scratch PVC creation.

#### Solution:

**We need both changes:**

1. Set `spec.config.scratchSpaceStorageClass` to `harvester-longhorn` in the Harvester chart. This preserves the previous behavior where CDI scratch PVCs used the default Harvester storage class instead of inheriting the target PVC’s storage class.

2. Add a narrow webhook bypass for upgrade image scratch PVCs. If a user intentionally removes `scratchSpaceStorageClass` from the CDI config, CDI falls back to the original data PVC storage class. For upgrade repo images, that storage class is `longhorn-static`, so scratch PVC creation can be rejected by the Harvester PVC webhook and cause the upgrade to fail. The webhook should handle this as a valid upgrade-image scratch PVC case.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11466

#### Test plan:

upgrade v1.9.0 to master branch, upgrade process should not stuck in the downloading phase.

<img width="2560" height="1309" alt="Screenshot 2026-08-21 at 5 39 42 PM" src="https://github.com/user-attachments/assets/a889c36c-c31f-4a3e-ad8a-4c4b2f97df8b" />

#### Additional documentation or context
