### PR TITLE
Downgrade kube-vip image tag to 1.1.2

### DIFF
--- a/deploy/charts/harvester/values.yaml
+++ b/deploy/charts/harvester/values.yaml
@@ -585,9 +585,11 @@ kube-vip:
   enabled: false
   image:
     repository: rancher/mirrored-kube-vip-kube-vip-iptables
-    # Updated to the latest image tag as of 2026.08.14 (kube-vip chart 0.11.0 default is v1.2.2)
-    # Always check this field if kube-vip sub-chart version is bumped to avoid accidentally/silently downgrading the image tag
-    tag: v1.2.3
+    # Workaround: Harvester requires kube-vip v1.1.2 due to breaking changes introduced in v1.2.0+.
+    # Ref: https://github.com/harvester/harvester/issues/11574
+    # Note: Keep the Helm chart at v0.11.0; only override the image tag to v1.1.2.
+    # CAUTION: Always verify this field when upgrading the sub-chart to prevent accidental image bumps.
+    tag: v1.1.2
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
   # https://github.com/kube-vip/kube-vip/blob/main/pkg/kubevip/config_envvar.go


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

kube-vip v1.2.0 has a breaking change and Harvester VM type LB does not work as expected

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Use this  workaround for master-head and v1.9.0, before https://github.com/harvester/harvester/issues/11574 is solved on v1.11.0 or v1.9.1

**[note]**
**1. Harvester kube-vip does not affect guest cluster, as guest cluster has it's own kube-vip to work for guest cluster service.  Harvester kube-vip serves for: Harvester management VIP and the VM type loadbalancer.
2. The fix is upon the Harvester chart values.yaml, hence on the upgrade path, it does not require additional effort.
3. The kube-vip chart version sticks on 0.11.0, as it has just minor incremental changes comparing to 0.9.8. It is not ncessary to downgrade the chart.**

```
kube-vipchart-verion kube-vip-default-image
------------------------------------
0.9.8               v1.0.4
0.9.9               v1.0.4
0.11.0              v1.2.2  (harvester patches it to v1.2.3
```

Past bump:
0.9.8->0.9.9 https://github.com/harvester/harvester/pull/11063

0.9.9->0.11.0 https://github.com/harvester/harvester/pull/11411

kube-vip chart 0.9.8->0.9.9

<img width="3454" height="502" alt="image" src="https://github.com/user-attachments/assets/7cbd8ed4-fbd2-48c0-8d9a-66473dab2457" />

kube-vip chart 0.9.9->0.11.0

<img width="3114" height="1016" alt="image" src="https://github.com/user-attachments/assets/8e5a6a75-035d-4de0-a2ed-6e2c281dc008" />


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11574

#### Test plan:
<!-- Describe the test plan by steps. -->

Per issue description, create pool or DHCP type VM loadbalancer, it should work

On existing cluster, edit `harvester managedchart` to change kube-vip tag to v1.1.2

Local test: (note: my env is a bit older, it is still on v190-rc5, but it does not affect the validation)

(1) Manual change current harvester chart with a new chart version and downgrade kube-vip image tag

```

diff -U 2 -r rc5/harvester/Chart.yaml rc6/harvester/Chart.yaml
--- rc5/harvester/Chart.yaml	2026-08-12 18:18:01.000000000 +0000
+++ rc6/harvester/Chart.yaml	2026-09-03 10:08:40.000000000 +0000
@@ -67,3 +67,3 @@
 - https://github.com/harvester/harvester
 type: application
-version: 1.9.0-rc5
+version: 1.9.0-rc6
diff -U 2 -r rc5/harvester/values.yaml rc6/harvester/values.yaml
--- rc5/harvester/values.yaml	2026-08-12 18:18:01.000000000 +0000
+++ rc6/harvester/values.yaml	2026-09-03 10:08:40.000000000 +0000
@@ -510,5 +510,5 @@
   image:
     repository: rancher/mirrored-kube-vip-kube-vip-iptables
-    tag: v1.2.1
+    tag: v1.1.2
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"


$ python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...

10.52.0.4 - - [03/Sep/2026 10:30:01] "GET /index.yaml HTTP/1.1" 200 -

10.52.0.4 - - [03/Sep/2026 10:39:13] "GET /harvester-1.9.0-rc5.tgz HTTP/1.1" 200 -


10.52.0.4 - - [03/Sep/2026 10:46:02] "GET /harvester-1.9.0-rc6.tgz HTTP/1.1" 200 -
```

3. Run `kubectl edit managedchart -n fleet-local harvester` to set the version to the home made one, check kube-vip image

```
$ kubectl get daemonset -n harvester-system kube-vip -oyaml | grep image
        image: rancher/mirrored-kube-vip-kube-vip-iptables:v1.2.1                      // original on rc5 version
        imagePullPolicy: IfNotPresent


$ kk get daemonset -n harvester-system kube-vip -oyaml | grep image
        image: rancher/mirrored-kube-vip-kube-vip-iptables:v1.1.2                      // new image tag per downgrade requirement
        imagePullPolicy: IfNotPresent
```


#### Additional documentation or context
