### PR TITLE
charts: bump Kubevirt v1.8.4

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -26,7 +26,7 @@ kubevirt-operator:
     operator:
       image:
         repository: registry.suse.com/suse/sles/16.0/virt-operator
-        tag: &kubevirtVersion 1.8.4-5.2
+        tag: &kubevirtVersion 1.8.4
     ## The following images are placeholder for images in use.
     ## They are not used by the kubevirt-operator chart.
     controller:
@@ -50,7 +50,7 @@ kubevirt-operator:
     libguestfs: # introduced from kubevirt v0.44.0
       image:
         repository: registry.suse.com/suse/sles/15.7/libguestfs-tools
-        tag: 1.7.4-150700.3.30.1
+        tag: 1.7.4-150700.3.36.1
 
 ## Specify the parameters to override the sub-chart.
 ##


### PR DESCRIPTION
    - for the latest virt-launcher with QEMU 10.0.12

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
bump Kubevirt v1.8.4

#### Solution:
bump Kubevirt v1.8.4

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
