### PR TITLE
Ensure addon version is expected on release branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ COPY --from=build /go/src/github.com/harvester/harvester/bin/ /bin/
 
 # ---- prepare-addons ----
 FROM builder AS prepare-addons
-ARG ADDONS_BRANCH=main
+ARG ADDONS_BRANCH=v1.9
 
 # re-pull when remote sha changed
 ARG REMOTE_SHA=unknown
@@ -250,7 +250,7 @@ RUN bash scripts/check-images
 
 # ---- build-iso ----
 FROM builder AS build-iso
-
+ARG ADDONS_BRANCH=v1.9
 WORKDIR /go/src/github.com/harvester/harvester
 
 COPY --from=build-installer /go/src/github.com/harvester/harvester/bin/harvester-installer package/harvester-os/files/usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,9 @@ MK_DOCKER_PULL            ?= --pull
 
 # Legacy dapper env variables
 CODECOV_TOKEN             ?=
-HARVESTER_ADDONS_VERSION  ?= main
+ # Default addons git ref (branch or tag) consumed by scripts/prepare-addons and Docker builds.
+ # Override HARVESTER_ADDONS_VERSION to pin a specific RC/release (e.g. v1.9.0-rc6).
+HARVESTER_ADDONS_VERSION  ?= v1.9
 HARVESTER_UI_VERSION      ?=
 HARVESTER_UI_PLUGIN_BUNDLED_VERSION ?=
 RKE2_IMAGE_REPO           ?= https://github.com/rancher/rke2/releases/download/
@@ -200,7 +202,9 @@ prepare-addons:
 # ---- Build ISO ----
 build-iso: gen-version-env build-installer check-images
 	$(BANNER)
-	$(DOCKER_BUILD) --target build-iso -t $(MK_ISO_BUILDER_IMAGE)
+	$(DOCKER_BUILD) --target build-iso \
+		--build-arg ADDONS_BRANCH=$(HARVESTER_ADDONS_VERSION) \
+		-t $(MK_ISO_BUILDER_IMAGE)
 	$(ROOT)/scripts/mk-build-iso
 
 

--- a/scripts/prepare-addons
+++ b/scripts/prepare-addons
@@ -8,6 +8,12 @@ TOP_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 REMOTE_URL="https://github.com/harvester/addons.git"
 ADDONS_BRANCH=${HARVESTER_ADDONS_VERSION:-v1.9}
 
+# Enforce strict release version pattern matching, double check upon Makefile env HARVESTER_ADDONS_VERSION
+if [[ ${ADDONS_BRANCH} != v1.9* ]]; then
+    echo "Error: ADDONS_BRANCH must start with 'v1.9' (got '${ADDONS_BRANCH}'). Check if Makefile env HARVESTER_ADDONS_VERSION is correctly set" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 echo "Checking remote addons commit for branch '$ADDONS_BRANCH'..."
 REMOTE_SHA=$(git ls-remote "$REMOTE_URL" "refs/heads/$ADDONS_BRANCH" | cut -f1)
 REMOTE_SHA="${REMOTE_SHA}"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Addon version is not correct on v190 rc-release branch & the final ISO

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix the build process.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11469#issuecomment-5375135921

#### Test plan:
<!-- Describe the test plan by steps. -->

With a local change to set HARVESTER_ADDONS_VERSION as v1.9.0-rc6, the `make build-iso` log:

```
--- a/Makefile
+++ b/Makefile

-HARVESTER_ADDONS_VERSION  ?= v1.9.0
+HARVESTER_ADDONS_VERSION  ?= v1.9.0-rc6





make build-iso 
[target: gen-version-env]
Warning: there are uncommitted files; the build result might not be as expected
[target: prepare-addons]
/go/src/github.com/harvester/harvester/scripts/prepare-addons
Checking remote addons commit for branch 'v1.9.0-rc6'...
Remote commit sha: 
#0 building with "default" instance using docker driver



[target: build-installer]
docker build --pull --progress=plain --build-arg MK_REPO_ID --build-arg MK_HOST_ARCH -f /go/src/github.com/harvester/harvester/Dockerfile /go/src/github.com/harvester/harvester --target build-installer-output \
    --build-arg ADDONS_BRANCH=v1.9.0-rc6 \
    --output type=local,dest=/go/src/github.com/harvester/harvester
#0 building with "default" instance using docker driver


[target: build-iso]
docker build --pull --progress=plain --build-arg MK_REPO_ID --build-arg MK_HOST_ARCH -f /go/src/github.com/harvester/harvester/Dockerfile /go/src/github.com/harvester/harvester --target build-iso \
	--build-arg ADDONS_BRANCH=v1.9.0-rc6 \
	-t harvester-iso-builder:d13d488b

Creating Helm repo index for charts...
/go/src/github.com/harvester/harvester/package/harvester-repo/charts
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/harvester-crd-0.0.0-fix-addon-version-d3514faa-dirty.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/harvester-0.0.0-fix-addon-version-d3514faa-dirty.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/harvester-pcidevices-controller-1.9.0-rc6.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/kubeovn-operator-crd-1.16.2-dev.0.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/rancher-logging-109.0.0+up4.10.0-rancher.23.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/rancher-monitoring-crd-109.0.3+up80.9.1-rancher.14.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/kubeovn-operator-1.16.2-dev.0.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/nvidia-driver-runtime-1.9.0-rc6.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/harvester-vm-import-controller-1.9.0-rc6.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/rancher-monitoring-109.0.3+up80.9.1-rancher.14.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/rancher-logging-crd-109.0.0+up4.10.0-rancher.23.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/harvester-seeder-1.9.0-rc6.tgz
/go/src/github.com/harvester/harvester/package/harvester-repo/charts/descheduler-0.36.0.tgz
Preparing rancherd bootstrap images...
```


#### Additional documentation or context

For change like https://github.com/harvester/harvester/pull/11451/changes#diff-435077c8d61a731a6fefcc9f8ec2325a43320cf3ccf8ee6c9c75c9469947df21R9, on new rc release, change the `Makefile`.