### PR TITLE
Change replicas from 1 to 2 in values.yaml

### DIFF
--- a/deploy/charts/harvester/dependency_charts/kubevirt-operator/values.yaml
+++ b/deploy/charts/harvester/dependency_charts/kubevirt-operator/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 
 ## Specify the replicas of workload.
 ##
-replicas: 1
+replicas: 2
 
 ## Specify the security context of workload.
 ##


### PR DESCRIPTION
This helps resolve the issue 

#### Problem:
Currently the alert are in FIRING state of a Harvester Cluster with a worker node count of 2 or greater than 2. 

#### Solution:
I have increased the replicas count 2 to match the default value as defined in and this will not raise any alert as it satisfies the condition.  https://kubevirt.io/monitoring/runbooks/LowVirtOperatorCount.html

#### Related Issue(s):
Solves #3473  and also close #2480