### PR TITLE
fix: make VM image StorageClass names deterministic again

### DIFF
--- a/pkg/image/common/operator.go
+++ b/pkg/image/common/operator.go
@@ -17,8 +17,6 @@ import (
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctlharvesterv1 "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester/pkg/util"
-	lhdatastore "github.com/longhorn/longhorn-manager/datastore"
-	lhutil "github.com/longhorn/longhorn-manager/util"
 )
 
 const (
@@ -196,13 +194,15 @@ func (vmio *vmiOperator) GetStorageClassName(vmi *harvesterv1.VirtualMachineImag
 	}
 
 	restoreSCName, hasRestoreSCName := util.GetRestoreSCName(vmi)
-	scName := lhutil.AutoCorrectName(
-		fmt.Sprintf("lh-%s", vmio.GetUID(vmi)),
-		lhdatastore.NameMaximumLength,
-	)
-	legacySCName := fmt.Sprintf("longhorn-%s", vmi.Name)
+	scName := util.GetImageStorageClassName(vmi)
+	// The UID based name was used by Harvester v1.8.x and the unqualified name
+	// by v1.7.x and earlier. Both are resolved so that images created on those
+	// versions keep working after an upgrade, but neither is ever used to name a
+	// newly created storage class.
+	uidSCName := util.GetUIDImageStorageClassName(vmi)
+	legacySCName := util.GetLegacyImageStorageClassName(vmi)
 
-	if existingSCName := vmio.getSCByNames(restoreSCName, scName, legacySCName); existingSCName != "" {
+	if existingSCName := vmio.getSCByNames(restoreSCName, scName, uidSCName, legacySCName); existingSCName != "" {
 		return existingSCName
 	}
 
@@ -211,10 +211,10 @@ func (vmio *vmiOperator) GetStorageClassName(vmi *harvesterv1.VirtualMachineImag
 		return restoreSCName
 	}
 
-	// If neither a storage class with the new naming nor with the old naming
-	// exists, then return the new name. This allows the GetStorageClassName
-	// method to be used to generate the name of the storage class to be used
-	// during creation.
+	// No storage class exists yet for this image, so return the name a new one
+	// has to be created with. It is derived from the image's namespace and name
+	// only, which means callers can compute it from the image spec alone,
+	// before the object is submitted to the API server.
 	return scName
 }
 

--- a/pkg/image/common/operator_test.go
+++ b/pkg/image/common/operator_test.go
@@ -38,7 +38,7 @@ func TestGetStorageClassName(t *testing.T) {
 			ex: output{name: "foobar"},
 		},
 		{
-			desc: "StoageClass lh-$UID",
+			desc: "existing v1.8.x lh-$UID StorageClass is reused",
 			in: input{
 				storageclasses: []*storagev1.StorageClass{
 					{
@@ -49,8 +49,9 @@ func TestGetStorageClassName(t *testing.T) {
 				},
 				vmi: &harvesterv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "image-foobar",
-						UID:  "abcdefghi-jklmno-pqrstu-123456",
+						Namespace: "default",
+						Name:      "image-foobar",
+						UID:       "abcdefghi-jklmno-pqrstu-123456",
 					},
 					Spec: harvesterv1.VirtualMachineImageSpec{
 						Backend: harvesterv1.VMIBackendBackingImage,
@@ -60,7 +61,7 @@ func TestGetStorageClassName(t *testing.T) {
 			ex: output{name: "lh-abcdefghi-jklmno-pqrstu-123456"},
 		},
 		{
-			desc: "StoageClass longhorn-$NAME",
+			desc: "existing v1.7.x longhorn-$NAME StorageClass is reused",
 			in: input{
 				storageclasses: []*storagev1.StorageClass{
 					{
@@ -71,8 +72,9 @@ func TestGetStorageClassName(t *testing.T) {
 				},
 				vmi: &harvesterv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "image-foobar",
-						UID:  "abcdefghi-jklmno-pqrstu-123456",
+						Namespace: "default",
+						Name:      "image-foobar",
+						UID:       "abcdefghi-jklmno-pqrstu-123456",
 					},
 					Spec: harvesterv1.VirtualMachineImageSpec{
 						Backend: harvesterv1.VMIBackendBackingImage,
@@ -82,20 +84,88 @@ func TestGetStorageClassName(t *testing.T) {
 			ex: output{name: "longhorn-image-foobar"},
 		},
 		{
-			desc: "StoageClass not found",
+			desc: "no StorageClass exists yet, name is derived from namespace and name",
 			in: input{
 				storageclasses: []*storagev1.StorageClass{},
 				vmi: &harvesterv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "image-foobar",
-						UID:  "abcdefghi-jklmno-pqrstu-123456",
+						Namespace: "default",
+						Name:      "image-foobar",
+						UID:       "abcdefghi-jklmno-pqrstu-123456",
 					},
 					Spec: harvesterv1.VirtualMachineImageSpec{
 						Backend: harvesterv1.VMIBackendBackingImage,
 					},
 				},
 			},
-			ex: output{name: "lh-abcdefghi-jklmno-pqrstu-123456"},
+			ex: output{name: "longhorn-default-image-foobar"},
+		},
+		{
+			desc: "name for a new image does not depend on the UID",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "image-foobar",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend: harvesterv1.VMIBackendBackingImage,
+					},
+				},
+			},
+			ex: output{name: "longhorn-default-image-foobar"},
+		},
+		{
+			desc: "identically named image in another namespace gets a distinct name",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-default-image-foobar",
+						},
+					},
+				},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "other",
+						Name:      "image-foobar",
+						UID:       "fedcba987-onmlkj-utsrqp-654321",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend: harvesterv1.VMIBackendBackingImage,
+					},
+				},
+			},
+			ex: output{name: "longhorn-other-image-foobar"},
+		},
+		{
+			desc: "namespaced name is preferred over a colliding v1.7.x name",
+			in: input{
+				storageclasses: []*storagev1.StorageClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-image-foobar",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "longhorn-other-image-foobar",
+						},
+					},
+				},
+				vmi: &harvesterv1.VirtualMachineImage{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "other",
+						Name:      "image-foobar",
+						UID:       "fedcba987-onmlkj-utsrqp-654321",
+					},
+					Spec: harvesterv1.VirtualMachineImageSpec{
+						Backend: harvesterv1.VMIBackendBackingImage,
+					},
+				},
+			},
+			ex: output{name: "longhorn-other-image-foobar"},
 		},
 		{
 			desc: "Restore StorageClass from backingImage URL parameter when none exists",
@@ -103,8 +173,9 @@ func TestGetStorageClassName(t *testing.T) {
 				storageclasses: []*storagev1.StorageClass{},
 				vmi: &harvesterv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "image-foobar",
-						UID:  "abcdefghi-jklmno-pqrstu-123456",
+						Namespace: "default",
+						Name:      "image-foobar",
+						UID:       "abcdefghi-jklmno-pqrstu-123456",
 					},
 					Spec: harvesterv1.VirtualMachineImageSpec{
 						Backend:    harvesterv1.VMIBackendBackingImage,
@@ -127,8 +198,9 @@ func TestGetStorageClassName(t *testing.T) {
 				},
 				vmi: &harvesterv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "image-foobar",
-						UID:  "abcdefghi-jklmno-pqrstu-123456",
+						Namespace: "default",
+						Name:      "image-foobar",
+						UID:       "abcdefghi-jklmno-pqrstu-123456",
 					},
 					Spec: harvesterv1.VirtualMachineImageSpec{
 						Backend:    harvesterv1.VMIBackendBackingImage,
@@ -156,8 +228,9 @@ func TestGetStorageClassName(t *testing.T) {
 				},
 				vmi: &harvesterv1.VirtualMachineImage{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "image-foobar",
-						UID:  "abcdefghi-jklmno-pqrstu-123456",
+						Namespace: "default",
+						Name:      "image-foobar",
+						UID:       "abcdefghi-jklmno-pqrstu-123456",
 					},
 					Spec: harvesterv1.VirtualMachineImageSpec{
 						Backend:    harvesterv1.VMIBackendBackingImage,

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -14,12 +14,17 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	harvesterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	ctllhv1 "github.com/harvester/harvester/pkg/generated/controllers/longhorn.io/v1beta2"
 )
 
-const backingimagePrefix = "vmi"
+const (
+	backingimagePrefix = "vmi"
+
+	imageStorageClassPrefix = "longhorn"
+)
 
 func backingImageLegacyName(image *harvesterv1.VirtualMachineImage) string {
 	return fmt.Sprintf("%s-%s", image.Namespace, image.Name)
@@ -63,6 +68,47 @@ func GetRestoreSCName(image *harvesterv1.VirtualMachineImage) (string, bool) {
 
 	scSuffix := strings.TrimPrefix(biName, backingimagePrefix+"-")
 	return lhutil.AutoCorrectName(fmt.Sprintf("lh-%s", scSuffix), lhdatastore.NameMaximumLength), true
+}
+
+// GetImageStorageClassName returns the name of the StorageClass that backs a
+// VirtualMachineImage.
+//
+// The name is derived exclusively from the image's namespace and name, both of
+// which are part of the object the user submits. This makes the StorageClass
+// name predictable before the object exists, so declarative tooling (GitOps,
+// Terraform, CAPI templates) can reference it in the same apply that creates
+// the image.
+//
+// StorageClasses are cluster scoped while VirtualMachineImages are namespaced,
+// so the namespace has to be part of the name to keep two identically named
+// images in different namespaces from colliding (harvester/harvester#5165).
+//
+// StorageClass names are DNS subdomains, so the 253 character limit applies
+// here, not Longhorn's 40 character limit for its own resources.
+func GetImageStorageClassName(image *harvesterv1.VirtualMachineImage) string {
+	return lhutil.AutoCorrectName(
+		fmt.Sprintf("%s-%s-%s", imageStorageClassPrefix, image.Namespace, image.Name),
+		validation.DNS1123SubdomainMaxLength,
+	)
+}
+
+// GetLegacyImageStorageClassName returns the StorageClass name used by
+// Harvester v1.7.x and earlier. It is only used to look up StorageClasses that
+// already exist; new StorageClasses are never created with this name because it
+// is not unique across namespaces.
+func GetLegacyImageStorageClassName(image *harvesterv1.VirtualMachineImage) string {
+	return fmt.Sprintf("%s-%s", imageStorageClassPrefix, image.Name)
+}
+
+// GetUIDImageStorageClassName returns the UID based StorageClass name used by
+// Harvester v1.8.x. It is only used to look up StorageClasses that already
+// exist; new StorageClasses are never created with this name because the UID is
+// not known until the API server has admitted the VirtualMachineImage.
+func GetUIDImageStorageClassName(image *harvesterv1.VirtualMachineImage) string {
+	return lhutil.AutoCorrectName(
+		fmt.Sprintf("lh-%s", image.UID),
+		lhdatastore.NameMaximumLength,
+	)
 }
 
 func getBackingImageByNames(


### PR DESCRIPTION
#### Problem:
Bug described in [here](https://github.com/harvester/harvester/issues/11586).  Regression of determinstic names.

Since #9392 the StorageClass backing a VirtualMachineImage is named `lh-<vmi.metadata.uid>`. The UID is assigned by the API server when the object is admitted, so the name cannot be known until after the image exists. That breaks any declarative workflow that has to reference the StorageClass in the same apply that creates the image -- GitOps, Terraform and CAPI templates all have to round-trip through the API server and re-apply, which is not possible for a single-pass reconcile.

Through v1.7.x the name was `longhorn-<name>`, which was predictable but not unique: StorageClasses are cluster scoped while VirtualMachineImages are namespaced, so two images with the same name in different namespaces collided on one StorageClass (#5165).

#### Solution:

Derive the name from the image's namespace and name instead:

    longhorn-<namespace>-<name>

Both properties hold at once. The namespace makes the name unique across the cluster, so #5165 stays fixed, and both components are supplied by the user in the object they submit, so the name is computable from the spec alone, as it was up to v1.7.x.

This uses the same `<namespace>-<name>` shape Harvester already uses for legacy BackingImage names. The name is bounded by the DNS subdomain limit of 253 characters that applies to StorageClass names, not by Longhorn's 40 character limit, which only applies to Longhorn's own resources -- the `longhorn-<name>` scheme was likewise unbounded through v1.7.x.

Existing clusters are unaffected. `GetStorageClassName` still resolves, in order: the StorageClass derived from `spec.url` for restores, the namespaced name, the v1.8.x `lh-<uid>` name, and the v1.7.x `longhorn-<name>` name. Only the name used to create a new StorageClass changes, so images created on any earlier version keep resolving to the StorageClass they already have after an upgrade.

Unit tests updated to match

#### Related Issue(s):
N/A

#### Test plan:
Scope-limited issue, backwards compatibility functions added for any 1.8.1->1.8.2 VM images so they can still be resolved. That might be overkill and I'm fine taking that out but I wanted this to be least impactful.



