### PR TITLE
remove the /1000 from kubevirt_vmi_vcpu_seconds_total metrics

### DIFF
--- a/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
+++ b/pkg/installer/config/templates/rancherd-12-monitoring-dashboard.yaml
@@ -96,7 +96,7 @@ resources:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "topk(${count}, (avg(rate(kubevirt_vmi_vcpu_seconds_total[5m])) by (domain, name)) / 1000)",
+                "expr": "topk(${count}, avg(rate(kubevirt_vmi_vcpu_seconds_total[5m])) by (domain, name))",
                 "instant": false,
                 "interval": "",
                 "legendFormat": "{{name}}",
@@ -903,7 +903,7 @@ resources:
             "pluginVersion": "7.5.8",
             "targets": [
               {
-                "expr": "sum(avg(rate(kubevirt_vmi_vcpu_seconds_total{namespace=\"$namespace\", name=\"$vm\"}[5m])) by (domain, name)) / 1000",
+                "expr": "sum(avg(rate(kubevirt_vmi_vcpu_seconds_total{namespace=\"$namespace\", name=\"$vm\"}[5m])) by (domain, name))",
                 "format": "time_series",
                 "instant": false,
                 "interval": "",


### PR DESCRIPTION
#### Problem:
Kubevirt 1.6.0 fixes a bug where kubevirt_vmi_vcpu_seconds_total was reported incorrectly, and Harvester has a workaround for this which divides by 1000 - however since we've upgraded to > 1.6.0 we can remove this workaround.

#### Solution:
Remove /1000 in dashboards

#### Related Issue(s):
related to #11637

#### Test plan:
Check CPU usage compared to VMs

#### Additional documentation or context
https://github.com/kubevirt/kubevirt/pull/13898
https://github.com/kubevirt/kubevirt/issues/13731