### PR TITLE
feat: add the failure reason when detecting a failed live migration VM

### DIFF
--- a/package/upgrade/upgrade_node.sh
+++ b/package/upgrade/upgrade_node.sh
@@ -248,7 +248,8 @@ check_migrations_phase() {
         warnings=$(kubectl -n "${vmi_namespace}" events --for=virtualmachineinstancemigration/"${vmim}" --types=warning -ojsonpath='{.items[*].reason}' 2>/dev/null)
         if [ ! -z "${warnings}" ]; then
           if echo "${warnings}" | grep -i -q "failedmigration"; then
-            echo "shutting down virtual machine ${vmi_namespace}/${vmi_name} due to failed migration. vmim: ${vmi_namespace}/${vmim}, reasons: ${warnings}"
+            failure_reason=$(kubectl -n "${vmi_namespace}" get vmim "${vmim}" -ojsonpath='{.status.migrationState.failureReason}' 2>/dev/null)
+            echo "shutting down virtual machine ${vmi_namespace}/${vmi_name} due to failed migration. vmim: ${vmi_namespace}/${vmim}, warnings: ${warnings}, failure reason: ${failure_reason}"
             virtctl -n "${vmi_namespace}" stop "${vmi_name}" || true # don't fail upgrade if virtctl failed
           fi
         fi


### PR DESCRIPTION
#### Problem:

Current:
`shutting down virtual machine default/rke2-pool2-r45r5-p2sb2 due to failed migration. vmim: default/kubevirt-evacuation-r2cjs, reasons: FailedMigration`

#### Solution:

Add more specified failure reason.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11577

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

This one could be included in 1.9.1 and 1.10.
