### PR TITLE
Add util helper functions to work with namespaced names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ DOCKER_BUILD = docker build $(MK_DOCKER_PULL) \
 	generate-manifest generate-openapi prepare-addons ci arm clean clean-all default \
 	image-cache-clean image-cache-show image-cache-debug \
 	gen-version-env gen-version-env-debug build-installer \
-	check-images
+	check-images fix
 
 
 # ---- Directories ----
@@ -126,6 +126,13 @@ validate: gen-version-env
 validate-ci: gen-version-env
 	$(BANNER)
 	$(DOCKER_BUILD) --target validate-ci
+
+
+# ---- Format Go code ----
+fix:
+	$(BANNER)
+	@echo "Formatting Go files ..."
+	@go fmt ./...
 
 
 # ---- Test ----

--- a/pkg/api/volume/formatter.go
+++ b/pkg/api/volume/formatter.go
@@ -7,7 +7,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 )
@@ -55,7 +54,7 @@ func (f *volFormatter) Formatter(request *types.APIRequest, resource *types.RawR
 		resource.AddAction(request, actionSnapshot)
 	}
 
-	if vms, err := f.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, ref.Construct(pvc.Namespace, pvc.Name)); err == nil && len(vms) == 0 {
+	if vms, err := f.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, util.NamespacedName(pvc.Namespace, pvc.Name)); err == nil && len(vms) == 0 {
 		resource.AddAction(request, actionDataMigration)
 	}
 }

--- a/pkg/api/volume/handler.go
+++ b/pkg/api/volume/handler.go
@@ -29,7 +29,6 @@ import (
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1"
-	"github.com/harvester/harvester/pkg/ref"
 	harvesterServer "github.com/harvester/harvester/pkg/server/http"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
@@ -251,7 +250,7 @@ func (h *ActionHandler) cancelExpand(_ context.Context, pvcNamespace, pvcName st
 		return err
 	}
 
-	vms, err := h.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, ref.Construct(pvcNamespace, pvcName))
+	vms, err := h.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, util.NamespacedName(pvcNamespace, pvcName))
 	if err != nil {
 		return fmt.Errorf("failed to get VMs by index: %s, PVC: %s/%s, err: %v", indexeresutil.VMByPVCIndex, pvcNamespace, pvcName, err)
 	}

--- a/pkg/controller/master/backup/backup_backing_image.go
+++ b/pkg/controller/master/backup/backup_backing_image.go
@@ -21,7 +21,6 @@ import (
 	"github.com/harvester/harvester/pkg/config"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	backuputil "github.com/harvester/harvester/pkg/util/backup"
@@ -84,7 +83,7 @@ func (h *backupBackingImageHandler) OnBackupBackingImageChange(_ string, backupB
 		return nil, err
 	}
 
-	vmImageNamespace, vmImageName := ref.Parse(backingImage.Annotations[util.AnnotationImageID])
+	vmImageNamespace, vmImageName, _ := util.SplitNamespacedName(backingImage.Annotations[util.AnnotationImageID])
 	if vmImageNamespace == "" || vmImageName == "" {
 		return nil, nil
 	}

--- a/pkg/controller/master/schedulevmbackup/common.go
+++ b/pkg/controller/master/schedulevmbackup/common.go
@@ -14,7 +14,6 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/backup/common"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -110,7 +109,7 @@ func createVMBackup(h *svmbackupHandler, svmbackup *harvesterv1.ScheduleVMBackup
 			Name:      vmBackupName(svmbackup, timestamp),
 			Namespace: svmbackup.Namespace,
 			Annotations: map[string]string{
-				util.AnnotationSVMBackupID: ref.Construct(svmbackup.Namespace, svmbackup.Name),
+				util.AnnotationSVMBackupID: util.NamespacedName(svmbackup.Namespace, svmbackup.Name),
 			},
 			Labels: map[string]string{
 				util.LabelSVMBackupUID:       string(svmbackup.UID),

--- a/pkg/controller/master/schedulevmbackup/common_test.go
+++ b/pkg/controller/master/schedulevmbackup/common_test.go
@@ -12,7 +12,6 @@ import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/backup/common"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
@@ -49,7 +48,7 @@ var (
 			Namespace: svmbackup.Namespace,
 			Name:      fmt.Sprintf("%s-%s-%s", svmbackupPrefix, svmbackup.UID, timestamp1),
 			Annotations: map[string]string{
-				util.AnnotationSVMBackupID: ref.Construct(svmbackup.Namespace, svmbackup.Name),
+				util.AnnotationSVMBackupID: util.NamespacedName(svmbackup.Namespace, svmbackup.Name),
 			},
 			Labels: map[string]string{
 				util.LabelSVMBackupUID:       string(svmbackup.UID),
@@ -75,7 +74,7 @@ var (
 			Namespace: svmbackup.Namespace,
 			Name:      fmt.Sprintf("%s-%s-%s", svmbackupPrefix, svmbackup.UID, timestamp2),
 			Annotations: map[string]string{
-				util.AnnotationSVMBackupID: ref.Construct(svmbackup.Namespace, svmbackup.Name),
+				util.AnnotationSVMBackupID: util.NamespacedName(svmbackup.Namespace, svmbackup.Name),
 			},
 			Labels: map[string]string{
 				util.LabelSVMBackupUID:       string(svmbackup.UID),
@@ -93,7 +92,7 @@ var (
 			Namespace: svmbackup.Namespace,
 			Name:      fmt.Sprintf("%s-%s-%s", svmbackupPrefix, svmbackup.UID, timestamp3),
 			Annotations: map[string]string{
-				util.AnnotationSVMBackupID: ref.Construct(svmbackup.Namespace, svmbackup.Name),
+				util.AnnotationSVMBackupID: util.NamespacedName(svmbackup.Namespace, svmbackup.Name),
 			},
 			Labels: map[string]string{
 				util.LabelSVMBackupUID:       string(svmbackup.UID),
@@ -111,7 +110,7 @@ var (
 			Namespace: svmbackup.Namespace,
 			Name:      fmt.Sprintf("%s-%s-%s", svmbackupPrefix, svmbackup.UID, timestampErr),
 			Annotations: map[string]string{
-				util.AnnotationSVMBackupID: ref.Construct(svmbackup.Namespace, svmbackup.Name),
+				util.AnnotationSVMBackupID: util.NamespacedName(svmbackup.Namespace, svmbackup.Name),
 			},
 			Labels: map[string]string{
 				util.LabelSVMBackupUID:       string(svmbackup.UID),

--- a/pkg/controller/master/schedulevmbackup/svmbackup.go
+++ b/pkg/controller/master/schedulevmbackup/svmbackup.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	utilHelm "github.com/harvester/harvester/pkg/util/helm"
 )
@@ -48,7 +47,7 @@ func createCronJob(h *svmbackupHandler, svmbackup *harvesterv1.ScheduleVMBackup)
 			Name:      cronJobName(svmbackup),
 			Namespace: cronJobNamespace,
 			Annotations: map[string]string{
-				util.AnnotationSVMBackupID: ref.Construct(svmbackup.Namespace, svmbackup.Name),
+				util.AnnotationSVMBackupID: util.NamespacedName(svmbackup.Namespace, svmbackup.Name),
 			},
 		},
 		Spec: batchv1.CronJobSpec{

--- a/pkg/controller/master/template/template_controller.go
+++ b/pkg/controller/master/template/template_controller.go
@@ -5,7 +5,7 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 // templateHandler sets status.Version to template objects
@@ -22,7 +22,7 @@ func (h *templateHandler) OnChanged(_ string, tp *harvesterv1.VirtualMachineTemp
 	}
 
 	copyTp := tp.DeepCopy()
-	templateID := ref.Construct(copyTp.Namespace, copyTp.Name)
+	templateID := util.NamespacedName(copyTp.Namespace, copyTp.Name)
 
 	latestVersion, latestVersionObj, err := getTemplateLatestVersion(copyTp.Namespace, templateID, h.templateVersions)
 	if err != nil {
@@ -36,7 +36,7 @@ func (h *templateHandler) OnChanged(_ string, tp *harvesterv1.VirtualMachineTemp
 	//set the first version as the default version
 	defaultVersionID := copyTp.Spec.DefaultVersionID
 	if defaultVersionID == "" && latestVersion == 1 {
-		defaultVersionID = ref.Construct(latestVersionObj.Namespace, latestVersionObj.Name)
+		defaultVersionID = util.NamespacedName(latestVersionObj.Namespace, latestVersionObj.Name)
 		if tp.Spec.DefaultVersionID != defaultVersionID {
 			copyTp.Spec.DefaultVersionID = defaultVersionID
 			if _, err = h.templates.Update(copyTp); err != nil {
@@ -48,7 +48,7 @@ func (h *templateHandler) OnChanged(_ string, tp *harvesterv1.VirtualMachineTemp
 
 	defaultVersion := copyTp.Status.DefaultVersion
 	if defaultVersionID != "" {
-		versionNs, versionName := ref.Parse(defaultVersionID)
+		versionNs, versionName, _ := util.SplitNamespacedName(defaultVersionID)
 		version, err := h.templateVersionCache.Get(versionNs, versionName)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/master/template/template_version_controller.go
+++ b/pkg/controller/master/template/template_version_controller.go
@@ -10,7 +10,6 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -33,7 +32,7 @@ func (h *templateVersionHandler) OnChanged(_ string, tv *harvesterv1.VirtualMach
 		return nil, nil
 	}
 
-	ns, templateName := ref.Parse(tv.Spec.TemplateID)
+	ns, templateName, _ := util.SplitNamespacedName(tv.Spec.TemplateID)
 	template, err := h.templateCache.Get(ns, templateName)
 	if err != nil {
 		return nil, err
@@ -116,7 +115,7 @@ func (h *templateVersionHandler) isVMImagesReady(tv *harvesterv1.VirtualMachineT
 			continue
 		}
 
-		imageNs, imageName := ref.Parse(imageID)
+		imageNs, imageName, _ := util.SplitNamespacedName(imageID)
 		if image, err := h.vmImageCache.Get(imageNs, imageName); err != nil {
 			return false, err
 		} else if !harvesterv1.ImageImported.IsTrue(image) {

--- a/pkg/image/backingimage/backing_image_controller.go
+++ b/pkg/image/backingimage/backing_image_controller.go
@@ -9,7 +9,6 @@ import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1beta1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/image/common"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 )
@@ -45,7 +44,7 @@ func (h *backingImageHandler) OnChanged(_ string, bi *lhv1beta2.BackingImage) (*
 	if bi.Annotations[util.AnnotationImageID] == "" || len(bi.Status.DiskFileStatusMap) != 1 {
 		return nil, nil
 	}
-	namespace, name := ref.Parse(bi.Annotations[util.AnnotationImageID])
+	namespace, name, _ := util.SplitNamespacedName(bi.Annotations[util.AnnotationImageID])
 	vmi, err := h.vmiCache.Get(namespace, name)
 	if errors.IsNotFound(err) {
 		return nil, nil

--- a/pkg/image/backingimage/backing_image_controller_test.go
+++ b/pkg/image/backingimage/backing_image_controller_test.go
@@ -12,7 +12,6 @@ import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	fakegenerated "github.com/harvester/harvester/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester/pkg/image/common"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/util/fakeclients"
 )
@@ -67,7 +66,7 @@ func TestBackingImageHandler_OnChanged_RetryLimitExceeded(t *testing.T) {
 					Name:      testImageName,
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						util.AnnotationImageID: ref.Construct(testNamespace, testImageName),
+						util.AnnotationImageID: util.NamespacedName(testNamespace, testImageName),
 					},
 				},
 				Status: lhv1beta2.BackingImageStatus{
@@ -115,7 +114,7 @@ func TestBackingImageHandler_OnChanged_RetryLimitExceeded(t *testing.T) {
 					Name:      testImageName,
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						util.AnnotationImageID: ref.Construct(testNamespace, testImageName),
+						util.AnnotationImageID: util.NamespacedName(testNamespace, testImageName),
 					},
 				},
 				Status: lhv1beta2.BackingImageStatus{
@@ -132,7 +131,7 @@ func TestBackingImageHandler_OnChanged_RetryLimitExceeded(t *testing.T) {
 					Name:      testImageName,
 					Namespace: testNamespace,
 					Annotations: map[string]string{
-						util.AnnotationImageID: ref.Construct(testNamespace, testImageName),
+						util.AnnotationImageID: util.NamespacedName(testNamespace, testImageName),
 					},
 				},
 				Status: lhv1beta2.BackingImageStatus{

--- a/pkg/image/backingimage/backingimage.go
+++ b/pkg/image/backingimage/backingimage.go
@@ -23,7 +23,6 @@ import (
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 	"github.com/harvester/harvester/pkg/image/backend"
 	"github.com/harvester/harvester/pkg/image/common"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 	backuputil "github.com/harvester/harvester/pkg/util/backup"
@@ -120,7 +119,7 @@ func (bib *Backend) createBackingImage(vmi *harvesterv1.VirtualMachineImage) err
 			Name:      biName,
 			Namespace: util.LonghornSystemNamespaceName,
 			Annotations: map[string]string{
-				util.AnnotationImageID: ref.Construct(vmio.GetNamespace(vmi), vmio.GetName(vmi)),
+				util.AnnotationImageID: util.NamespacedName(vmio.GetNamespace(vmi), vmio.GetName(vmi)),
 			},
 		},
 		Spec: lhv1beta2.BackingImageSpec{

--- a/pkg/ref/api_id.go
+++ b/pkg/ref/api_id.go
@@ -1,23 +1,18 @@
 package ref
 
 import (
-	"fmt"
-	"strings"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 // Parse parses the steve api ID.
+// Deprecated: use util.SplitNamespacedName instead.
 func Parse(ref string) (namespace string, name string) {
-	parts := strings.SplitN(ref, "/", 2)
-	if len(parts) == 1 {
-		return "", parts[0]
-	}
-	return parts[0], parts[1]
+	namespace, name, _ = util.SplitNamespacedName(ref)
+	return
 }
 
 // Construct creates the steve api ID.
+// Deprecated: use util.NamespacedName instead.
 func Construct(namespace string, name string) string {
-	if namespace == "" {
-		return name
-	}
-	return fmt.Sprintf("%s/%s", namespace, name)
+	return util.NamespacedName(namespace, name)
 }

--- a/pkg/util/fakeclients/storageclass.go
+++ b/pkg/util/fakeclients/storageclass.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	storagev1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/storage.k8s.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 
-	"github.com/harvester/harvester/pkg/ref"
+	storagev1type "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/storage.k8s.io/v1"
+
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 )
@@ -82,7 +82,7 @@ func (c StorageClassCache) AddIndexer(_ string, _ generic.Indexer[*storagev1.Sto
 func (c StorageClassCache) GetByIndex(indexName, key string) ([]*storagev1.StorageClass, error) {
 	switch indexName {
 	case indexeresutil.StorageClassBySecretIndex:
-		secretNS, secretName := ref.Parse(key)
+		secretNS, secretName, _ := util.SplitNamespacedName(key)
 		scList, err := c().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err

--- a/pkg/util/fakeclients/svmbackup.go
+++ b/pkg/util/fakeclients/svmbackup.go
@@ -13,7 +13,7 @@ import (
 	harvesterv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	harvestertype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/indexeres"
-	"github.com/harvester/harvester/pkg/ref"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 type SVMBackupClient func(string) harvestertype.ScheduleVMBackupInterface
@@ -79,7 +79,7 @@ func (c SVMBackupCache) AddIndexer(_ string, _ generic.Indexer[*harvesterv1beta1
 func (c SVMBackupCache) GetByIndex(indexName, key string) ([]*harvesterv1beta1.ScheduleVMBackup, error) {
 	switch indexName {
 	case indexeres.VMBackupBySourceVMNameIndex:
-		vmNamespace, _ := ref.Parse(key)
+		vmNamespace, _, _ := util.SplitNamespacedName(key)
 		backupList, err := c(vmNamespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err

--- a/pkg/util/fakeclients/vmbackup.go
+++ b/pkg/util/fakeclients/vmbackup.go
@@ -13,7 +13,7 @@ import (
 	harvesterv1beta1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	harvestertype "github.com/harvester/harvester/pkg/generated/clientset/versioned/typed/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/indexeres"
-	"github.com/harvester/harvester/pkg/ref"
+	"github.com/harvester/harvester/pkg/util"
 )
 
 type VMBackupClient func(string) harvestertype.VirtualMachineBackupInterface
@@ -79,7 +79,7 @@ func (c VMBackupCache) AddIndexer(_ string, _ generic.Indexer[*harvesterv1beta1.
 func (c VMBackupCache) GetByIndex(indexName, key string) ([]*harvesterv1beta1.VirtualMachineBackup, error) {
 	switch indexName {
 	case indexeres.VMBackupBySourceVMNameIndex:
-		vmNamespace, _ := ref.Parse(key)
+		vmNamespace, _, _ := util.SplitNamespacedName(key)
 		backupList, err := c(vmNamespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err

--- a/pkg/util/indexeres/pod.go
+++ b/pkg/util/indexeres/pod.go
@@ -3,7 +3,6 @@ package indexeres
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -16,5 +15,5 @@ func PodByVMName(obj *corev1.Pod) ([]string, error) {
 	if !ok {
 		return nil, nil
 	}
-	return []string{ref.Construct(obj.Namespace, vmName)}, nil
+	return []string{util.NamespacedName(obj.Namespace, vmName)}, nil
 }

--- a/pkg/util/indexeres/storageclass.go
+++ b/pkg/util/indexeres/storageclass.go
@@ -3,7 +3,6 @@ package indexeres
 import (
 	storagev1 "k8s.io/api/storage/v1"
 
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -21,6 +20,6 @@ func StorageClassBySecret(sc *storagev1.StorageClass) ([]string, error) {
 	secretNS := sc.Parameters[util.CSINodePublishSecretNamespaceKey]
 
 	return []string{
-		ref.Construct(secretNS, secretName),
+		util.NamespacedName(secretNS, secretName),
 	}, nil
 }

--- a/pkg/util/indexeres/virtualmachine.go
+++ b/pkg/util/indexeres/virtualmachine.go
@@ -6,7 +6,6 @@ import (
 	"github.com/harvester/go-common/ds"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 )
 
@@ -25,7 +24,7 @@ func VMByPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
 
 	for _, volume := range obj.Spec.Template.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName != "" {
-			results = append(results, ref.Construct(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
+			results = append(results, util.NamespacedName(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
 		}
 	}
 
@@ -50,7 +49,7 @@ func vmSourcePVCsFromAnnotation(obj *kubevirtv1.VirtualMachine) []string {
 	var results []string
 	for _, entry := range entries {
 		if entry.Name != "" {
-			results = append(results, ref.Construct(obj.Namespace, entry.Name))
+			results = append(results, util.NamespacedName(obj.Namespace, entry.Name))
 		}
 	}
 	return results
@@ -70,7 +69,7 @@ func VMByHotplugPVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
 	var results []string
 	for _, volume := range obj.Spec.Template.Spec.Volumes {
 		if isVolumeHotplugged(volume) {
-			results = append(results, ref.Construct(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
+			results = append(results, util.NamespacedName(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
 		}
 	}
 	return results, nil
@@ -95,7 +94,7 @@ func VMByNonShareablePVC(obj *kubevirtv1.VirtualMachine) ([]string, error) {
 		if volume.PersistentVolumeClaim != nil &&
 			volume.PersistentVolumeClaim.ClaimName != "" &&
 			slices.Contains(nonShareableDisks, volume.Name) {
-			results = append(results, ref.Construct(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
+			results = append(results, util.NamespacedName(obj.Namespace, volume.PersistentVolumeClaim.ClaimName))
 		}
 	}
 	return results, nil

--- a/pkg/util/meta.go
+++ b/pkg/util/meta.go
@@ -1,14 +1,35 @@
 package util
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 func NamespacedName(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
 	return types.NamespacedName{Namespace: namespace, Name: name}.String()
 }
 
 func GetNamespacedName(obj metav1.Object) string {
 	return NamespacedName(obj.GetNamespace(), obj.GetName())
+}
+
+// SplitNamespacedName splits a string in the format "namespace/name" into its two components.
+// If the input string does not contain a slash, it is assumed to be a non-namespaced name,
+// and the function will return an empty namespace and the original string as the name.
+// Malformed strings (e.g., empty string, leading or trailing slashes) will return an empty
+// namespace and name, along with a false boolean indicating failure.
+func SplitNamespacedName(namespacedName string) (string, string, bool) {
+	if namespacedName == "" || strings.HasPrefix(namespacedName, string(types.Separator)) || strings.HasSuffix(namespacedName, string(types.Separator)) {
+		return "", "", false
+	}
+	parts := strings.SplitN(namespacedName, string(types.Separator), 2)
+	if len(parts) == 1 {
+		return "", parts[0], true
+	}
+	return parts[0], parts[1], true
 }

--- a/pkg/util/meta_test.go
+++ b/pkg/util/meta_test.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamespacedName(t *testing.T) {
+	type input struct {
+		namespace string
+		name      string
+	}
+	type output struct {
+		namespacedName string
+	}
+
+	var testCases = []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "Cluster-Scoped Name",
+			given: input{
+				namespace: "",
+				name:      "test",
+			},
+			expected: output{
+				namespacedName: "test",
+			},
+		},
+		{
+			name: "Namespaced Name",
+			given: input{
+				namespace: "default",
+				name:      "test",
+			},
+			expected: output{
+				namespacedName: "default/test",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var actual output
+		actual.namespacedName = NamespacedName(tc.given.namespace, tc.given.name)
+		assert.Equal(t, tc.expected, actual)
+	}
+}
+
+func TestSplitNamespacedName(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		Input             string
+		ExpectedNamespace string
+		ExpectedName      string
+		ExpectedOK        bool
+	}{
+		{
+			Name:              "Namespaced Name",
+			Input:             "default/my-resource",
+			ExpectedNamespace: "default",
+			ExpectedName:      "my-resource",
+			ExpectedOK:        true,
+		},
+		{
+			Name:              "Cluster-Scoped Resource",
+			Input:             "cluster-resource",
+			ExpectedNamespace: "",
+			ExpectedName:      "cluster-resource",
+			ExpectedOK:        true,
+		},
+		{
+			Name:              "Empty Input",
+			Input:             "",
+			ExpectedNamespace: "",
+			ExpectedName:      "",
+			ExpectedOK:        false,
+		},
+		{
+			Name:              "Input with only a slash",
+			Input:             "/",
+			ExpectedNamespace: "",
+			ExpectedName:      "",
+			ExpectedOK:        false,
+		},
+		{
+			Name:              "Input with leading slash",
+			Input:             "/resource-name",
+			ExpectedNamespace: "",
+			ExpectedName:      "",
+			ExpectedOK:        false,
+		},
+		{
+			Name:              "Input with trailing slash",
+			Input:             "default/",
+			ExpectedNamespace: "",
+			ExpectedName:      "",
+			ExpectedOK:        false,
+		},
+		{
+			Name:              "Input with multiple slashes",
+			Input:             "kube-system/resource/with-slashes",
+			ExpectedNamespace: "kube-system",
+			ExpectedName:      "resource/with-slashes",
+			ExpectedOK:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			namespace, name, ok := SplitNamespacedName(tc.Input)
+			assert.Equal(t, tc.ExpectedNamespace, namespace, "namespace should match")
+			assert.Equal(t, tc.ExpectedName, name, "name should match")
+			assert.Equal(t, tc.ExpectedOK, ok, "ok flag should match")
+		})
+	}
+}

--- a/pkg/util/resourcequota/calculator.go
+++ b/pkg/util/resourcequota/calculator.go
@@ -17,7 +17,6 @@ import (
 	ctlharvestercorev1 "github.com/harvester/harvester/pkg/generated/controllers/core/v1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 )
@@ -279,7 +278,7 @@ func GetMemoryLimitsFromRancherNamespaceResourceQuota(nrq *v3.NamespaceResourceQ
 }
 
 func (c *Calculator) getVMPods(namespace, vmName string) ([]*corev1.Pod, error) {
-	return c.podCache.GetByIndex(indexeresutil.PodByVMNameIndex, ref.Construct(namespace, vmName))
+	return c.podCache.GetByIndex(indexeresutil.PodByVMNameIndex, util.NamespacedName(namespace, vmName))
 }
 
 func (c *Calculator) CheckStorageResourceQuota(vm *kubevirtv1.VirtualMachine, oldVM *kubevirtv1.VirtualMachine) error {

--- a/pkg/util/svmbackup.go
+++ b/pkg/util/svmbackup.go
@@ -9,7 +9,6 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
 )
 
 func ResolveSVMBackupRef(svmbackupCache ctlharvesterv1.ScheduleVMBackupCache, obj metav1.Object) *harvesterv1.ScheduleVMBackup {
@@ -18,7 +17,7 @@ func ResolveSVMBackupRef(svmbackupCache ctlharvesterv1.ScheduleVMBackupCache, ob
 		return nil
 	}
 
-	namespace, name := ref.Parse(annotations[AnnotationSVMBackupID])
+	namespace, name, _ := SplitNamespacedName(annotations[AnnotationSVMBackupID])
 	svmbackup, err := svmbackupCache.Get(namespace, name)
 	if err != nil {
 		return nil

--- a/pkg/util/virtualmachine/virtualmachine.go
+++ b/pkg/util/virtualmachine/virtualmachine.go
@@ -13,7 +13,6 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 )
@@ -154,7 +153,7 @@ func CheckBlockRWXVolumeForVM(pvcCache v1.PersistentVolumeClaimCache, scCache ct
 	if volumeSupportRWXForVM(targetAccessMode, targetProvisioner) {
 		return nil
 	}
-	vms, err := vmCache.GetByIndex(indexeresutil.VMByNonShareablePVCIndex, ref.Construct(pvcNS, pvcName))
+	vms, err := vmCache.GetByIndex(indexeresutil.VMByNonShareablePVCIndex, util.NamespacedName(pvcNS, pvcName))
 	if err != nil {
 		return fmt.Errorf("failed to get VMs by index: %s, PVC: %s/%s, err: %s", indexeresutil.VMByNonShareablePVCIndex, pvcNS, pvcName, err)
 	}

--- a/pkg/volumeremotebackup/common/operator.go
+++ b/pkg/volumeremotebackup/common/operator.go
@@ -15,7 +15,6 @@ import (
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
 )
@@ -401,7 +400,7 @@ func (ro *restoreOperator) GetFrom(vrr *harvesterv1.VolumeRemoteRestore) string 
 }
 
 func (ro *restoreOperator) GetSnapshotClassInfo(vrr *harvesterv1.VolumeRemoteRestore) (*settings.CSIDriverInfo, error) {
-	vrbNamespace, vrbName := ref.Parse(ro.GetFrom(vrr))
+	vrbNamespace, vrbName, _ := util.SplitNamespacedName(ro.GetFrom(vrr))
 	vrb, err := ro.vrbCache.Get(vrbNamespace, vrbName)
 	if err != nil {
 		return nil, err

--- a/pkg/volumeremotebackup/longhorn/restore.go
+++ b/pkg/volumeremotebackup/longhorn/restore.go
@@ -15,7 +15,6 @@ import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/volumeremotebackup/common"
 	"github.com/harvester/harvester/pkg/volumeremotebackup/driver"
@@ -215,7 +214,7 @@ func (lbr *LHRestoreOperation) ensureRestoreResourcesExist(
 
 func (lbr *LHRestoreOperation) getSourceRemoteBackup(vrr *harvesterv1.VolumeRemoteRestore) (*harvesterv1.VolumeRemoteBackup, error) {
 	fromRef := lbr.ro.GetFrom(vrr)
-	namespace, name := ref.Parse(fromRef)
+	namespace, name, _ := util.SplitNamespacedName(fromRef)
 
 	// If namespace is empty, use the same namespace as PVCRestore
 	if namespace == "" {

--- a/pkg/webhook/resources/addon/validator.go
+++ b/pkg/webhook/resources/addon/validator.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	ctlstoragev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/storage/v1"
@@ -26,6 +25,8 @@ import (
 	validationutil "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
@@ -717,7 +718,7 @@ func objectNamespacedName(obj metav1.Object) string {
 	if obj.GetNamespace() == "" {
 		return obj.GetName()
 	}
-	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+	return util.GetNamespacedName(obj)
 }
 
 func formatLVMBlocker(kind string, names []string) string {

--- a/pkg/webhook/resources/persistentvolumeclaim/validator.go
+++ b/pkg/webhook/resources/persistentvolumeclaim/validator.go
@@ -20,7 +20,6 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
@@ -106,7 +105,7 @@ func (v *pvcValidator) Delete(request *types.Request, oldObj runtime.Object) err
 		}
 	}
 
-	vms, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, ref.Construct(oldPVC.Namespace, oldPVC.Name))
+	vms, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, util.NamespacedName(oldPVC.Namespace, oldPVC.Name))
 	if err != nil {
 		return werror.NewInternalError(fmt.Sprintf("failed to get VMs by index: %s, PVC: %s/%s, err: %s", indexeresutil.VMByPVCIndex, oldPVC.Namespace, oldPVC.Name, err))
 	}

--- a/pkg/webhook/resources/templateversion/mutator.go
+++ b/pkg/webhook/resources/templateversion/mutator.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
+	"github.com/harvester/harvester/pkg/util"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
 )
@@ -45,7 +45,7 @@ func (m *templateVersionMutator) Create(_ *types.Request, newObj runtime.Object)
 		return nil, werror.NewInvalidError("TemplateId is empty", fieldTemplateID)
 	}
 
-	_, templateName := ref.Parse(templateID)
+	_, templateName, _ := util.SplitNamespacedName(templateID)
 
 	// Do not generate a name if there is a name.
 	if vmTemplVersion.Name != "" {

--- a/pkg/webhook/resources/templateversion/validator.go
+++ b/pkg/webhook/resources/templateversion/validator.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -55,7 +54,7 @@ func (v *templateVersionValidator) Create(_ *types.Request, newObj runtime.Objec
 		return werror.NewInvalidError("TemplateId is empty", fieldTemplateID)
 	}
 
-	templateNs, templateName := ref.Parse(templateID)
+	templateNs, templateName, _ := util.SplitNamespacedName(templateID)
 	if vmTemplVersion.Namespace != templateNs {
 		return werror.NewInvalidError("Template version and template should reside in the same namespace", "metadata.namespace")
 	}
@@ -67,7 +66,7 @@ func (v *templateVersionValidator) Create(_ *types.Request, newObj runtime.Objec
 	keyPairIDs := vmTemplVersion.Spec.KeyPairIDs
 	if len(keyPairIDs) > 0 {
 		for i, kp := range keyPairIDs {
-			keyPairNs, keyPairName := ref.Parse(kp)
+			keyPairNs, keyPairName, _ := util.SplitNamespacedName(kp)
 			_, err := v.keypairs.Get(keyPairNs, keyPairName)
 			if err != nil {
 				message := fmt.Sprintf("KeyPairID %s is invalid, %v", v, err)
@@ -119,13 +118,13 @@ func (v *templateVersionValidator) Delete(request *types.Request, oldObj runtime
 		return err
 	}
 
-	templNs, templName := ref.Parse(version.Spec.TemplateID)
+	templNs, templName, _ := util.SplitNamespacedName(version.Spec.TemplateID)
 	vt, err := v.templateCache.Get(templNs, templName)
 	if err != nil {
 		return err
 	}
 
-	vresionID := ref.Construct(vmTemplVersion.Namespace, vmTemplVersion.Name)
+	vresionID := util.NamespacedName(vmTemplVersion.Namespace, vmTemplVersion.Name)
 	if vt.Spec.DefaultVersionID == vresionID {
 		return werror.NewBadRequest("Cannot delete the default templateVersion")
 	}

--- a/pkg/webhook/resources/virtualmachinerestore/validator.go
+++ b/pkg/webhook/resources/virtualmachinerestore/validator.go
@@ -21,7 +21,6 @@ import (
 	ctlcniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctlsnapshotv1 "github.com/harvester/harvester/pkg/generated/controllers/snapshot.storage.k8s.io/v1"
-	"github.com/harvester/harvester/pkg/ref"
 	restorecommon "github.com/harvester/harvester/pkg/restore/common"
 	"github.com/harvester/harvester/pkg/settings"
 	"github.com/harvester/harvester/pkg/util"
@@ -328,7 +327,7 @@ func (v *restoreValidator) checkNetwork(vmBackup *v1beta1.VirtualMachineBackup) 
 	sourceSpec := v.vmbr.GetSourceSpec(vmBackup)
 	for _, network := range sourceSpec.Spec.Template.Spec.Networks {
 		if network.Multus != nil {
-			namespace, name := ref.Parse(network.Multus.NetworkName)
+			namespace, name, _ := util.SplitNamespacedName(network.Multus.NetworkName)
 			_, err := v.networkAttachmentDefinitionsCache.Get(namespace, name)
 			if err != nil {
 				return fmt.Errorf("failed to get network attachment definition %s, err: %v", network.Multus.NetworkName, err)

--- a/pkg/webhook/resources/volumeremotebackup/validator.go
+++ b/pkg/webhook/resources/volumeremotebackup/validator.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
-	"github.com/harvester/harvester/pkg/ref"
+	"github.com/harvester/harvester/pkg/util"
 	"github.com/harvester/harvester/pkg/volumeremotebackup/common"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
 	"github.com/harvester/harvester/pkg/webhook/types"
@@ -134,7 +134,7 @@ func (v *remoteRestoreValidator) Create(request *types.Request, newObj runtime.O
 	}
 
 	// Parse the backup reference (namespace/name format)
-	vrbNamespace, vrbName := ref.Parse(v.ro.GetFrom(vrr))
+	vrbNamespace, vrbName, _ := util.SplitNamespacedName(v.ro.GetFrom(vrr))
 	if vrbNamespace == "" {
 		vrbNamespace = v.ro.GetNamespace(vrr)
 	}

--- a/pkg/webhook/resources/volumesnapshot/validator.go
+++ b/pkg/webhook/resources/volumesnapshot/validator.go
@@ -13,7 +13,6 @@ import (
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
 	ctllonghornv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 	vmutil "github.com/harvester/harvester/pkg/util/virtualmachine"
@@ -76,7 +75,7 @@ func (v *volumeSnapshotValidator) Create(_ *types.Request, newObj runtime.Object
 	}
 
 	pvcName := *newVolumeSnapshot.Spec.Source.PersistentVolumeClaimName
-	attachedVMs, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, ref.Construct(newVolumeSnapshot.Namespace, pvcName))
+	attachedVMs, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, util.NamespacedName(newVolumeSnapshot.Namespace, pvcName))
 	if err != nil && !apierrors.IsNotFound(err) {
 		return werror.NewInternalError(fmt.Sprintf("failed to get VM by PVC %s/%s, err: %s", newVolumeSnapshot.Namespace, pvcName, err))
 	}
@@ -98,7 +97,7 @@ func (v *volumeSnapshotValidator) Create(_ *types.Request, newObj runtime.Object
 		return werror.NewInternalError(fmt.Sprintf("failed to get resource quota %s/%s, err: %s", newVolumeSnapshot.Namespace, util.DefaultResourceQuotaName, err))
 	}
 
-	vms, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, ref.Construct(newVolumeSnapshot.Namespace, *newVolumeSnapshot.Spec.Source.PersistentVolumeClaimName))
+	vms, err := v.vmCache.GetByIndex(indexeresutil.VMByPVCIndex, util.NamespacedName(newVolumeSnapshot.Namespace, *newVolumeSnapshot.Spec.Source.PersistentVolumeClaimName))
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return werror.NewInternalError(fmt.Sprintf("failed to get VM by PVC %s/%s, err: %s", newVolumeSnapshot.Namespace, *newVolumeSnapshot.Spec.Source.PersistentVolumeClaimName, err))

--- a/pkg/webhook/util/volume.go
+++ b/pkg/webhook/util/volume.go
@@ -11,7 +11,6 @@ import (
 
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	ctlkv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	"github.com/harvester/harvester/pkg/ref"
 	"github.com/harvester/harvester/pkg/util"
 	indexeresutil "github.com/harvester/harvester/pkg/util/indexeres"
 	werror "github.com/harvester/harvester/pkg/webhook/error"
@@ -39,7 +38,7 @@ func getPVCProvisioner(pvc *corev1.PersistentVolumeClaim, scCache ctlstoragev1.S
 }
 
 func isOnlineExpandNeeded(pvc *corev1.PersistentVolumeClaim, vmCache ctlkv1.VirtualMachineCache) (bool, error) {
-	indexKey := ref.Construct(pvc.Namespace, pvc.Name)
+	indexKey := util.NamespacedName(pvc.Namespace, pvc.Name)
 	vms, err := vmCache.GetByIndex(indexeresutil.VMByPVCIndex, indexKey)
 	if err != nil {
 		return false, werror.NewInternalError(fmt.Sprintf("failed to get VMs by index: %s, PVC: %s/%s, err: %s", indexeresutil.VMByPVCIndex, pvc.Namespace, pvc.Name, err))
@@ -61,7 +60,7 @@ func isHotpluggedFilesystemPVC(pvc *corev1.PersistentVolumeClaim, vmCache ctlkv1
 	}
 
 	// Check if the PVC is hotplugged to any VM
-	vms, err := vmCache.GetByIndex(indexeresutil.VMByHotplugPVCIndex, ref.Construct(pvc.Namespace, pvc.Name))
+	vms, err := vmCache.GetByIndex(indexeresutil.VMByHotplugPVCIndex, util.NamespacedName(pvc.Namespace, pvc.Name))
 	if err != nil {
 		return false, werror.NewInternalError(err.Error())
 	}


### PR DESCRIPTION
These helper functions are intended to partly replace https://github.com/harvester/go-common/pull/24 and will be available, at least for the Harvester project. The existing `ref.Parse` and `ref.Construct` functions (location and naming for such helper functions is a bit poorly chosen and it doesn't help to find them and understand what they do) will then use these new helper functions under the hood. In addition, the `ref` functions will be marked as deprecated but not removed, since external projects/repositories might import these functions.

Compared to `ref.Parse`, `util.SplitNamespacedName` performs some additional validations to handle malformed strings, but ultimately, the `ref.Parse` function behaves the same as before.

With the new functions under `util` they should be found by anyone looking for such features.

Additionally the `fix` target is added to the Makefile to be able to manually format the Go code properly if necessary.

> [!NOTE]
A namespaced name like `kube-system/resource/with-slashes` is not identified as invalid with the new implementation (name is not RFC 1123 compliant) to be backward compatible with `ref.Parse`.

Related to: https://github.com/harvester/harvester/issues/11547