### PR TITLE
additional logic to promote addons in upgrade path

### DIFF
--- a/package/upgrade/upgrade_manifests.sh
+++ b/package/upgrade/upgrade_manifests.sh
@@ -1686,6 +1686,14 @@ annotate_management_cluster_provisioning_administrated() {
   kubectl annotate clusters.management.cattle.io local provisioning.cattle.io/administrated=true --overwrite
 }
 
+# Harvester v1.9.x marks harvester-seeder addon as GA
+# We need to remove the experimental label for the harvester-seeder addon
+# this is already being done for new installs via addon packaging
+promote_addons() {
+  echo "promoting addon harvester-seeder"
+  kubectl label -n harvester-system addons.harvester harvester-seeder  "addon.harvesterhci.io/experimental-"
+}
+
 wait_repo
 detect_repo
 detect_upgrade
@@ -1714,5 +1722,6 @@ upgrade_addons
 upgrade_harvester_csi_rbac
 # wait fleet bundles upto 90 seconds
 wait_for_fleet_bundles 9
+promote_addons
 # ingress will be swapped during the pre drain stage but we can apply traefik default config here
 patch_rke2_traefik_config


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
promote harvester-seeder addon to GA

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR adds a minor patch to remove the experimental label from the harvester-seeder addon in the upgrade path

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10649


#### Test plan:
<!-- Describe the test plan by steps. -->
* Install Harvester v1.8.2
* trigger upgrade to a harvester build containing this change
* once upgrade is finished, browse to addons page
* harvester-seeder addon will no longer be marked experimental
<img width="1572" height="147" alt="image" src="https://github.com/user-attachments/assets/a51ede7d-f56d-42a2-9588-9ba09f486877" />


#### Additional documentation or context
