### PR TITLE
Add kubeovn/vpc-nat-gateway images to the ISO

### DIFF
--- a/scripts/images/harvester-additional-images.txt
+++ b/scripts/images/harvester-additional-images.txt
@@ -1,3 +1,4 @@
 registry.suse.com/suse/vmdp/vmdp:2.5.5
 docker.io/kubeovn/kube-ovn:v1.16.2
+docker.io/kubeovn/vpc-nat-gateway:v1.16.2
 registry.k8s.io/descheduler/descheduler:v0.36.0


### PR DESCRIPTION
The image is required when creating a NAT Gateway, but it is missing in the air-gapped environment.