### PR TITLE
fix:validate upgrade image PVCs in system namespace

### DIFF
--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -281,6 +281,11 @@ func (v *pvcValidator) isBelongToUpgradeImage(pvc *corev1.PersistentVolumeClaim)
 }
 
 func (v *pvcValidator) isUpgradeImagePVC(pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	// upgrade vm image is created in harvester-system namespace and so does all related resources, so only check the owner in harvester-system namespace
+	if pvc.Namespace != util.HarvesterSystemNamespaceName {
+		return false, nil
+	}
+
 	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != util.StorageClassLonghornStatic {
 		return false, nil
 	}

--- a/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator_test.go
@@ -46,6 +46,50 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pvc",
+					Namespace: util.HarvesterSystemNamespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "cdi.kubevirt.io/v1beta1",
+							Kind:       util.DVObjectName,
+							Name:       "upgrade-image",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			image:          newUpgradeImage(util.HarvesterSystemNamespaceName, "upgrade-image"),
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "PVC owned by PVC with upgrade image annotation",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: util.HarvesterSystemNamespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "cdi.kubevirt.io/v1beta1",
+							Kind:       util.PVCObjectName,
+							Name:       "upgrade-image",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			image:          newUpgradeImage(util.HarvesterSystemNamespaceName, "upgrade-image"),
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "PVC owned by DataVolume with upgrade image annotation outside system namespace",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -60,29 +104,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 				},
 			},
 			image:          newUpgradeImage("default", "upgrade-image"),
-			expectedResult: true,
-			expectError:    false,
-		},
-		{
-			name: "PVC owned by PVC with upgrade image annotation",
-			pvc: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: "default",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: "cdi.kubevirt.io/v1beta1",
-							Kind:       util.PVCObjectName,
-							Name:       "upgrade-image",
-						},
-					},
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
-				},
-			},
-			image:          newUpgradeImage("default", "upgrade-image"),
-			expectedResult: true,
+			expectedResult: false,
 			expectError:    false,
 		},
 		{
@@ -90,7 +112,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test-scratch",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "v1",
@@ -108,7 +130,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			dataPVC: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "v1",
@@ -121,7 +143,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
 				},
 			},
-			image:          newUpgradeImage("default", "upgrade-image"),
+			image:          newUpgradeImage(util.HarvesterSystemNamespaceName, "upgrade-image"),
 			expectedResult: true,
 			expectError:    false,
 		},
@@ -130,7 +152,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test-scratch",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "v1",
@@ -148,7 +170,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			dataPVC: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
@@ -162,7 +184,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "other-scratch",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "v1",
@@ -180,7 +202,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			dataPVC: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "v1",
@@ -193,7 +215,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
 				},
 			},
-			image:          newUpgradeImage("default", "upgrade-image"),
+			image:          newUpgradeImage(util.HarvesterSystemNamespaceName, "upgrade-image"),
 			expectedResult: false,
 			expectError:    false,
 		},
@@ -202,7 +224,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test-scratch",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "v1",
@@ -219,7 +241,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			dataPVC: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "v1",
@@ -232,7 +254,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
 				},
 			},
-			image:          newUpgradeImage("default", "upgrade-image"),
+			image:          newUpgradeImage(util.HarvesterSystemNamespaceName, "upgrade-image"),
 			expectedResult: false,
 			expectError:    false,
 		},
@@ -241,7 +263,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pvc",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "cdi.kubevirt.io/v1beta1",
@@ -254,7 +276,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			image: &harvesterv1.VirtualMachineImage{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "normal-image",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 				},
 			},
 			expectedResult: false,
@@ -265,7 +287,7 @@ func TestIsBelongToUpgradeImage(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pvc",
-					Namespace: "default",
+					Namespace: util.HarvesterSystemNamespaceName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "cdi.kubevirt.io/v1beta1",
@@ -420,6 +442,45 @@ func TestCreate(t *testing.T) {
 			pvc: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prime-test-scratch",
+					Namespace: util.HarvesterSystemNamespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "importer-prime-test",
+							UID:        "pod-uid",
+							Controller: ptr.To(true),
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			dataPVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test",
+					Namespace: util.HarvesterSystemNamespaceName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       util.PVCObjectName,
+							Name:       "upgrade-image",
+						},
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
+				},
+			},
+			image:       newUpgradeImage(util.HarvesterSystemNamespaceName, "upgrade-image"),
+			expectError: false,
+		},
+		{
+			name: "reject scratch PVC with reserved longhorn-static storage class outside system namespace",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prime-test-scratch",
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -451,8 +512,9 @@ func TestCreate(t *testing.T) {
 					StorageClassName: ptr.To(util.StorageClassLonghornStatic),
 				},
 			},
-			image:       newUpgradeImage("default", "upgrade-image"),
-			expectError: false,
+			image:         newUpgradeImage("default", "upgrade-image"),
+			expectError:   true,
+			errorContains: "reserved storage class",
 		},
 		{
 			name: "create PVC with reserved vmstate-persistence storage class",


### PR DESCRIPTION
#### Problem:
This is a follow up from @w13915984028's comment

> In Rancher Manager managed Harvester case, there are mutli tenants, different tenants are working on different namespaces (say user namespace),  the data from user namespaces are untrustable. without a namespace check, a fake image with above annotation could bypass the isUpgradeImagePVC and then use `longhorn-static` SC.

#### Solution:

validate upgrade image PVCs in system namespace

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11466

#### Test plan:

#### Additional documentation or context

<img width="2555" height="1315" alt="Screenshot 2026-08-25 at 3 52 10 PM" src="https://github.com/user-attachments/assets/52e3728a-c609-4b21-a832-6208472c37d3" />
